### PR TITLE
Adds bug-fixes for the Malayalam block

### DIFF
--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/c_cha-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/c_cha-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="c_cha-malayalam" format="2">
   <advance width="908"/>
   <anchor x="485" y="-361" name="bottom"/>
-  <anchor x="799" y="0" name="bottomright"/>
   <anchor x="452" y="596" name="top"/>
   <anchor x="778" y="596" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/d_da-malayalam.glif
@@ -1,23 +1,23 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
-  <advance width="689"/>
-  <anchor x="384" y="-209" name="bottom"/>
+  <advance width="679"/>
+  <anchor x="381" y="-269" name="bottom"/>
   <anchor x="376" y="596" name="top"/>
   <outline>
     <contour>
-      <point x="449" y="-225" type="curve" smooth="yes"/>
-      <point x="577" y="-225"/>
-      <point x="641" y="-177"/>
-      <point x="641" y="-86" type="curve" smooth="yes"/>
-      <point x="641" y="-27"/>
-      <point x="602" y="13"/>
-      <point x="532" y="23" type="curve"/>
-      <point x="532" y="33" type="line"/>
-      <point x="581" y="49"/>
-      <point x="631" y="85"/>
+      <point x="414" y="-285" type="curve" smooth="yes"/>
+      <point x="546" y="-285"/>
+      <point x="631" y="-220"/>
+      <point x="631" y="-119" type="curve" smooth="yes"/>
+      <point x="631" y="-47"/>
+      <point x="595" y="4"/>
+      <point x="531" y="22" type="curve"/>
+      <point x="531" y="32" type="line"/>
+      <point x="596" y="53"/>
+      <point x="631" y="100"/>
       <point x="631" y="166" type="curve" smooth="yes"/>
-      <point x="631" y="239"/>
-      <point x="586" y="284"/>
+      <point x="631" y="237"/>
+      <point x="588" y="284"/>
       <point x="511" y="298" type="curve"/>
       <point x="511" y="308" type="line"/>
       <point x="572" y="324"/>
@@ -48,27 +48,27 @@
       <point x="372" y="337" type="line"/>
       <point x="372" y="263" type="line"/>
       <point x="414" y="263" type="line" smooth="yes"/>
-      <point x="500" y="263"/>
-      <point x="549" y="228"/>
+      <point x="502" y="263"/>
+      <point x="549" y="227"/>
       <point x="549" y="159" type="curve" smooth="yes"/>
-      <point x="549" y="94"/>
-      <point x="495" y="62"/>
+      <point x="549" y="99"/>
+      <point x="502" y="62"/>
       <point x="425" y="62" type="curve" smooth="yes"/>
-      <point x="372" y="62" type="line"/>
-      <point x="372" y="-12" type="line"/>
-      <point x="435" y="-12" type="line" smooth="yes"/>
-      <point x="521" y="-12"/>
-      <point x="559" y="-35"/>
-      <point x="559" y="-77" type="curve" smooth="yes"/>
-      <point x="559" y="-126"/>
-      <point x="519" y="-147"/>
-      <point x="452" y="-147" type="curve" smooth="yes"/>
-      <point x="403" y="-147"/>
-      <point x="369" y="-140"/>
-      <point x="336" y="-129" type="curve"/>
-      <point x="308" y="-201" type="line"/>
-      <point x="344" y="-216"/>
-      <point x="397" y="-225"/>
+      <point x="352" y="62" type="line"/>
+      <point x="352" y="-12" type="line"/>
+      <point x="425" y="-12" type="line" smooth="yes"/>
+      <point x="508" y="-12"/>
+      <point x="549" y="-44"/>
+      <point x="549" y="-110" type="curve" smooth="yes"/>
+      <point x="549" y="-173"/>
+      <point x="502" y="-207"/>
+      <point x="416" y="-207" type="curve" smooth="yes"/>
+      <point x="360" y="-207"/>
+      <point x="313" y="-195"/>
+      <point x="261" y="-169" type="curve"/>
+      <point x="228" y="-238" type="line"/>
+      <point x="289" y="-269"/>
+      <point x="352" y="-285"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="987"/>
-  <anchor x="669" y="0" name="bottom"/>
+  <advance width="980"/>
+  <anchor x="662" y="0" name="bottom"/>
   <anchor x="493" y="596" name="top"/>
-  <anchor x="859" y="596" name="topright"/>
+  <anchor x="852" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="284" y="-16" type="curve" smooth="yes"/>
-      <point x="411" y="-16"/>
-      <point x="488" y="72"/>
-      <point x="507" y="240" type="curve" smooth="yes"/>
-      <point x="519" y="348" type="line" smooth="yes"/>
-      <point x="532" y="465"/>
-      <point x="581" y="532"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="463"/>
+      <point x="576" y="532"/>
       <point x="695" y="532" type="curve" smooth="yes"/>
-      <point x="794" y="532"/>
-      <point x="836" y="492"/>
-      <point x="836" y="429" type="curve" smooth="yes"/>
-      <point x="836" y="373"/>
-      <point x="792" y="337"/>
-      <point x="722" y="337" type="curve" smooth="yes"/>
-      <point x="670" y="337" type="line"/>
-      <point x="670" y="263" type="line"/>
-      <point x="722" y="263" type="line" smooth="yes"/>
-      <point x="813" y="263"/>
-      <point x="857" y="225"/>
-      <point x="857" y="161" type="curve" smooth="yes"/>
-      <point x="857" y="94"/>
-      <point x="815" y="62"/>
-      <point x="741" y="62" type="curve" smooth="yes"/>
-      <point x="707" y="62"/>
-      <point x="679" y="70"/>
-      <point x="650" y="83" type="curve"/>
-      <point x="614" y="10" type="line"/>
-      <point x="650" y="-7"/>
-      <point x="694" y="-16"/>
-      <point x="742" y="-16" type="curve" smooth="yes"/>
-      <point x="860" y="-16"/>
-      <point x="939" y="48"/>
-      <point x="939" y="155" type="curve" smooth="yes"/>
-      <point x="939" y="230"/>
-      <point x="893" y="284"/>
-      <point x="819" y="298" type="curve"/>
-      <point x="819" y="308" type="line"/>
-      <point x="882" y="325"/>
-      <point x="918" y="375"/>
-      <point x="918" y="439" type="curve" smooth="yes"/>
-      <point x="918" y="539"/>
-      <point x="842" y="612"/>
-      <point x="690" y="612" type="curve" smooth="yes"/>
-      <point x="533" y="612"/>
-      <point x="444" y="523"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="789" y="532"/>
+      <point x="829" y="493"/>
+      <point x="829" y="433" type="curve" smooth="yes"/>
+      <point x="829" y="375"/>
+      <point x="785" y="337"/>
+      <point x="715" y="337" type="curve" smooth="yes"/>
+      <point x="663" y="337" type="line"/>
+      <point x="663" y="263" type="line"/>
+      <point x="715" y="263" type="line" smooth="yes"/>
+      <point x="806" y="263"/>
+      <point x="850" y="225"/>
+      <point x="850" y="161" type="curve" smooth="yes"/>
+      <point x="850" y="94"/>
+      <point x="808" y="62"/>
+      <point x="734" y="62" type="curve" smooth="yes"/>
+      <point x="700" y="62"/>
+      <point x="672" y="70"/>
+      <point x="643" y="83" type="curve"/>
+      <point x="607" y="10" type="line"/>
+      <point x="643" y="-7"/>
+      <point x="687" y="-16"/>
+      <point x="735" y="-16" type="curve" smooth="yes"/>
+      <point x="853" y="-16"/>
+      <point x="932" y="48"/>
+      <point x="932" y="155" type="curve" smooth="yes"/>
+      <point x="932" y="230"/>
+      <point x="886" y="284"/>
+      <point x="812" y="298" type="curve"/>
+      <point x="812" y="308" type="line"/>
+      <point x="875" y="326"/>
+      <point x="911" y="378"/>
+      <point x="911" y="445" type="curve" smooth="yes"/>
+      <point x="911" y="542"/>
+      <point x="840" y="612"/>
+      <point x="697" y="612" type="curve" smooth="yes"/>
+      <point x="529" y="612"/>
+      <point x="421" y="515"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="92"/>
-      <point x="143" y="-16"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/g_ga-malayalam.glif
@@ -6,92 +6,96 @@
   <anchor x="763" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="403" y="-378" type="curve" smooth="yes"/>
-      <point x="519" y="-378"/>
-      <point x="561" y="-315"/>
-      <point x="569" y="-173" type="curve" smooth="yes"/>
-      <point x="570" y="-156" type="line" smooth="yes"/>
-      <point x="576" y="-52"/>
-      <point x="603" y="-22"/>
-      <point x="657" y="-22" type="curve" smooth="yes"/>
-      <point x="721" y="-22"/>
-      <point x="759" y="-67"/>
-      <point x="759" y="-160" type="curve" smooth="yes"/>
-      <point x="759" y="-241"/>
-      <point x="732" y="-291"/>
-      <point x="691" y="-338" type="curve"/>
-      <point x="747" y="-378" type="line"/>
-      <point x="808" y="-313"/>
-      <point x="833" y="-247"/>
-      <point x="833" y="-157" type="curve" smooth="yes"/>
-      <point x="833" y="-9"/>
-      <point x="756" y="48"/>
-      <point x="661" y="48" type="curve" smooth="yes"/>
-      <point x="547" y="48"/>
-      <point x="507" y="-14"/>
-      <point x="498" y="-152" type="curve" smooth="yes"/>
-      <point x="497" y="-168" type="line" smooth="yes"/>
-      <point x="490" y="-278"/>
-      <point x="463" y="-308"/>
-      <point x="407" y="-308" type="curve" smooth="yes"/>
-      <point x="349" y="-308"/>
-      <point x="307" y="-266"/>
-      <point x="307" y="-166" type="curve" smooth="yes"/>
-      <point x="307" y="-100"/>
-      <point x="330" y="-47"/>
-      <point x="376" y="7" type="curve"/>
-      <point x="360" y="-4" type="line"/>
-      <point x="442" y="26"/>
-      <point x="494" y="109"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="516" y="348" type="line" smooth="yes"/>
-      <point x="527" y="465"/>
-      <point x="579" y="528"/>
-      <point x="661" y="528" type="curve" smooth="yes"/>
-      <point x="757" y="528"/>
-      <point x="797" y="453"/>
-      <point x="797" y="330" type="curve" smooth="yes"/>
-      <point x="797" y="217"/>
-      <point x="773" y="122"/>
-      <point x="679" y="41" type="curve"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="460"/>
+      <point x="560" y="528"/>
+      <point x="653" y="528" type="curve" smooth="yes"/>
+      <point x="748" y="528"/>
+      <point x="796" y="462"/>
+      <point x="796" y="332" type="curve" smooth="yes"/>
+      <point x="796" y="200"/>
+      <point x="761" y="115"/>
+      <point x="678" y="44" type="curve"/>
       <point x="731" y="-16" type="line"/>
-      <point x="843" y="80"/>
-      <point x="880" y="187"/>
-      <point x="880" y="331" type="curve" smooth="yes"/>
-      <point x="880" y="505"/>
-      <point x="803" y="612"/>
-      <point x="655" y="612" type="curve" smooth="yes"/>
-      <point x="523" y="612"/>
-      <point x="444" y="525"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="836" y="74"/>
+      <point x="880" y="177"/>
+      <point x="880" y="332" type="curve" smooth="yes"/>
+      <point x="880" y="511"/>
+      <point x="797" y="612"/>
+      <point x="651" y="612" type="curve" smooth="yes"/>
+      <point x="507" y="612"/>
+      <point x="421" y="517"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="94"/>
-      <point x="142" y="-14"/>
-      <point x="285" y="-14" type="curve" smooth="yes"/>
-      <point x="301" y="-14"/>
-      <point x="316" y="-13"/>
-      <point x="333" y="-10" type="curve"/>
-      <point x="256" y="27" type="line"/>
-      <point x="288" y="-61" type="line"/>
-      <point x="294" y="-5" type="line"/>
-      <point x="262" y="-34"/>
-      <point x="233" y="-104"/>
-      <point x="233" y="-168" type="curve" smooth="yes"/>
-      <point x="233" y="-320"/>
-      <point x="311" y="-378"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
+    </contour>
+    <contour>
+      <point x="411" y="-378" type="curve" smooth="yes"/>
+      <point x="513" y="-378"/>
+      <point x="573" y="-310"/>
+      <point x="573" y="-198" type="curve" smooth="yes"/>
+      <point x="573" y="-178"/>
+      <point x="571" y="-157"/>
+      <point x="571" y="-137" type="curve" smooth="yes"/>
+      <point x="571" y="-56"/>
+      <point x="604" y="-24"/>
+      <point x="663" y="-24" type="curve" smooth="yes"/>
+      <point x="724" y="-24"/>
+      <point x="757" y="-71"/>
+      <point x="757" y="-157" type="curve" smooth="yes"/>
+      <point x="757" y="-228"/>
+      <point x="736" y="-280"/>
+      <point x="688" y="-331" type="curve"/>
+      <point x="741" y="-378" type="line"/>
+      <point x="806" y="-313"/>
+      <point x="833" y="-248"/>
+      <point x="833" y="-157" type="curve" smooth="yes"/>
+      <point x="833" y="-27"/>
+      <point x="771" y="48"/>
+      <point x="661" y="48" type="curve" smooth="yes"/>
+      <point x="561" y="48"/>
+      <point x="493" y="-10"/>
+      <point x="493" y="-131" type="curve" smooth="yes"/>
+      <point x="493" y="-151"/>
+      <point x="495" y="-172"/>
+      <point x="495" y="-192" type="curve" smooth="yes"/>
+      <point x="495" y="-267"/>
+      <point x="466" y="-306"/>
+      <point x="409" y="-306" type="curve" smooth="yes"/>
+      <point x="345" y="-306"/>
+      <point x="309" y="-257"/>
+      <point x="309" y="-169" type="curve" smooth="yes"/>
+      <point x="309" y="-102"/>
+      <point x="326" y="-44"/>
+      <point x="374" y="13" type="curve"/>
+      <point x="302" y="13" type="line"/>
+      <point x="258" y="-29"/>
+      <point x="233" y="-103"/>
+      <point x="233" y="-169" type="curve" smooth="yes"/>
+      <point x="233" y="-301"/>
+      <point x="299" y="-378"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/g_la-malayalam.glif
@@ -13,13 +13,13 @@
       <point x="425" y="-163"/>
       <point x="381" y="-121"/>
       <point x="311" y="-121" type="curve" smooth="yes"/>
-      <point x="258" y="-121"/>
+      <point x="260" y="-121"/>
       <point x="200" y="-154"/>
       <point x="200" y="-239" type="curve"/>
-      <point x="224" y="-172" type="line"/>
-      <point x="165" y="-172" type="line"/>
-      <point x="202" y="-198" type="line"/>
-      <point x="202" y="-84"/>
+      <point x="224" y="-175" type="line"/>
+      <point x="165" y="-175" type="line"/>
+      <point x="204" y="-198" type="line"/>
+      <point x="204" y="-84"/>
       <point x="256" y="-22"/>
       <point x="352" y="-22" type="curve" smooth="yes"/>
       <point x="448" y="-22"/>
@@ -36,31 +36,33 @@
       <point x="821" y="-7"/>
       <point x="771" y="48" type="curve"/>
       <point x="767" y="18" type="line"/>
-      <point x="851" y="106"/>
-      <point x="880" y="204"/>
-      <point x="880" y="331" type="curve" smooth="yes"/>
-      <point x="880" y="505"/>
-      <point x="803" y="612"/>
-      <point x="655" y="612" type="curve" smooth="yes"/>
-      <point x="523" y="612"/>
-      <point x="444" y="525"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="846" y="100"/>
+      <point x="880" y="196"/>
+      <point x="880" y="332" type="curve" smooth="yes"/>
+      <point x="880" y="511"/>
+      <point x="797" y="612"/>
+      <point x="651" y="612" type="curve" smooth="yes"/>
+      <point x="507" y="612"/>
+      <point x="421" y="517"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="132"/>
+      <point x="377" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="129"/>
-      <point x="113" y="38"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="138"/>
+      <point x="111" y="42"/>
       <point x="209" y="6" type="curve"/>
       <point x="211" y="-4" type="line"/>
       <point x="162" y="-47"/>
@@ -74,10 +76,10 @@
       <point x="234" y="-313"/>
       <point x="207" y="-256"/>
       <point x="207" y="-200" type="curve"/>
-      <point x="187" y="-208" type="line"/>
+      <point x="190" y="-218" type="line"/>
       <point x="208" y="-265" type="line"/>
       <point x="208" y="-221"/>
-      <point x="240" y="-181"/>
+      <point x="241" y="-181"/>
       <point x="294" y="-181" type="curve" smooth="yes"/>
       <point x="335" y="-181"/>
       <point x="355" y="-206"/>
@@ -91,25 +93,27 @@
       <point x="611" y="-271"/>
       <point x="587" y="-185" type="curve" smooth="yes"/>
       <point x="575" y="-142" type="line" smooth="yes"/>
-      <point x="548" y="-45"/>
-      <point x="501" y="17"/>
-      <point x="425" y="37" type="curve"/>
-      <point x="423" y="47" type="line"/>
-      <point x="474" y="90"/>
-      <point x="498" y="153"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="516" y="348" type="line" smooth="yes"/>
-      <point x="527" y="465"/>
-      <point x="579" y="528"/>
-      <point x="661" y="528" type="curve" smooth="yes"/>
-      <point x="757" y="528"/>
-      <point x="797" y="453"/>
-      <point x="797" y="330" type="curve" smooth="yes"/>
-      <point x="797" y="217"/>
-      <point x="773" y="126"/>
+      <point x="549" y="-47"/>
+      <point x="504" y="13"/>
+      <point x="431" y="33" type="curve"/>
+      <point x="429" y="43" type="line"/>
+      <point x="486" y="85"/>
+      <point x="513" y="148"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="460"/>
+      <point x="560" y="528"/>
+      <point x="653" y="528" type="curve" smooth="yes"/>
+      <point x="748" y="528"/>
+      <point x="796" y="462"/>
+      <point x="796" y="332" type="curve" smooth="yes"/>
+      <point x="796" y="200"/>
+      <point x="761" y="115"/>
       <point x="678" y="44" type="curve"/>
-      <point x="731" y="-8"/>
-      <point x="780" y="-72"/>
+      <point x="751" y="-24"/>
+      <point x="780" y="-94"/>
       <point x="780" y="-185" type="curve" smooth="yes"/>
       <point x="780" y="-262"/>
       <point x="753" y="-308"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/g_ma-malayalam.glif
@@ -6,16 +6,18 @@
   <anchor x="1312" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="284" y="-16" type="curve" smooth="yes"/>
-      <point x="411" y="-16"/>
-      <point x="492" y="72"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="515" y="346" type="line" smooth="yes"/>
-      <point x="525" y="460"/>
-      <point x="569" y="528"/>
-      <point x="660" y="528" type="curve" smooth="yes"/>
-      <point x="750" y="528"/>
-      <point x="796" y="456"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="460"/>
+      <point x="557" y="528"/>
+      <point x="653" y="528" type="curve" smooth="yes"/>
+      <point x="748" y="528"/>
+      <point x="796" y="462"/>
       <point x="796" y="331" type="curve" smooth="yes"/>
       <point x="796" y="0" type="line"/>
       <point x="1362" y="0" type="line"/>
@@ -27,28 +29,30 @@
       <point x="892" y="571"/>
       <point x="848" y="490" type="curve"/>
       <point x="838" y="490" type="line"/>
-      <point x="801" y="575"/>
-      <point x="738" y="612"/>
-      <point x="653" y="612" type="curve" smooth="yes"/>
-      <point x="521" y="612"/>
-      <point x="442" y="529"/>
-      <point x="427" y="353" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="408" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="803" y="571"/>
+      <point x="740" y="612"/>
+      <point x="651" y="612" type="curve" smooth="yes"/>
+      <point x="509" y="612"/>
+      <point x="421" y="517"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="92"/>
-      <point x="143" y="-16"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
     </contour>
     <contour>
       <point x="846" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/g_na-malayalam.glif
@@ -6,16 +6,18 @@
   <anchor x="1199" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="284" y="-16" type="curve" smooth="yes"/>
-      <point x="411" y="-16"/>
-      <point x="490" y="72"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="516" y="348" type="line" smooth="yes"/>
-      <point x="527" y="465"/>
-      <point x="576" y="528"/>
-      <point x="661" y="528" type="curve" smooth="yes"/>
-      <point x="757" y="528"/>
-      <point x="796" y="453"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="462"/>
+      <point x="562" y="528"/>
+      <point x="656" y="528" type="curve" smooth="yes"/>
+      <point x="750" y="528"/>
+      <point x="796" y="463"/>
       <point x="796" y="330" type="curve" smooth="yes"/>
       <point x="796" y="0" type="line"/>
       <point x="880" y="0" type="line"/>
@@ -37,31 +39,33 @@
       <point x="1186" y="612"/>
       <point x="1035" y="612" type="curve" smooth="yes"/>
       <point x="942" y="612"/>
-      <point x="876" y="570"/>
+      <point x="874" y="567"/>
       <point x="843" y="499" type="curve"/>
       <point x="833" y="499" type="line"/>
-      <point x="806" y="570"/>
-      <point x="745" y="612"/>
-      <point x="657" y="612" type="curve" smooth="yes"/>
-      <point x="523" y="612"/>
-      <point x="444" y="525"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="802" y="571"/>
+      <point x="737" y="612"/>
+      <point x="652" y="612" type="curve" smooth="yes"/>
+      <point x="506" y="612"/>
+      <point x="421" y="516"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="92"/>
-      <point x="143" y="-16"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ga-malayalam.glif
@@ -7,46 +7,50 @@
   <anchor x="763" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="284" y="-16" type="curve" smooth="yes"/>
-      <point x="411" y="-16"/>
-      <point x="490" y="72"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="516" y="348" type="line" smooth="yes"/>
-      <point x="527" y="465"/>
-      <point x="579" y="528"/>
-      <point x="661" y="528" type="curve" smooth="yes"/>
-      <point x="757" y="528"/>
-      <point x="797" y="453"/>
-      <point x="797" y="330" type="curve" smooth="yes"/>
-      <point x="797" y="217"/>
-      <point x="773" y="126"/>
-      <point x="679" y="45" type="curve"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="460"/>
+      <point x="560" y="528"/>
+      <point x="653" y="528" type="curve" smooth="yes"/>
+      <point x="748" y="528"/>
+      <point x="796" y="462"/>
+      <point x="796" y="332" type="curve" smooth="yes"/>
+      <point x="796" y="200"/>
+      <point x="761" y="115"/>
+      <point x="678" y="44" type="curve"/>
       <point x="731" y="-16" type="line"/>
-      <point x="843" y="80"/>
-      <point x="880" y="187"/>
-      <point x="880" y="331" type="curve" smooth="yes"/>
-      <point x="880" y="505"/>
-      <point x="803" y="612"/>
-      <point x="655" y="612" type="curve" smooth="yes"/>
-      <point x="523" y="612"/>
-      <point x="444" y="525"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="836" y="74"/>
+      <point x="880" y="177"/>
+      <point x="880" y="332" type="curve" smooth="yes"/>
+      <point x="880" y="511"/>
+      <point x="797" y="612"/>
+      <point x="651" y="612" type="curve" smooth="yes"/>
+      <point x="507" y="612"/>
+      <point x="421" y="517"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="92"/>
-      <point x="143" y="-16"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ga-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ga-malayalam.half" format="2">
   <advance width="934"/>
+  <anchor x="524" y="0" name="bottom"/>
+  <anchor x="469" y="596" name="top"/>
+  <anchor x="763" y="596" name="topright"/>
   <outline>
     <component base="ga-malayalam"/>
     <component base="halant-malayalam" xOffset="763"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/j_ja-malayalam.glif
@@ -1,224 +1,224 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1626"/>
-  <anchor x="1233" y="0" name="bottom"/>
-  <anchor x="828" y="596" name="top"/>
-  <anchor x="1471" y="596" name="topright"/>
+  <advance width="1700"/>
+  <anchor x="1275" y="-6" name="bottom"/>
+  <anchor x="850" y="596" name="top"/>
+  <anchor x="1536" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="348" y="-16" type="curve" smooth="yes"/>
-      <point x="627" y="-16"/>
-      <point x="782" y="87"/>
-      <point x="864" y="317" type="curve"/>
-      <point x="879" y="371" type="line"/>
-      <point x="884" y="371" type="line"/>
-      <point x="907" y="318"/>
-      <point x="944" y="300"/>
-      <point x="991" y="300" type="curve" smooth="yes"/>
-      <point x="1075" y="300"/>
-      <point x="1125" y="354"/>
-      <point x="1125" y="429" type="curve" smooth="yes"/>
-      <point x="1125" y="488"/>
-      <point x="1093" y="539"/>
-      <point x="1012" y="539" type="curve" smooth="yes"/>
-      <point x="990" y="539"/>
-      <point x="969" y="535"/>
-      <point x="958" y="529" type="curve"/>
-      <point x="981" y="504" type="line"/>
-      <point x="962" y="566" type="line"/>
-      <point x="935" y="528" type="line"/>
-      <point x="962" y="544"/>
-      <point x="983" y="552"/>
-      <point x="1029" y="552" type="curve" smooth="yes"/>
-      <point x="1146" y="552"/>
-      <point x="1184" y="466"/>
-      <point x="1184" y="392" type="curve" smooth="yes"/>
-      <point x="1184" y="353" type="line"/>
-      <point x="1268" y="353" type="line"/>
-      <point x="1268" y="388" type="line" smooth="yes"/>
-      <point x="1268" y="479"/>
-      <point x="1321" y="534"/>
-      <point x="1392" y="534" type="curve" smooth="yes"/>
-      <point x="1456" y="534"/>
-      <point x="1490" y="490"/>
-      <point x="1490" y="425" type="curve" smooth="yes"/>
-      <point x="1490" y="359"/>
-      <point x="1452" y="294"/>
-      <point x="1329" y="294" type="curve" smooth="yes"/>
-      <point x="1070" y="294" type="line" smooth="yes"/>
-      <point x="940" y="294"/>
-      <point x="872" y="230"/>
-      <point x="872" y="135" type="curve" smooth="yes"/>
-      <point x="872" y="46"/>
-      <point x="923" y="-16"/>
-      <point x="1023" y="-16" type="curve" smooth="yes"/>
-      <point x="1081" y="-16"/>
-      <point x="1133" y="0"/>
-      <point x="1203" y="51" type="curve" smooth="yes"/>
-      <point x="1265" y="96" type="line" smooth="yes"/>
-      <point x="1350" y="158"/>
-      <point x="1396" y="172"/>
-      <point x="1440" y="172" type="curve" smooth="yes"/>
-      <point x="1485" y="172"/>
-      <point x="1501" y="147"/>
-      <point x="1501" y="111" type="curve" smooth="yes"/>
-      <point x="1501" y="74"/>
-      <point x="1481" y="48"/>
-      <point x="1444" y="48" type="curve" smooth="yes"/>
-      <point x="1408" y="48"/>
-      <point x="1388" y="70"/>
-      <point x="1388" y="109" type="curve" smooth="yes"/>
-      <point x="1388" y="148"/>
-      <point x="1406" y="171"/>
-      <point x="1423" y="190" type="curve"/>
-      <point x="1323" y="157" type="line"/>
-      <point x="1342" y="135" type="line"/>
-      <point x="1336" y="121"/>
-      <point x="1332" y="107"/>
-      <point x="1332" y="90" type="curve" smooth="yes"/>
-      <point x="1332" y="34"/>
-      <point x="1369" y="-16"/>
-      <point x="1445" y="-16" type="curve" smooth="yes"/>
-      <point x="1525" y="-16"/>
-      <point x="1567" y="39"/>
-      <point x="1567" y="110" type="curve" smooth="yes"/>
-      <point x="1567" y="188"/>
-      <point x="1517" y="238"/>
-      <point x="1444" y="238" type="curve" smooth="yes"/>
-      <point x="1382" y="238"/>
-      <point x="1339" y="229"/>
-      <point x="1248" y="169" type="curve" smooth="yes"/>
-      <point x="1173" y="119" type="line" smooth="yes"/>
-      <point x="1102" y="72"/>
-      <point x="1067" y="61"/>
-      <point x="1032" y="61" type="curve" smooth="yes"/>
-      <point x="980" y="61"/>
-      <point x="950" y="82"/>
-      <point x="950" y="136" type="curve" smooth="yes"/>
-      <point x="950" y="189"/>
-      <point x="986" y="222"/>
-      <point x="1073" y="222" type="curve" smooth="yes"/>
-      <point x="1313" y="222" type="line" smooth="yes"/>
-      <point x="1506" y="222"/>
-      <point x="1572" y="320"/>
-      <point x="1572" y="428" type="curve" smooth="yes"/>
-      <point x="1572" y="534"/>
-      <point x="1502" y="612"/>
-      <point x="1390" y="612" type="curve" smooth="yes"/>
-      <point x="1309" y="612"/>
-      <point x="1254" y="567"/>
-      <point x="1233" y="490" type="curve"/>
-      <point x="1223" y="490" type="line"/>
-      <point x="1198" y="569"/>
-      <point x="1132" y="613"/>
-      <point x="1038" y="613" type="curve" smooth="yes"/>
-      <point x="944" y="613"/>
-      <point x="879" y="572"/>
-      <point x="841" y="460" type="curve" smooth="yes"/>
-      <point x="809" y="366" type="line" smooth="yes"/>
-      <point x="727" y="126"/>
-      <point x="573" y="61"/>
-      <point x="348" y="61" type="curve" smooth="yes"/>
-      <point x="214" y="61"/>
-      <point x="138" y="80"/>
-      <point x="138" y="149" type="curve" smooth="yes"/>
-      <point x="138" y="190"/>
-      <point x="170" y="222"/>
-      <point x="269" y="222" type="curve" smooth="yes"/>
-      <point x="521" y="222" type="line" smooth="yes"/>
-      <point x="704" y="222"/>
-      <point x="768" y="320"/>
-      <point x="768" y="432" type="curve" smooth="yes"/>
-      <point x="768" y="534"/>
-      <point x="709" y="612"/>
-      <point x="598" y="612" type="curve" smooth="yes"/>
-      <point x="510" y="612"/>
-      <point x="457" y="564"/>
-      <point x="438" y="490" type="curve"/>
-      <point x="428" y="490" type="line"/>
-      <point x="405" y="565"/>
-      <point x="340" y="612"/>
-      <point x="240" y="612" type="curve" smooth="yes"/>
-      <point x="128" y="612"/>
-      <point x="54" y="546"/>
-      <point x="54" y="448" type="curve" smooth="yes"/>
-      <point x="54" y="361"/>
-      <point x="110" y="300"/>
-      <point x="195" y="300" type="curve" smooth="yes"/>
-      <point x="281" y="300"/>
-      <point x="331" y="354"/>
-      <point x="331" y="429" type="curve" smooth="yes"/>
-      <point x="331" y="486"/>
-      <point x="299" y="540"/>
-      <point x="216" y="540" type="curve" smooth="yes"/>
-      <point x="196" y="540"/>
-      <point x="172" y="534"/>
-      <point x="159" y="524" type="curve"/>
-      <point x="191" y="502" type="line"/>
-      <point x="165" y="566" type="line"/>
-      <point x="149" y="530" type="line"/>
-      <point x="167" y="541"/>
-      <point x="193" y="552"/>
-      <point x="238" y="552" type="curve" smooth="yes"/>
-      <point x="352" y="552"/>
-      <point x="390" y="466"/>
-      <point x="390" y="392" type="curve" smooth="yes"/>
-      <point x="390" y="353" type="line"/>
-      <point x="474" y="353" type="line"/>
-      <point x="474" y="388" type="line" smooth="yes"/>
-      <point x="474" y="479"/>
-      <point x="523" y="534"/>
-      <point x="593" y="534" type="curve" smooth="yes"/>
-      <point x="658" y="534"/>
-      <point x="688" y="492"/>
-      <point x="688" y="425" type="curve" smooth="yes"/>
-      <point x="688" y="359"/>
-      <point x="650" y="294"/>
-      <point x="527" y="294" type="curve" smooth="yes"/>
-      <point x="265" y="294" type="line" smooth="yes"/>
-      <point x="124" y="294"/>
-      <point x="60" y="230"/>
-      <point x="60" y="147" type="curve" smooth="yes"/>
-      <point x="60" y="37"/>
-      <point x="157" y="-16"/>
+      <point x="336" y="-16" type="curve" smooth="yes"/>
+      <point x="636" y="-16"/>
+      <point x="804" y="75"/>
+      <point x="893" y="289" type="curve"/>
+      <point x="905" y="339" type="line"/>
+      <point x="910" y="339" type="line"/>
+      <point x="924" y="298"/>
+      <point x="966" y="274"/>
+      <point x="1024" y="274" type="curve" smooth="yes"/>
+      <point x="1103" y="274"/>
+      <point x="1153" y="323"/>
+      <point x="1153" y="399" type="curve" smooth="yes"/>
+      <point x="1153" y="469"/>
+      <point x="1115" y="512"/>
+      <point x="1041" y="512" type="curve" smooth="yes"/>
+      <point x="1011" y="512"/>
+      <point x="989" y="508"/>
+      <point x="966" y="499" type="curve"/>
+      <point x="947" y="527" type="line"/>
+      <point x="954" y="499" type="line"/>
+      <point x="977" y="531"/>
+      <point x="1020" y="552"/>
+      <point x="1079" y="552" type="curve" smooth="yes"/>
+      <point x="1180" y="552"/>
+      <point x="1228" y="499"/>
+      <point x="1228" y="392" type="curve" smooth="yes"/>
+      <point x="1228" y="333" type="line"/>
+      <point x="1312" y="333" type="line"/>
+      <point x="1312" y="392" type="line" smooth="yes"/>
+      <point x="1312" y="483"/>
+      <point x="1364" y="534"/>
+      <point x="1445" y="534" type="curve" smooth="yes"/>
+      <point x="1524" y="534"/>
+      <point x="1564" y="490"/>
+      <point x="1564" y="415" type="curve" smooth="yes"/>
+      <point x="1564" y="313"/>
+      <point x="1503" y="264"/>
+      <point x="1375" y="264" type="curve" smooth="yes"/>
+      <point x="1053" y="264" type="line" smooth="yes"/>
+      <point x="946" y="264"/>
+      <point x="878" y="209"/>
+      <point x="878" y="122" type="curve" smooth="yes"/>
+      <point x="878" y="37"/>
+      <point x="943" y="-16"/>
+      <point x="1036" y="-16" type="curve" smooth="yes"/>
+      <point x="1087" y="-16"/>
+      <point x="1129" y="-5"/>
+      <point x="1194" y="27" type="curve" smooth="yes"/>
+      <point x="1339" y="98" type="line"/>
+      <point x="1404" y="147" type="line"/>
+      <point x="1430" y="147" type="line"/>
+      <point x="1455" y="167"/>
+      <point x="1478" y="178"/>
+      <point x="1510" y="178" type="curve" smooth="yes"/>
+      <point x="1551" y="178"/>
+      <point x="1571" y="156"/>
+      <point x="1571" y="117" type="curve" smooth="yes"/>
+      <point x="1571" y="78"/>
+      <point x="1547" y="56"/>
+      <point x="1509" y="56" type="curve" smooth="yes"/>
+      <point x="1469" y="56"/>
+      <point x="1447" y="78"/>
+      <point x="1447" y="116" type="curve" smooth="yes"/>
+      <point x="1447" y="144"/>
+      <point x="1457" y="164"/>
+      <point x="1482" y="190" type="curve"/>
+      <point x="1378" y="150" type="line"/>
+      <point x="1399" y="129" type="line"/>
+      <point x="1394" y="117"/>
+      <point x="1391" y="103"/>
+      <point x="1391" y="86" type="curve" smooth="yes"/>
+      <point x="1391" y="24"/>
+      <point x="1441" y="-16"/>
+      <point x="1512" y="-16" type="curve" smooth="yes"/>
+      <point x="1592" y="-16"/>
+      <point x="1643" y="33"/>
+      <point x="1643" y="110" type="curve" smooth="yes"/>
+      <point x="1643" y="182"/>
+      <point x="1602" y="232"/>
+      <point x="1518" y="232" type="curve" smooth="yes"/>
+      <point x="1472" y="232"/>
+      <point x="1437" y="222"/>
+      <point x="1360" y="184" type="curve" smooth="yes"/>
+      <point x="1165" y="89" type="line" smooth="yes"/>
+      <point x="1122" y="68"/>
+      <point x="1084" y="58"/>
+      <point x="1041" y="58" type="curve" smooth="yes"/>
+      <point x="990" y="58"/>
+      <point x="960" y="80"/>
+      <point x="960" y="123" type="curve" smooth="yes"/>
+      <point x="960" y="168"/>
+      <point x="992" y="192"/>
+      <point x="1057" y="192" type="curve" smooth="yes"/>
+      <point x="1367" y="192" type="line" smooth="yes"/>
+      <point x="1538" y="192"/>
+      <point x="1646" y="279"/>
+      <point x="1646" y="417" type="curve" smooth="yes"/>
+      <point x="1646" y="532"/>
+      <point x="1576" y="612"/>
+      <point x="1458" y="612" type="curve" smooth="yes"/>
+      <point x="1367" y="612"/>
+      <point x="1307" y="567"/>
+      <point x="1281" y="494" type="curve"/>
+      <point x="1271" y="494" type="line"/>
+      <point x="1242" y="572"/>
+      <point x="1185" y="612"/>
+      <point x="1088" y="612" type="curve" smooth="yes"/>
+      <point x="977" y="612"/>
+      <point x="900" y="558"/>
+      <point x="871" y="454" type="curve" smooth="yes"/>
+      <point x="845" y="362" type="line" smooth="yes"/>
+      <point x="786" y="151"/>
+      <point x="628" y="61"/>
+      <point x="336" y="61" type="curve" smooth="yes"/>
+      <point x="213" y="61"/>
+      <point x="142" y="76"/>
+      <point x="142" y="131" type="curve" smooth="yes"/>
+      <point x="142" y="170"/>
+      <point x="175" y="192"/>
+      <point x="239" y="192" type="curve" smooth="yes"/>
+      <point x="517" y="192" type="line" smooth="yes"/>
+      <point x="694" y="192"/>
+      <point x="802" y="281"/>
+      <point x="802" y="422" type="curve" smooth="yes"/>
+      <point x="802" y="534"/>
+      <point x="740" y="612"/>
+      <point x="631" y="612" type="curve" smooth="yes"/>
+      <point x="545" y="612"/>
+      <point x="487" y="567"/>
+      <point x="463" y="494" type="curve"/>
+      <point x="453" y="494" type="line"/>
+      <point x="424" y="573"/>
+      <point x="367" y="612"/>
+      <point x="271" y="612" type="curve" smooth="yes"/>
+      <point x="143" y="612"/>
+      <point x="54" y="533"/>
+      <point x="54" y="423" type="curve" smooth="yes"/>
+      <point x="54" y="336"/>
+      <point x="114" y="274"/>
+      <point x="197" y="274" type="curve" smooth="yes"/>
+      <point x="281" y="274"/>
+      <point x="335" y="323"/>
+      <point x="335" y="399" type="curve" smooth="yes"/>
+      <point x="335" y="469"/>
+      <point x="297" y="512"/>
+      <point x="223" y="512" type="curve" smooth="yes"/>
+      <point x="193" y="512"/>
+      <point x="171" y="508"/>
+      <point x="148" y="499" type="curve"/>
+      <point x="129" y="527" type="line"/>
+      <point x="136" y="499" type="line"/>
+      <point x="157" y="529"/>
+      <point x="206" y="552"/>
+      <point x="269" y="552" type="curve" smooth="yes"/>
+      <point x="364" y="552"/>
+      <point x="410" y="499"/>
+      <point x="410" y="392" type="curve" smooth="yes"/>
+      <point x="410" y="333" type="line"/>
+      <point x="494" y="333" type="line"/>
+      <point x="494" y="392" type="line" smooth="yes"/>
+      <point x="494" y="483"/>
+      <point x="539" y="534"/>
+      <point x="618" y="534" type="curve" smooth="yes"/>
+      <point x="687" y="534"/>
+      <point x="720" y="493"/>
+      <point x="720" y="423" type="curve" smooth="yes"/>
+      <point x="720" y="315"/>
+      <point x="652" y="264"/>
+      <point x="513" y="264" type="curve" smooth="yes"/>
+      <point x="235" y="264" type="line" smooth="yes"/>
+      <point x="128" y="264"/>
+      <point x="60" y="212"/>
+      <point x="60" y="130" type="curve" smooth="yes"/>
+      <point x="60" y="33"/>
+      <point x="153" y="-16"/>
     </contour>
     <contour>
-      <point x="196" y="363" type="curve" smooth="yes"/>
-      <point x="149" y="363"/>
-      <point x="130" y="398"/>
-      <point x="130" y="445" type="curve" smooth="yes"/>
-      <point x="130" y="465"/>
-      <point x="133" y="483"/>
-      <point x="140" y="497" type="curve"/>
-      <point x="118" y="497" type="line"/>
-      <point x="95" y="455" type="line"/>
-      <point x="118" y="482"/>
-      <point x="160" y="496"/>
-      <point x="191" y="496" type="curve" smooth="yes"/>
-      <point x="248" y="496"/>
-      <point x="259" y="461"/>
-      <point x="259" y="434" type="curve" smooth="yes"/>
-      <point x="259" y="390"/>
-      <point x="236" y="363"/>
+      <point x="198" y="338" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="128" y="365"/>
+      <point x="128" y="418" type="curve" smooth="yes"/>
+      <point x="128" y="440"/>
+      <point x="131" y="457"/>
+      <point x="138" y="473" type="curve"/>
+      <point x="106" y="473" type="line"/>
+      <point x="95" y="433" type="line"/>
+      <point x="120" y="454"/>
+      <point x="155" y="468"/>
+      <point x="192" y="468" type="curve" smooth="yes"/>
+      <point x="240" y="468"/>
+      <point x="263" y="446"/>
+      <point x="263" y="401" type="curve" smooth="yes"/>
+      <point x="263" y="363"/>
+      <point x="240" y="338"/>
     </contour>
     <contour>
-      <point x="990" y="363" type="curve" smooth="yes"/>
-      <point x="943" y="363"/>
-      <point x="924" y="398"/>
-      <point x="924" y="447" type="curve" smooth="yes"/>
-      <point x="924" y="467"/>
-      <point x="927" y="485"/>
-      <point x="934" y="499" type="curve"/>
-      <point x="905" y="499" type="line"/>
-      <point x="889" y="465" type="line"/>
-      <point x="913" y="484"/>
-      <point x="954" y="496"/>
-      <point x="985" y="496" type="curve" smooth="yes"/>
-      <point x="1042" y="496"/>
-      <point x="1053" y="461"/>
-      <point x="1053" y="432" type="curve" smooth="yes"/>
-      <point x="1053" y="390"/>
-      <point x="1030" y="363"/>
+      <point x="1016" y="338" type="curve" smooth="yes"/>
+      <point x="971" y="338"/>
+      <point x="946" y="365"/>
+      <point x="946" y="418" type="curve" smooth="yes"/>
+      <point x="946" y="440"/>
+      <point x="949" y="457"/>
+      <point x="956" y="473" type="curve"/>
+      <point x="924" y="473" type="line"/>
+      <point x="913" y="433" type="line"/>
+      <point x="938" y="454"/>
+      <point x="973" y="468"/>
+      <point x="1010" y="468" type="curve" smooth="yes"/>
+      <point x="1058" y="468"/>
+      <point x="1081" y="446"/>
+      <point x="1081" y="401" type="curve" smooth="yes"/>
+      <point x="1081" y="363"/>
+      <point x="1058" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/j_nya-malayalam.glif
@@ -1,185 +1,184 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2219"/>
-  <anchor x="1809" y="0" name="bottom"/>
-  <anchor x="1103" y="596" name="top"/>
-  <anchor x="2069" y="596" name="topright"/>
+  <advance width="2252"/>
+  <anchor x="1842" y="0" name="bottom"/>
+  <anchor x="1126" y="596" name="top"/>
+  <anchor x="2102" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="358" y="-16" type="curve" smooth="yes"/>
-      <point x="578" y="-16"/>
-      <point x="734" y="47"/>
-      <point x="808" y="185" type="curve"/>
-      <point x="818" y="184" type="line"/>
-      <point x="843" y="63"/>
-      <point x="920" y="-16"/>
-      <point x="1035" y="-16" type="curve" smooth="yes"/>
-      <point x="1139" y="-16"/>
-      <point x="1207" y="59"/>
-      <point x="1207" y="175" type="curve" smooth="yes"/>
-      <point x="1207" y="284"/>
-      <point x="1142" y="356"/>
-      <point x="1042" y="356" type="curve" smooth="yes"/>
-      <point x="977" y="356"/>
-      <point x="921" y="324"/>
-      <point x="892" y="269" type="curve"/>
-      <point x="857" y="274" type="line"/>
-      <point x="890" y="141" type="line"/>
-      <point x="900" y="223"/>
-      <point x="959" y="282"/>
-      <point x="1030" y="282" type="curve" smooth="yes"/>
-      <point x="1090" y="282"/>
-      <point x="1125" y="241"/>
-      <point x="1125" y="172" type="curve" smooth="yes"/>
-      <point x="1125" y="102"/>
-      <point x="1091" y="62"/>
-      <point x="1031" y="62" type="curve" smooth="yes"/>
-      <point x="936" y="62"/>
-      <point x="883" y="151"/>
-      <point x="883" y="274" type="curve" smooth="yes"/>
-      <point x="883" y="429"/>
-      <point x="967" y="533"/>
-      <point x="1101" y="533" type="curve" smooth="yes"/>
-      <point x="1218" y="533"/>
-      <point x="1280" y="459"/>
-      <point x="1280" y="328" type="curve" smooth="yes"/>
-      <point x="1280" y="0" type="line"/>
-      <point x="1364" y="0" type="line"/>
-      <point x="1364" y="328" type="line" smooth="yes"/>
-      <point x="1364" y="457"/>
-      <point x="1434" y="534"/>
-      <point x="1557" y="534" type="curve" smooth="yes"/>
-      <point x="1729" y="534"/>
-      <point x="1820" y="411"/>
-      <point x="1820" y="249" type="curve" smooth="yes"/>
-      <point x="1820" y="135"/>
-      <point x="1782" y="62"/>
-      <point x="1706" y="62" type="curve" smooth="yes"/>
-      <point x="1637" y="62"/>
-      <point x="1595" y="126"/>
-      <point x="1595" y="224" type="curve" smooth="yes"/>
-      <point x="1595" y="398"/>
-      <point x="1706" y="534"/>
-      <point x="1868" y="534" type="curve" smooth="yes"/>
-      <point x="2005" y="534"/>
-      <point x="2082" y="449"/>
-      <point x="2082" y="309" type="curve" smooth="yes"/>
-      <point x="2082" y="201"/>
-      <point x="2042" y="116"/>
-      <point x="1978" y="41" type="curve"/>
-      <point x="2046" y="-14" type="line"/>
-      <point x="2120" y="77"/>
-      <point x="2165" y="177"/>
-      <point x="2165" y="304" type="curve" smooth="yes"/>
-      <point x="2165" y="494"/>
-      <point x="2053" y="612"/>
-      <point x="1871" y="612" type="curve" smooth="yes"/>
-      <point x="1663" y="612"/>
-      <point x="1513" y="434"/>
-      <point x="1513" y="223" type="curve" smooth="yes"/>
-      <point x="1513" y="78"/>
-      <point x="1590" y="-16"/>
-      <point x="1708" y="-16" type="curve" smooth="yes"/>
-      <point x="1831" y="-16"/>
-      <point x="1902" y="95"/>
-      <point x="1902" y="244" type="curve" smooth="yes"/>
-      <point x="1902" y="446"/>
-      <point x="1774" y="612"/>
-      <point x="1560" y="612" type="curve" smooth="yes"/>
-      <point x="1453" y="612"/>
-      <point x="1373" y="567"/>
-      <point x="1331" y="482" type="curve"/>
-      <point x="1321" y="482" type="line"/>
-      <point x="1281" y="568"/>
-      <point x="1207" y="612"/>
-      <point x="1104" y="612" type="curve" smooth="yes"/>
-      <point x="947" y="612"/>
-      <point x="848" y="528"/>
-      <point x="806" y="353" type="curve" smooth="yes"/>
-      <point x="751" y="123"/>
-      <point x="586" y="61"/>
-      <point x="358" y="61" type="curve" smooth="yes"/>
-      <point x="214" y="61"/>
-      <point x="138" y="80"/>
-      <point x="138" y="149" type="curve" smooth="yes"/>
-      <point x="138" y="190"/>
-      <point x="170" y="222"/>
-      <point x="269" y="222" type="curve" smooth="yes"/>
-      <point x="521" y="222" type="line" smooth="yes"/>
-      <point x="704" y="222"/>
-      <point x="768" y="320"/>
-      <point x="768" y="432" type="curve" smooth="yes"/>
-      <point x="768" y="534"/>
-      <point x="709" y="612"/>
-      <point x="600" y="612" type="curve" smooth="yes"/>
-      <point x="510" y="612"/>
-      <point x="457" y="564"/>
-      <point x="438" y="490" type="curve"/>
-      <point x="428" y="490" type="line"/>
-      <point x="405" y="565"/>
-      <point x="340" y="612"/>
-      <point x="240" y="612" type="curve" smooth="yes"/>
-      <point x="128" y="612"/>
-      <point x="54" y="546"/>
-      <point x="54" y="448" type="curve" smooth="yes"/>
-      <point x="54" y="361"/>
-      <point x="110" y="300"/>
-      <point x="195" y="300" type="curve" smooth="yes"/>
-      <point x="281" y="300"/>
-      <point x="331" y="354"/>
-      <point x="331" y="429" type="curve" smooth="yes"/>
-      <point x="331" y="486"/>
-      <point x="299" y="540"/>
-      <point x="216" y="540" type="curve" smooth="yes"/>
-      <point x="196" y="540"/>
-      <point x="172" y="534"/>
-      <point x="159" y="524" type="curve"/>
-      <point x="191" y="502" type="line"/>
-      <point x="165" y="566" type="line"/>
-      <point x="149" y="530" type="line"/>
-      <point x="167" y="541"/>
-      <point x="193" y="552"/>
-      <point x="240" y="552" type="curve" smooth="yes"/>
-      <point x="352" y="552"/>
-      <point x="390" y="466"/>
-      <point x="390" y="392" type="curve" smooth="yes"/>
-      <point x="390" y="353" type="line"/>
-      <point x="474" y="353" type="line"/>
-      <point x="474" y="388" type="line" smooth="yes"/>
-      <point x="474" y="479"/>
-      <point x="523" y="534"/>
-      <point x="593" y="534" type="curve" smooth="yes"/>
-      <point x="658" y="534"/>
-      <point x="688" y="492"/>
-      <point x="688" y="425" type="curve" smooth="yes"/>
-      <point x="688" y="359"/>
-      <point x="650" y="294"/>
-      <point x="527" y="294" type="curve" smooth="yes"/>
-      <point x="265" y="294" type="line" smooth="yes"/>
-      <point x="124" y="294"/>
-      <point x="60" y="230"/>
-      <point x="60" y="147" type="curve" smooth="yes"/>
-      <point x="60" y="37"/>
-      <point x="157" y="-16"/>
+      <point x="346" y="-16" type="curve" smooth="yes"/>
+      <point x="600" y="-16"/>
+      <point x="763" y="53"/>
+      <point x="842" y="194" type="curve"/>
+      <point x="852" y="193" type="line"/>
+      <point x="874" y="62"/>
+      <point x="958" y="-16"/>
+      <point x="1068" y="-16" type="curve" smooth="yes"/>
+      <point x="1172" y="-16"/>
+      <point x="1240" y="59"/>
+      <point x="1240" y="175" type="curve" smooth="yes"/>
+      <point x="1240" y="284"/>
+      <point x="1175" y="356"/>
+      <point x="1075" y="356" type="curve" smooth="yes"/>
+      <point x="1010" y="356"/>
+      <point x="954" y="324"/>
+      <point x="925" y="269" type="curve"/>
+      <point x="890" y="274" type="line"/>
+      <point x="923" y="141" type="line"/>
+      <point x="933" y="223"/>
+      <point x="992" y="282"/>
+      <point x="1063" y="282" type="curve" smooth="yes"/>
+      <point x="1123" y="282"/>
+      <point x="1158" y="241"/>
+      <point x="1158" y="172" type="curve" smooth="yes"/>
+      <point x="1158" y="102"/>
+      <point x="1124" y="62"/>
+      <point x="1064" y="62" type="curve" smooth="yes"/>
+      <point x="969" y="62"/>
+      <point x="916" y="151"/>
+      <point x="916" y="274" type="curve" smooth="yes"/>
+      <point x="916" y="429"/>
+      <point x="1000" y="533"/>
+      <point x="1134" y="533" type="curve" smooth="yes"/>
+      <point x="1251" y="533"/>
+      <point x="1313" y="459"/>
+      <point x="1313" y="328" type="curve" smooth="yes"/>
+      <point x="1313" y="0" type="line"/>
+      <point x="1397" y="0" type="line"/>
+      <point x="1397" y="328" type="line" smooth="yes"/>
+      <point x="1397" y="457"/>
+      <point x="1467" y="534"/>
+      <point x="1590" y="534" type="curve" smooth="yes"/>
+      <point x="1762" y="534"/>
+      <point x="1853" y="411"/>
+      <point x="1853" y="249" type="curve" smooth="yes"/>
+      <point x="1853" y="135"/>
+      <point x="1815" y="62"/>
+      <point x="1739" y="62" type="curve" smooth="yes"/>
+      <point x="1670" y="62"/>
+      <point x="1628" y="126"/>
+      <point x="1628" y="224" type="curve" smooth="yes"/>
+      <point x="1628" y="398"/>
+      <point x="1739" y="534"/>
+      <point x="1901" y="534" type="curve" smooth="yes"/>
+      <point x="2038" y="534"/>
+      <point x="2115" y="449"/>
+      <point x="2115" y="309" type="curve" smooth="yes"/>
+      <point x="2115" y="201"/>
+      <point x="2075" y="116"/>
+      <point x="2011" y="41" type="curve"/>
+      <point x="2079" y="-14" type="line"/>
+      <point x="2153" y="77"/>
+      <point x="2198" y="177"/>
+      <point x="2198" y="304" type="curve" smooth="yes"/>
+      <point x="2198" y="494"/>
+      <point x="2086" y="612"/>
+      <point x="1904" y="612" type="curve" smooth="yes"/>
+      <point x="1696" y="612"/>
+      <point x="1546" y="434"/>
+      <point x="1546" y="223" type="curve" smooth="yes"/>
+      <point x="1546" y="78"/>
+      <point x="1623" y="-16"/>
+      <point x="1741" y="-16" type="curve" smooth="yes"/>
+      <point x="1864" y="-16"/>
+      <point x="1935" y="95"/>
+      <point x="1935" y="244" type="curve" smooth="yes"/>
+      <point x="1935" y="446"/>
+      <point x="1807" y="612"/>
+      <point x="1593" y="612" type="curve" smooth="yes"/>
+      <point x="1486" y="612"/>
+      <point x="1406" y="567"/>
+      <point x="1364" y="482" type="curve"/>
+      <point x="1354" y="482" type="line"/>
+      <point x="1314" y="568"/>
+      <point x="1240" y="612"/>
+      <point x="1137" y="612" type="curve" smooth="yes"/>
+      <point x="980" y="612"/>
+      <point x="881" y="528"/>
+      <point x="839" y="353" type="curve" smooth="yes"/>
+      <point x="791" y="151"/>
+      <point x="639" y="61"/>
+      <point x="346" y="61" type="curve" smooth="yes"/>
+      <point x="216" y="61"/>
+      <point x="142" y="76"/>
+      <point x="142" y="131" type="curve" smooth="yes"/>
+      <point x="142" y="170"/>
+      <point x="175" y="192"/>
+      <point x="239" y="192" type="curve" smooth="yes"/>
+      <point x="517" y="192" type="line" smooth="yes"/>
+      <point x="693" y="192"/>
+      <point x="802" y="280"/>
+      <point x="802" y="420" type="curve" smooth="yes"/>
+      <point x="802" y="533"/>
+      <point x="740" y="612"/>
+      <point x="630" y="612" type="curve" smooth="yes"/>
+      <point x="544" y="612"/>
+      <point x="487" y="567"/>
+      <point x="463" y="494" type="curve"/>
+      <point x="453" y="494" type="line"/>
+      <point x="422" y="575"/>
+      <point x="362" y="612"/>
+      <point x="262" y="612" type="curve" smooth="yes"/>
+      <point x="141" y="612"/>
+      <point x="54" y="533"/>
+      <point x="54" y="423" type="curve" smooth="yes"/>
+      <point x="54" y="336"/>
+      <point x="114" y="274"/>
+      <point x="197" y="274" type="curve" smooth="yes"/>
+      <point x="281" y="274"/>
+      <point x="335" y="323"/>
+      <point x="335" y="399" type="curve" smooth="yes"/>
+      <point x="335" y="469"/>
+      <point x="297" y="512"/>
+      <point x="223" y="512" type="curve" smooth="yes"/>
+      <point x="193" y="512"/>
+      <point x="171" y="508"/>
+      <point x="148" y="499" type="curve"/>
+      <point x="129" y="527" type="line"/>
+      <point x="136" y="499" type="line"/>
+      <point x="156" y="529"/>
+      <point x="202" y="552"/>
+      <point x="261" y="552" type="curve" smooth="yes"/>
+      <point x="361" y="552"/>
+      <point x="410" y="499"/>
+      <point x="410" y="392" type="curve" smooth="yes"/>
+      <point x="410" y="333" type="line"/>
+      <point x="494" y="333" type="line"/>
+      <point x="494" y="392" type="line" smooth="yes"/>
+      <point x="494" y="483"/>
+      <point x="539" y="534"/>
+      <point x="616" y="534" type="curve" smooth="yes"/>
+      <point x="686" y="534"/>
+      <point x="720" y="492"/>
+      <point x="720" y="421" type="curve" smooth="yes"/>
+      <point x="720" y="314"/>
+      <point x="652" y="264"/>
+      <point x="513" y="264" type="curve" smooth="yes"/>
+      <point x="235" y="264" type="line" smooth="yes"/>
+      <point x="128" y="264"/>
+      <point x="60" y="212"/>
+      <point x="60" y="130" type="curve" smooth="yes"/>
+      <point x="60" y="33"/>
+      <point x="156" y="-16"/>
     </contour>
     <contour>
-      <point x="196" y="363" type="curve" smooth="yes"/>
-      <point x="149" y="363"/>
-      <point x="130" y="398"/>
-      <point x="130" y="445" type="curve" smooth="yes"/>
-      <point x="130" y="465"/>
-      <point x="133" y="483"/>
-      <point x="140" y="497" type="curve"/>
-      <point x="118" y="497" type="line"/>
-      <point x="95" y="455" type="line"/>
-      <point x="118" y="482"/>
-      <point x="160" y="496"/>
-      <point x="191" y="496" type="curve" smooth="yes"/>
-      <point x="248" y="496"/>
-      <point x="259" y="461"/>
-      <point x="259" y="434" type="curve" smooth="yes"/>
-      <point x="259" y="390"/>
-      <point x="236" y="363"/>
+      <point x="198" y="338" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="128" y="365"/>
+      <point x="128" y="418" type="curve" smooth="yes"/>
+      <point x="128" y="440"/>
+      <point x="131" y="457"/>
+      <point x="138" y="473" type="curve"/>
+      <point x="106" y="473" type="line"/>
+      <point x="95" y="433" type="line"/>
+      <point x="120" y="454"/>
+      <point x="155" y="468"/>
+      <point x="192" y="468" type="curve" smooth="yes"/>
+      <point x="240" y="468"/>
+      <point x="263" y="446"/>
+      <point x="263" y="401" type="curve" smooth="yes"/>
+      <point x="263" y="363"/>
+      <point x="240" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ja-malayalam.glif
@@ -1,135 +1,135 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <unicode hex="0D1C"/>
-  <anchor x="439" y="-4" name="bottom"/>
-  <anchor x="431" y="596" name="top"/>
-  <anchor x="677" y="596" name="topright"/>
+  <anchor x="457" y="-6" name="bottom"/>
+  <anchor x="441" y="596" name="top"/>
+  <anchor x="718" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="205" y="-16" type="curve" smooth="yes"/>
-      <point x="265" y="-16"/>
-      <point x="315" y="3"/>
-      <point x="409" y="59" type="curve" smooth="yes"/>
-      <point x="499" y="113" type="line"/>
-      <point x="546" y="145" type="line"/>
-      <point x="562" y="147" type="line"/>
-      <point x="601" y="167"/>
-      <point x="622" y="172"/>
-      <point x="646" y="172" type="curve" smooth="yes"/>
-      <point x="687" y="172"/>
-      <point x="707" y="152"/>
-      <point x="707" y="111" type="curve" smooth="yes"/>
-      <point x="707" y="72"/>
-      <point x="685" y="48"/>
-      <point x="650" y="48" type="curve" smooth="yes"/>
-      <point x="614" y="48"/>
-      <point x="594" y="70"/>
-      <point x="594" y="109" type="curve" smooth="yes"/>
-      <point x="594" y="139"/>
-      <point x="604" y="162"/>
-      <point x="629" y="190" type="curve"/>
-      <point x="527" y="155" type="line"/>
-      <point x="547" y="134" type="line"/>
-      <point x="543" y="125"/>
-      <point x="538" y="109"/>
-      <point x="538" y="90" type="curve" smooth="yes"/>
-      <point x="538" y="26"/>
-      <point x="583" y="-16"/>
-      <point x="651" y="-16" type="curve" smooth="yes"/>
-      <point x="725" y="-16"/>
-      <point x="773" y="33"/>
-      <point x="773" y="110" type="curve" smooth="yes"/>
-      <point x="773" y="187"/>
-      <point x="724" y="238"/>
-      <point x="650" y="238" type="curve" smooth="yes"/>
-      <point x="590" y="238"/>
-      <point x="552" y="224"/>
-      <point x="454" y="169" type="curve" smooth="yes"/>
-      <point x="379" y="127" type="line" smooth="yes"/>
-      <point x="278" y="71"/>
-      <point x="253" y="61"/>
-      <point x="214" y="61" type="curve" smooth="yes"/>
-      <point x="163" y="61"/>
-      <point x="138" y="85"/>
-      <point x="138" y="134" type="curve" smooth="yes"/>
-      <point x="138" y="192"/>
-      <point x="182" y="222"/>
-      <point x="269" y="222" type="curve" smooth="yes"/>
-      <point x="519" y="222" type="line" smooth="yes"/>
-      <point x="683" y="222"/>
-      <point x="778" y="299"/>
-      <point x="778" y="432" type="curve" smooth="yes"/>
-      <point x="778" y="542"/>
-      <point x="711" y="612"/>
-      <point x="606" y="612" type="curve" smooth="yes"/>
-      <point x="525" y="612"/>
-      <point x="464" y="567"/>
-      <point x="443" y="490" type="curve"/>
-      <point x="433" y="490" type="line"/>
-      <point x="414" y="569"/>
-      <point x="352" y="612"/>
-      <point x="255" y="612" type="curve" smooth="yes"/>
-      <point x="136" y="612"/>
-      <point x="54" y="545"/>
-      <point x="54" y="448" type="curve" smooth="yes"/>
-      <point x="54" y="360"/>
-      <point x="111" y="300"/>
-      <point x="195" y="300" type="curve" smooth="yes"/>
-      <point x="278" y="300"/>
-      <point x="331" y="349"/>
-      <point x="331" y="426" type="curve" smooth="yes"/>
-      <point x="331" y="492"/>
-      <point x="294" y="532"/>
-      <point x="226" y="532" type="curve" smooth="yes"/>
-      <point x="206" y="532"/>
-      <point x="186" y="529"/>
-      <point x="167" y="524" type="curve"/>
-      <point x="156" y="547" type="line"/>
-      <point x="150" y="525" type="line"/>
-      <point x="174" y="542"/>
-      <point x="210" y="552"/>
-      <point x="255" y="552" type="curve" smooth="yes"/>
-      <point x="345" y="552"/>
-      <point x="390" y="499"/>
-      <point x="390" y="392" type="curve" smooth="yes"/>
-      <point x="390" y="353" type="line"/>
-      <point x="474" y="353" type="line"/>
-      <point x="474" y="388" type="line" smooth="yes"/>
-      <point x="474" y="475"/>
-      <point x="524" y="534"/>
-      <point x="598" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="696" y="495"/>
-      <point x="696" y="429" type="curve" smooth="yes"/>
-      <point x="696" y="343"/>
-      <point x="637" y="294"/>
-      <point x="535" y="294" type="curve" smooth="yes"/>
-      <point x="266" y="294" type="line" smooth="yes"/>
-      <point x="138" y="294"/>
-      <point x="60" y="233"/>
-      <point x="60" y="133" type="curve" smooth="yes"/>
-      <point x="60" y="41"/>
-      <point x="116" y="-16"/>
+      <point x="218" y="-16" type="curve" smooth="yes"/>
+      <point x="269" y="-16"/>
+      <point x="311" y="-5"/>
+      <point x="376" y="27" type="curve" smooth="yes"/>
+      <point x="521" y="98" type="line"/>
+      <point x="586" y="147" type="line"/>
+      <point x="612" y="147" type="line"/>
+      <point x="637" y="167"/>
+      <point x="660" y="178"/>
+      <point x="692" y="178" type="curve" smooth="yes"/>
+      <point x="733" y="178"/>
+      <point x="753" y="156"/>
+      <point x="753" y="117" type="curve" smooth="yes"/>
+      <point x="753" y="78"/>
+      <point x="729" y="56"/>
+      <point x="691" y="56" type="curve" smooth="yes"/>
+      <point x="651" y="56"/>
+      <point x="629" y="78"/>
+      <point x="629" y="116" type="curve" smooth="yes"/>
+      <point x="629" y="144"/>
+      <point x="639" y="164"/>
+      <point x="664" y="190" type="curve"/>
+      <point x="560" y="150" type="line"/>
+      <point x="581" y="129" type="line"/>
+      <point x="576" y="117"/>
+      <point x="573" y="103"/>
+      <point x="573" y="86" type="curve" smooth="yes"/>
+      <point x="573" y="24"/>
+      <point x="623" y="-16"/>
+      <point x="694" y="-16" type="curve" smooth="yes"/>
+      <point x="774" y="-16"/>
+      <point x="825" y="33"/>
+      <point x="825" y="110" type="curve" smooth="yes"/>
+      <point x="825" y="182"/>
+      <point x="784" y="232"/>
+      <point x="700" y="232" type="curve" smooth="yes"/>
+      <point x="654" y="232"/>
+      <point x="619" y="222"/>
+      <point x="542" y="184" type="curve" smooth="yes"/>
+      <point x="347" y="89" type="line" smooth="yes"/>
+      <point x="304" y="68"/>
+      <point x="266" y="58"/>
+      <point x="223" y="58" type="curve" smooth="yes"/>
+      <point x="171" y="58"/>
+      <point x="142" y="81"/>
+      <point x="142" y="123" type="curve" smooth="yes"/>
+      <point x="142" y="168"/>
+      <point x="174" y="192"/>
+      <point x="239" y="192" type="curve" smooth="yes"/>
+      <point x="549" y="192" type="line" smooth="yes"/>
+      <point x="720" y="192"/>
+      <point x="828" y="279"/>
+      <point x="828" y="417" type="curve" smooth="yes"/>
+      <point x="828" y="532"/>
+      <point x="758" y="612"/>
+      <point x="640" y="612" type="curve" smooth="yes"/>
+      <point x="549" y="612"/>
+      <point x="489" y="567"/>
+      <point x="463" y="494" type="curve"/>
+      <point x="453" y="494" type="line"/>
+      <point x="422" y="575"/>
+      <point x="363" y="612"/>
+      <point x="262" y="612" type="curve" smooth="yes"/>
+      <point x="141" y="612"/>
+      <point x="54" y="533"/>
+      <point x="54" y="423" type="curve" smooth="yes"/>
+      <point x="54" y="336"/>
+      <point x="114" y="274"/>
+      <point x="197" y="274" type="curve" smooth="yes"/>
+      <point x="281" y="274"/>
+      <point x="335" y="323"/>
+      <point x="335" y="399" type="curve" smooth="yes"/>
+      <point x="335" y="469"/>
+      <point x="297" y="512"/>
+      <point x="223" y="512" type="curve" smooth="yes"/>
+      <point x="193" y="512"/>
+      <point x="171" y="508"/>
+      <point x="148" y="499" type="curve"/>
+      <point x="129" y="527" type="line"/>
+      <point x="136" y="499" type="line"/>
+      <point x="156" y="529"/>
+      <point x="202" y="552"/>
+      <point x="261" y="552" type="curve" smooth="yes"/>
+      <point x="362" y="552"/>
+      <point x="410" y="499"/>
+      <point x="410" y="392" type="curve" smooth="yes"/>
+      <point x="410" y="333" type="line"/>
+      <point x="494" y="333" type="line"/>
+      <point x="494" y="392" type="line" smooth="yes"/>
+      <point x="494" y="483"/>
+      <point x="546" y="534"/>
+      <point x="627" y="534" type="curve" smooth="yes"/>
+      <point x="706" y="534"/>
+      <point x="746" y="490"/>
+      <point x="746" y="415" type="curve" smooth="yes"/>
+      <point x="746" y="313"/>
+      <point x="685" y="264"/>
+      <point x="557" y="264" type="curve" smooth="yes"/>
+      <point x="235" y="264" type="line" smooth="yes"/>
+      <point x="128" y="264"/>
+      <point x="60" y="209"/>
+      <point x="60" y="122" type="curve" smooth="yes"/>
+      <point x="60" y="39"/>
+      <point x="123" y="-16"/>
     </contour>
     <contour>
-      <point x="196" y="363" type="curve" smooth="yes"/>
-      <point x="153" y="363"/>
-      <point x="130" y="393"/>
-      <point x="130" y="447" type="curve" smooth="yes"/>
-      <point x="130" y="471"/>
-      <point x="133" y="489"/>
-      <point x="140" y="499" type="curve"/>
-      <point x="118" y="499" type="line"/>
-      <point x="95" y="459" type="line"/>
-      <point x="119" y="477"/>
-      <point x="160" y="488"/>
-      <point x="193" y="488" type="curve" smooth="yes"/>
-      <point x="235" y="488"/>
-      <point x="259" y="467"/>
-      <point x="259" y="426" type="curve" smooth="yes"/>
-      <point x="259" y="387"/>
-      <point x="236" y="363"/>
+      <point x="198" y="338" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="128" y="365"/>
+      <point x="128" y="418" type="curve" smooth="yes"/>
+      <point x="128" y="440"/>
+      <point x="131" y="457"/>
+      <point x="138" y="473" type="curve"/>
+      <point x="106" y="473" type="line"/>
+      <point x="95" y="433" type="line"/>
+      <point x="120" y="454"/>
+      <point x="155" y="468"/>
+      <point x="192" y="468" type="curve" smooth="yes"/>
+      <point x="240" y="468"/>
+      <point x="263" y="446"/>
+      <point x="263" y="401" type="curve" smooth="yes"/>
+      <point x="263" y="363"/>
+      <point x="240" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
+  <anchor x="457" y="-6" name="bottom"/>
+  <anchor x="441" y="596" name="top"/>
+  <anchor x="718" y="596" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="677"/>
+    <component base="halant-malayalam" xOffset="718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
+  <anchor x="457" y="-6" name="bottom"/>
+  <anchor x="441" y="596" name="top"/>
+  <anchor x="718" y="596" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="439" yOffset="-4"/>
+    <component base="lVocalicMatra-malayalam" xOffset="457" yOffset="-6"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
+  <anchor x="457" y="-6" name="bottom"/>
+  <anchor x="441" y="596" name="top"/>
+  <anchor x="718" y="596" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="439" yOffset="-4"/>
+    <component base="llVocalicMatra-malayalam" xOffset="457" yOffset="-6"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/kC_hillu-malayalam.glif
@@ -2,96 +2,95 @@
 <glyph name="kChillu-malayalam" format="2">
   <advance width="1066"/>
   <unicode hex="0D7F"/>
-  <guideline x="1024"/>
   <anchor x="668" y="0" name="bottom"/>
   <anchor x="353" y="596" name="top"/>
   <outline>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
       <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="546" y="-16" type="curve" smooth="yes"/>
-      <point x="612" y="-16"/>
-      <point x="663" y="25"/>
+      <point x="608" y="-16"/>
+      <point x="661" y="21"/>
       <point x="691" y="85" type="curve"/>
       <point x="701" y="85" type="line"/>
-      <point x="724" y="28"/>
-      <point x="775" y="-16"/>
-      <point x="860" y="-16" type="curve" smooth="yes"/>
-      <point x="953" y="-16"/>
-      <point x="1023" y="44"/>
-      <point x="1023" y="154" type="curve" smooth="yes"/>
-      <point x="1023" y="261"/>
-      <point x="949" y="333"/>
-      <point x="815" y="333" type="curve" smooth="yes"/>
-      <point x="778" y="333" type="line"/>
-      <point x="744" y="259" type="line"/>
-      <point x="819" y="259" type="line" smooth="yes"/>
-      <point x="908" y="259"/>
-      <point x="938" y="216"/>
-      <point x="938" y="158" type="curve" smooth="yes"/>
-      <point x="938" y="99"/>
-      <point x="911" y="62"/>
-      <point x="852" y="62" type="curve" smooth="yes"/>
-      <point x="792" y="62"/>
-      <point x="750" y="107"/>
-      <point x="750" y="184" type="curve" smooth="yes"/>
-      <point x="750" y="265"/>
-      <point x="792" y="333"/>
+      <point x="726" y="20"/>
+      <point x="782" y="-16"/>
+      <point x="856" y="-16" type="curve" smooth="yes"/>
+      <point x="957" y="-16"/>
+      <point x="1023" y="55"/>
+      <point x="1023" y="165" type="curve" smooth="yes"/>
+      <point x="1023" y="282"/>
+      <point x="941" y="353"/>
+      <point x="806" y="353" type="curve" smooth="yes"/>
+      <point x="778" y="353" type="line"/>
+      <point x="744" y="279" type="line"/>
+      <point x="810" y="279" type="line" smooth="yes"/>
+      <point x="895" y="279"/>
+      <point x="939" y="242"/>
+      <point x="939" y="169" type="curve" smooth="yes"/>
+      <point x="939" y="102"/>
+      <point x="908" y="62"/>
+      <point x="847" y="62" type="curve" smooth="yes"/>
+      <point x="783" y="62"/>
+      <point x="746" y="103"/>
+      <point x="746" y="172" type="curve" smooth="yes"/>
+      <point x="746" y="241"/>
+      <point x="769" y="295"/>
       <point x="857" y="435" type="curve" smooth="yes"/>
-      <point x="908" y="516"/>
-      <point x="936" y="577"/>
+      <point x="915" y="527"/>
+      <point x="936" y="585"/>
       <point x="936" y="652" type="curve" smooth="yes"/>
-      <point x="936" y="743"/>
-      <point x="885" y="810"/>
+      <point x="936" y="751"/>
+      <point x="877" y="810"/>
       <point x="780" y="810" type="curve" smooth="yes"/>
-      <point x="722" y="810"/>
-      <point x="673" y="795"/>
+      <point x="720" y="810"/>
+      <point x="672" y="794"/>
       <point x="621" y="758" type="curve"/>
       <point x="659" y="691" type="line"/>
-      <point x="694" y="716"/>
-      <point x="731" y="731"/>
+      <point x="697" y="718"/>
+      <point x="734" y="731"/>
       <point x="774" y="731" type="curve" smooth="yes"/>
-      <point x="833" y="731"/>
-      <point x="853" y="697"/>
+      <point x="827" y="731"/>
+      <point x="853" y="704"/>
       <point x="853" y="649" type="curve" smooth="yes"/>
-      <point x="853" y="592"/>
-      <point x="832" y="545"/>
+      <point x="853" y="596"/>
+      <point x="836" y="552"/>
       <point x="783" y="464" type="curve" smooth="yes"/>
-      <point x="765" y="434"/>
-      <point x="752" y="407"/>
-      <point x="742" y="377" type="curve"/>
-      <point x="732" y="377" type="line"/>
-      <point x="721" y="515"/>
-      <point x="660" y="612"/>
+      <point x="760" y="426"/>
+      <point x="746" y="393"/>
+      <point x="739" y="361" type="curve"/>
+      <point x="731" y="361" type="line"/>
+      <point x="725" y="520"/>
+      <point x="656" y="612"/>
       <point x="543" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="330" y="495"/>
+      <point x="411" y="612"/>
+      <point x="330" y="500"/>
       <point x="330" y="318" type="curve" smooth="yes"/>
-      <point x="330" y="295"/>
-      <point x="333" y="248"/>
-      <point x="333" y="219" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="159" type="curve" smooth="yes"/>
-      <point x="123" y="220"/>
-      <point x="160" y="259"/>
-      <point x="247" y="259" type="curve" smooth="yes"/>
-      <point x="710" y="259" type="line"/>
-      <point x="717" y="333" type="line"/>
-      <point x="249" y="333" type="line" smooth="yes"/>
-      <point x="111" y="333"/>
-      <point x="41" y="263"/>
-      <point x="41" y="153" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="330" y="293"/>
+      <point x="333" y="242"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="710" y="279" type="line"/>
+      <point x="717" y="353" type="line"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/k_ka-malayalam.glif
@@ -1,102 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ka-malayalam" format="2">
   <advance width="1454"/>
-  <guideline x="1400"/>
   <anchor x="1044" y="0" name="bottom"/>
   <anchor x="793" y="596" name="top"/>
   <anchor x="1321" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
-      <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="377" y="94" type="line"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="756" y="106"/>
-      <point x="756" y="286" type="curve" smooth="yes"/>
-      <point x="756" y="310" type="line" smooth="yes"/>
-      <point x="756" y="489"/>
-      <point x="687" y="612"/>
-      <point x="544" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="330" y="495"/>
-      <point x="330" y="310" type="curve" smooth="yes"/>
-      <point x="330" y="287"/>
-      <point x="333" y="247"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="952" y="259" type="line" smooth="yes"/>
-      <point x="1050" y="259"/>
-      <point x="1075" y="209"/>
-      <point x="1075" y="144" type="curve" smooth="yes"/>
-      <point x="1075" y="86"/>
-      <point x="1050" y="62"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
+      <point x="759" y="287" type="curve" smooth="yes"/>
+      <point x="759" y="311" type="line" smooth="yes"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
+      <point x="546" y="612" type="curve" smooth="yes"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
+      <point x="329" y="311" type="curve" smooth="yes"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="960" y="279" type="line" smooth="yes"/>
+      <point x="1044" y="279"/>
+      <point x="1083" y="243"/>
+      <point x="1083" y="165" type="curve" smooth="yes"/>
+      <point x="1083" y="97"/>
+      <point x="1058" y="62"/>
       <point x="1010" y="62" type="curve" smooth="yes"/>
-      <point x="936" y="62"/>
-      <point x="911" y="146"/>
-      <point x="911" y="249" type="curve" smooth="yes"/>
-      <point x="911" y="421"/>
-      <point x="979" y="533"/>
+      <point x="946" y="62"/>
+      <point x="911" y="121"/>
+      <point x="911" y="230" type="curve" smooth="yes"/>
+      <point x="911" y="425"/>
+      <point x="988" y="533"/>
       <point x="1124" y="533" type="curve" smooth="yes"/>
-      <point x="1253" y="533"/>
-      <point x="1318" y="432"/>
+      <point x="1249" y="533"/>
+      <point x="1318" y="441"/>
       <point x="1318" y="286" type="curve" smooth="yes"/>
-      <point x="1318" y="194"/>
-      <point x="1285" y="106"/>
+      <point x="1318" y="197"/>
+      <point x="1287" y="109"/>
       <point x="1230" y="34" type="curve"/>
       <point x="1296" y="-16" type="line"/>
-      <point x="1367" y="68"/>
-      <point x="1400" y="182"/>
+      <point x="1362" y="62"/>
+      <point x="1400" y="173"/>
       <point x="1400" y="285" type="curve" smooth="yes"/>
-      <point x="1400" y="486"/>
-      <point x="1297" y="612"/>
+      <point x="1400" y="488"/>
+      <point x="1299" y="612"/>
       <point x="1126" y="612" type="curve" smooth="yes"/>
-      <point x="940" y="612"/>
-      <point x="829" y="465"/>
-      <point x="829" y="246" type="curve" smooth="yes"/>
-      <point x="829" y="116"/>
-      <point x="878" y="-16"/>
+      <point x="945" y="612"/>
+      <point x="829" y="463"/>
+      <point x="829" y="227" type="curve" smooth="yes"/>
+      <point x="829" y="77"/>
+      <point x="900" y="-16"/>
       <point x="1013" y="-16" type="curve" smooth="yes"/>
-      <point x="1111" y="-16"/>
-      <point x="1157" y="53"/>
-      <point x="1157" y="144" type="curve" smooth="yes"/>
-      <point x="1157" y="242"/>
-      <point x="1110" y="333"/>
-      <point x="948" y="333" type="curve" smooth="yes"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="1107" y="-16"/>
+      <point x="1165" y="54"/>
+      <point x="1165" y="165" type="curve" smooth="yes"/>
+      <point x="1165" y="288"/>
+      <point x="1092" y="353"/>
+      <point x="956" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="154"/>
-      <point x="412" y="288" type="curve" smooth="yes"/>
-      <point x="412" y="308" type="line" smooth="yes"/>
-      <point x="412" y="443"/>
-      <point x="453" y="534"/>
-      <point x="544" y="534" type="curve" smooth="yes"/>
-      <point x="636" y="534"/>
-      <point x="672" y="442"/>
-      <point x="672" y="308" type="curve" smooth="yes"/>
-      <point x="672" y="288" type="line" smooth="yes"/>
-      <point x="672" y="154"/>
-      <point x="633" y="62"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
+      <point x="412" y="289" type="curve" smooth="yes"/>
+      <point x="412" y="309" type="line" smooth="yes"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
+      <point x="545" y="534" type="curve" smooth="yes"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
+      <point x="672" y="309" type="curve" smooth="yes"/>
+      <point x="672" y="289" type="line" smooth="yes"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/k_la-malayalam.glif
@@ -54,29 +54,29 @@
       <point x="759" y="152"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="815" y="259" type="line" smooth="yes"/>
-      <point x="895" y="259"/>
-      <point x="936" y="223"/>
-      <point x="936" y="157" type="curve" smooth="yes"/>
-      <point x="936" y="94"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="806" y="279" type="line" smooth="yes"/>
+      <point x="893" y="279"/>
+      <point x="936" y="242"/>
+      <point x="936" y="168" type="curve" smooth="yes"/>
+      <point x="936" y="98"/>
       <point x="902" y="60"/>
       <point x="847" y="60" type="curve" smooth="yes"/>
       <point x="827" y="60"/>
@@ -87,20 +87,20 @@
       <point x="819" y="-16"/>
       <point x="850" y="-16" type="curve" smooth="yes"/>
       <point x="950" y="-16"/>
-      <point x="1018" y="53"/>
-      <point x="1018" y="155" type="curve" smooth="yes"/>
-      <point x="1018" y="264"/>
-      <point x="938" y="333"/>
-      <point x="811" y="333" type="curve" smooth="yes"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="1018" y="57"/>
+      <point x="1018" y="166" type="curve" smooth="yes"/>
+      <point x="1018" y="283"/>
+      <point x="937" y="353"/>
+      <point x="802" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
       <point x="377" y="94" type="line"/>
       <point x="388" y="72"/>
@@ -118,7 +118,7 @@
       <point x="381" y="-313"/>
       <point x="354" y="-256"/>
       <point x="354" y="-200" type="curve"/>
-      <point x="334" y="-208" type="line"/>
+      <point x="337" y="-218" type="line"/>
       <point x="355" y="-265" type="line"/>
       <point x="355" y="-221"/>
       <point x="387" y="-181"/>
@@ -131,19 +131,19 @@
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="442"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.glif
@@ -1,45 +1,44 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam" format="2">
   <advance width="1726"/>
-  <guideline x="1637"/>
   <anchor x="1281" y="0" name="bottom"/>
   <anchor x="879" y="596" name="top"/>
   <anchor x="1604" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
-      <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="377" y="94" type="line"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="759" y="104"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="159" type="curve" smooth="yes"/>
-      <point x="123" y="223"/>
-      <point x="166" y="265"/>
-      <point x="238" y="265" type="curve" smooth="yes"/>
-      <point x="815" y="265" type="line" smooth="yes"/>
-      <point x="905" y="265"/>
-      <point x="936" y="229"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="806" y="279" type="line" smooth="yes"/>
+      <point x="893" y="279"/>
+      <point x="936" y="244"/>
       <point x="936" y="175" type="curve" smooth="yes"/>
       <point x="936" y="129"/>
       <point x="919" y="95"/>
@@ -76,38 +75,38 @@
       <point x="1473" y="295"/>
       <point x="1543" y="391" type="curve"/>
       <point x="1553" y="389" type="line"/>
-      <point x="1552" y="40" type="line"/>
+      <point x="1553" y="40" type="line"/>
       <point x="1593" y="74" type="line"/>
       <point x="985" y="74" type="line"/>
       <point x="981" y="82" type="line"/>
       <point x="1009" y="112"/>
       <point x="1018" y="151"/>
       <point x="1018" y="182" type="curve" smooth="yes"/>
-      <point x="1018" y="274"/>
-      <point x="958" y="339"/>
-      <point x="811" y="339" type="curve" smooth="yes"/>
-      <point x="243" y="339" type="line" smooth="yes"/>
-      <point x="120" y="339"/>
-      <point x="41" y="266"/>
-      <point x="41" y="153" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="1018" y="289"/>
+      <point x="937" y="353"/>
+      <point x="802" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="442"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam.half" format="2">
   <advance width="1726"/>
+  <anchor x="1281" y="0" name="bottom"/>
+  <anchor x="879" y="596" name="top"/>
+  <anchor x="1604" y="596" name="topright"/>
   <outline>
     <component base="k_ssa-malayalam"/>
     <component base="halant-malayalam" xOffset="1604"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/k_ta-malayalam.glif
@@ -58,60 +58,60 @@
       <point x="908" y="73"/>
     </contour>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
-      <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="377" y="94" type="line"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="759" y="104"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="903" y="259" type="line"/>
-      <point x="903" y="333" type="line"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="904" y="279" type="line"/>
+      <point x="904" y="353" type="line"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="442"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/k_tta-malayalam.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_tta-malayalam" format="2">
   <advance width="1060"/>
-  <guideline x="1018" y="165" angle="90"/>
   <anchor x="852" y="-362" name="bottom"/>
   <anchor x="546" y="596" name="top"/>
   <anchor x="891" y="556" name="topright"/>
@@ -29,53 +28,53 @@
       <point x="973" y="27"/>
       <point x="955" y="31" type="curve"/>
       <point x="955" y="41" type="line"/>
-      <point x="1000" y="64"/>
-      <point x="1018" y="111"/>
-      <point x="1018" y="165" type="curve" smooth="yes"/>
-      <point x="1018" y="274"/>
-      <point x="938" y="333"/>
-      <point x="808" y="333" type="curve" smooth="yes"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="996" y="69"/>
+      <point x="1018" y="108"/>
+      <point x="1018" y="171" type="curve" smooth="yes"/>
+      <point x="1018" y="282"/>
+      <point x="940" y="353"/>
+      <point x="810" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
-      <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="377" y="94" type="line"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="759" y="104"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="815" y="259" type="line" smooth="yes"/>
-      <point x="895" y="259"/>
-      <point x="936" y="223"/>
-      <point x="936" y="157" type="curve" smooth="yes"/>
-      <point x="936" y="94"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="806" y="279" type="line" smooth="yes"/>
+      <point x="894" y="279"/>
+      <point x="936" y="241"/>
+      <point x="936" y="166" type="curve" smooth="yes"/>
+      <point x="936" y="97"/>
       <point x="902" y="60"/>
       <point x="847" y="60" type="curve" smooth="yes"/>
       <point x="827" y="60"/>
@@ -105,19 +104,19 @@
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="440"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ka-malayalam.glif
@@ -7,78 +7,78 @@
   <anchor x="891" y="556" name="topright"/>
   <outline>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
       <point x="377" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="759" y="104"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="815" y="259" type="line" smooth="yes"/>
-      <point x="895" y="259"/>
-      <point x="936" y="223"/>
-      <point x="936" y="157" type="curve" smooth="yes"/>
-      <point x="936" y="94"/>
-      <point x="902" y="60"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="806" y="279" type="line" smooth="yes"/>
+      <point x="893" y="279"/>
+      <point x="936" y="242"/>
+      <point x="936" y="168" type="curve" smooth="yes"/>
+      <point x="936" y="100"/>
+      <point x="903" y="60"/>
       <point x="847" y="60" type="curve" smooth="yes"/>
-      <point x="827" y="60"/>
-      <point x="809" y="63"/>
+      <point x="828" y="60"/>
+      <point x="810" y="63"/>
       <point x="795" y="68" type="curve"/>
       <point x="774" y="-5" type="line"/>
-      <point x="797" y="-12"/>
-      <point x="819" y="-16"/>
+      <point x="800" y="-13"/>
+      <point x="822" y="-16"/>
       <point x="850" y="-16" type="curve" smooth="yes"/>
       <point x="950" y="-16"/>
-      <point x="1018" y="53"/>
-      <point x="1018" y="155" type="curve" smooth="yes"/>
-      <point x="1018" y="264"/>
-      <point x="938" y="333"/>
-      <point x="811" y="333" type="curve" smooth="yes"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="1018" y="57"/>
+      <point x="1018" y="166" type="curve" smooth="yes"/>
+      <point x="1018" y="283"/>
+      <point x="937" y="353"/>
+      <point x="802" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="442"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/m_la-malayalam.glif
@@ -1,56 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="m_la-malayalam" format="2">
   <advance width="692"/>
-  <anchor x="354" y="-362" name="bottom"/>
+  <anchor x="346" y="-362" name="bottom"/>
   <anchor x="349" y="596" name="top"/>
   <anchor x="577" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="129" y="-378" type="curve" smooth="yes"/>
-      <point x="211" y="-378"/>
-      <point x="259" y="-328"/>
-      <point x="259" y="-245" type="curve" smooth="yes"/>
-      <point x="259" y="-163"/>
-      <point x="215" y="-121"/>
-      <point x="145" y="-121" type="curve" smooth="yes"/>
-      <point x="92" y="-121"/>
-      <point x="34" y="-154"/>
-      <point x="34" y="-239" type="curve"/>
-      <point x="58" y="-172" type="line"/>
-      <point x="-1" y="-172" type="line"/>
-      <point x="38" y="-198" type="line"/>
-      <point x="38" y="-84"/>
-      <point x="90" y="-22"/>
-      <point x="186" y="-22" type="curve" smooth="yes"/>
-      <point x="282" y="-22"/>
-      <point x="318" y="-84"/>
-      <point x="339" y="-167" type="curve" smooth="yes"/>
-      <point x="349" y="-206" type="line" smooth="yes"/>
-      <point x="379" y="-322"/>
-      <point x="429" y="-378"/>
-      <point x="528" y="-378" type="curve" smooth="yes"/>
-      <point x="622" y="-378"/>
-      <point x="688" y="-319"/>
-      <point x="688" y="-185" type="curve" smooth="yes"/>
-      <point x="688" y="-80"/>
-      <point x="655" y="-7"/>
-      <point x="605" y="48" type="curve"/>
-      <point x="546" y="8" type="line"/>
-      <point x="586" y="-39"/>
-      <point x="614" y="-96"/>
-      <point x="614" y="-185" type="curve" smooth="yes"/>
-      <point x="614" y="-262"/>
-      <point x="587" y="-308"/>
-      <point x="527" y="-308" type="curve" smooth="yes"/>
-      <point x="472" y="-308"/>
-      <point x="445" y="-271"/>
-      <point x="421" y="-185" type="curve" smooth="yes"/>
-      <point x="409" y="-142" type="line" smooth="yes"/>
-      <point x="392" y="-83"/>
-      <point x="372" y="-36"/>
-      <point x="330" y="-10" type="curve"/>
-      <point x="333" y="0" type="line"/>
-      <point x="599" y="0" type="line"/>
+      <point x="63" y="0" type="line"/>
       <point x="629" y="0" type="line"/>
       <point x="629" y="340" type="line" smooth="yes"/>
       <point x="629" y="497"/>
@@ -59,29 +15,72 @@
       <point x="169" y="612"/>
       <point x="63" y="496"/>
       <point x="63" y="339" type="curve" smooth="yes"/>
-      <point x="63" y="3" type="line"/>
-      <point x="86" y="26" type="line"/>
-      <point x="14" y="-9"/>
-      <point x="-28" y="-85"/>
-      <point x="-28" y="-184" type="curve" smooth="yes"/>
-      <point x="-28" y="-316"/>
-      <point x="44" y="-378"/>
     </contour>
     <contour>
-      <point x="126" y="-313" type="curve" smooth="yes"/>
-      <point x="68" y="-313"/>
-      <point x="41" y="-256"/>
-      <point x="41" y="-200" type="curve"/>
-      <point x="21" y="-208" type="line"/>
-      <point x="42" y="-265" type="line"/>
-      <point x="42" y="-221"/>
-      <point x="74" y="-181"/>
-      <point x="128" y="-181" type="curve" smooth="yes"/>
-      <point x="169" y="-181"/>
-      <point x="189" y="-206"/>
-      <point x="189" y="-245" type="curve" smooth="yes"/>
-      <point x="189" y="-287"/>
-      <point x="168" y="-313"/>
+      <point x="201" y="-378" type="curve" smooth="yes"/>
+      <point x="279" y="-378"/>
+      <point x="328" y="-324"/>
+      <point x="328" y="-238" type="curve" smooth="yes"/>
+      <point x="328" y="-154"/>
+      <point x="289" y="-104"/>
+      <point x="224" y="-104" type="curve" smooth="yes"/>
+      <point x="167" y="-104"/>
+      <point x="120" y="-145"/>
+      <point x="115" y="-199" type="curve"/>
+      <point x="150" y="-158" type="line"/>
+      <point x="91" y="-158" type="line"/>
+      <point x="119" y="-198" type="line"/>
+      <point x="119" y="-84"/>
+      <point x="167" y="-18"/>
+      <point x="250" y="-18" type="curve" smooth="yes"/>
+      <point x="319" y="-18"/>
+      <point x="354" y="-58"/>
+      <point x="369" y="-155" type="curve" smooth="yes"/>
+      <point x="382" y="-238" type="line" smooth="yes"/>
+      <point x="396" y="-328"/>
+      <point x="443" y="-378"/>
+      <point x="515" y="-378" type="curve" smooth="yes"/>
+      <point x="601" y="-378"/>
+      <point x="649" y="-314"/>
+      <point x="649" y="-200" type="curve" smooth="yes"/>
+      <point x="649" y="-114"/>
+      <point x="618" y="-28"/>
+      <point x="560" y="47" type="curve"/>
+      <point x="500" y="6" type="line"/>
+      <point x="549" y="-54"/>
+      <point x="575" y="-126"/>
+      <point x="575" y="-204" type="curve" smooth="yes"/>
+      <point x="575" y="-273"/>
+      <point x="556" y="-308"/>
+      <point x="518" y="-308" type="curve" smooth="yes"/>
+      <point x="479" y="-308"/>
+      <point x="463" y="-281"/>
+      <point x="450" y="-201" type="curve" smooth="yes"/>
+      <point x="437" y="-118" type="line" smooth="yes"/>
+      <point x="421" y="-16"/>
+      <point x="361" y="32"/>
+      <point x="252" y="32" type="curve" smooth="yes"/>
+      <point x="129" y="32"/>
+      <point x="53" y="-50"/>
+      <point x="53" y="-184" type="curve" smooth="yes"/>
+      <point x="53" y="-302"/>
+      <point x="111" y="-378"/>
+    </contour>
+    <contour>
+      <point x="197" y="-312" type="curve" smooth="yes"/>
+      <point x="143" y="-312"/>
+      <point x="122" y="-267"/>
+      <point x="122" y="-213" type="curve"/>
+      <point x="102" y="-221" type="line"/>
+      <point x="123" y="-245" type="line"/>
+      <point x="123" y="-203"/>
+      <point x="154" y="-164"/>
+      <point x="199" y="-164" type="curve" smooth="yes"/>
+      <point x="238" y="-164"/>
+      <point x="258" y="-193"/>
+      <point x="258" y="-238" type="curve" smooth="yes"/>
+      <point x="258" y="-284"/>
+      <point x="237" y="-312"/>
     </contour>
     <contour>
       <point x="113" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ng_ka-malayalam.glif
@@ -6,13 +6,13 @@
   <anchor x="872" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="218" y="-16" type="curve" smooth="yes"/>
-      <point x="302" y="-16"/>
-      <point x="351" y="30"/>
-      <point x="375" y="96" type="curve"/>
-      <point x="385" y="96" type="line"/>
-      <point x="415" y="24"/>
-      <point x="473" y="-16"/>
+      <point x="222" y="-16" type="curve" smooth="yes"/>
+      <point x="292" y="-16"/>
+      <point x="345" y="23"/>
+      <point x="372" y="94" type="curve"/>
+      <point x="382" y="94" type="line"/>
+      <point x="414" y="25"/>
+      <point x="472" y="-16"/>
       <point x="552" y="-16" type="curve" smooth="yes"/>
       <point x="688" y="-16"/>
       <point x="764" y="104"/>
@@ -27,61 +27,61 @@
       <point x="374" y="498" type="line"/>
       <point x="352" y="566"/>
       <point x="301" y="612"/>
-      <point x="218" y="612" type="curve" smooth="yes"/>
+      <point x="217" y="612" type="curve" smooth="yes"/>
       <point x="112" y="612"/>
-      <point x="53" y="541"/>
-      <point x="53" y="450" type="curve" smooth="yes"/>
-      <point x="53" y="382"/>
-      <point x="88" y="327"/>
-      <point x="142" y="303" type="curve"/>
-      <point x="142" y="293" type="line"/>
-      <point x="86" y="272"/>
-      <point x="46" y="221"/>
-      <point x="46" y="150" type="curve" smooth="yes"/>
-      <point x="46" y="56"/>
-      <point x="111" y="-16"/>
+      <point x="53" y="543"/>
+      <point x="53" y="454" type="curve" smooth="yes"/>
+      <point x="53" y="393"/>
+      <point x="87" y="347"/>
+      <point x="142" y="323" type="curve"/>
+      <point x="142" y="313" type="line"/>
+      <point x="87" y="289"/>
+      <point x="46" y="233"/>
+      <point x="46" y="157" type="curve" smooth="yes"/>
+      <point x="46" y="59"/>
+      <point x="122" y="-16"/>
     </contour>
     <contour>
       <point x="855" y="-16" type="curve" smooth="yes"/>
       <point x="955" y="-16"/>
-      <point x="1023" y="53"/>
-      <point x="1023" y="155" type="curve" smooth="yes"/>
-      <point x="1023" y="264"/>
-      <point x="943" y="333"/>
-      <point x="816" y="333" type="curve" smooth="yes"/>
-      <point x="267" y="333" type="line" smooth="yes"/>
-      <point x="176" y="333"/>
-      <point x="135" y="381"/>
-      <point x="135" y="445" type="curve" smooth="yes"/>
-      <point x="135" y="498"/>
+      <point x="1023" y="57"/>
+      <point x="1023" y="166" type="curve" smooth="yes"/>
+      <point x="1023" y="283"/>
+      <point x="942" y="353"/>
+      <point x="807" y="353" type="curve" smooth="yes"/>
+      <point x="267" y="353" type="line" smooth="yes"/>
+      <point x="176" y="353"/>
+      <point x="135" y="394"/>
+      <point x="135" y="449" type="curve" smooth="yes"/>
+      <point x="135" y="500"/>
       <point x="169" y="534"/>
-      <point x="227" y="534" type="curve" smooth="yes"/>
+      <point x="226" y="534" type="curve" smooth="yes"/>
       <point x="306" y="534"/>
       <point x="338" y="475"/>
       <point x="338" y="375" type="curve" smooth="yes"/>
-      <point x="338" y="221" type="line" smooth="yes"/>
-      <point x="338" y="125"/>
-      <point x="294" y="62"/>
-      <point x="224" y="62" type="curve" smooth="yes"/>
-      <point x="163" y="62"/>
-      <point x="128" y="100"/>
-      <point x="128" y="156" type="curve" smooth="yes"/>
-      <point x="128" y="217"/>
-      <point x="171" y="259"/>
-      <point x="243" y="259" type="curve" smooth="yes"/>
-      <point x="820" y="259" type="line" smooth="yes"/>
-      <point x="900" y="259"/>
-      <point x="941" y="223"/>
-      <point x="941" y="157" type="curve" smooth="yes"/>
-      <point x="941" y="94"/>
-      <point x="907" y="60"/>
+      <point x="338" y="209" type="line" smooth="yes"/>
+      <point x="338" y="112"/>
+      <point x="296" y="62"/>
+      <point x="228" y="62" type="curve" smooth="yes"/>
+      <point x="168" y="62"/>
+      <point x="128" y="102"/>
+      <point x="128" y="163" type="curve" smooth="yes"/>
+      <point x="128" y="233"/>
+      <point x="173" y="279"/>
+      <point x="253" y="279" type="curve" smooth="yes"/>
+      <point x="811" y="279" type="line" smooth="yes"/>
+      <point x="898" y="279"/>
+      <point x="941" y="242"/>
+      <point x="941" y="168" type="curve" smooth="yes"/>
+      <point x="941" y="100"/>
+      <point x="908" y="60"/>
       <point x="852" y="60" type="curve" smooth="yes"/>
-      <point x="832" y="60"/>
-      <point x="814" y="63"/>
+      <point x="833" y="60"/>
+      <point x="815" y="63"/>
       <point x="800" y="68" type="curve"/>
       <point x="779" y="-5" type="line"/>
-      <point x="802" y="-12"/>
-      <point x="824" y="-16"/>
+      <point x="805" y="-13"/>
+      <point x="827" y="-16"/>
     </contour>
     <contour>
       <point x="550" y="62" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1542"/>
-  <anchor x="1141" y="-16" name="bottom"/>
-  <anchor x="801" y="596" name="top"/>
-  <anchor x="1409" y="596" name="topright"/>
+  <advance width="1592"/>
+  <anchor x="1167" y="-6" name="bottom"/>
+  <anchor x="796" y="596" name="top"/>
+  <anchor x="1428" y="596" name="topright"/>
   <outline>
     <contour>
       <point x="287" y="-16" type="curve" smooth="yes"/>
@@ -45,112 +45,112 @@
       <point x="821" y="548"/>
       <point x="833" y="547"/>
       <point x="845" y="546" type="curve"/>
-      <point x="801" y="586" type="line"/>
-      <point x="809" y="539" type="line"/>
-      <point x="778" y="512"/>
-      <point x="764" y="476"/>
-      <point x="764" y="435" type="curve" smooth="yes"/>
-      <point x="764" y="362"/>
-      <point x="819" y="306"/>
-      <point x="901" y="306" type="curve" smooth="yes"/>
-      <point x="994" y="306"/>
-      <point x="1041" y="363"/>
-      <point x="1041" y="443" type="curve" smooth="yes"/>
-      <point x="1041" y="476"/>
-      <point x="1027" y="519"/>
-      <point x="982" y="545" type="curve"/>
-      <point x="994" y="592" type="line"/>
-      <point x="900" y="555" type="line"/>
-      <point x="914" y="557"/>
-      <point x="927" y="557"/>
-      <point x="939" y="557" type="curve" smooth="yes"/>
-      <point x="1070" y="557"/>
-      <point x="1104" y="467"/>
-      <point x="1104" y="396" type="curve" smooth="yes"/>
-      <point x="1104" y="353" type="line"/>
-      <point x="1188" y="353" type="line"/>
-      <point x="1188" y="388" type="line" smooth="yes"/>
-      <point x="1188" y="479"/>
-      <point x="1232" y="534"/>
-      <point x="1307" y="534" type="curve" smooth="yes"/>
-      <point x="1371" y="534"/>
-      <point x="1406" y="490"/>
-      <point x="1406" y="425" type="curve" smooth="yes"/>
-      <point x="1406" y="359"/>
-      <point x="1368" y="294"/>
-      <point x="1245" y="294" type="curve" smooth="yes"/>
-      <point x="976" y="294" type="line" smooth="yes"/>
-      <point x="838" y="294"/>
-      <point x="770" y="226"/>
-      <point x="770" y="133" type="curve" smooth="yes"/>
-      <point x="770" y="46"/>
-      <point x="821" y="-16"/>
-      <point x="915" y="-16" type="curve" smooth="yes"/>
-      <point x="981" y="-16"/>
-      <point x="1035" y="9"/>
-      <point x="1119" y="59" type="curve" smooth="yes"/>
-      <point x="1209" y="113" type="line"/>
-      <point x="1256" y="145" type="line"/>
-      <point x="1272" y="147" type="line"/>
-      <point x="1311" y="167"/>
-      <point x="1332" y="172"/>
-      <point x="1356" y="172" type="curve" smooth="yes"/>
-      <point x="1397" y="172"/>
-      <point x="1417" y="152"/>
-      <point x="1417" y="111" type="curve" smooth="yes"/>
-      <point x="1417" y="72"/>
-      <point x="1395" y="48"/>
-      <point x="1360" y="48" type="curve" smooth="yes"/>
-      <point x="1324" y="48"/>
-      <point x="1304" y="70"/>
-      <point x="1304" y="109" type="curve" smooth="yes"/>
-      <point x="1304" y="139"/>
-      <point x="1314" y="162"/>
-      <point x="1339" y="190" type="curve"/>
-      <point x="1237" y="155" type="line"/>
-      <point x="1257" y="134" type="line"/>
-      <point x="1253" y="125"/>
-      <point x="1248" y="109"/>
-      <point x="1248" y="90" type="curve" smooth="yes"/>
-      <point x="1248" y="26"/>
-      <point x="1293" y="-16"/>
-      <point x="1361" y="-16" type="curve" smooth="yes"/>
-      <point x="1435" y="-16"/>
-      <point x="1483" y="33"/>
-      <point x="1483" y="110" type="curve" smooth="yes"/>
-      <point x="1483" y="187"/>
-      <point x="1434" y="238"/>
-      <point x="1360" y="238" type="curve" smooth="yes"/>
-      <point x="1300" y="238"/>
-      <point x="1262" y="224"/>
-      <point x="1164" y="169" type="curve" smooth="yes"/>
-      <point x="1089" y="127" type="line" smooth="yes"/>
-      <point x="1002" y="78"/>
-      <point x="969" y="61"/>
-      <point x="924" y="61" type="curve" smooth="yes"/>
-      <point x="878" y="61"/>
-      <point x="848" y="80"/>
-      <point x="848" y="134" type="curve" smooth="yes"/>
-      <point x="848" y="187"/>
-      <point x="884" y="222"/>
-      <point x="979" y="222" type="curve" smooth="yes"/>
-      <point x="1229" y="222" type="line" smooth="yes"/>
-      <point x="1422" y="222"/>
-      <point x="1488" y="320"/>
-      <point x="1488" y="428" type="curve" smooth="yes"/>
-      <point x="1488" y="534"/>
-      <point x="1416" y="612"/>
-      <point x="1309" y="612" type="curve" smooth="yes"/>
-      <point x="1225" y="612"/>
-      <point x="1168" y="565"/>
-      <point x="1150" y="490" type="curve"/>
-      <point x="1145" y="490" type="line"/>
-      <point x="1123" y="565"/>
-      <point x="1050" y="612"/>
-      <point x="957" y="612" type="curve" smooth="yes"/>
-      <point x="924" y="612"/>
-      <point x="897" y="605"/>
-      <point x="877" y="595" type="curve"/>
+      <point x="810" y="568" type="line"/>
+      <point x="817" y="539" type="line"/>
+      <point x="784" y="510"/>
+      <point x="764" y="469"/>
+      <point x="764" y="422" type="curve" smooth="yes"/>
+      <point x="764" y="346"/>
+      <point x="827" y="286"/>
+      <point x="909" y="286" type="curve" smooth="yes"/>
+      <point x="995" y="286"/>
+      <point x="1051" y="341"/>
+      <point x="1051" y="420" type="curve" smooth="yes"/>
+      <point x="1051" y="474"/>
+      <point x="1031" y="519"/>
+      <point x="993" y="544" type="curve"/>
+      <point x="1004" y="579" type="line"/>
+      <point x="945" y="550" type="line"/>
+      <point x="953" y="552"/>
+      <point x="965" y="554"/>
+      <point x="978" y="554" type="curve" smooth="yes"/>
+      <point x="1074" y="554"/>
+      <point x="1120" y="500"/>
+      <point x="1120" y="392" type="curve" smooth="yes"/>
+      <point x="1120" y="333" type="line"/>
+      <point x="1204" y="333" type="line"/>
+      <point x="1204" y="392" type="line" smooth="yes"/>
+      <point x="1204" y="483"/>
+      <point x="1256" y="534"/>
+      <point x="1337" y="534" type="curve" smooth="yes"/>
+      <point x="1416" y="534"/>
+      <point x="1456" y="490"/>
+      <point x="1456" y="415" type="curve" smooth="yes"/>
+      <point x="1456" y="313"/>
+      <point x="1395" y="264"/>
+      <point x="1267" y="264" type="curve" smooth="yes"/>
+      <point x="945" y="264" type="line" smooth="yes"/>
+      <point x="838" y="264"/>
+      <point x="770" y="209"/>
+      <point x="770" y="122" type="curve" smooth="yes"/>
+      <point x="770" y="37"/>
+      <point x="835" y="-16"/>
+      <point x="928" y="-16" type="curve" smooth="yes"/>
+      <point x="979" y="-16"/>
+      <point x="1021" y="-5"/>
+      <point x="1086" y="27" type="curve" smooth="yes"/>
+      <point x="1231" y="98" type="line"/>
+      <point x="1296" y="147" type="line"/>
+      <point x="1322" y="147" type="line"/>
+      <point x="1347" y="167"/>
+      <point x="1370" y="178"/>
+      <point x="1402" y="178" type="curve" smooth="yes"/>
+      <point x="1443" y="178"/>
+      <point x="1463" y="156"/>
+      <point x="1463" y="117" type="curve" smooth="yes"/>
+      <point x="1463" y="78"/>
+      <point x="1439" y="56"/>
+      <point x="1401" y="56" type="curve" smooth="yes"/>
+      <point x="1361" y="56"/>
+      <point x="1339" y="78"/>
+      <point x="1339" y="116" type="curve" smooth="yes"/>
+      <point x="1339" y="144"/>
+      <point x="1349" y="164"/>
+      <point x="1374" y="190" type="curve"/>
+      <point x="1270" y="150" type="line"/>
+      <point x="1291" y="129" type="line"/>
+      <point x="1286" y="117"/>
+      <point x="1283" y="103"/>
+      <point x="1283" y="86" type="curve" smooth="yes"/>
+      <point x="1283" y="24"/>
+      <point x="1333" y="-16"/>
+      <point x="1404" y="-16" type="curve" smooth="yes"/>
+      <point x="1484" y="-16"/>
+      <point x="1535" y="33"/>
+      <point x="1535" y="110" type="curve" smooth="yes"/>
+      <point x="1535" y="182"/>
+      <point x="1494" y="232"/>
+      <point x="1410" y="232" type="curve" smooth="yes"/>
+      <point x="1364" y="232"/>
+      <point x="1329" y="222"/>
+      <point x="1252" y="184" type="curve" smooth="yes"/>
+      <point x="1057" y="89" type="line" smooth="yes"/>
+      <point x="1014" y="68"/>
+      <point x="976" y="58"/>
+      <point x="933" y="58" type="curve" smooth="yes"/>
+      <point x="883" y="58"/>
+      <point x="852" y="80"/>
+      <point x="852" y="123" type="curve" smooth="yes"/>
+      <point x="852" y="168"/>
+      <point x="884" y="192"/>
+      <point x="949" y="192" type="curve" smooth="yes"/>
+      <point x="1259" y="192" type="line" smooth="yes"/>
+      <point x="1430" y="192"/>
+      <point x="1538" y="279"/>
+      <point x="1538" y="417" type="curve" smooth="yes"/>
+      <point x="1538" y="532"/>
+      <point x="1468" y="612"/>
+      <point x="1350" y="612" type="curve" smooth="yes"/>
+      <point x="1259" y="612"/>
+      <point x="1199" y="567"/>
+      <point x="1173" y="494" type="curve"/>
+      <point x="1163" y="494" type="line"/>
+      <point x="1132" y="574"/>
+      <point x="1073" y="612"/>
+      <point x="975" y="612" type="curve" smooth="yes"/>
+      <point x="941" y="612"/>
+      <point x="909" y="606"/>
+      <point x="881" y="595" type="curve"/>
       <point x="904" y="595" type="line"/>
       <point x="878" y="605"/>
       <point x="844" y="612"/>
@@ -169,19 +169,19 @@
       <point x="150" y="-16"/>
     </contour>
     <contour>
-      <point x="902" y="376" type="curve" smooth="yes"/>
-      <point x="865" y="376"/>
-      <point x="836" y="400"/>
-      <point x="836" y="450" type="curve" smooth="yes"/>
-      <point x="836" y="492"/>
-      <point x="862" y="541"/>
-      <point x="930" y="549" type="curve"/>
-      <point x="851" y="544" type="line"/>
-      <point x="927" y="543"/>
-      <point x="965" y="501"/>
-      <point x="965" y="448" type="curve" smooth="yes"/>
-      <point x="965" y="402"/>
-      <point x="943" y="376"/>
+      <point x="909" y="356" type="curve" smooth="yes"/>
+      <point x="866" y="356"/>
+      <point x="840" y="386"/>
+      <point x="840" y="431" type="curve" smooth="yes"/>
+      <point x="840" y="489"/>
+      <point x="867" y="530"/>
+      <point x="940" y="552" type="curve"/>
+      <point x="875" y="552" type="line"/>
+      <point x="948" y="530"/>
+      <point x="975" y="489"/>
+      <point x="975" y="431" type="curve" smooth="yes"/>
+      <point x="975" y="386"/>
+      <point x="952" y="356"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/t_la-malayalam.glif
@@ -56,22 +56,6 @@
       <point x="300" y="-378"/>
     </contour>
     <contour>
-      <point x="382" y="-313" type="curve" smooth="yes"/>
-      <point x="324" y="-313"/>
-      <point x="297" y="-256"/>
-      <point x="297" y="-200" type="curve"/>
-      <point x="277" y="-208" type="line"/>
-      <point x="298" y="-265" type="line"/>
-      <point x="298" y="-221"/>
-      <point x="330" y="-181"/>
-      <point x="384" y="-181" type="curve" smooth="yes"/>
-      <point x="425" y="-181"/>
-      <point x="445" y="-206"/>
-      <point x="445" y="-245" type="curve" smooth="yes"/>
-      <point x="445" y="-287"/>
-      <point x="424" y="-313"/>
-    </contour>
-    <contour>
       <point x="176" y="-16" type="curve"/>
       <point x="237" y="36" type="line"/>
       <point x="169" y="109"/>
@@ -94,6 +78,22 @@
       <point x="93" y="72"/>
     </contour>
     <contour>
+      <point x="382" y="-313" type="curve" smooth="yes"/>
+      <point x="324" y="-313"/>
+      <point x="297" y="-256"/>
+      <point x="297" y="-200" type="curve"/>
+      <point x="277" y="-208" type="line"/>
+      <point x="298" y="-265" type="line"/>
+      <point x="298" y="-221"/>
+      <point x="330" y="-181"/>
+      <point x="384" y="-181" type="curve" smooth="yes"/>
+      <point x="425" y="-181"/>
+      <point x="445" y="-206"/>
+      <point x="445" y="-245" type="curve" smooth="yes"/>
+      <point x="445" y="-287"/>
+      <point x="424" y="-313"/>
+    </contour>
+    <contour>
       <point x="783" y="-308" type="curve" smooth="yes"/>
       <point x="728" y="-308"/>
       <point x="701" y="-271"/>
@@ -106,11 +106,11 @@
       <point x="664" y="44"/>
       <point x="699" y="129"/>
       <point x="699" y="249" type="curve" smooth="yes"/>
-      <point x="699" y="370"/>
-      <point x="646" y="484"/>
-      <point x="555" y="551" type="curve"/>
-      <point x="483" y="505" type="line"/>
-      <point x="568" y="458"/>
+      <point x="699" y="369"/>
+      <point x="647" y="482"/>
+      <point x="557" y="549" type="curve"/>
+      <point x="485" y="504" type="line"/>
+      <point x="569" y="457"/>
       <point x="613" y="358"/>
       <point x="613" y="249" type="curve" smooth="yes"/>
       <point x="613" y="129"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="597"/>
-  <anchor x="331" y="-219" name="bottom"/>
+  <anchor x="329" y="-271" name="bottom"/>
   <anchor x="296" y="596" name="top"/>
   <anchor x="435" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="301" y="-225" type="curve" smooth="yes"/>
-      <point x="462" y="-225"/>
-      <point x="551" y="-171"/>
-      <point x="551" y="-69" type="curve" smooth="yes"/>
-      <point x="551" y="-9"/>
-      <point x="513" y="33"/>
+      <point x="301" y="-277" type="curve" smooth="yes"/>
+      <point x="457" y="-277"/>
+      <point x="551" y="-209"/>
+      <point x="551" y="-96" type="curve" smooth="yes"/>
+      <point x="551" y="-22"/>
+      <point x="512" y="27"/>
       <point x="442" y="42" type="curve"/>
       <point x="442" y="52" type="line"/>
-      <point x="491" y="66"/>
-      <point x="541" y="102"/>
-      <point x="541" y="194" type="curve" smooth="yes"/>
-      <point x="541" y="292"/>
-      <point x="482" y="348"/>
+      <point x="507" y="75"/>
+      <point x="541" y="121"/>
+      <point x="541" y="186" type="curve" smooth="yes"/>
+      <point x="541" y="291"/>
+      <point x="472" y="349"/>
       <point x="340" y="355" type="curve" smooth="yes"/>
       <point x="233" y="360" type="line" smooth="yes"/>
       <point x="161" y="363"/>
-      <point x="123" y="393"/>
-      <point x="123" y="446" type="curve" smooth="yes"/>
-      <point x="123" y="506"/>
-      <point x="180" y="531"/>
-      <point x="284" y="531" type="curve" smooth="yes"/>
-      <point x="355" y="531"/>
-      <point x="415" y="518"/>
-      <point x="479" y="492" type="curve"/>
-      <point x="511" y="566" type="line"/>
-      <point x="441" y="598"/>
-      <point x="370" y="612"/>
+      <point x="123" y="391"/>
+      <point x="123" y="441" type="curve" smooth="yes"/>
+      <point x="123" y="503"/>
+      <point x="176" y="534"/>
+      <point x="284" y="534" type="curve" smooth="yes"/>
+      <point x="358" y="534"/>
+      <point x="420" y="521"/>
+      <point x="480" y="494" type="curve"/>
+      <point x="511" y="563" type="line"/>
+      <point x="435" y="597"/>
+      <point x="365" y="612"/>
       <point x="284" y="612" type="curve" smooth="yes"/>
-      <point x="131" y="612"/>
-      <point x="38" y="550"/>
+      <point x="129" y="612"/>
+      <point x="38" y="547"/>
       <point x="38" y="435" type="curve" smooth="yes"/>
-      <point x="38" y="338"/>
-      <point x="107" y="280"/>
+      <point x="38" y="339"/>
+      <point x="106" y="280"/>
       <point x="223" y="273" type="curve" smooth="yes"/>
       <point x="330" y="267" type="line" smooth="yes"/>
-      <point x="418" y="262"/>
-      <point x="459" y="232"/>
-      <point x="459" y="180" type="curve" smooth="yes"/>
-      <point x="459" y="112"/>
-      <point x="405" y="80"/>
+      <point x="414" y="262"/>
+      <point x="456" y="232"/>
+      <point x="456" y="176" type="curve" smooth="yes"/>
+      <point x="456" y="111"/>
+      <point x="404" y="80"/>
       <point x="295" y="80" type="curve" smooth="yes"/>
       <point x="82" y="80" type="line"/>
       <point x="82" y="6" type="line"/>
-      <point x="305" y="6" type="line" smooth="yes"/>
-      <point x="431" y="6"/>
-      <point x="469" y="-17"/>
-      <point x="469" y="-68" type="curve" smooth="yes"/>
-      <point x="469" y="-126"/>
-      <point x="409" y="-147"/>
-      <point x="301" y="-147" type="curve" smooth="yes"/>
-      <point x="208" y="-147"/>
-      <point x="132" y="-125"/>
-      <point x="82" y="-98" type="curve"/>
-      <point x="48" y="-166" type="line"/>
-      <point x="99" y="-198"/>
-      <point x="192" y="-225"/>
+      <point x="319" y="6" type="line" smooth="yes"/>
+      <point x="426" y="6"/>
+      <point x="469" y="-23"/>
+      <point x="469" y="-94" type="curve" smooth="yes"/>
+      <point x="469" y="-162"/>
+      <point x="410" y="-199"/>
+      <point x="301" y="-199" type="curve" smooth="yes"/>
+      <point x="223" y="-199"/>
+      <point x="147" y="-177"/>
+      <point x="87" y="-136" type="curve"/>
+      <point x="46" y="-200" type="line"/>
+      <point x="119" y="-250"/>
+      <point x="209" y="-277"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/tta-malayalam.glif
@@ -8,45 +8,45 @@
   <outline>
     <contour>
       <point x="318" y="-16" type="curve" smooth="yes"/>
-      <point x="465" y="-16"/>
-      <point x="553" y="56"/>
+      <point x="464" y="-16"/>
+      <point x="553" y="55"/>
       <point x="553" y="170" type="curve" smooth="yes"/>
-      <point x="553" y="272"/>
-      <point x="481" y="336"/>
+      <point x="553" y="273"/>
+      <point x="480" y="336"/>
       <point x="352" y="342" type="curve" smooth="yes"/>
       <point x="245" y="347" type="line" smooth="yes"/>
-      <point x="168" y="351"/>
-      <point x="135" y="384"/>
+      <point x="173" y="350"/>
+      <point x="135" y="381"/>
       <point x="135" y="434" type="curve" smooth="yes"/>
       <point x="135" y="497"/>
       <point x="192" y="531"/>
       <point x="296" y="531" type="curve" smooth="yes"/>
-      <point x="365" y="531"/>
-      <point x="427" y="518"/>
+      <point x="364" y="531"/>
+      <point x="426" y="518"/>
       <point x="491" y="491" type="curve"/>
       <point x="523" y="565" type="line"/>
-      <point x="453" y="598"/>
-      <point x="382" y="612"/>
+      <point x="454" y="597"/>
+      <point x="384" y="612"/>
       <point x="296" y="612" type="curve" smooth="yes"/>
-      <point x="142" y="612"/>
-      <point x="50" y="541"/>
+      <point x="143" y="612"/>
+      <point x="50" y="542"/>
       <point x="50" y="427" type="curve" smooth="yes"/>
-      <point x="50" y="330"/>
-      <point x="119" y="264"/>
+      <point x="50" y="328"/>
+      <point x="121" y="264"/>
       <point x="235" y="259" type="curve" smooth="yes"/>
       <point x="342" y="254" type="line" smooth="yes"/>
-      <point x="430" y="250"/>
-      <point x="470" y="217"/>
-      <point x="470" y="162" type="curve" smooth="yes"/>
-      <point x="470" y="99"/>
+      <point x="426" y="250"/>
+      <point x="468" y="219"/>
+      <point x="468" y="162" type="curve" smooth="yes"/>
+      <point x="468" y="99"/>
       <point x="415" y="65"/>
       <point x="318" y="65" type="curve" smooth="yes"/>
-      <point x="236" y="65"/>
-      <point x="159" y="89"/>
+      <point x="237" y="65"/>
+      <point x="160" y="88"/>
       <point x="84" y="136" type="curve"/>
       <point x="38" y="61" type="line"/>
-      <point x="123" y="9"/>
-      <point x="216" y="-16"/>
+      <point x="122" y="10"/>
+      <point x="215" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/uuM_atra-malayalam.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="100" y="31" type="curve"/>
       <point x="184" y="31" type="line"/>
-      <point x="225" y="139"/>
-      <point x="248" y="251"/>
+      <point x="225" y="138"/>
+      <point x="248" y="250"/>
       <point x="248" y="339" type="curve" smooth="yes"/>
       <point x="248" y="515"/>
       <point x="170" y="612"/>
@@ -17,52 +17,58 @@
       <point x="120" y="534"/>
       <point x="166" y="478"/>
       <point x="166" y="337" type="curve" smooth="yes"/>
-      <point x="166" y="241"/>
-      <point x="143" y="133"/>
+      <point x="166" y="240"/>
+      <point x="143" y="132"/>
     </contour>
     <contour>
       <point x="144" y="-259" type="curve" smooth="yes"/>
-      <point x="249" y="-259"/>
-      <point x="323" y="-191"/>
-      <point x="323" y="-95" type="curve" smooth="yes"/>
-      <point x="323" y="3"/>
-      <point x="244" y="82"/>
+      <point x="248" y="-259"/>
+      <point x="323" y="-189"/>
+      <point x="323" y="-93" type="curve" smooth="yes"/>
+      <point x="323" y="6"/>
+      <point x="245" y="82"/>
       <point x="144" y="82" type="curve" smooth="yes"/>
-      <point x="45" y="82"/>
-      <point x="-32" y="5"/>
+      <point x="44" y="82"/>
+      <point x="-32" y="7"/>
       <point x="-32" y="-93" type="curve" smooth="yes"/>
-      <point x="-32" y="-191"/>
-      <point x="40" y="-259"/>
+      <point x="-32" y="-190"/>
+      <point x="41" y="-259"/>
     </contour>
     <contour>
-      <point x="145" y="-185" type="curve" smooth="yes"/>
-      <point x="77" y="-185"/>
-      <point x="40" y="-150"/>
-      <point x="40" y="-85" type="curve" smooth="yes"/>
-      <point x="40" y="-20"/>
-      <point x="79" y="17"/>
-      <point x="145" y="17" type="curve" smooth="yes"/>
-      <point x="211" y="17"/>
-      <point x="251" y="-21"/>
-      <point x="251" y="-85" type="curve" smooth="yes"/>
-      <point x="251" y="-149"/>
-      <point x="213" y="-185"/>
+      <point x="146" y="-185" type="curve" smooth="yes"/>
+      <point x="81" y="-185"/>
+      <point x="39" y="-146"/>
+      <point x="39" y="-85" type="curve" smooth="yes"/>
+      <point x="39" y="-78"/>
+      <point x="40" y="-71"/>
+      <point x="41" y="-65" type="curve"/>
+      <point x="47" y="-65" type="line"/>
+      <point x="62" y="-105"/>
+      <point x="96" y="-127"/>
+      <point x="146" y="-127" type="curve" smooth="yes"/>
+      <point x="196" y="-127"/>
+      <point x="229" y="-105"/>
+      <point x="245" y="-65" type="curve"/>
+      <point x="251" y="-65" type="line"/>
+      <point x="252" y="-71"/>
+      <point x="253" y="-78"/>
+      <point x="253" y="-85" type="curve" smooth="yes"/>
+      <point x="253" y="-145"/>
+      <point x="211" y="-185"/>
     </contour>
     <contour>
-      <point x="145" y="-115" type="curve" smooth="yes"/>
-      <point x="199" y="-115"/>
-      <point x="243" y="-101"/>
-      <point x="279" y="-78" type="curve"/>
-      <point x="256" y="-42" type="line"/>
-      <point x="229" y="-49"/>
-      <point x="192" y="-53"/>
-      <point x="145" y="-53" type="curve" smooth="yes"/>
-      <point x="98" y="-53"/>
-      <point x="60" y="-49"/>
-      <point x="34" y="-42" type="curve"/>
-      <point x="11" y="-78" type="line"/>
-      <point x="47" y="-101"/>
-      <point x="91" y="-115"/>
+      <point x="146" y="-57" type="curve" smooth="yes"/>
+      <point x="95" y="-57"/>
+      <point x="69" y="-35"/>
+      <point x="69" y="-10" type="curve" smooth="yes"/>
+      <point x="69" y="12"/>
+      <point x="98" y="24"/>
+      <point x="146" y="24" type="curve" smooth="yes"/>
+      <point x="194" y="24"/>
+      <point x="223" y="12"/>
+      <point x="223" y="-10" type="curve" smooth="yes"/>
+      <point x="223" y="-35"/>
+      <point x="197" y="-57"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/v_va-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/v_va-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="v_va-malayalam" format="2">
   <advance width="1053"/>
   <anchor x="699" y="-306" name="bottom"/>
-  <anchor x="944" y="0" name="bottomright"/>
   <anchor x="553" y="596" name="top"/>
   <anchor x="924" y="596" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/y_ya-malayalam.glif
@@ -1,97 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="1008"/>
-  <anchor x="614" y="-322" name="bottom"/>
-  <anchor x="859" y="-16" name="bottomright"/>
+  <anchor x="614" y="-306" name="bottom"/>
   <anchor x="515" y="596" name="top"/>
   <anchor x="821" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="309" y="-322" type="line"/>
-      <point x="879" y="-322" type="line"/>
+      <point x="309" y="-306" type="line"/>
+      <point x="879" y="-306" type="line"/>
       <point x="879" y="105" type="line"/>
-      <point x="865" y="55" type="line"/>
-      <point x="924" y="113"/>
-      <point x="954" y="203"/>
-      <point x="954" y="309" type="curve" smooth="yes"/>
-      <point x="954" y="413"/>
-      <point x="915" y="526"/>
-      <point x="843" y="612" type="curve"/>
-      <point x="775" y="563" type="line"/>
-      <point x="829" y="494"/>
-      <point x="872" y="410"/>
-      <point x="872" y="311" type="curve" smooth="yes"/>
-      <point x="872" y="165"/>
-      <point x="828" y="62"/>
-      <point x="677" y="62" type="curve" smooth="yes"/>
-      <point x="498" y="62"/>
-      <point x="417" y="212"/>
-      <point x="417" y="373" type="curve" smooth="yes"/>
-      <point x="417" y="473"/>
-      <point x="454" y="534"/>
-      <point x="516" y="534" type="curve" smooth="yes"/>
-      <point x="579" y="534"/>
-      <point x="616" y="472"/>
-      <point x="616" y="374" type="curve" smooth="yes"/>
-      <point x="616" y="257"/>
-      <point x="580" y="160"/>
-      <point x="506" y="105" type="curve"/>
-      <point x="559" y="51" type="line"/>
-      <point x="650" y="125"/>
-      <point x="698" y="244"/>
-      <point x="698" y="378" type="curve" smooth="yes"/>
-      <point x="698" y="515"/>
-      <point x="633" y="612"/>
-      <point x="516" y="612" type="curve" smooth="yes"/>
-      <point x="397" y="612"/>
-      <point x="335" y="512"/>
-      <point x="335" y="382" type="curve" smooth="yes"/>
-      <point x="335" y="197"/>
-      <point x="456" y="-13"/>
-      <point x="683" y="-13" type="curve" smooth="yes"/>
-      <point x="702" y="-13"/>
-      <point x="722" y="-11"/>
-      <point x="743" y="-8" type="curve"/>
-      <point x="662" y="25" type="line"/>
-      <point x="679" y="-27" type="line"/>
-      <point x="596" y="-72" type="line"/>
-      <point x="309" y="-264" type="line"/>
+      <point x="867" y="76" type="line"/>
+      <point x="922" y="134"/>
+      <point x="954" y="216"/>
+      <point x="954" y="313" type="curve" smooth="yes"/>
+      <point x="954" y="419"/>
+      <point x="910" y="527"/>
+      <point x="831" y="612" type="curve"/>
+      <point x="769" y="561" type="line"/>
+      <point x="840" y="486"/>
+      <point x="874" y="407"/>
+      <point x="874" y="315" type="curve" smooth="yes"/>
+      <point x="874" y="155"/>
+      <point x="793" y="62"/>
+      <point x="654" y="62" type="curve" smooth="yes"/>
+      <point x="491" y="62"/>
+      <point x="386" y="179"/>
+      <point x="386" y="354" type="curve" smooth="yes"/>
+      <point x="386" y="464"/>
+      <point x="436" y="534"/>
+      <point x="515" y="534" type="curve" smooth="yes"/>
+      <point x="588" y="534"/>
+      <point x="631" y="474"/>
+      <point x="631" y="372" type="curve" smooth="yes"/>
+      <point x="631" y="259"/>
+      <point x="578" y="152"/>
+      <point x="496" y="100" type="curve"/>
+      <point x="553" y="55" type="line"/>
+      <point x="650" y="117"/>
+      <point x="713" y="243"/>
+      <point x="713" y="374" type="curve" smooth="yes"/>
+      <point x="713" y="520"/>
+      <point x="637" y="612"/>
+      <point x="515" y="612" type="curve" smooth="yes"/>
+      <point x="391" y="612"/>
+      <point x="304" y="504"/>
+      <point x="304" y="350" type="curve" smooth="yes"/>
+      <point x="304" y="153"/>
+      <point x="461" y="-14"/>
+      <point x="655" y="-14" type="curve" smooth="yes"/>
+      <point x="685" y="-14"/>
+      <point x="713" y="-10"/>
+      <point x="739" y="-3" type="curve"/>
+      <point x="645" y="29" type="line"/>
+      <point x="651" y="-23" type="line"/>
+      <point x="579" y="-62" type="line"/>
+      <point x="309" y="-248" type="line"/>
     </contour>
     <contour>
-      <point x="392" y="-293" type="line"/>
-      <point x="815" y="-1" type="line"/>
-      <point x="797" y="-1" type="line"/>
-      <point x="797" y="-270" type="line"/>
-      <point x="832" y="-257" type="line"/>
-      <point x="392" y="-257" type="line"/>
+      <point x="392" y="-277" type="line"/>
+      <point x="815" y="15" type="line"/>
+      <point x="797" y="15" type="line"/>
+      <point x="797" y="-254" type="line"/>
+      <point x="832" y="-241" type="line"/>
+      <point x="392" y="-241" type="line"/>
     </contour>
     <contour>
-      <point x="358" y="-16" type="curve" smooth="yes"/>
-      <point x="430" y="-16"/>
-      <point x="487" y="3"/>
-      <point x="534" y="34" type="curve"/>
-      <point x="472" y="86" type="line"/>
-      <point x="442" y="71"/>
-      <point x="417" y="62"/>
-      <point x="362" y="62" type="curve" smooth="yes"/>
-      <point x="219" y="62"/>
-      <point x="136" y="171"/>
-      <point x="136" y="333" type="curve" smooth="yes"/>
-      <point x="136" y="444"/>
-      <point x="189" y="534"/>
-      <point x="286" y="534" type="curve" smooth="yes"/>
-      <point x="333" y="534"/>
-      <point x="361" y="517"/>
-      <point x="383" y="492" type="curve"/>
-      <point x="425" y="546" type="line"/>
-      <point x="392" y="588"/>
-      <point x="348" y="612"/>
-      <point x="283" y="612" type="curve" smooth="yes"/>
-      <point x="143" y="612"/>
-      <point x="54" y="492"/>
+      <point x="373" y="-16" type="curve" smooth="yes"/>
+      <point x="434" y="-16"/>
+      <point x="490" y="2"/>
+      <point x="530" y="37" type="curve"/>
+      <point x="473" y="88" type="line"/>
+      <point x="446" y="69"/>
+      <point x="418" y="62"/>
+      <point x="379" y="62" type="curve" smooth="yes"/>
+      <point x="230" y="62"/>
+      <point x="134" y="167"/>
+      <point x="134" y="333" type="curve" smooth="yes"/>
+      <point x="134" y="455"/>
+      <point x="194" y="534"/>
+      <point x="282" y="534" type="curve" smooth="yes"/>
+      <point x="322" y="534"/>
+      <point x="348" y="519"/>
+      <point x="375" y="491" type="curve"/>
+      <point x="431" y="545" type="line"/>
+      <point x="383" y="595"/>
+      <point x="346" y="612"/>
+      <point x="290" y="612" type="curve" smooth="yes"/>
+      <point x="150" y="612"/>
+      <point x="54" y="499"/>
       <point x="54" y="331" type="curve" smooth="yes"/>
       <point x="54" y="128"/>
-      <point x="172" y="-16"/>
+      <point x="187" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ya-malayalam.glif
@@ -8,72 +8,72 @@
   <anchor x="821" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="678" y="-16" type="curve" smooth="yes"/>
-      <point x="859" y="-16"/>
-      <point x="954" y="122"/>
-      <point x="954" y="309" type="curve" smooth="yes"/>
-      <point x="954" y="413"/>
-      <point x="915" y="526"/>
-      <point x="843" y="612" type="curve"/>
-      <point x="775" y="563" type="line"/>
-      <point x="829" y="494"/>
-      <point x="872" y="410"/>
-      <point x="872" y="311" type="curve" smooth="yes"/>
-      <point x="872" y="165"/>
-      <point x="808" y="62"/>
-      <point x="677" y="62" type="curve" smooth="yes"/>
-      <point x="498" y="62"/>
-      <point x="417" y="212"/>
-      <point x="417" y="373" type="curve" smooth="yes"/>
-      <point x="417" y="473"/>
-      <point x="454" y="534"/>
-      <point x="516" y="534" type="curve" smooth="yes"/>
-      <point x="579" y="534"/>
-      <point x="616" y="472"/>
-      <point x="616" y="374" type="curve" smooth="yes"/>
-      <point x="616" y="257"/>
-      <point x="580" y="160"/>
-      <point x="506" y="105" type="curve"/>
-      <point x="559" y="51" type="line"/>
-      <point x="650" y="125"/>
-      <point x="698" y="244"/>
-      <point x="698" y="378" type="curve" smooth="yes"/>
-      <point x="698" y="515"/>
-      <point x="633" y="612"/>
-      <point x="516" y="612" type="curve" smooth="yes"/>
-      <point x="397" y="612"/>
-      <point x="335" y="512"/>
-      <point x="335" y="382" type="curve" smooth="yes"/>
-      <point x="335" y="195"/>
-      <point x="458" y="-16"/>
+      <point x="655" y="-16" type="curve" smooth="yes"/>
+      <point x="832" y="-16"/>
+      <point x="954" y="118"/>
+      <point x="954" y="313" type="curve" smooth="yes"/>
+      <point x="954" y="419"/>
+      <point x="910" y="527"/>
+      <point x="831" y="612" type="curve"/>
+      <point x="769" y="561" type="line"/>
+      <point x="840" y="486"/>
+      <point x="874" y="407"/>
+      <point x="874" y="315" type="curve" smooth="yes"/>
+      <point x="874" y="159"/>
+      <point x="789" y="62"/>
+      <point x="654" y="62" type="curve" smooth="yes"/>
+      <point x="491" y="62"/>
+      <point x="386" y="179"/>
+      <point x="386" y="354" type="curve" smooth="yes"/>
+      <point x="386" y="464"/>
+      <point x="436" y="534"/>
+      <point x="515" y="534" type="curve" smooth="yes"/>
+      <point x="588" y="534"/>
+      <point x="631" y="474"/>
+      <point x="631" y="372" type="curve" smooth="yes"/>
+      <point x="631" y="259"/>
+      <point x="578" y="152"/>
+      <point x="496" y="100" type="curve"/>
+      <point x="553" y="55" type="line"/>
+      <point x="650" y="117"/>
+      <point x="713" y="243"/>
+      <point x="713" y="374" type="curve" smooth="yes"/>
+      <point x="713" y="520"/>
+      <point x="637" y="612"/>
+      <point x="515" y="612" type="curve" smooth="yes"/>
+      <point x="391" y="612"/>
+      <point x="304" y="504"/>
+      <point x="304" y="350" type="curve" smooth="yes"/>
+      <point x="304" y="152"/>
+      <point x="461" y="-16"/>
     </contour>
     <contour>
-      <point x="358" y="-16" type="curve" smooth="yes"/>
-      <point x="430" y="-16"/>
-      <point x="487" y="3"/>
-      <point x="534" y="34" type="curve"/>
-      <point x="472" y="86" type="line"/>
-      <point x="442" y="71"/>
-      <point x="417" y="62"/>
-      <point x="362" y="62" type="curve" smooth="yes"/>
-      <point x="219" y="62"/>
-      <point x="136" y="171"/>
-      <point x="136" y="333" type="curve" smooth="yes"/>
-      <point x="136" y="444"/>
-      <point x="189" y="534"/>
-      <point x="286" y="534" type="curve" smooth="yes"/>
-      <point x="333" y="534"/>
-      <point x="361" y="517"/>
-      <point x="383" y="492" type="curve"/>
-      <point x="425" y="546" type="line"/>
-      <point x="392" y="588"/>
-      <point x="348" y="612"/>
-      <point x="283" y="612" type="curve" smooth="yes"/>
-      <point x="143" y="612"/>
-      <point x="54" y="492"/>
+      <point x="373" y="-16" type="curve" smooth="yes"/>
+      <point x="434" y="-16"/>
+      <point x="490" y="2"/>
+      <point x="530" y="37" type="curve"/>
+      <point x="473" y="88" type="line"/>
+      <point x="446" y="69"/>
+      <point x="418" y="62"/>
+      <point x="379" y="62" type="curve" smooth="yes"/>
+      <point x="230" y="62"/>
+      <point x="134" y="167"/>
+      <point x="134" y="333" type="curve" smooth="yes"/>
+      <point x="134" y="455"/>
+      <point x="194" y="534"/>
+      <point x="282" y="534" type="curve" smooth="yes"/>
+      <point x="322" y="534"/>
+      <point x="348" y="519"/>
+      <point x="375" y="491" type="curve"/>
+      <point x="431" y="545" type="line"/>
+      <point x="383" y="595"/>
+      <point x="346" y="612"/>
+      <point x="290" y="612" type="curve" smooth="yes"/>
+      <point x="150" y="612"/>
+      <point x="54" y="499"/>
       <point x="54" y="331" type="curve" smooth="yes"/>
       <point x="54" y="128"/>
-      <point x="172" y="-16"/>
+      <point x="187" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/kerning.plist
@@ -45782,8 +45782,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -45893,7 +45891,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -45949,7 +45947,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>80</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46002,7 +46000,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>180</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -46049,7 +46047,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -46084,7 +46082,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -46112,8 +46110,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46148,7 +46144,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46217,7 +46213,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46277,7 +46273,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46326,7 +46322,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46384,7 +46380,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46425,7 +46421,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46561,8 +46557,6 @@
       <integer>-30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46591,7 +46585,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46639,8 +46633,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>10</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>0</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>0</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46726,8 +46718,6 @@
       <integer>50</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -46760,7 +46750,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -46835,8 +46825,6 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46880,8 +46868,6 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47001,8 +46987,6 @@
       <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47110,7 +47094,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47157,7 +47141,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47203,41 +47187,39 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>50</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_braceright.loclMALM_R</key>
-      <integer>40</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
       <integer>20</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>40</integer>
-      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>70</integer>
-      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
+      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
+      <integer>60</integer>
+      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
-      <integer>110</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
-      <integer>100</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
       <integer>20</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
       <integer>-20</integer>
-      <key>public.kern2.MAL_rVocalic-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
-      <integer>90</integer>
-      <key>public.kern2.MAL_uMatra-malayalam_L</key>
       <integer>80</integer>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>60</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>220</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
       <integer>150</integer>
     </dict>
@@ -47264,7 +47246,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47313,7 +47295,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47346,8 +47328,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -47387,7 +47367,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47590,7 +47570,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47616,8 +47596,6 @@
       <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47644,7 +47622,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47700,7 +47678,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -47732,8 +47710,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47843,8 +47819,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_p_pa-malayalam_L</key>
@@ -47911,7 +47885,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
@@ -47956,7 +47930,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47997,7 +47971,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48087,7 +48061,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>150</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48226,8 +48200,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48275,8 +48247,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48339,7 +48309,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48392,7 +48362,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>240</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>170</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -48477,7 +48447,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48516,7 +48486,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>130</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48612,8 +48582,6 @@
       <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
-      <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
@@ -48718,7 +48686,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_ng_ka-malayalam_L</key>
@@ -48770,6 +48738,24 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-30</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>-20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>50</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.ODI_a-oriya-L</key>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/c_cha-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/c_cha-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="c_cha-malayalam" format="2">
   <advance width="908"/>
   <anchor x="485" y="-361" name="bottom"/>
-  <anchor x="799" y="0" name="bottomright"/>
   <anchor x="452" y="596" name="top"/>
   <anchor x="778" y="596" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/d_da-malayalam.glif
@@ -1,23 +1,23 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
-  <advance width="689"/>
-  <anchor x="384" y="-209" name="bottom"/>
+  <advance width="679"/>
+  <anchor x="381" y="-269" name="bottom"/>
   <anchor x="376" y="596" name="top"/>
   <outline>
     <contour>
-      <point x="449" y="-225" type="curve" smooth="yes"/>
-      <point x="577" y="-225"/>
-      <point x="641" y="-177"/>
-      <point x="641" y="-86" type="curve" smooth="yes"/>
-      <point x="641" y="-27"/>
-      <point x="602" y="13"/>
-      <point x="532" y="23" type="curve"/>
-      <point x="532" y="33" type="line"/>
-      <point x="581" y="49"/>
-      <point x="631" y="85"/>
+      <point x="414" y="-285" type="curve" smooth="yes"/>
+      <point x="546" y="-285"/>
+      <point x="631" y="-220"/>
+      <point x="631" y="-119" type="curve" smooth="yes"/>
+      <point x="631" y="-47"/>
+      <point x="595" y="4"/>
+      <point x="531" y="22" type="curve"/>
+      <point x="531" y="32" type="line"/>
+      <point x="596" y="53"/>
+      <point x="631" y="100"/>
       <point x="631" y="166" type="curve" smooth="yes"/>
-      <point x="631" y="239"/>
-      <point x="586" y="284"/>
+      <point x="631" y="237"/>
+      <point x="588" y="284"/>
       <point x="511" y="298" type="curve"/>
       <point x="511" y="308" type="line"/>
       <point x="572" y="324"/>
@@ -48,27 +48,27 @@
       <point x="372" y="337" type="line"/>
       <point x="372" y="263" type="line"/>
       <point x="414" y="263" type="line" smooth="yes"/>
-      <point x="500" y="263"/>
-      <point x="549" y="228"/>
+      <point x="502" y="263"/>
+      <point x="549" y="227"/>
       <point x="549" y="159" type="curve" smooth="yes"/>
-      <point x="549" y="94"/>
-      <point x="495" y="62"/>
+      <point x="549" y="99"/>
+      <point x="502" y="62"/>
       <point x="425" y="62" type="curve" smooth="yes"/>
-      <point x="372" y="62" type="line"/>
-      <point x="372" y="-12" type="line"/>
-      <point x="435" y="-12" type="line" smooth="yes"/>
-      <point x="521" y="-12"/>
-      <point x="559" y="-35"/>
-      <point x="559" y="-77" type="curve" smooth="yes"/>
-      <point x="559" y="-126"/>
-      <point x="519" y="-147"/>
-      <point x="452" y="-147" type="curve" smooth="yes"/>
-      <point x="403" y="-147"/>
-      <point x="369" y="-140"/>
-      <point x="336" y="-129" type="curve"/>
-      <point x="308" y="-201" type="line"/>
-      <point x="344" y="-216"/>
-      <point x="397" y="-225"/>
+      <point x="352" y="62" type="line"/>
+      <point x="352" y="-12" type="line"/>
+      <point x="425" y="-12" type="line" smooth="yes"/>
+      <point x="508" y="-12"/>
+      <point x="549" y="-44"/>
+      <point x="549" y="-110" type="curve" smooth="yes"/>
+      <point x="549" y="-173"/>
+      <point x="502" y="-207"/>
+      <point x="416" y="-207" type="curve" smooth="yes"/>
+      <point x="360" y="-207"/>
+      <point x="313" y="-195"/>
+      <point x="261" y="-169" type="curve"/>
+      <point x="228" y="-238" type="line"/>
+      <point x="289" y="-269"/>
+      <point x="352" y="-285"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="987"/>
-  <anchor x="669" y="0" name="bottom"/>
+  <advance width="980"/>
+  <anchor x="662" y="0" name="bottom"/>
   <anchor x="493" y="596" name="top"/>
-  <anchor x="859" y="596" name="topright"/>
+  <anchor x="852" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="284" y="-16" type="curve" smooth="yes"/>
-      <point x="411" y="-16"/>
-      <point x="488" y="72"/>
-      <point x="507" y="240" type="curve" smooth="yes"/>
-      <point x="519" y="348" type="line" smooth="yes"/>
-      <point x="532" y="465"/>
-      <point x="581" y="532"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="463"/>
+      <point x="576" y="532"/>
       <point x="695" y="532" type="curve" smooth="yes"/>
-      <point x="794" y="532"/>
-      <point x="836" y="492"/>
-      <point x="836" y="429" type="curve" smooth="yes"/>
-      <point x="836" y="373"/>
-      <point x="792" y="337"/>
-      <point x="722" y="337" type="curve" smooth="yes"/>
-      <point x="670" y="337" type="line"/>
-      <point x="670" y="263" type="line"/>
-      <point x="722" y="263" type="line" smooth="yes"/>
-      <point x="813" y="263"/>
-      <point x="857" y="225"/>
-      <point x="857" y="161" type="curve" smooth="yes"/>
-      <point x="857" y="94"/>
-      <point x="815" y="62"/>
-      <point x="741" y="62" type="curve" smooth="yes"/>
-      <point x="707" y="62"/>
-      <point x="679" y="70"/>
-      <point x="650" y="83" type="curve"/>
-      <point x="614" y="10" type="line"/>
-      <point x="650" y="-7"/>
-      <point x="694" y="-16"/>
-      <point x="742" y="-16" type="curve" smooth="yes"/>
-      <point x="860" y="-16"/>
-      <point x="939" y="48"/>
-      <point x="939" y="155" type="curve" smooth="yes"/>
-      <point x="939" y="230"/>
-      <point x="893" y="284"/>
-      <point x="819" y="298" type="curve"/>
-      <point x="819" y="308" type="line"/>
-      <point x="882" y="325"/>
-      <point x="918" y="375"/>
-      <point x="918" y="439" type="curve" smooth="yes"/>
-      <point x="918" y="539"/>
-      <point x="842" y="612"/>
-      <point x="690" y="612" type="curve" smooth="yes"/>
-      <point x="533" y="612"/>
-      <point x="444" y="523"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="789" y="532"/>
+      <point x="829" y="493"/>
+      <point x="829" y="433" type="curve" smooth="yes"/>
+      <point x="829" y="375"/>
+      <point x="785" y="337"/>
+      <point x="715" y="337" type="curve" smooth="yes"/>
+      <point x="663" y="337" type="line"/>
+      <point x="663" y="263" type="line"/>
+      <point x="715" y="263" type="line" smooth="yes"/>
+      <point x="806" y="263"/>
+      <point x="850" y="225"/>
+      <point x="850" y="161" type="curve" smooth="yes"/>
+      <point x="850" y="94"/>
+      <point x="808" y="62"/>
+      <point x="734" y="62" type="curve" smooth="yes"/>
+      <point x="700" y="62"/>
+      <point x="672" y="70"/>
+      <point x="643" y="83" type="curve"/>
+      <point x="607" y="10" type="line"/>
+      <point x="643" y="-7"/>
+      <point x="687" y="-16"/>
+      <point x="735" y="-16" type="curve" smooth="yes"/>
+      <point x="853" y="-16"/>
+      <point x="932" y="48"/>
+      <point x="932" y="155" type="curve" smooth="yes"/>
+      <point x="932" y="230"/>
+      <point x="886" y="284"/>
+      <point x="812" y="298" type="curve"/>
+      <point x="812" y="308" type="line"/>
+      <point x="875" y="326"/>
+      <point x="911" y="378"/>
+      <point x="911" y="445" type="curve" smooth="yes"/>
+      <point x="911" y="542"/>
+      <point x="840" y="612"/>
+      <point x="697" y="612" type="curve" smooth="yes"/>
+      <point x="529" y="612"/>
+      <point x="421" y="515"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="92"/>
-      <point x="143" y="-16"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/g_ga-malayalam.glif
@@ -6,92 +6,96 @@
   <anchor x="763" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="403" y="-378" type="curve" smooth="yes"/>
-      <point x="519" y="-378"/>
-      <point x="561" y="-315"/>
-      <point x="569" y="-173" type="curve" smooth="yes"/>
-      <point x="570" y="-156" type="line" smooth="yes"/>
-      <point x="576" y="-52"/>
-      <point x="603" y="-22"/>
-      <point x="657" y="-22" type="curve" smooth="yes"/>
-      <point x="721" y="-22"/>
-      <point x="759" y="-67"/>
-      <point x="759" y="-160" type="curve" smooth="yes"/>
-      <point x="759" y="-241"/>
-      <point x="732" y="-291"/>
-      <point x="691" y="-338" type="curve"/>
-      <point x="747" y="-378" type="line"/>
-      <point x="808" y="-313"/>
-      <point x="833" y="-247"/>
-      <point x="833" y="-157" type="curve" smooth="yes"/>
-      <point x="833" y="-9"/>
-      <point x="756" y="48"/>
-      <point x="661" y="48" type="curve" smooth="yes"/>
-      <point x="547" y="48"/>
-      <point x="507" y="-14"/>
-      <point x="498" y="-152" type="curve" smooth="yes"/>
-      <point x="497" y="-168" type="line" smooth="yes"/>
-      <point x="490" y="-278"/>
-      <point x="463" y="-308"/>
-      <point x="407" y="-308" type="curve" smooth="yes"/>
-      <point x="349" y="-308"/>
-      <point x="307" y="-266"/>
-      <point x="307" y="-166" type="curve" smooth="yes"/>
-      <point x="307" y="-100"/>
-      <point x="330" y="-47"/>
-      <point x="376" y="7" type="curve"/>
-      <point x="360" y="-4" type="line"/>
-      <point x="442" y="26"/>
-      <point x="494" y="109"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="516" y="348" type="line" smooth="yes"/>
-      <point x="527" y="465"/>
-      <point x="579" y="528"/>
-      <point x="661" y="528" type="curve" smooth="yes"/>
-      <point x="757" y="528"/>
-      <point x="797" y="453"/>
-      <point x="797" y="330" type="curve" smooth="yes"/>
-      <point x="797" y="217"/>
-      <point x="773" y="122"/>
-      <point x="679" y="41" type="curve"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="460"/>
+      <point x="560" y="528"/>
+      <point x="653" y="528" type="curve" smooth="yes"/>
+      <point x="748" y="528"/>
+      <point x="796" y="462"/>
+      <point x="796" y="332" type="curve" smooth="yes"/>
+      <point x="796" y="200"/>
+      <point x="761" y="115"/>
+      <point x="678" y="44" type="curve"/>
       <point x="731" y="-16" type="line"/>
-      <point x="843" y="80"/>
-      <point x="880" y="187"/>
-      <point x="880" y="331" type="curve" smooth="yes"/>
-      <point x="880" y="505"/>
-      <point x="803" y="612"/>
-      <point x="655" y="612" type="curve" smooth="yes"/>
-      <point x="523" y="612"/>
-      <point x="444" y="525"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="836" y="74"/>
+      <point x="880" y="177"/>
+      <point x="880" y="332" type="curve" smooth="yes"/>
+      <point x="880" y="511"/>
+      <point x="797" y="612"/>
+      <point x="651" y="612" type="curve" smooth="yes"/>
+      <point x="507" y="612"/>
+      <point x="421" y="517"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="94"/>
-      <point x="142" y="-14"/>
-      <point x="285" y="-14" type="curve" smooth="yes"/>
-      <point x="301" y="-14"/>
-      <point x="316" y="-13"/>
-      <point x="333" y="-10" type="curve"/>
-      <point x="256" y="27" type="line"/>
-      <point x="288" y="-61" type="line"/>
-      <point x="294" y="-5" type="line"/>
-      <point x="262" y="-34"/>
-      <point x="233" y="-104"/>
-      <point x="233" y="-168" type="curve" smooth="yes"/>
-      <point x="233" y="-320"/>
-      <point x="311" y="-378"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
+    </contour>
+    <contour>
+      <point x="411" y="-378" type="curve" smooth="yes"/>
+      <point x="513" y="-378"/>
+      <point x="573" y="-310"/>
+      <point x="573" y="-198" type="curve" smooth="yes"/>
+      <point x="573" y="-178"/>
+      <point x="571" y="-157"/>
+      <point x="571" y="-137" type="curve" smooth="yes"/>
+      <point x="571" y="-56"/>
+      <point x="604" y="-24"/>
+      <point x="663" y="-24" type="curve" smooth="yes"/>
+      <point x="724" y="-24"/>
+      <point x="757" y="-71"/>
+      <point x="757" y="-157" type="curve" smooth="yes"/>
+      <point x="757" y="-228"/>
+      <point x="736" y="-280"/>
+      <point x="688" y="-331" type="curve"/>
+      <point x="741" y="-378" type="line"/>
+      <point x="806" y="-313"/>
+      <point x="833" y="-248"/>
+      <point x="833" y="-157" type="curve" smooth="yes"/>
+      <point x="833" y="-27"/>
+      <point x="771" y="48"/>
+      <point x="661" y="48" type="curve" smooth="yes"/>
+      <point x="561" y="48"/>
+      <point x="493" y="-10"/>
+      <point x="493" y="-131" type="curve" smooth="yes"/>
+      <point x="493" y="-151"/>
+      <point x="495" y="-172"/>
+      <point x="495" y="-192" type="curve" smooth="yes"/>
+      <point x="495" y="-267"/>
+      <point x="466" y="-306"/>
+      <point x="409" y="-306" type="curve" smooth="yes"/>
+      <point x="345" y="-306"/>
+      <point x="309" y="-257"/>
+      <point x="309" y="-169" type="curve" smooth="yes"/>
+      <point x="309" y="-102"/>
+      <point x="326" y="-44"/>
+      <point x="374" y="13" type="curve"/>
+      <point x="302" y="13" type="line"/>
+      <point x="258" y="-29"/>
+      <point x="233" y="-103"/>
+      <point x="233" y="-169" type="curve" smooth="yes"/>
+      <point x="233" y="-301"/>
+      <point x="299" y="-378"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/g_la-malayalam.glif
@@ -13,13 +13,13 @@
       <point x="425" y="-163"/>
       <point x="381" y="-121"/>
       <point x="311" y="-121" type="curve" smooth="yes"/>
-      <point x="258" y="-121"/>
+      <point x="260" y="-121"/>
       <point x="200" y="-154"/>
       <point x="200" y="-239" type="curve"/>
-      <point x="224" y="-172" type="line"/>
-      <point x="165" y="-172" type="line"/>
-      <point x="202" y="-198" type="line"/>
-      <point x="202" y="-84"/>
+      <point x="224" y="-175" type="line"/>
+      <point x="165" y="-175" type="line"/>
+      <point x="204" y="-198" type="line"/>
+      <point x="204" y="-84"/>
       <point x="256" y="-22"/>
       <point x="352" y="-22" type="curve" smooth="yes"/>
       <point x="448" y="-22"/>
@@ -36,31 +36,33 @@
       <point x="821" y="-7"/>
       <point x="771" y="48" type="curve"/>
       <point x="767" y="18" type="line"/>
-      <point x="851" y="106"/>
-      <point x="880" y="204"/>
-      <point x="880" y="331" type="curve" smooth="yes"/>
-      <point x="880" y="505"/>
-      <point x="803" y="612"/>
-      <point x="655" y="612" type="curve" smooth="yes"/>
-      <point x="523" y="612"/>
-      <point x="444" y="525"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="846" y="100"/>
+      <point x="880" y="196"/>
+      <point x="880" y="332" type="curve" smooth="yes"/>
+      <point x="880" y="511"/>
+      <point x="797" y="612"/>
+      <point x="651" y="612" type="curve" smooth="yes"/>
+      <point x="507" y="612"/>
+      <point x="421" y="517"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="132"/>
+      <point x="377" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="129"/>
-      <point x="113" y="38"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="138"/>
+      <point x="111" y="42"/>
       <point x="209" y="6" type="curve"/>
       <point x="211" y="-4" type="line"/>
       <point x="162" y="-47"/>
@@ -74,10 +76,10 @@
       <point x="234" y="-313"/>
       <point x="207" y="-256"/>
       <point x="207" y="-200" type="curve"/>
-      <point x="187" y="-208" type="line"/>
+      <point x="190" y="-218" type="line"/>
       <point x="208" y="-265" type="line"/>
       <point x="208" y="-221"/>
-      <point x="240" y="-181"/>
+      <point x="241" y="-181"/>
       <point x="294" y="-181" type="curve" smooth="yes"/>
       <point x="335" y="-181"/>
       <point x="355" y="-206"/>
@@ -91,25 +93,27 @@
       <point x="611" y="-271"/>
       <point x="587" y="-185" type="curve" smooth="yes"/>
       <point x="575" y="-142" type="line" smooth="yes"/>
-      <point x="548" y="-45"/>
-      <point x="501" y="17"/>
-      <point x="425" y="37" type="curve"/>
-      <point x="423" y="47" type="line"/>
-      <point x="474" y="90"/>
-      <point x="498" y="153"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="516" y="348" type="line" smooth="yes"/>
-      <point x="527" y="465"/>
-      <point x="579" y="528"/>
-      <point x="661" y="528" type="curve" smooth="yes"/>
-      <point x="757" y="528"/>
-      <point x="797" y="453"/>
-      <point x="797" y="330" type="curve" smooth="yes"/>
-      <point x="797" y="217"/>
-      <point x="773" y="126"/>
+      <point x="549" y="-47"/>
+      <point x="504" y="13"/>
+      <point x="431" y="33" type="curve"/>
+      <point x="429" y="43" type="line"/>
+      <point x="486" y="85"/>
+      <point x="513" y="148"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="460"/>
+      <point x="560" y="528"/>
+      <point x="653" y="528" type="curve" smooth="yes"/>
+      <point x="748" y="528"/>
+      <point x="796" y="462"/>
+      <point x="796" y="332" type="curve" smooth="yes"/>
+      <point x="796" y="200"/>
+      <point x="761" y="115"/>
       <point x="678" y="44" type="curve"/>
-      <point x="731" y="-8"/>
-      <point x="780" y="-72"/>
+      <point x="751" y="-24"/>
+      <point x="780" y="-94"/>
       <point x="780" y="-185" type="curve" smooth="yes"/>
       <point x="780" y="-262"/>
       <point x="753" y="-308"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/g_ma-malayalam.glif
@@ -6,16 +6,18 @@
   <anchor x="1312" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="284" y="-16" type="curve" smooth="yes"/>
-      <point x="411" y="-16"/>
-      <point x="492" y="72"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="515" y="346" type="line" smooth="yes"/>
-      <point x="525" y="460"/>
-      <point x="569" y="528"/>
-      <point x="660" y="528" type="curve" smooth="yes"/>
-      <point x="750" y="528"/>
-      <point x="796" y="456"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="460"/>
+      <point x="557" y="528"/>
+      <point x="653" y="528" type="curve" smooth="yes"/>
+      <point x="748" y="528"/>
+      <point x="796" y="462"/>
       <point x="796" y="331" type="curve" smooth="yes"/>
       <point x="796" y="0" type="line"/>
       <point x="1362" y="0" type="line"/>
@@ -27,28 +29,30 @@
       <point x="892" y="571"/>
       <point x="848" y="490" type="curve"/>
       <point x="838" y="490" type="line"/>
-      <point x="801" y="575"/>
-      <point x="738" y="612"/>
-      <point x="653" y="612" type="curve" smooth="yes"/>
-      <point x="521" y="612"/>
-      <point x="442" y="529"/>
-      <point x="427" y="353" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="408" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="803" y="571"/>
+      <point x="740" y="612"/>
+      <point x="651" y="612" type="curve" smooth="yes"/>
+      <point x="509" y="612"/>
+      <point x="421" y="517"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="92"/>
-      <point x="143" y="-16"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
     </contour>
     <contour>
       <point x="846" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/g_na-malayalam.glif
@@ -6,16 +6,18 @@
   <anchor x="1199" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="284" y="-16" type="curve" smooth="yes"/>
-      <point x="411" y="-16"/>
-      <point x="490" y="72"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="516" y="348" type="line" smooth="yes"/>
-      <point x="527" y="465"/>
-      <point x="576" y="528"/>
-      <point x="661" y="528" type="curve" smooth="yes"/>
-      <point x="757" y="528"/>
-      <point x="796" y="453"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="462"/>
+      <point x="562" y="528"/>
+      <point x="656" y="528" type="curve" smooth="yes"/>
+      <point x="750" y="528"/>
+      <point x="796" y="463"/>
       <point x="796" y="330" type="curve" smooth="yes"/>
       <point x="796" y="0" type="line"/>
       <point x="880" y="0" type="line"/>
@@ -37,31 +39,33 @@
       <point x="1186" y="612"/>
       <point x="1035" y="612" type="curve" smooth="yes"/>
       <point x="942" y="612"/>
-      <point x="876" y="570"/>
+      <point x="874" y="567"/>
       <point x="843" y="499" type="curve"/>
       <point x="833" y="499" type="line"/>
-      <point x="806" y="570"/>
-      <point x="745" y="612"/>
-      <point x="657" y="612" type="curve" smooth="yes"/>
-      <point x="523" y="612"/>
-      <point x="444" y="525"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="802" y="571"/>
+      <point x="737" y="612"/>
+      <point x="652" y="612" type="curve" smooth="yes"/>
+      <point x="506" y="612"/>
+      <point x="421" y="516"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="92"/>
-      <point x="143" y="-16"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ga-malayalam.glif
@@ -7,46 +7,50 @@
   <anchor x="763" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="284" y="-16" type="curve" smooth="yes"/>
-      <point x="411" y="-16"/>
-      <point x="490" y="72"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="516" y="348" type="line" smooth="yes"/>
-      <point x="527" y="465"/>
-      <point x="579" y="528"/>
-      <point x="661" y="528" type="curve" smooth="yes"/>
-      <point x="757" y="528"/>
-      <point x="797" y="453"/>
-      <point x="797" y="330" type="curve" smooth="yes"/>
-      <point x="797" y="217"/>
-      <point x="773" y="126"/>
-      <point x="679" y="45" type="curve"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="460"/>
+      <point x="560" y="528"/>
+      <point x="653" y="528" type="curve" smooth="yes"/>
+      <point x="748" y="528"/>
+      <point x="796" y="462"/>
+      <point x="796" y="332" type="curve" smooth="yes"/>
+      <point x="796" y="200"/>
+      <point x="761" y="115"/>
+      <point x="678" y="44" type="curve"/>
       <point x="731" y="-16" type="line"/>
-      <point x="843" y="80"/>
-      <point x="880" y="187"/>
-      <point x="880" y="331" type="curve" smooth="yes"/>
-      <point x="880" y="505"/>
-      <point x="803" y="612"/>
-      <point x="655" y="612" type="curve" smooth="yes"/>
-      <point x="523" y="612"/>
-      <point x="444" y="525"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="836" y="74"/>
+      <point x="880" y="177"/>
+      <point x="880" y="332" type="curve" smooth="yes"/>
+      <point x="880" y="511"/>
+      <point x="797" y="612"/>
+      <point x="651" y="612" type="curve" smooth="yes"/>
+      <point x="507" y="612"/>
+      <point x="421" y="517"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="92"/>
-      <point x="143" y="-16"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ga-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ga-malayalam.half" format="2">
   <advance width="934"/>
+  <anchor x="524" y="0" name="bottom"/>
+  <anchor x="469" y="596" name="top"/>
+  <anchor x="763" y="596" name="topright"/>
   <outline>
     <component base="ga-malayalam"/>
     <component base="halant-malayalam" xOffset="763"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/j_ja-malayalam.glif
@@ -1,224 +1,224 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1626"/>
-  <anchor x="1233" y="0" name="bottom"/>
-  <anchor x="828" y="596" name="top"/>
-  <anchor x="1471" y="596" name="topright"/>
+  <advance width="1700"/>
+  <anchor x="1275" y="-6" name="bottom"/>
+  <anchor x="850" y="596" name="top"/>
+  <anchor x="1536" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="348" y="-16" type="curve" smooth="yes"/>
-      <point x="627" y="-16"/>
-      <point x="782" y="87"/>
-      <point x="864" y="317" type="curve"/>
-      <point x="879" y="371" type="line"/>
-      <point x="884" y="371" type="line"/>
-      <point x="907" y="318"/>
-      <point x="944" y="300"/>
-      <point x="991" y="300" type="curve" smooth="yes"/>
-      <point x="1075" y="300"/>
-      <point x="1125" y="354"/>
-      <point x="1125" y="429" type="curve" smooth="yes"/>
-      <point x="1125" y="488"/>
-      <point x="1093" y="539"/>
-      <point x="1012" y="539" type="curve" smooth="yes"/>
-      <point x="990" y="539"/>
-      <point x="969" y="535"/>
-      <point x="958" y="529" type="curve"/>
-      <point x="981" y="504" type="line"/>
-      <point x="962" y="566" type="line"/>
-      <point x="935" y="528" type="line"/>
-      <point x="962" y="544"/>
-      <point x="983" y="552"/>
-      <point x="1029" y="552" type="curve" smooth="yes"/>
-      <point x="1146" y="552"/>
-      <point x="1184" y="466"/>
-      <point x="1184" y="392" type="curve" smooth="yes"/>
-      <point x="1184" y="353" type="line"/>
-      <point x="1268" y="353" type="line"/>
-      <point x="1268" y="388" type="line" smooth="yes"/>
-      <point x="1268" y="479"/>
-      <point x="1321" y="534"/>
-      <point x="1392" y="534" type="curve" smooth="yes"/>
-      <point x="1456" y="534"/>
-      <point x="1490" y="490"/>
-      <point x="1490" y="425" type="curve" smooth="yes"/>
-      <point x="1490" y="359"/>
-      <point x="1452" y="294"/>
-      <point x="1329" y="294" type="curve" smooth="yes"/>
-      <point x="1070" y="294" type="line" smooth="yes"/>
-      <point x="940" y="294"/>
-      <point x="872" y="230"/>
-      <point x="872" y="135" type="curve" smooth="yes"/>
-      <point x="872" y="46"/>
-      <point x="923" y="-16"/>
-      <point x="1023" y="-16" type="curve" smooth="yes"/>
-      <point x="1081" y="-16"/>
-      <point x="1133" y="0"/>
-      <point x="1203" y="51" type="curve" smooth="yes"/>
-      <point x="1265" y="96" type="line" smooth="yes"/>
-      <point x="1350" y="158"/>
-      <point x="1396" y="172"/>
-      <point x="1440" y="172" type="curve" smooth="yes"/>
-      <point x="1485" y="172"/>
-      <point x="1501" y="147"/>
-      <point x="1501" y="111" type="curve" smooth="yes"/>
-      <point x="1501" y="74"/>
-      <point x="1481" y="48"/>
-      <point x="1444" y="48" type="curve" smooth="yes"/>
-      <point x="1408" y="48"/>
-      <point x="1388" y="70"/>
-      <point x="1388" y="109" type="curve" smooth="yes"/>
-      <point x="1388" y="148"/>
-      <point x="1406" y="171"/>
-      <point x="1423" y="190" type="curve"/>
-      <point x="1323" y="157" type="line"/>
-      <point x="1342" y="135" type="line"/>
-      <point x="1336" y="121"/>
-      <point x="1332" y="107"/>
-      <point x="1332" y="90" type="curve" smooth="yes"/>
-      <point x="1332" y="34"/>
-      <point x="1369" y="-16"/>
-      <point x="1445" y="-16" type="curve" smooth="yes"/>
-      <point x="1525" y="-16"/>
-      <point x="1567" y="39"/>
-      <point x="1567" y="110" type="curve" smooth="yes"/>
-      <point x="1567" y="188"/>
-      <point x="1517" y="238"/>
-      <point x="1444" y="238" type="curve" smooth="yes"/>
-      <point x="1382" y="238"/>
-      <point x="1339" y="229"/>
-      <point x="1248" y="169" type="curve" smooth="yes"/>
-      <point x="1173" y="119" type="line" smooth="yes"/>
-      <point x="1102" y="72"/>
-      <point x="1067" y="61"/>
-      <point x="1032" y="61" type="curve" smooth="yes"/>
-      <point x="980" y="61"/>
-      <point x="950" y="82"/>
-      <point x="950" y="136" type="curve" smooth="yes"/>
-      <point x="950" y="189"/>
-      <point x="986" y="222"/>
-      <point x="1073" y="222" type="curve" smooth="yes"/>
-      <point x="1313" y="222" type="line" smooth="yes"/>
-      <point x="1506" y="222"/>
-      <point x="1572" y="320"/>
-      <point x="1572" y="428" type="curve" smooth="yes"/>
-      <point x="1572" y="534"/>
-      <point x="1502" y="612"/>
-      <point x="1390" y="612" type="curve" smooth="yes"/>
-      <point x="1309" y="612"/>
-      <point x="1254" y="567"/>
-      <point x="1233" y="490" type="curve"/>
-      <point x="1223" y="490" type="line"/>
-      <point x="1198" y="569"/>
-      <point x="1132" y="613"/>
-      <point x="1038" y="613" type="curve" smooth="yes"/>
-      <point x="944" y="613"/>
-      <point x="879" y="572"/>
-      <point x="841" y="460" type="curve" smooth="yes"/>
-      <point x="809" y="366" type="line" smooth="yes"/>
-      <point x="727" y="126"/>
-      <point x="573" y="61"/>
-      <point x="348" y="61" type="curve" smooth="yes"/>
-      <point x="214" y="61"/>
-      <point x="138" y="80"/>
-      <point x="138" y="149" type="curve" smooth="yes"/>
-      <point x="138" y="190"/>
-      <point x="170" y="222"/>
-      <point x="269" y="222" type="curve" smooth="yes"/>
-      <point x="521" y="222" type="line" smooth="yes"/>
-      <point x="704" y="222"/>
-      <point x="768" y="320"/>
-      <point x="768" y="432" type="curve" smooth="yes"/>
-      <point x="768" y="534"/>
-      <point x="709" y="612"/>
-      <point x="598" y="612" type="curve" smooth="yes"/>
-      <point x="510" y="612"/>
-      <point x="457" y="564"/>
-      <point x="438" y="490" type="curve"/>
-      <point x="428" y="490" type="line"/>
-      <point x="405" y="565"/>
-      <point x="340" y="612"/>
-      <point x="240" y="612" type="curve" smooth="yes"/>
-      <point x="128" y="612"/>
-      <point x="54" y="546"/>
-      <point x="54" y="448" type="curve" smooth="yes"/>
-      <point x="54" y="361"/>
-      <point x="110" y="300"/>
-      <point x="195" y="300" type="curve" smooth="yes"/>
-      <point x="281" y="300"/>
-      <point x="331" y="354"/>
-      <point x="331" y="429" type="curve" smooth="yes"/>
-      <point x="331" y="486"/>
-      <point x="299" y="540"/>
-      <point x="216" y="540" type="curve" smooth="yes"/>
-      <point x="196" y="540"/>
-      <point x="172" y="534"/>
-      <point x="159" y="524" type="curve"/>
-      <point x="191" y="502" type="line"/>
-      <point x="165" y="566" type="line"/>
-      <point x="149" y="530" type="line"/>
-      <point x="167" y="541"/>
-      <point x="193" y="552"/>
-      <point x="238" y="552" type="curve" smooth="yes"/>
-      <point x="352" y="552"/>
-      <point x="390" y="466"/>
-      <point x="390" y="392" type="curve" smooth="yes"/>
-      <point x="390" y="353" type="line"/>
-      <point x="474" y="353" type="line"/>
-      <point x="474" y="388" type="line" smooth="yes"/>
-      <point x="474" y="479"/>
-      <point x="523" y="534"/>
-      <point x="593" y="534" type="curve" smooth="yes"/>
-      <point x="658" y="534"/>
-      <point x="688" y="492"/>
-      <point x="688" y="425" type="curve" smooth="yes"/>
-      <point x="688" y="359"/>
-      <point x="650" y="294"/>
-      <point x="527" y="294" type="curve" smooth="yes"/>
-      <point x="265" y="294" type="line" smooth="yes"/>
-      <point x="124" y="294"/>
-      <point x="60" y="230"/>
-      <point x="60" y="147" type="curve" smooth="yes"/>
-      <point x="60" y="37"/>
-      <point x="157" y="-16"/>
+      <point x="336" y="-16" type="curve" smooth="yes"/>
+      <point x="636" y="-16"/>
+      <point x="804" y="75"/>
+      <point x="893" y="289" type="curve"/>
+      <point x="905" y="339" type="line"/>
+      <point x="910" y="339" type="line"/>
+      <point x="924" y="298"/>
+      <point x="966" y="274"/>
+      <point x="1024" y="274" type="curve" smooth="yes"/>
+      <point x="1103" y="274"/>
+      <point x="1153" y="323"/>
+      <point x="1153" y="399" type="curve" smooth="yes"/>
+      <point x="1153" y="469"/>
+      <point x="1115" y="512"/>
+      <point x="1041" y="512" type="curve" smooth="yes"/>
+      <point x="1011" y="512"/>
+      <point x="989" y="508"/>
+      <point x="966" y="499" type="curve"/>
+      <point x="947" y="527" type="line"/>
+      <point x="954" y="499" type="line"/>
+      <point x="977" y="531"/>
+      <point x="1020" y="552"/>
+      <point x="1079" y="552" type="curve" smooth="yes"/>
+      <point x="1180" y="552"/>
+      <point x="1228" y="499"/>
+      <point x="1228" y="392" type="curve" smooth="yes"/>
+      <point x="1228" y="333" type="line"/>
+      <point x="1312" y="333" type="line"/>
+      <point x="1312" y="392" type="line" smooth="yes"/>
+      <point x="1312" y="483"/>
+      <point x="1364" y="534"/>
+      <point x="1445" y="534" type="curve" smooth="yes"/>
+      <point x="1524" y="534"/>
+      <point x="1564" y="490"/>
+      <point x="1564" y="415" type="curve" smooth="yes"/>
+      <point x="1564" y="313"/>
+      <point x="1503" y="264"/>
+      <point x="1375" y="264" type="curve" smooth="yes"/>
+      <point x="1053" y="264" type="line" smooth="yes"/>
+      <point x="946" y="264"/>
+      <point x="878" y="209"/>
+      <point x="878" y="122" type="curve" smooth="yes"/>
+      <point x="878" y="37"/>
+      <point x="943" y="-16"/>
+      <point x="1036" y="-16" type="curve" smooth="yes"/>
+      <point x="1087" y="-16"/>
+      <point x="1129" y="-5"/>
+      <point x="1194" y="27" type="curve" smooth="yes"/>
+      <point x="1339" y="98" type="line"/>
+      <point x="1404" y="147" type="line"/>
+      <point x="1430" y="147" type="line"/>
+      <point x="1455" y="167"/>
+      <point x="1478" y="178"/>
+      <point x="1510" y="178" type="curve" smooth="yes"/>
+      <point x="1551" y="178"/>
+      <point x="1571" y="156"/>
+      <point x="1571" y="117" type="curve" smooth="yes"/>
+      <point x="1571" y="78"/>
+      <point x="1547" y="56"/>
+      <point x="1509" y="56" type="curve" smooth="yes"/>
+      <point x="1469" y="56"/>
+      <point x="1447" y="78"/>
+      <point x="1447" y="116" type="curve" smooth="yes"/>
+      <point x="1447" y="144"/>
+      <point x="1457" y="164"/>
+      <point x="1482" y="190" type="curve"/>
+      <point x="1378" y="150" type="line"/>
+      <point x="1399" y="129" type="line"/>
+      <point x="1394" y="117"/>
+      <point x="1391" y="103"/>
+      <point x="1391" y="86" type="curve" smooth="yes"/>
+      <point x="1391" y="24"/>
+      <point x="1441" y="-16"/>
+      <point x="1512" y="-16" type="curve" smooth="yes"/>
+      <point x="1592" y="-16"/>
+      <point x="1643" y="33"/>
+      <point x="1643" y="110" type="curve" smooth="yes"/>
+      <point x="1643" y="182"/>
+      <point x="1602" y="232"/>
+      <point x="1518" y="232" type="curve" smooth="yes"/>
+      <point x="1472" y="232"/>
+      <point x="1437" y="222"/>
+      <point x="1360" y="184" type="curve" smooth="yes"/>
+      <point x="1165" y="89" type="line" smooth="yes"/>
+      <point x="1122" y="68"/>
+      <point x="1084" y="58"/>
+      <point x="1041" y="58" type="curve" smooth="yes"/>
+      <point x="990" y="58"/>
+      <point x="960" y="80"/>
+      <point x="960" y="123" type="curve" smooth="yes"/>
+      <point x="960" y="168"/>
+      <point x="992" y="192"/>
+      <point x="1057" y="192" type="curve" smooth="yes"/>
+      <point x="1367" y="192" type="line" smooth="yes"/>
+      <point x="1538" y="192"/>
+      <point x="1646" y="279"/>
+      <point x="1646" y="417" type="curve" smooth="yes"/>
+      <point x="1646" y="532"/>
+      <point x="1576" y="612"/>
+      <point x="1458" y="612" type="curve" smooth="yes"/>
+      <point x="1367" y="612"/>
+      <point x="1307" y="567"/>
+      <point x="1281" y="494" type="curve"/>
+      <point x="1271" y="494" type="line"/>
+      <point x="1242" y="572"/>
+      <point x="1185" y="612"/>
+      <point x="1088" y="612" type="curve" smooth="yes"/>
+      <point x="977" y="612"/>
+      <point x="900" y="558"/>
+      <point x="871" y="454" type="curve" smooth="yes"/>
+      <point x="845" y="362" type="line" smooth="yes"/>
+      <point x="786" y="151"/>
+      <point x="628" y="61"/>
+      <point x="336" y="61" type="curve" smooth="yes"/>
+      <point x="213" y="61"/>
+      <point x="142" y="76"/>
+      <point x="142" y="131" type="curve" smooth="yes"/>
+      <point x="142" y="170"/>
+      <point x="175" y="192"/>
+      <point x="239" y="192" type="curve" smooth="yes"/>
+      <point x="517" y="192" type="line" smooth="yes"/>
+      <point x="694" y="192"/>
+      <point x="802" y="281"/>
+      <point x="802" y="422" type="curve" smooth="yes"/>
+      <point x="802" y="534"/>
+      <point x="740" y="612"/>
+      <point x="631" y="612" type="curve" smooth="yes"/>
+      <point x="545" y="612"/>
+      <point x="487" y="567"/>
+      <point x="463" y="494" type="curve"/>
+      <point x="453" y="494" type="line"/>
+      <point x="424" y="573"/>
+      <point x="367" y="612"/>
+      <point x="271" y="612" type="curve" smooth="yes"/>
+      <point x="143" y="612"/>
+      <point x="54" y="533"/>
+      <point x="54" y="423" type="curve" smooth="yes"/>
+      <point x="54" y="336"/>
+      <point x="114" y="274"/>
+      <point x="197" y="274" type="curve" smooth="yes"/>
+      <point x="281" y="274"/>
+      <point x="335" y="323"/>
+      <point x="335" y="399" type="curve" smooth="yes"/>
+      <point x="335" y="469"/>
+      <point x="297" y="512"/>
+      <point x="223" y="512" type="curve" smooth="yes"/>
+      <point x="193" y="512"/>
+      <point x="171" y="508"/>
+      <point x="148" y="499" type="curve"/>
+      <point x="129" y="527" type="line"/>
+      <point x="136" y="499" type="line"/>
+      <point x="157" y="529"/>
+      <point x="206" y="552"/>
+      <point x="269" y="552" type="curve" smooth="yes"/>
+      <point x="364" y="552"/>
+      <point x="410" y="499"/>
+      <point x="410" y="392" type="curve" smooth="yes"/>
+      <point x="410" y="333" type="line"/>
+      <point x="494" y="333" type="line"/>
+      <point x="494" y="392" type="line" smooth="yes"/>
+      <point x="494" y="483"/>
+      <point x="539" y="534"/>
+      <point x="618" y="534" type="curve" smooth="yes"/>
+      <point x="687" y="534"/>
+      <point x="720" y="493"/>
+      <point x="720" y="423" type="curve" smooth="yes"/>
+      <point x="720" y="315"/>
+      <point x="652" y="264"/>
+      <point x="513" y="264" type="curve" smooth="yes"/>
+      <point x="235" y="264" type="line" smooth="yes"/>
+      <point x="128" y="264"/>
+      <point x="60" y="212"/>
+      <point x="60" y="130" type="curve" smooth="yes"/>
+      <point x="60" y="33"/>
+      <point x="153" y="-16"/>
     </contour>
     <contour>
-      <point x="196" y="363" type="curve" smooth="yes"/>
-      <point x="149" y="363"/>
-      <point x="130" y="398"/>
-      <point x="130" y="445" type="curve" smooth="yes"/>
-      <point x="130" y="465"/>
-      <point x="133" y="483"/>
-      <point x="140" y="497" type="curve"/>
-      <point x="118" y="497" type="line"/>
-      <point x="95" y="455" type="line"/>
-      <point x="118" y="482"/>
-      <point x="160" y="496"/>
-      <point x="191" y="496" type="curve" smooth="yes"/>
-      <point x="248" y="496"/>
-      <point x="259" y="461"/>
-      <point x="259" y="434" type="curve" smooth="yes"/>
-      <point x="259" y="390"/>
-      <point x="236" y="363"/>
+      <point x="198" y="338" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="128" y="365"/>
+      <point x="128" y="418" type="curve" smooth="yes"/>
+      <point x="128" y="440"/>
+      <point x="131" y="457"/>
+      <point x="138" y="473" type="curve"/>
+      <point x="106" y="473" type="line"/>
+      <point x="95" y="433" type="line"/>
+      <point x="120" y="454"/>
+      <point x="155" y="468"/>
+      <point x="192" y="468" type="curve" smooth="yes"/>
+      <point x="240" y="468"/>
+      <point x="263" y="446"/>
+      <point x="263" y="401" type="curve" smooth="yes"/>
+      <point x="263" y="363"/>
+      <point x="240" y="338"/>
     </contour>
     <contour>
-      <point x="990" y="363" type="curve" smooth="yes"/>
-      <point x="943" y="363"/>
-      <point x="924" y="398"/>
-      <point x="924" y="447" type="curve" smooth="yes"/>
-      <point x="924" y="467"/>
-      <point x="927" y="485"/>
-      <point x="934" y="499" type="curve"/>
-      <point x="905" y="499" type="line"/>
-      <point x="889" y="465" type="line"/>
-      <point x="913" y="484"/>
-      <point x="954" y="496"/>
-      <point x="985" y="496" type="curve" smooth="yes"/>
-      <point x="1042" y="496"/>
-      <point x="1053" y="461"/>
-      <point x="1053" y="432" type="curve" smooth="yes"/>
-      <point x="1053" y="390"/>
-      <point x="1030" y="363"/>
+      <point x="1016" y="338" type="curve" smooth="yes"/>
+      <point x="971" y="338"/>
+      <point x="946" y="365"/>
+      <point x="946" y="418" type="curve" smooth="yes"/>
+      <point x="946" y="440"/>
+      <point x="949" y="457"/>
+      <point x="956" y="473" type="curve"/>
+      <point x="924" y="473" type="line"/>
+      <point x="913" y="433" type="line"/>
+      <point x="938" y="454"/>
+      <point x="973" y="468"/>
+      <point x="1010" y="468" type="curve" smooth="yes"/>
+      <point x="1058" y="468"/>
+      <point x="1081" y="446"/>
+      <point x="1081" y="401" type="curve" smooth="yes"/>
+      <point x="1081" y="363"/>
+      <point x="1058" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/j_nya-malayalam.glif
@@ -1,185 +1,184 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2219"/>
-  <anchor x="1809" y="0" name="bottom"/>
-  <anchor x="1103" y="596" name="top"/>
-  <anchor x="2069" y="596" name="topright"/>
+  <advance width="2252"/>
+  <anchor x="1842" y="0" name="bottom"/>
+  <anchor x="1126" y="596" name="top"/>
+  <anchor x="2102" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="358" y="-16" type="curve" smooth="yes"/>
-      <point x="578" y="-16"/>
-      <point x="734" y="47"/>
-      <point x="808" y="185" type="curve"/>
-      <point x="818" y="184" type="line"/>
-      <point x="843" y="63"/>
-      <point x="920" y="-16"/>
-      <point x="1035" y="-16" type="curve" smooth="yes"/>
-      <point x="1139" y="-16"/>
-      <point x="1207" y="59"/>
-      <point x="1207" y="175" type="curve" smooth="yes"/>
-      <point x="1207" y="284"/>
-      <point x="1142" y="356"/>
-      <point x="1042" y="356" type="curve" smooth="yes"/>
-      <point x="977" y="356"/>
-      <point x="921" y="324"/>
-      <point x="892" y="269" type="curve"/>
-      <point x="857" y="274" type="line"/>
-      <point x="890" y="141" type="line"/>
-      <point x="900" y="223"/>
-      <point x="959" y="282"/>
-      <point x="1030" y="282" type="curve" smooth="yes"/>
-      <point x="1090" y="282"/>
-      <point x="1125" y="241"/>
-      <point x="1125" y="172" type="curve" smooth="yes"/>
-      <point x="1125" y="102"/>
-      <point x="1091" y="62"/>
-      <point x="1031" y="62" type="curve" smooth="yes"/>
-      <point x="936" y="62"/>
-      <point x="883" y="151"/>
-      <point x="883" y="274" type="curve" smooth="yes"/>
-      <point x="883" y="429"/>
-      <point x="967" y="533"/>
-      <point x="1101" y="533" type="curve" smooth="yes"/>
-      <point x="1218" y="533"/>
-      <point x="1280" y="459"/>
-      <point x="1280" y="328" type="curve" smooth="yes"/>
-      <point x="1280" y="0" type="line"/>
-      <point x="1364" y="0" type="line"/>
-      <point x="1364" y="328" type="line" smooth="yes"/>
-      <point x="1364" y="457"/>
-      <point x="1434" y="534"/>
-      <point x="1557" y="534" type="curve" smooth="yes"/>
-      <point x="1729" y="534"/>
-      <point x="1820" y="411"/>
-      <point x="1820" y="249" type="curve" smooth="yes"/>
-      <point x="1820" y="135"/>
-      <point x="1782" y="62"/>
-      <point x="1706" y="62" type="curve" smooth="yes"/>
-      <point x="1637" y="62"/>
-      <point x="1595" y="126"/>
-      <point x="1595" y="224" type="curve" smooth="yes"/>
-      <point x="1595" y="398"/>
-      <point x="1706" y="534"/>
-      <point x="1868" y="534" type="curve" smooth="yes"/>
-      <point x="2005" y="534"/>
-      <point x="2082" y="449"/>
-      <point x="2082" y="309" type="curve" smooth="yes"/>
-      <point x="2082" y="201"/>
-      <point x="2042" y="116"/>
-      <point x="1978" y="41" type="curve"/>
-      <point x="2046" y="-14" type="line"/>
-      <point x="2120" y="77"/>
-      <point x="2165" y="177"/>
-      <point x="2165" y="304" type="curve" smooth="yes"/>
-      <point x="2165" y="494"/>
-      <point x="2053" y="612"/>
-      <point x="1871" y="612" type="curve" smooth="yes"/>
-      <point x="1663" y="612"/>
-      <point x="1513" y="434"/>
-      <point x="1513" y="223" type="curve" smooth="yes"/>
-      <point x="1513" y="78"/>
-      <point x="1590" y="-16"/>
-      <point x="1708" y="-16" type="curve" smooth="yes"/>
-      <point x="1831" y="-16"/>
-      <point x="1902" y="95"/>
-      <point x="1902" y="244" type="curve" smooth="yes"/>
-      <point x="1902" y="446"/>
-      <point x="1774" y="612"/>
-      <point x="1560" y="612" type="curve" smooth="yes"/>
-      <point x="1453" y="612"/>
-      <point x="1373" y="567"/>
-      <point x="1331" y="482" type="curve"/>
-      <point x="1321" y="482" type="line"/>
-      <point x="1281" y="568"/>
-      <point x="1207" y="612"/>
-      <point x="1104" y="612" type="curve" smooth="yes"/>
-      <point x="947" y="612"/>
-      <point x="848" y="528"/>
-      <point x="806" y="353" type="curve" smooth="yes"/>
-      <point x="751" y="123"/>
-      <point x="586" y="61"/>
-      <point x="358" y="61" type="curve" smooth="yes"/>
-      <point x="214" y="61"/>
-      <point x="138" y="80"/>
-      <point x="138" y="149" type="curve" smooth="yes"/>
-      <point x="138" y="190"/>
-      <point x="170" y="222"/>
-      <point x="269" y="222" type="curve" smooth="yes"/>
-      <point x="521" y="222" type="line" smooth="yes"/>
-      <point x="704" y="222"/>
-      <point x="768" y="320"/>
-      <point x="768" y="432" type="curve" smooth="yes"/>
-      <point x="768" y="534"/>
-      <point x="709" y="612"/>
-      <point x="600" y="612" type="curve" smooth="yes"/>
-      <point x="510" y="612"/>
-      <point x="457" y="564"/>
-      <point x="438" y="490" type="curve"/>
-      <point x="428" y="490" type="line"/>
-      <point x="405" y="565"/>
-      <point x="340" y="612"/>
-      <point x="240" y="612" type="curve" smooth="yes"/>
-      <point x="128" y="612"/>
-      <point x="54" y="546"/>
-      <point x="54" y="448" type="curve" smooth="yes"/>
-      <point x="54" y="361"/>
-      <point x="110" y="300"/>
-      <point x="195" y="300" type="curve" smooth="yes"/>
-      <point x="281" y="300"/>
-      <point x="331" y="354"/>
-      <point x="331" y="429" type="curve" smooth="yes"/>
-      <point x="331" y="486"/>
-      <point x="299" y="540"/>
-      <point x="216" y="540" type="curve" smooth="yes"/>
-      <point x="196" y="540"/>
-      <point x="172" y="534"/>
-      <point x="159" y="524" type="curve"/>
-      <point x="191" y="502" type="line"/>
-      <point x="165" y="566" type="line"/>
-      <point x="149" y="530" type="line"/>
-      <point x="167" y="541"/>
-      <point x="193" y="552"/>
-      <point x="240" y="552" type="curve" smooth="yes"/>
-      <point x="352" y="552"/>
-      <point x="390" y="466"/>
-      <point x="390" y="392" type="curve" smooth="yes"/>
-      <point x="390" y="353" type="line"/>
-      <point x="474" y="353" type="line"/>
-      <point x="474" y="388" type="line" smooth="yes"/>
-      <point x="474" y="479"/>
-      <point x="523" y="534"/>
-      <point x="593" y="534" type="curve" smooth="yes"/>
-      <point x="658" y="534"/>
-      <point x="688" y="492"/>
-      <point x="688" y="425" type="curve" smooth="yes"/>
-      <point x="688" y="359"/>
-      <point x="650" y="294"/>
-      <point x="527" y="294" type="curve" smooth="yes"/>
-      <point x="265" y="294" type="line" smooth="yes"/>
-      <point x="124" y="294"/>
-      <point x="60" y="230"/>
-      <point x="60" y="147" type="curve" smooth="yes"/>
-      <point x="60" y="37"/>
-      <point x="157" y="-16"/>
+      <point x="346" y="-16" type="curve" smooth="yes"/>
+      <point x="600" y="-16"/>
+      <point x="763" y="53"/>
+      <point x="842" y="194" type="curve"/>
+      <point x="852" y="193" type="line"/>
+      <point x="874" y="62"/>
+      <point x="958" y="-16"/>
+      <point x="1068" y="-16" type="curve" smooth="yes"/>
+      <point x="1172" y="-16"/>
+      <point x="1240" y="59"/>
+      <point x="1240" y="175" type="curve" smooth="yes"/>
+      <point x="1240" y="284"/>
+      <point x="1175" y="356"/>
+      <point x="1075" y="356" type="curve" smooth="yes"/>
+      <point x="1010" y="356"/>
+      <point x="954" y="324"/>
+      <point x="925" y="269" type="curve"/>
+      <point x="890" y="274" type="line"/>
+      <point x="923" y="141" type="line"/>
+      <point x="933" y="223"/>
+      <point x="992" y="282"/>
+      <point x="1063" y="282" type="curve" smooth="yes"/>
+      <point x="1123" y="282"/>
+      <point x="1158" y="241"/>
+      <point x="1158" y="172" type="curve" smooth="yes"/>
+      <point x="1158" y="102"/>
+      <point x="1124" y="62"/>
+      <point x="1064" y="62" type="curve" smooth="yes"/>
+      <point x="969" y="62"/>
+      <point x="916" y="151"/>
+      <point x="916" y="274" type="curve" smooth="yes"/>
+      <point x="916" y="429"/>
+      <point x="1000" y="533"/>
+      <point x="1134" y="533" type="curve" smooth="yes"/>
+      <point x="1251" y="533"/>
+      <point x="1313" y="459"/>
+      <point x="1313" y="328" type="curve" smooth="yes"/>
+      <point x="1313" y="0" type="line"/>
+      <point x="1397" y="0" type="line"/>
+      <point x="1397" y="328" type="line" smooth="yes"/>
+      <point x="1397" y="457"/>
+      <point x="1467" y="534"/>
+      <point x="1590" y="534" type="curve" smooth="yes"/>
+      <point x="1762" y="534"/>
+      <point x="1853" y="411"/>
+      <point x="1853" y="249" type="curve" smooth="yes"/>
+      <point x="1853" y="135"/>
+      <point x="1815" y="62"/>
+      <point x="1739" y="62" type="curve" smooth="yes"/>
+      <point x="1670" y="62"/>
+      <point x="1628" y="126"/>
+      <point x="1628" y="224" type="curve" smooth="yes"/>
+      <point x="1628" y="398"/>
+      <point x="1739" y="534"/>
+      <point x="1901" y="534" type="curve" smooth="yes"/>
+      <point x="2038" y="534"/>
+      <point x="2115" y="449"/>
+      <point x="2115" y="309" type="curve" smooth="yes"/>
+      <point x="2115" y="201"/>
+      <point x="2075" y="116"/>
+      <point x="2011" y="41" type="curve"/>
+      <point x="2079" y="-14" type="line"/>
+      <point x="2153" y="77"/>
+      <point x="2198" y="177"/>
+      <point x="2198" y="304" type="curve" smooth="yes"/>
+      <point x="2198" y="494"/>
+      <point x="2086" y="612"/>
+      <point x="1904" y="612" type="curve" smooth="yes"/>
+      <point x="1696" y="612"/>
+      <point x="1546" y="434"/>
+      <point x="1546" y="223" type="curve" smooth="yes"/>
+      <point x="1546" y="78"/>
+      <point x="1623" y="-16"/>
+      <point x="1741" y="-16" type="curve" smooth="yes"/>
+      <point x="1864" y="-16"/>
+      <point x="1935" y="95"/>
+      <point x="1935" y="244" type="curve" smooth="yes"/>
+      <point x="1935" y="446"/>
+      <point x="1807" y="612"/>
+      <point x="1593" y="612" type="curve" smooth="yes"/>
+      <point x="1486" y="612"/>
+      <point x="1406" y="567"/>
+      <point x="1364" y="482" type="curve"/>
+      <point x="1354" y="482" type="line"/>
+      <point x="1314" y="568"/>
+      <point x="1240" y="612"/>
+      <point x="1137" y="612" type="curve" smooth="yes"/>
+      <point x="980" y="612"/>
+      <point x="881" y="528"/>
+      <point x="839" y="353" type="curve" smooth="yes"/>
+      <point x="791" y="151"/>
+      <point x="639" y="61"/>
+      <point x="346" y="61" type="curve" smooth="yes"/>
+      <point x="216" y="61"/>
+      <point x="142" y="76"/>
+      <point x="142" y="131" type="curve" smooth="yes"/>
+      <point x="142" y="170"/>
+      <point x="175" y="192"/>
+      <point x="239" y="192" type="curve" smooth="yes"/>
+      <point x="517" y="192" type="line" smooth="yes"/>
+      <point x="693" y="192"/>
+      <point x="802" y="280"/>
+      <point x="802" y="420" type="curve" smooth="yes"/>
+      <point x="802" y="533"/>
+      <point x="740" y="612"/>
+      <point x="630" y="612" type="curve" smooth="yes"/>
+      <point x="544" y="612"/>
+      <point x="487" y="567"/>
+      <point x="463" y="494" type="curve"/>
+      <point x="453" y="494" type="line"/>
+      <point x="422" y="575"/>
+      <point x="362" y="612"/>
+      <point x="262" y="612" type="curve" smooth="yes"/>
+      <point x="141" y="612"/>
+      <point x="54" y="533"/>
+      <point x="54" y="423" type="curve" smooth="yes"/>
+      <point x="54" y="336"/>
+      <point x="114" y="274"/>
+      <point x="197" y="274" type="curve" smooth="yes"/>
+      <point x="281" y="274"/>
+      <point x="335" y="323"/>
+      <point x="335" y="399" type="curve" smooth="yes"/>
+      <point x="335" y="469"/>
+      <point x="297" y="512"/>
+      <point x="223" y="512" type="curve" smooth="yes"/>
+      <point x="193" y="512"/>
+      <point x="171" y="508"/>
+      <point x="148" y="499" type="curve"/>
+      <point x="129" y="527" type="line"/>
+      <point x="136" y="499" type="line"/>
+      <point x="156" y="529"/>
+      <point x="202" y="552"/>
+      <point x="261" y="552" type="curve" smooth="yes"/>
+      <point x="361" y="552"/>
+      <point x="410" y="499"/>
+      <point x="410" y="392" type="curve" smooth="yes"/>
+      <point x="410" y="333" type="line"/>
+      <point x="494" y="333" type="line"/>
+      <point x="494" y="392" type="line" smooth="yes"/>
+      <point x="494" y="483"/>
+      <point x="539" y="534"/>
+      <point x="616" y="534" type="curve" smooth="yes"/>
+      <point x="686" y="534"/>
+      <point x="720" y="492"/>
+      <point x="720" y="421" type="curve" smooth="yes"/>
+      <point x="720" y="314"/>
+      <point x="652" y="264"/>
+      <point x="513" y="264" type="curve" smooth="yes"/>
+      <point x="235" y="264" type="line" smooth="yes"/>
+      <point x="128" y="264"/>
+      <point x="60" y="212"/>
+      <point x="60" y="130" type="curve" smooth="yes"/>
+      <point x="60" y="33"/>
+      <point x="156" y="-16"/>
     </contour>
     <contour>
-      <point x="196" y="363" type="curve" smooth="yes"/>
-      <point x="149" y="363"/>
-      <point x="130" y="398"/>
-      <point x="130" y="445" type="curve" smooth="yes"/>
-      <point x="130" y="465"/>
-      <point x="133" y="483"/>
-      <point x="140" y="497" type="curve"/>
-      <point x="118" y="497" type="line"/>
-      <point x="95" y="455" type="line"/>
-      <point x="118" y="482"/>
-      <point x="160" y="496"/>
-      <point x="191" y="496" type="curve" smooth="yes"/>
-      <point x="248" y="496"/>
-      <point x="259" y="461"/>
-      <point x="259" y="434" type="curve" smooth="yes"/>
-      <point x="259" y="390"/>
-      <point x="236" y="363"/>
+      <point x="198" y="338" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="128" y="365"/>
+      <point x="128" y="418" type="curve" smooth="yes"/>
+      <point x="128" y="440"/>
+      <point x="131" y="457"/>
+      <point x="138" y="473" type="curve"/>
+      <point x="106" y="473" type="line"/>
+      <point x="95" y="433" type="line"/>
+      <point x="120" y="454"/>
+      <point x="155" y="468"/>
+      <point x="192" y="468" type="curve" smooth="yes"/>
+      <point x="240" y="468"/>
+      <point x="263" y="446"/>
+      <point x="263" y="401" type="curve" smooth="yes"/>
+      <point x="263" y="363"/>
+      <point x="240" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ja-malayalam.glif
@@ -1,135 +1,135 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <unicode hex="0D1C"/>
-  <anchor x="439" y="-4" name="bottom"/>
-  <anchor x="431" y="596" name="top"/>
-  <anchor x="677" y="596" name="topright"/>
+  <anchor x="457" y="-6" name="bottom"/>
+  <anchor x="441" y="596" name="top"/>
+  <anchor x="718" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="205" y="-16" type="curve" smooth="yes"/>
-      <point x="265" y="-16"/>
-      <point x="315" y="3"/>
-      <point x="409" y="59" type="curve" smooth="yes"/>
-      <point x="499" y="113" type="line"/>
-      <point x="546" y="145" type="line"/>
-      <point x="562" y="147" type="line"/>
-      <point x="601" y="167"/>
-      <point x="622" y="172"/>
-      <point x="646" y="172" type="curve" smooth="yes"/>
-      <point x="687" y="172"/>
-      <point x="707" y="152"/>
-      <point x="707" y="111" type="curve" smooth="yes"/>
-      <point x="707" y="72"/>
-      <point x="685" y="48"/>
-      <point x="650" y="48" type="curve" smooth="yes"/>
-      <point x="614" y="48"/>
-      <point x="594" y="70"/>
-      <point x="594" y="109" type="curve" smooth="yes"/>
-      <point x="594" y="139"/>
-      <point x="604" y="162"/>
-      <point x="629" y="190" type="curve"/>
-      <point x="527" y="155" type="line"/>
-      <point x="547" y="134" type="line"/>
-      <point x="543" y="125"/>
-      <point x="538" y="109"/>
-      <point x="538" y="90" type="curve" smooth="yes"/>
-      <point x="538" y="26"/>
-      <point x="583" y="-16"/>
-      <point x="651" y="-16" type="curve" smooth="yes"/>
-      <point x="725" y="-16"/>
-      <point x="773" y="33"/>
-      <point x="773" y="110" type="curve" smooth="yes"/>
-      <point x="773" y="187"/>
-      <point x="724" y="238"/>
-      <point x="650" y="238" type="curve" smooth="yes"/>
-      <point x="590" y="238"/>
-      <point x="552" y="224"/>
-      <point x="454" y="169" type="curve" smooth="yes"/>
-      <point x="379" y="127" type="line" smooth="yes"/>
-      <point x="278" y="71"/>
-      <point x="253" y="61"/>
-      <point x="214" y="61" type="curve" smooth="yes"/>
-      <point x="163" y="61"/>
-      <point x="138" y="85"/>
-      <point x="138" y="134" type="curve" smooth="yes"/>
-      <point x="138" y="192"/>
-      <point x="182" y="222"/>
-      <point x="269" y="222" type="curve" smooth="yes"/>
-      <point x="519" y="222" type="line" smooth="yes"/>
-      <point x="683" y="222"/>
-      <point x="778" y="299"/>
-      <point x="778" y="432" type="curve" smooth="yes"/>
-      <point x="778" y="542"/>
-      <point x="711" y="612"/>
-      <point x="606" y="612" type="curve" smooth="yes"/>
-      <point x="525" y="612"/>
-      <point x="464" y="567"/>
-      <point x="443" y="490" type="curve"/>
-      <point x="433" y="490" type="line"/>
-      <point x="414" y="569"/>
-      <point x="352" y="612"/>
-      <point x="255" y="612" type="curve" smooth="yes"/>
-      <point x="136" y="612"/>
-      <point x="54" y="545"/>
-      <point x="54" y="448" type="curve" smooth="yes"/>
-      <point x="54" y="360"/>
-      <point x="111" y="300"/>
-      <point x="195" y="300" type="curve" smooth="yes"/>
-      <point x="278" y="300"/>
-      <point x="331" y="349"/>
-      <point x="331" y="426" type="curve" smooth="yes"/>
-      <point x="331" y="492"/>
-      <point x="294" y="532"/>
-      <point x="226" y="532" type="curve" smooth="yes"/>
-      <point x="206" y="532"/>
-      <point x="186" y="529"/>
-      <point x="167" y="524" type="curve"/>
-      <point x="156" y="547" type="line"/>
-      <point x="150" y="525" type="line"/>
-      <point x="174" y="542"/>
-      <point x="210" y="552"/>
-      <point x="255" y="552" type="curve" smooth="yes"/>
-      <point x="345" y="552"/>
-      <point x="390" y="499"/>
-      <point x="390" y="392" type="curve" smooth="yes"/>
-      <point x="390" y="353" type="line"/>
-      <point x="474" y="353" type="line"/>
-      <point x="474" y="388" type="line" smooth="yes"/>
-      <point x="474" y="475"/>
-      <point x="524" y="534"/>
-      <point x="598" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="696" y="495"/>
-      <point x="696" y="429" type="curve" smooth="yes"/>
-      <point x="696" y="343"/>
-      <point x="637" y="294"/>
-      <point x="535" y="294" type="curve" smooth="yes"/>
-      <point x="266" y="294" type="line" smooth="yes"/>
-      <point x="138" y="294"/>
-      <point x="60" y="233"/>
-      <point x="60" y="133" type="curve" smooth="yes"/>
-      <point x="60" y="41"/>
-      <point x="116" y="-16"/>
+      <point x="218" y="-16" type="curve" smooth="yes"/>
+      <point x="269" y="-16"/>
+      <point x="311" y="-5"/>
+      <point x="376" y="27" type="curve" smooth="yes"/>
+      <point x="521" y="98" type="line"/>
+      <point x="586" y="147" type="line"/>
+      <point x="612" y="147" type="line"/>
+      <point x="637" y="167"/>
+      <point x="660" y="178"/>
+      <point x="692" y="178" type="curve" smooth="yes"/>
+      <point x="733" y="178"/>
+      <point x="753" y="156"/>
+      <point x="753" y="117" type="curve" smooth="yes"/>
+      <point x="753" y="78"/>
+      <point x="729" y="56"/>
+      <point x="691" y="56" type="curve" smooth="yes"/>
+      <point x="651" y="56"/>
+      <point x="629" y="78"/>
+      <point x="629" y="116" type="curve" smooth="yes"/>
+      <point x="629" y="144"/>
+      <point x="639" y="164"/>
+      <point x="664" y="190" type="curve"/>
+      <point x="560" y="150" type="line"/>
+      <point x="581" y="129" type="line"/>
+      <point x="576" y="117"/>
+      <point x="573" y="103"/>
+      <point x="573" y="86" type="curve" smooth="yes"/>
+      <point x="573" y="24"/>
+      <point x="623" y="-16"/>
+      <point x="694" y="-16" type="curve" smooth="yes"/>
+      <point x="774" y="-16"/>
+      <point x="825" y="33"/>
+      <point x="825" y="110" type="curve" smooth="yes"/>
+      <point x="825" y="182"/>
+      <point x="784" y="232"/>
+      <point x="700" y="232" type="curve" smooth="yes"/>
+      <point x="654" y="232"/>
+      <point x="619" y="222"/>
+      <point x="542" y="184" type="curve" smooth="yes"/>
+      <point x="347" y="89" type="line" smooth="yes"/>
+      <point x="304" y="68"/>
+      <point x="266" y="58"/>
+      <point x="223" y="58" type="curve" smooth="yes"/>
+      <point x="171" y="58"/>
+      <point x="142" y="81"/>
+      <point x="142" y="123" type="curve" smooth="yes"/>
+      <point x="142" y="168"/>
+      <point x="174" y="192"/>
+      <point x="239" y="192" type="curve" smooth="yes"/>
+      <point x="549" y="192" type="line" smooth="yes"/>
+      <point x="720" y="192"/>
+      <point x="828" y="279"/>
+      <point x="828" y="417" type="curve" smooth="yes"/>
+      <point x="828" y="532"/>
+      <point x="758" y="612"/>
+      <point x="640" y="612" type="curve" smooth="yes"/>
+      <point x="549" y="612"/>
+      <point x="489" y="567"/>
+      <point x="463" y="494" type="curve"/>
+      <point x="453" y="494" type="line"/>
+      <point x="422" y="575"/>
+      <point x="363" y="612"/>
+      <point x="262" y="612" type="curve" smooth="yes"/>
+      <point x="141" y="612"/>
+      <point x="54" y="533"/>
+      <point x="54" y="423" type="curve" smooth="yes"/>
+      <point x="54" y="336"/>
+      <point x="114" y="274"/>
+      <point x="197" y="274" type="curve" smooth="yes"/>
+      <point x="281" y="274"/>
+      <point x="335" y="323"/>
+      <point x="335" y="399" type="curve" smooth="yes"/>
+      <point x="335" y="469"/>
+      <point x="297" y="512"/>
+      <point x="223" y="512" type="curve" smooth="yes"/>
+      <point x="193" y="512"/>
+      <point x="171" y="508"/>
+      <point x="148" y="499" type="curve"/>
+      <point x="129" y="527" type="line"/>
+      <point x="136" y="499" type="line"/>
+      <point x="156" y="529"/>
+      <point x="202" y="552"/>
+      <point x="261" y="552" type="curve" smooth="yes"/>
+      <point x="362" y="552"/>
+      <point x="410" y="499"/>
+      <point x="410" y="392" type="curve" smooth="yes"/>
+      <point x="410" y="333" type="line"/>
+      <point x="494" y="333" type="line"/>
+      <point x="494" y="392" type="line" smooth="yes"/>
+      <point x="494" y="483"/>
+      <point x="546" y="534"/>
+      <point x="627" y="534" type="curve" smooth="yes"/>
+      <point x="706" y="534"/>
+      <point x="746" y="490"/>
+      <point x="746" y="415" type="curve" smooth="yes"/>
+      <point x="746" y="313"/>
+      <point x="685" y="264"/>
+      <point x="557" y="264" type="curve" smooth="yes"/>
+      <point x="235" y="264" type="line" smooth="yes"/>
+      <point x="128" y="264"/>
+      <point x="60" y="209"/>
+      <point x="60" y="122" type="curve" smooth="yes"/>
+      <point x="60" y="39"/>
+      <point x="123" y="-16"/>
     </contour>
     <contour>
-      <point x="196" y="363" type="curve" smooth="yes"/>
-      <point x="153" y="363"/>
-      <point x="130" y="393"/>
-      <point x="130" y="447" type="curve" smooth="yes"/>
-      <point x="130" y="471"/>
-      <point x="133" y="489"/>
-      <point x="140" y="499" type="curve"/>
-      <point x="118" y="499" type="line"/>
-      <point x="95" y="459" type="line"/>
-      <point x="119" y="477"/>
-      <point x="160" y="488"/>
-      <point x="193" y="488" type="curve" smooth="yes"/>
-      <point x="235" y="488"/>
-      <point x="259" y="467"/>
-      <point x="259" y="426" type="curve" smooth="yes"/>
-      <point x="259" y="387"/>
-      <point x="236" y="363"/>
+      <point x="198" y="338" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="128" y="365"/>
+      <point x="128" y="418" type="curve" smooth="yes"/>
+      <point x="128" y="440"/>
+      <point x="131" y="457"/>
+      <point x="138" y="473" type="curve"/>
+      <point x="106" y="473" type="line"/>
+      <point x="95" y="433" type="line"/>
+      <point x="120" y="454"/>
+      <point x="155" y="468"/>
+      <point x="192" y="468" type="curve" smooth="yes"/>
+      <point x="240" y="468"/>
+      <point x="263" y="446"/>
+      <point x="263" y="401" type="curve" smooth="yes"/>
+      <point x="263" y="363"/>
+      <point x="240" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
+  <anchor x="457" y="-6" name="bottom"/>
+  <anchor x="441" y="596" name="top"/>
+  <anchor x="718" y="596" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="677"/>
+    <component base="halant-malayalam" xOffset="718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
+  <anchor x="457" y="-6" name="bottom"/>
+  <anchor x="441" y="596" name="top"/>
+  <anchor x="718" y="596" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="439" yOffset="-4"/>
+    <component base="lVocalicMatra-malayalam" xOffset="457" yOffset="-6"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
+  <anchor x="457" y="-6" name="bottom"/>
+  <anchor x="441" y="596" name="top"/>
+  <anchor x="718" y="596" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="439" yOffset="-4"/>
+    <component base="llVocalicMatra-malayalam" xOffset="457" yOffset="-6"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
@@ -2,96 +2,95 @@
 <glyph name="kChillu-malayalam" format="2">
   <advance width="1066"/>
   <unicode hex="0D7F"/>
-  <guideline x="1024"/>
   <anchor x="668" y="0" name="bottom"/>
   <anchor x="353" y="596" name="top"/>
   <outline>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
       <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="546" y="-16" type="curve" smooth="yes"/>
-      <point x="612" y="-16"/>
-      <point x="663" y="25"/>
+      <point x="608" y="-16"/>
+      <point x="661" y="21"/>
       <point x="691" y="85" type="curve"/>
       <point x="701" y="85" type="line"/>
-      <point x="724" y="28"/>
-      <point x="775" y="-16"/>
-      <point x="860" y="-16" type="curve" smooth="yes"/>
-      <point x="953" y="-16"/>
-      <point x="1023" y="44"/>
-      <point x="1023" y="154" type="curve" smooth="yes"/>
-      <point x="1023" y="261"/>
-      <point x="949" y="333"/>
-      <point x="815" y="333" type="curve" smooth="yes"/>
-      <point x="778" y="333" type="line"/>
-      <point x="744" y="259" type="line"/>
-      <point x="819" y="259" type="line" smooth="yes"/>
-      <point x="908" y="259"/>
-      <point x="938" y="216"/>
-      <point x="938" y="158" type="curve" smooth="yes"/>
-      <point x="938" y="99"/>
-      <point x="911" y="62"/>
-      <point x="852" y="62" type="curve" smooth="yes"/>
-      <point x="792" y="62"/>
-      <point x="750" y="107"/>
-      <point x="750" y="184" type="curve" smooth="yes"/>
-      <point x="750" y="265"/>
-      <point x="792" y="333"/>
+      <point x="726" y="20"/>
+      <point x="782" y="-16"/>
+      <point x="856" y="-16" type="curve" smooth="yes"/>
+      <point x="957" y="-16"/>
+      <point x="1023" y="55"/>
+      <point x="1023" y="165" type="curve" smooth="yes"/>
+      <point x="1023" y="282"/>
+      <point x="941" y="353"/>
+      <point x="806" y="353" type="curve" smooth="yes"/>
+      <point x="778" y="353" type="line"/>
+      <point x="744" y="279" type="line"/>
+      <point x="810" y="279" type="line" smooth="yes"/>
+      <point x="895" y="279"/>
+      <point x="939" y="242"/>
+      <point x="939" y="169" type="curve" smooth="yes"/>
+      <point x="939" y="102"/>
+      <point x="908" y="62"/>
+      <point x="847" y="62" type="curve" smooth="yes"/>
+      <point x="783" y="62"/>
+      <point x="746" y="103"/>
+      <point x="746" y="172" type="curve" smooth="yes"/>
+      <point x="746" y="241"/>
+      <point x="769" y="295"/>
       <point x="857" y="435" type="curve" smooth="yes"/>
-      <point x="908" y="516"/>
-      <point x="936" y="577"/>
+      <point x="915" y="527"/>
+      <point x="936" y="585"/>
       <point x="936" y="652" type="curve" smooth="yes"/>
-      <point x="936" y="743"/>
-      <point x="885" y="810"/>
+      <point x="936" y="751"/>
+      <point x="877" y="810"/>
       <point x="780" y="810" type="curve" smooth="yes"/>
-      <point x="722" y="810"/>
-      <point x="673" y="795"/>
+      <point x="720" y="810"/>
+      <point x="672" y="794"/>
       <point x="621" y="758" type="curve"/>
       <point x="659" y="691" type="line"/>
-      <point x="694" y="716"/>
-      <point x="731" y="731"/>
+      <point x="697" y="718"/>
+      <point x="734" y="731"/>
       <point x="774" y="731" type="curve" smooth="yes"/>
-      <point x="833" y="731"/>
-      <point x="853" y="697"/>
+      <point x="827" y="731"/>
+      <point x="853" y="704"/>
       <point x="853" y="649" type="curve" smooth="yes"/>
-      <point x="853" y="592"/>
-      <point x="832" y="545"/>
+      <point x="853" y="596"/>
+      <point x="836" y="552"/>
       <point x="783" y="464" type="curve" smooth="yes"/>
-      <point x="765" y="434"/>
-      <point x="752" y="407"/>
-      <point x="742" y="377" type="curve"/>
-      <point x="732" y="377" type="line"/>
-      <point x="721" y="515"/>
-      <point x="660" y="612"/>
+      <point x="760" y="426"/>
+      <point x="746" y="393"/>
+      <point x="739" y="361" type="curve"/>
+      <point x="731" y="361" type="line"/>
+      <point x="725" y="520"/>
+      <point x="656" y="612"/>
       <point x="543" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="330" y="495"/>
+      <point x="411" y="612"/>
+      <point x="330" y="500"/>
       <point x="330" y="318" type="curve" smooth="yes"/>
-      <point x="330" y="295"/>
-      <point x="333" y="248"/>
-      <point x="333" y="219" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="159" type="curve" smooth="yes"/>
-      <point x="123" y="220"/>
-      <point x="160" y="259"/>
-      <point x="247" y="259" type="curve" smooth="yes"/>
-      <point x="710" y="259" type="line"/>
-      <point x="717" y="333" type="line"/>
-      <point x="249" y="333" type="line" smooth="yes"/>
-      <point x="111" y="333"/>
-      <point x="41" y="263"/>
-      <point x="41" y="153" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="330" y="293"/>
+      <point x="333" y="242"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="710" y="279" type="line"/>
+      <point x="717" y="353" type="line"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/k_ka-malayalam.glif
@@ -1,102 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ka-malayalam" format="2">
   <advance width="1454"/>
-  <guideline x="1400"/>
   <anchor x="1044" y="0" name="bottom"/>
   <anchor x="793" y="596" name="top"/>
   <anchor x="1321" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
-      <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="377" y="94" type="line"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="756" y="106"/>
-      <point x="756" y="286" type="curve" smooth="yes"/>
-      <point x="756" y="310" type="line" smooth="yes"/>
-      <point x="756" y="489"/>
-      <point x="687" y="612"/>
-      <point x="544" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="330" y="495"/>
-      <point x="330" y="310" type="curve" smooth="yes"/>
-      <point x="330" y="287"/>
-      <point x="333" y="247"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="952" y="259" type="line" smooth="yes"/>
-      <point x="1050" y="259"/>
-      <point x="1075" y="209"/>
-      <point x="1075" y="144" type="curve" smooth="yes"/>
-      <point x="1075" y="86"/>
-      <point x="1050" y="62"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
+      <point x="759" y="287" type="curve" smooth="yes"/>
+      <point x="759" y="311" type="line" smooth="yes"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
+      <point x="546" y="612" type="curve" smooth="yes"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
+      <point x="329" y="311" type="curve" smooth="yes"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="960" y="279" type="line" smooth="yes"/>
+      <point x="1044" y="279"/>
+      <point x="1083" y="243"/>
+      <point x="1083" y="165" type="curve" smooth="yes"/>
+      <point x="1083" y="97"/>
+      <point x="1058" y="62"/>
       <point x="1010" y="62" type="curve" smooth="yes"/>
-      <point x="936" y="62"/>
-      <point x="911" y="146"/>
-      <point x="911" y="249" type="curve" smooth="yes"/>
-      <point x="911" y="421"/>
-      <point x="979" y="533"/>
+      <point x="946" y="62"/>
+      <point x="911" y="121"/>
+      <point x="911" y="230" type="curve" smooth="yes"/>
+      <point x="911" y="425"/>
+      <point x="988" y="533"/>
       <point x="1124" y="533" type="curve" smooth="yes"/>
-      <point x="1253" y="533"/>
-      <point x="1318" y="432"/>
+      <point x="1249" y="533"/>
+      <point x="1318" y="441"/>
       <point x="1318" y="286" type="curve" smooth="yes"/>
-      <point x="1318" y="194"/>
-      <point x="1285" y="106"/>
+      <point x="1318" y="197"/>
+      <point x="1287" y="109"/>
       <point x="1230" y="34" type="curve"/>
       <point x="1296" y="-16" type="line"/>
-      <point x="1367" y="68"/>
-      <point x="1400" y="182"/>
+      <point x="1362" y="62"/>
+      <point x="1400" y="173"/>
       <point x="1400" y="285" type="curve" smooth="yes"/>
-      <point x="1400" y="486"/>
-      <point x="1297" y="612"/>
+      <point x="1400" y="488"/>
+      <point x="1299" y="612"/>
       <point x="1126" y="612" type="curve" smooth="yes"/>
-      <point x="940" y="612"/>
-      <point x="829" y="465"/>
-      <point x="829" y="246" type="curve" smooth="yes"/>
-      <point x="829" y="116"/>
-      <point x="878" y="-16"/>
+      <point x="945" y="612"/>
+      <point x="829" y="463"/>
+      <point x="829" y="227" type="curve" smooth="yes"/>
+      <point x="829" y="77"/>
+      <point x="900" y="-16"/>
       <point x="1013" y="-16" type="curve" smooth="yes"/>
-      <point x="1111" y="-16"/>
-      <point x="1157" y="53"/>
-      <point x="1157" y="144" type="curve" smooth="yes"/>
-      <point x="1157" y="242"/>
-      <point x="1110" y="333"/>
-      <point x="948" y="333" type="curve" smooth="yes"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="1107" y="-16"/>
+      <point x="1165" y="54"/>
+      <point x="1165" y="165" type="curve" smooth="yes"/>
+      <point x="1165" y="288"/>
+      <point x="1092" y="353"/>
+      <point x="956" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="154"/>
-      <point x="412" y="288" type="curve" smooth="yes"/>
-      <point x="412" y="308" type="line" smooth="yes"/>
-      <point x="412" y="443"/>
-      <point x="453" y="534"/>
-      <point x="544" y="534" type="curve" smooth="yes"/>
-      <point x="636" y="534"/>
-      <point x="672" y="442"/>
-      <point x="672" y="308" type="curve" smooth="yes"/>
-      <point x="672" y="288" type="line" smooth="yes"/>
-      <point x="672" y="154"/>
-      <point x="633" y="62"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
+      <point x="412" y="289" type="curve" smooth="yes"/>
+      <point x="412" y="309" type="line" smooth="yes"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
+      <point x="545" y="534" type="curve" smooth="yes"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
+      <point x="672" y="309" type="curve" smooth="yes"/>
+      <point x="672" y="289" type="line" smooth="yes"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/k_la-malayalam.glif
@@ -54,29 +54,29 @@
       <point x="759" y="152"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="815" y="259" type="line" smooth="yes"/>
-      <point x="895" y="259"/>
-      <point x="936" y="223"/>
-      <point x="936" y="157" type="curve" smooth="yes"/>
-      <point x="936" y="94"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="806" y="279" type="line" smooth="yes"/>
+      <point x="893" y="279"/>
+      <point x="936" y="242"/>
+      <point x="936" y="168" type="curve" smooth="yes"/>
+      <point x="936" y="98"/>
       <point x="902" y="60"/>
       <point x="847" y="60" type="curve" smooth="yes"/>
       <point x="827" y="60"/>
@@ -87,20 +87,20 @@
       <point x="819" y="-16"/>
       <point x="850" y="-16" type="curve" smooth="yes"/>
       <point x="950" y="-16"/>
-      <point x="1018" y="53"/>
-      <point x="1018" y="155" type="curve" smooth="yes"/>
-      <point x="1018" y="264"/>
-      <point x="938" y="333"/>
-      <point x="811" y="333" type="curve" smooth="yes"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="1018" y="57"/>
+      <point x="1018" y="166" type="curve" smooth="yes"/>
+      <point x="1018" y="283"/>
+      <point x="937" y="353"/>
+      <point x="802" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
       <point x="377" y="94" type="line"/>
       <point x="388" y="72"/>
@@ -118,7 +118,7 @@
       <point x="381" y="-313"/>
       <point x="354" y="-256"/>
       <point x="354" y="-200" type="curve"/>
-      <point x="334" y="-208" type="line"/>
+      <point x="337" y="-218" type="line"/>
       <point x="355" y="-265" type="line"/>
       <point x="355" y="-221"/>
       <point x="387" y="-181"/>
@@ -131,19 +131,19 @@
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="442"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
@@ -1,45 +1,44 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam" format="2">
   <advance width="1726"/>
-  <guideline x="1637"/>
   <anchor x="1281" y="0" name="bottom"/>
   <anchor x="879" y="596" name="top"/>
   <anchor x="1604" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
-      <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="377" y="94" type="line"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="759" y="104"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="159" type="curve" smooth="yes"/>
-      <point x="123" y="223"/>
-      <point x="166" y="265"/>
-      <point x="238" y="265" type="curve" smooth="yes"/>
-      <point x="815" y="265" type="line" smooth="yes"/>
-      <point x="905" y="265"/>
-      <point x="936" y="229"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="806" y="279" type="line" smooth="yes"/>
+      <point x="893" y="279"/>
+      <point x="936" y="244"/>
       <point x="936" y="175" type="curve" smooth="yes"/>
       <point x="936" y="129"/>
       <point x="919" y="95"/>
@@ -76,38 +75,38 @@
       <point x="1473" y="295"/>
       <point x="1543" y="391" type="curve"/>
       <point x="1553" y="389" type="line"/>
-      <point x="1552" y="40" type="line"/>
+      <point x="1553" y="40" type="line"/>
       <point x="1593" y="74" type="line"/>
       <point x="985" y="74" type="line"/>
       <point x="981" y="82" type="line"/>
       <point x="1009" y="112"/>
       <point x="1018" y="151"/>
       <point x="1018" y="182" type="curve" smooth="yes"/>
-      <point x="1018" y="274"/>
-      <point x="958" y="339"/>
-      <point x="811" y="339" type="curve" smooth="yes"/>
-      <point x="243" y="339" type="line" smooth="yes"/>
-      <point x="120" y="339"/>
-      <point x="41" y="266"/>
-      <point x="41" y="153" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="1018" y="289"/>
+      <point x="937" y="353"/>
+      <point x="802" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="442"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam.half" format="2">
   <advance width="1726"/>
+  <anchor x="1281" y="0" name="bottom"/>
+  <anchor x="879" y="596" name="top"/>
+  <anchor x="1604" y="596" name="topright"/>
   <outline>
     <component base="k_ssa-malayalam"/>
     <component base="halant-malayalam" xOffset="1604"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/k_ta-malayalam.glif
@@ -58,60 +58,60 @@
       <point x="908" y="73"/>
     </contour>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
-      <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="377" y="94" type="line"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="759" y="104"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="903" y="259" type="line"/>
-      <point x="903" y="333" type="line"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="904" y="279" type="line"/>
+      <point x="904" y="353" type="line"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="442"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/k_tta-malayalam.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_tta-malayalam" format="2">
   <advance width="1060"/>
-  <guideline x="1018" y="165" angle="90"/>
   <anchor x="852" y="-362" name="bottom"/>
   <anchor x="546" y="596" name="top"/>
   <anchor x="891" y="556" name="topright"/>
@@ -29,53 +28,53 @@
       <point x="973" y="27"/>
       <point x="955" y="31" type="curve"/>
       <point x="955" y="41" type="line"/>
-      <point x="1000" y="64"/>
-      <point x="1018" y="111"/>
-      <point x="1018" y="165" type="curve" smooth="yes"/>
-      <point x="1018" y="274"/>
-      <point x="938" y="333"/>
-      <point x="808" y="333" type="curve" smooth="yes"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="996" y="69"/>
+      <point x="1018" y="108"/>
+      <point x="1018" y="171" type="curve" smooth="yes"/>
+      <point x="1018" y="282"/>
+      <point x="940" y="353"/>
+      <point x="810" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
-      <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="377" y="94" type="line"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="759" y="104"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="815" y="259" type="line" smooth="yes"/>
-      <point x="895" y="259"/>
-      <point x="936" y="223"/>
-      <point x="936" y="157" type="curve" smooth="yes"/>
-      <point x="936" y="94"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="806" y="279" type="line" smooth="yes"/>
+      <point x="894" y="279"/>
+      <point x="936" y="241"/>
+      <point x="936" y="166" type="curve" smooth="yes"/>
+      <point x="936" y="97"/>
       <point x="902" y="60"/>
       <point x="847" y="60" type="curve" smooth="yes"/>
       <point x="827" y="60"/>
@@ -105,19 +104,19 @@
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="440"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ka-malayalam.glif
@@ -7,78 +7,78 @@
   <anchor x="891" y="556" name="topright"/>
   <outline>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
       <point x="377" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="759" y="104"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="815" y="259" type="line" smooth="yes"/>
-      <point x="895" y="259"/>
-      <point x="936" y="223"/>
-      <point x="936" y="157" type="curve" smooth="yes"/>
-      <point x="936" y="94"/>
-      <point x="902" y="60"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="806" y="279" type="line" smooth="yes"/>
+      <point x="893" y="279"/>
+      <point x="936" y="242"/>
+      <point x="936" y="168" type="curve" smooth="yes"/>
+      <point x="936" y="100"/>
+      <point x="903" y="60"/>
       <point x="847" y="60" type="curve" smooth="yes"/>
-      <point x="827" y="60"/>
-      <point x="809" y="63"/>
+      <point x="828" y="60"/>
+      <point x="810" y="63"/>
       <point x="795" y="68" type="curve"/>
       <point x="774" y="-5" type="line"/>
-      <point x="797" y="-12"/>
-      <point x="819" y="-16"/>
+      <point x="800" y="-13"/>
+      <point x="822" y="-16"/>
       <point x="850" y="-16" type="curve" smooth="yes"/>
       <point x="950" y="-16"/>
-      <point x="1018" y="53"/>
-      <point x="1018" y="155" type="curve" smooth="yes"/>
-      <point x="1018" y="264"/>
-      <point x="938" y="333"/>
-      <point x="811" y="333" type="curve" smooth="yes"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="1018" y="57"/>
+      <point x="1018" y="166" type="curve" smooth="yes"/>
+      <point x="1018" y="283"/>
+      <point x="937" y="353"/>
+      <point x="802" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="442"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/m_la-malayalam.glif
@@ -1,56 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="m_la-malayalam" format="2">
   <advance width="692"/>
-  <anchor x="354" y="-362" name="bottom"/>
+  <anchor x="346" y="-362" name="bottom"/>
   <anchor x="349" y="596" name="top"/>
   <anchor x="577" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="129" y="-378" type="curve" smooth="yes"/>
-      <point x="211" y="-378"/>
-      <point x="259" y="-328"/>
-      <point x="259" y="-245" type="curve" smooth="yes"/>
-      <point x="259" y="-163"/>
-      <point x="215" y="-121"/>
-      <point x="145" y="-121" type="curve" smooth="yes"/>
-      <point x="92" y="-121"/>
-      <point x="34" y="-154"/>
-      <point x="34" y="-239" type="curve"/>
-      <point x="58" y="-172" type="line"/>
-      <point x="-1" y="-172" type="line"/>
-      <point x="38" y="-198" type="line"/>
-      <point x="38" y="-84"/>
-      <point x="90" y="-22"/>
-      <point x="186" y="-22" type="curve" smooth="yes"/>
-      <point x="282" y="-22"/>
-      <point x="318" y="-84"/>
-      <point x="339" y="-167" type="curve" smooth="yes"/>
-      <point x="349" y="-206" type="line" smooth="yes"/>
-      <point x="379" y="-322"/>
-      <point x="429" y="-378"/>
-      <point x="528" y="-378" type="curve" smooth="yes"/>
-      <point x="622" y="-378"/>
-      <point x="688" y="-319"/>
-      <point x="688" y="-185" type="curve" smooth="yes"/>
-      <point x="688" y="-80"/>
-      <point x="655" y="-7"/>
-      <point x="605" y="48" type="curve"/>
-      <point x="546" y="8" type="line"/>
-      <point x="586" y="-39"/>
-      <point x="614" y="-96"/>
-      <point x="614" y="-185" type="curve" smooth="yes"/>
-      <point x="614" y="-262"/>
-      <point x="587" y="-308"/>
-      <point x="527" y="-308" type="curve" smooth="yes"/>
-      <point x="472" y="-308"/>
-      <point x="445" y="-271"/>
-      <point x="421" y="-185" type="curve" smooth="yes"/>
-      <point x="409" y="-142" type="line" smooth="yes"/>
-      <point x="392" y="-83"/>
-      <point x="372" y="-36"/>
-      <point x="330" y="-10" type="curve"/>
-      <point x="333" y="0" type="line"/>
-      <point x="599" y="0" type="line"/>
+      <point x="63" y="0" type="line"/>
       <point x="629" y="0" type="line"/>
       <point x="629" y="340" type="line" smooth="yes"/>
       <point x="629" y="497"/>
@@ -59,29 +15,72 @@
       <point x="169" y="612"/>
       <point x="63" y="496"/>
       <point x="63" y="339" type="curve" smooth="yes"/>
-      <point x="63" y="3" type="line"/>
-      <point x="86" y="26" type="line"/>
-      <point x="14" y="-9"/>
-      <point x="-28" y="-85"/>
-      <point x="-28" y="-184" type="curve" smooth="yes"/>
-      <point x="-28" y="-316"/>
-      <point x="44" y="-378"/>
     </contour>
     <contour>
-      <point x="126" y="-313" type="curve" smooth="yes"/>
-      <point x="68" y="-313"/>
-      <point x="41" y="-256"/>
-      <point x="41" y="-200" type="curve"/>
-      <point x="21" y="-208" type="line"/>
-      <point x="42" y="-265" type="line"/>
-      <point x="42" y="-221"/>
-      <point x="74" y="-181"/>
-      <point x="128" y="-181" type="curve" smooth="yes"/>
-      <point x="169" y="-181"/>
-      <point x="189" y="-206"/>
-      <point x="189" y="-245" type="curve" smooth="yes"/>
-      <point x="189" y="-287"/>
-      <point x="168" y="-313"/>
+      <point x="201" y="-378" type="curve" smooth="yes"/>
+      <point x="279" y="-378"/>
+      <point x="328" y="-324"/>
+      <point x="328" y="-238" type="curve" smooth="yes"/>
+      <point x="328" y="-154"/>
+      <point x="289" y="-104"/>
+      <point x="224" y="-104" type="curve" smooth="yes"/>
+      <point x="167" y="-104"/>
+      <point x="120" y="-145"/>
+      <point x="115" y="-199" type="curve"/>
+      <point x="150" y="-158" type="line"/>
+      <point x="91" y="-158" type="line"/>
+      <point x="119" y="-198" type="line"/>
+      <point x="119" y="-84"/>
+      <point x="167" y="-18"/>
+      <point x="250" y="-18" type="curve" smooth="yes"/>
+      <point x="319" y="-18"/>
+      <point x="354" y="-58"/>
+      <point x="369" y="-155" type="curve" smooth="yes"/>
+      <point x="382" y="-238" type="line" smooth="yes"/>
+      <point x="396" y="-328"/>
+      <point x="443" y="-378"/>
+      <point x="515" y="-378" type="curve" smooth="yes"/>
+      <point x="601" y="-378"/>
+      <point x="649" y="-314"/>
+      <point x="649" y="-200" type="curve" smooth="yes"/>
+      <point x="649" y="-114"/>
+      <point x="618" y="-28"/>
+      <point x="560" y="47" type="curve"/>
+      <point x="500" y="6" type="line"/>
+      <point x="549" y="-54"/>
+      <point x="575" y="-126"/>
+      <point x="575" y="-204" type="curve" smooth="yes"/>
+      <point x="575" y="-273"/>
+      <point x="556" y="-308"/>
+      <point x="518" y="-308" type="curve" smooth="yes"/>
+      <point x="479" y="-308"/>
+      <point x="463" y="-281"/>
+      <point x="450" y="-201" type="curve" smooth="yes"/>
+      <point x="437" y="-118" type="line" smooth="yes"/>
+      <point x="421" y="-16"/>
+      <point x="361" y="32"/>
+      <point x="252" y="32" type="curve" smooth="yes"/>
+      <point x="129" y="32"/>
+      <point x="53" y="-50"/>
+      <point x="53" y="-184" type="curve" smooth="yes"/>
+      <point x="53" y="-302"/>
+      <point x="111" y="-378"/>
+    </contour>
+    <contour>
+      <point x="197" y="-312" type="curve" smooth="yes"/>
+      <point x="143" y="-312"/>
+      <point x="122" y="-267"/>
+      <point x="122" y="-213" type="curve"/>
+      <point x="102" y="-221" type="line"/>
+      <point x="123" y="-245" type="line"/>
+      <point x="123" y="-203"/>
+      <point x="154" y="-164"/>
+      <point x="199" y="-164" type="curve" smooth="yes"/>
+      <point x="238" y="-164"/>
+      <point x="258" y="-193"/>
+      <point x="258" y="-238" type="curve" smooth="yes"/>
+      <point x="258" y="-284"/>
+      <point x="237" y="-312"/>
     </contour>
     <contour>
       <point x="113" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
@@ -6,13 +6,13 @@
   <anchor x="872" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="218" y="-16" type="curve" smooth="yes"/>
-      <point x="302" y="-16"/>
-      <point x="351" y="30"/>
-      <point x="375" y="96" type="curve"/>
-      <point x="385" y="96" type="line"/>
-      <point x="415" y="24"/>
-      <point x="473" y="-16"/>
+      <point x="222" y="-16" type="curve" smooth="yes"/>
+      <point x="292" y="-16"/>
+      <point x="345" y="23"/>
+      <point x="372" y="94" type="curve"/>
+      <point x="382" y="94" type="line"/>
+      <point x="414" y="25"/>
+      <point x="472" y="-16"/>
       <point x="552" y="-16" type="curve" smooth="yes"/>
       <point x="688" y="-16"/>
       <point x="764" y="104"/>
@@ -27,61 +27,61 @@
       <point x="374" y="498" type="line"/>
       <point x="352" y="566"/>
       <point x="301" y="612"/>
-      <point x="218" y="612" type="curve" smooth="yes"/>
+      <point x="217" y="612" type="curve" smooth="yes"/>
       <point x="112" y="612"/>
-      <point x="53" y="541"/>
-      <point x="53" y="450" type="curve" smooth="yes"/>
-      <point x="53" y="382"/>
-      <point x="88" y="327"/>
-      <point x="142" y="303" type="curve"/>
-      <point x="142" y="293" type="line"/>
-      <point x="86" y="272"/>
-      <point x="46" y="221"/>
-      <point x="46" y="150" type="curve" smooth="yes"/>
-      <point x="46" y="56"/>
-      <point x="111" y="-16"/>
+      <point x="53" y="543"/>
+      <point x="53" y="454" type="curve" smooth="yes"/>
+      <point x="53" y="393"/>
+      <point x="87" y="347"/>
+      <point x="142" y="323" type="curve"/>
+      <point x="142" y="313" type="line"/>
+      <point x="87" y="289"/>
+      <point x="46" y="233"/>
+      <point x="46" y="157" type="curve" smooth="yes"/>
+      <point x="46" y="59"/>
+      <point x="122" y="-16"/>
     </contour>
     <contour>
       <point x="855" y="-16" type="curve" smooth="yes"/>
       <point x="955" y="-16"/>
-      <point x="1023" y="53"/>
-      <point x="1023" y="155" type="curve" smooth="yes"/>
-      <point x="1023" y="264"/>
-      <point x="943" y="333"/>
-      <point x="816" y="333" type="curve" smooth="yes"/>
-      <point x="267" y="333" type="line" smooth="yes"/>
-      <point x="176" y="333"/>
-      <point x="135" y="381"/>
-      <point x="135" y="445" type="curve" smooth="yes"/>
-      <point x="135" y="498"/>
+      <point x="1023" y="57"/>
+      <point x="1023" y="166" type="curve" smooth="yes"/>
+      <point x="1023" y="283"/>
+      <point x="942" y="353"/>
+      <point x="807" y="353" type="curve" smooth="yes"/>
+      <point x="267" y="353" type="line" smooth="yes"/>
+      <point x="176" y="353"/>
+      <point x="135" y="394"/>
+      <point x="135" y="449" type="curve" smooth="yes"/>
+      <point x="135" y="500"/>
       <point x="169" y="534"/>
-      <point x="227" y="534" type="curve" smooth="yes"/>
+      <point x="226" y="534" type="curve" smooth="yes"/>
       <point x="306" y="534"/>
       <point x="338" y="475"/>
       <point x="338" y="375" type="curve" smooth="yes"/>
-      <point x="338" y="221" type="line" smooth="yes"/>
-      <point x="338" y="125"/>
-      <point x="294" y="62"/>
-      <point x="224" y="62" type="curve" smooth="yes"/>
-      <point x="163" y="62"/>
-      <point x="128" y="100"/>
-      <point x="128" y="156" type="curve" smooth="yes"/>
-      <point x="128" y="217"/>
-      <point x="171" y="259"/>
-      <point x="243" y="259" type="curve" smooth="yes"/>
-      <point x="820" y="259" type="line" smooth="yes"/>
-      <point x="900" y="259"/>
-      <point x="941" y="223"/>
-      <point x="941" y="157" type="curve" smooth="yes"/>
-      <point x="941" y="94"/>
-      <point x="907" y="60"/>
+      <point x="338" y="209" type="line" smooth="yes"/>
+      <point x="338" y="112"/>
+      <point x="296" y="62"/>
+      <point x="228" y="62" type="curve" smooth="yes"/>
+      <point x="168" y="62"/>
+      <point x="128" y="102"/>
+      <point x="128" y="163" type="curve" smooth="yes"/>
+      <point x="128" y="233"/>
+      <point x="173" y="279"/>
+      <point x="253" y="279" type="curve" smooth="yes"/>
+      <point x="811" y="279" type="line" smooth="yes"/>
+      <point x="898" y="279"/>
+      <point x="941" y="242"/>
+      <point x="941" y="168" type="curve" smooth="yes"/>
+      <point x="941" y="100"/>
+      <point x="908" y="60"/>
       <point x="852" y="60" type="curve" smooth="yes"/>
-      <point x="832" y="60"/>
-      <point x="814" y="63"/>
+      <point x="833" y="60"/>
+      <point x="815" y="63"/>
       <point x="800" y="68" type="curve"/>
       <point x="779" y="-5" type="line"/>
-      <point x="802" y="-12"/>
-      <point x="824" y="-16"/>
+      <point x="805" y="-13"/>
+      <point x="827" y="-16"/>
     </contour>
     <contour>
       <point x="550" y="62" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1542"/>
-  <anchor x="1141" y="-16" name="bottom"/>
-  <anchor x="801" y="596" name="top"/>
-  <anchor x="1409" y="596" name="topright"/>
+  <advance width="1592"/>
+  <anchor x="1167" y="-6" name="bottom"/>
+  <anchor x="796" y="596" name="top"/>
+  <anchor x="1428" y="596" name="topright"/>
   <outline>
     <contour>
       <point x="287" y="-16" type="curve" smooth="yes"/>
@@ -45,112 +45,112 @@
       <point x="821" y="548"/>
       <point x="833" y="547"/>
       <point x="845" y="546" type="curve"/>
-      <point x="801" y="586" type="line"/>
-      <point x="809" y="539" type="line"/>
-      <point x="778" y="512"/>
-      <point x="764" y="476"/>
-      <point x="764" y="435" type="curve" smooth="yes"/>
-      <point x="764" y="362"/>
-      <point x="819" y="306"/>
-      <point x="901" y="306" type="curve" smooth="yes"/>
-      <point x="994" y="306"/>
-      <point x="1041" y="363"/>
-      <point x="1041" y="443" type="curve" smooth="yes"/>
-      <point x="1041" y="476"/>
-      <point x="1027" y="519"/>
-      <point x="982" y="545" type="curve"/>
-      <point x="994" y="592" type="line"/>
-      <point x="900" y="555" type="line"/>
-      <point x="914" y="557"/>
-      <point x="927" y="557"/>
-      <point x="939" y="557" type="curve" smooth="yes"/>
-      <point x="1070" y="557"/>
-      <point x="1104" y="467"/>
-      <point x="1104" y="396" type="curve" smooth="yes"/>
-      <point x="1104" y="353" type="line"/>
-      <point x="1188" y="353" type="line"/>
-      <point x="1188" y="388" type="line" smooth="yes"/>
-      <point x="1188" y="479"/>
-      <point x="1232" y="534"/>
-      <point x="1307" y="534" type="curve" smooth="yes"/>
-      <point x="1371" y="534"/>
-      <point x="1406" y="490"/>
-      <point x="1406" y="425" type="curve" smooth="yes"/>
-      <point x="1406" y="359"/>
-      <point x="1368" y="294"/>
-      <point x="1245" y="294" type="curve" smooth="yes"/>
-      <point x="976" y="294" type="line" smooth="yes"/>
-      <point x="838" y="294"/>
-      <point x="770" y="226"/>
-      <point x="770" y="133" type="curve" smooth="yes"/>
-      <point x="770" y="46"/>
-      <point x="821" y="-16"/>
-      <point x="915" y="-16" type="curve" smooth="yes"/>
-      <point x="981" y="-16"/>
-      <point x="1035" y="9"/>
-      <point x="1119" y="59" type="curve" smooth="yes"/>
-      <point x="1209" y="113" type="line"/>
-      <point x="1256" y="145" type="line"/>
-      <point x="1272" y="147" type="line"/>
-      <point x="1311" y="167"/>
-      <point x="1332" y="172"/>
-      <point x="1356" y="172" type="curve" smooth="yes"/>
-      <point x="1397" y="172"/>
-      <point x="1417" y="152"/>
-      <point x="1417" y="111" type="curve" smooth="yes"/>
-      <point x="1417" y="72"/>
-      <point x="1395" y="48"/>
-      <point x="1360" y="48" type="curve" smooth="yes"/>
-      <point x="1324" y="48"/>
-      <point x="1304" y="70"/>
-      <point x="1304" y="109" type="curve" smooth="yes"/>
-      <point x="1304" y="139"/>
-      <point x="1314" y="162"/>
-      <point x="1339" y="190" type="curve"/>
-      <point x="1237" y="155" type="line"/>
-      <point x="1257" y="134" type="line"/>
-      <point x="1253" y="125"/>
-      <point x="1248" y="109"/>
-      <point x="1248" y="90" type="curve" smooth="yes"/>
-      <point x="1248" y="26"/>
-      <point x="1293" y="-16"/>
-      <point x="1361" y="-16" type="curve" smooth="yes"/>
-      <point x="1435" y="-16"/>
-      <point x="1483" y="33"/>
-      <point x="1483" y="110" type="curve" smooth="yes"/>
-      <point x="1483" y="187"/>
-      <point x="1434" y="238"/>
-      <point x="1360" y="238" type="curve" smooth="yes"/>
-      <point x="1300" y="238"/>
-      <point x="1262" y="224"/>
-      <point x="1164" y="169" type="curve" smooth="yes"/>
-      <point x="1089" y="127" type="line" smooth="yes"/>
-      <point x="1002" y="78"/>
-      <point x="969" y="61"/>
-      <point x="924" y="61" type="curve" smooth="yes"/>
-      <point x="878" y="61"/>
-      <point x="848" y="80"/>
-      <point x="848" y="134" type="curve" smooth="yes"/>
-      <point x="848" y="187"/>
-      <point x="884" y="222"/>
-      <point x="979" y="222" type="curve" smooth="yes"/>
-      <point x="1229" y="222" type="line" smooth="yes"/>
-      <point x="1422" y="222"/>
-      <point x="1488" y="320"/>
-      <point x="1488" y="428" type="curve" smooth="yes"/>
-      <point x="1488" y="534"/>
-      <point x="1416" y="612"/>
-      <point x="1309" y="612" type="curve" smooth="yes"/>
-      <point x="1225" y="612"/>
-      <point x="1168" y="565"/>
-      <point x="1150" y="490" type="curve"/>
-      <point x="1145" y="490" type="line"/>
-      <point x="1123" y="565"/>
-      <point x="1050" y="612"/>
-      <point x="957" y="612" type="curve" smooth="yes"/>
-      <point x="924" y="612"/>
-      <point x="897" y="605"/>
-      <point x="877" y="595" type="curve"/>
+      <point x="810" y="568" type="line"/>
+      <point x="817" y="539" type="line"/>
+      <point x="784" y="510"/>
+      <point x="764" y="469"/>
+      <point x="764" y="422" type="curve" smooth="yes"/>
+      <point x="764" y="346"/>
+      <point x="827" y="286"/>
+      <point x="909" y="286" type="curve" smooth="yes"/>
+      <point x="995" y="286"/>
+      <point x="1051" y="341"/>
+      <point x="1051" y="420" type="curve" smooth="yes"/>
+      <point x="1051" y="474"/>
+      <point x="1031" y="519"/>
+      <point x="993" y="544" type="curve"/>
+      <point x="1004" y="579" type="line"/>
+      <point x="945" y="550" type="line"/>
+      <point x="953" y="552"/>
+      <point x="965" y="554"/>
+      <point x="978" y="554" type="curve" smooth="yes"/>
+      <point x="1074" y="554"/>
+      <point x="1120" y="500"/>
+      <point x="1120" y="392" type="curve" smooth="yes"/>
+      <point x="1120" y="333" type="line"/>
+      <point x="1204" y="333" type="line"/>
+      <point x="1204" y="392" type="line" smooth="yes"/>
+      <point x="1204" y="483"/>
+      <point x="1256" y="534"/>
+      <point x="1337" y="534" type="curve" smooth="yes"/>
+      <point x="1416" y="534"/>
+      <point x="1456" y="490"/>
+      <point x="1456" y="415" type="curve" smooth="yes"/>
+      <point x="1456" y="313"/>
+      <point x="1395" y="264"/>
+      <point x="1267" y="264" type="curve" smooth="yes"/>
+      <point x="945" y="264" type="line" smooth="yes"/>
+      <point x="838" y="264"/>
+      <point x="770" y="209"/>
+      <point x="770" y="122" type="curve" smooth="yes"/>
+      <point x="770" y="37"/>
+      <point x="835" y="-16"/>
+      <point x="928" y="-16" type="curve" smooth="yes"/>
+      <point x="979" y="-16"/>
+      <point x="1021" y="-5"/>
+      <point x="1086" y="27" type="curve" smooth="yes"/>
+      <point x="1231" y="98" type="line"/>
+      <point x="1296" y="147" type="line"/>
+      <point x="1322" y="147" type="line"/>
+      <point x="1347" y="167"/>
+      <point x="1370" y="178"/>
+      <point x="1402" y="178" type="curve" smooth="yes"/>
+      <point x="1443" y="178"/>
+      <point x="1463" y="156"/>
+      <point x="1463" y="117" type="curve" smooth="yes"/>
+      <point x="1463" y="78"/>
+      <point x="1439" y="56"/>
+      <point x="1401" y="56" type="curve" smooth="yes"/>
+      <point x="1361" y="56"/>
+      <point x="1339" y="78"/>
+      <point x="1339" y="116" type="curve" smooth="yes"/>
+      <point x="1339" y="144"/>
+      <point x="1349" y="164"/>
+      <point x="1374" y="190" type="curve"/>
+      <point x="1270" y="150" type="line"/>
+      <point x="1291" y="129" type="line"/>
+      <point x="1286" y="117"/>
+      <point x="1283" y="103"/>
+      <point x="1283" y="86" type="curve" smooth="yes"/>
+      <point x="1283" y="24"/>
+      <point x="1333" y="-16"/>
+      <point x="1404" y="-16" type="curve" smooth="yes"/>
+      <point x="1484" y="-16"/>
+      <point x="1535" y="33"/>
+      <point x="1535" y="110" type="curve" smooth="yes"/>
+      <point x="1535" y="182"/>
+      <point x="1494" y="232"/>
+      <point x="1410" y="232" type="curve" smooth="yes"/>
+      <point x="1364" y="232"/>
+      <point x="1329" y="222"/>
+      <point x="1252" y="184" type="curve" smooth="yes"/>
+      <point x="1057" y="89" type="line" smooth="yes"/>
+      <point x="1014" y="68"/>
+      <point x="976" y="58"/>
+      <point x="933" y="58" type="curve" smooth="yes"/>
+      <point x="883" y="58"/>
+      <point x="852" y="80"/>
+      <point x="852" y="123" type="curve" smooth="yes"/>
+      <point x="852" y="168"/>
+      <point x="884" y="192"/>
+      <point x="949" y="192" type="curve" smooth="yes"/>
+      <point x="1259" y="192" type="line" smooth="yes"/>
+      <point x="1430" y="192"/>
+      <point x="1538" y="279"/>
+      <point x="1538" y="417" type="curve" smooth="yes"/>
+      <point x="1538" y="532"/>
+      <point x="1468" y="612"/>
+      <point x="1350" y="612" type="curve" smooth="yes"/>
+      <point x="1259" y="612"/>
+      <point x="1199" y="567"/>
+      <point x="1173" y="494" type="curve"/>
+      <point x="1163" y="494" type="line"/>
+      <point x="1132" y="574"/>
+      <point x="1073" y="612"/>
+      <point x="975" y="612" type="curve" smooth="yes"/>
+      <point x="941" y="612"/>
+      <point x="909" y="606"/>
+      <point x="881" y="595" type="curve"/>
       <point x="904" y="595" type="line"/>
       <point x="878" y="605"/>
       <point x="844" y="612"/>
@@ -169,19 +169,19 @@
       <point x="150" y="-16"/>
     </contour>
     <contour>
-      <point x="902" y="376" type="curve" smooth="yes"/>
-      <point x="865" y="376"/>
-      <point x="836" y="400"/>
-      <point x="836" y="450" type="curve" smooth="yes"/>
-      <point x="836" y="492"/>
-      <point x="862" y="541"/>
-      <point x="930" y="549" type="curve"/>
-      <point x="851" y="544" type="line"/>
-      <point x="927" y="543"/>
-      <point x="965" y="501"/>
-      <point x="965" y="448" type="curve" smooth="yes"/>
-      <point x="965" y="402"/>
-      <point x="943" y="376"/>
+      <point x="909" y="356" type="curve" smooth="yes"/>
+      <point x="866" y="356"/>
+      <point x="840" y="386"/>
+      <point x="840" y="431" type="curve" smooth="yes"/>
+      <point x="840" y="489"/>
+      <point x="867" y="530"/>
+      <point x="940" y="552" type="curve"/>
+      <point x="875" y="552" type="line"/>
+      <point x="948" y="530"/>
+      <point x="975" y="489"/>
+      <point x="975" y="431" type="curve" smooth="yes"/>
+      <point x="975" y="386"/>
+      <point x="952" y="356"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/t_la-malayalam.glif
@@ -56,22 +56,6 @@
       <point x="300" y="-378"/>
     </contour>
     <contour>
-      <point x="382" y="-313" type="curve" smooth="yes"/>
-      <point x="324" y="-313"/>
-      <point x="297" y="-256"/>
-      <point x="297" y="-200" type="curve"/>
-      <point x="277" y="-208" type="line"/>
-      <point x="298" y="-265" type="line"/>
-      <point x="298" y="-221"/>
-      <point x="330" y="-181"/>
-      <point x="384" y="-181" type="curve" smooth="yes"/>
-      <point x="425" y="-181"/>
-      <point x="445" y="-206"/>
-      <point x="445" y="-245" type="curve" smooth="yes"/>
-      <point x="445" y="-287"/>
-      <point x="424" y="-313"/>
-    </contour>
-    <contour>
       <point x="176" y="-16" type="curve"/>
       <point x="237" y="36" type="line"/>
       <point x="169" y="109"/>
@@ -94,6 +78,22 @@
       <point x="93" y="72"/>
     </contour>
     <contour>
+      <point x="382" y="-313" type="curve" smooth="yes"/>
+      <point x="324" y="-313"/>
+      <point x="297" y="-256"/>
+      <point x="297" y="-200" type="curve"/>
+      <point x="277" y="-208" type="line"/>
+      <point x="298" y="-265" type="line"/>
+      <point x="298" y="-221"/>
+      <point x="330" y="-181"/>
+      <point x="384" y="-181" type="curve" smooth="yes"/>
+      <point x="425" y="-181"/>
+      <point x="445" y="-206"/>
+      <point x="445" y="-245" type="curve" smooth="yes"/>
+      <point x="445" y="-287"/>
+      <point x="424" y="-313"/>
+    </contour>
+    <contour>
       <point x="783" y="-308" type="curve" smooth="yes"/>
       <point x="728" y="-308"/>
       <point x="701" y="-271"/>
@@ -106,11 +106,11 @@
       <point x="664" y="44"/>
       <point x="699" y="129"/>
       <point x="699" y="249" type="curve" smooth="yes"/>
-      <point x="699" y="370"/>
-      <point x="646" y="484"/>
-      <point x="555" y="551" type="curve"/>
-      <point x="483" y="505" type="line"/>
-      <point x="568" y="458"/>
+      <point x="699" y="369"/>
+      <point x="647" y="482"/>
+      <point x="557" y="549" type="curve"/>
+      <point x="485" y="504" type="line"/>
+      <point x="569" y="457"/>
       <point x="613" y="358"/>
       <point x="613" y="249" type="curve" smooth="yes"/>
       <point x="613" y="129"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="597"/>
-  <anchor x="331" y="-219" name="bottom"/>
+  <anchor x="329" y="-271" name="bottom"/>
   <anchor x="296" y="596" name="top"/>
   <anchor x="435" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="301" y="-225" type="curve" smooth="yes"/>
-      <point x="462" y="-225"/>
-      <point x="551" y="-171"/>
-      <point x="551" y="-69" type="curve" smooth="yes"/>
-      <point x="551" y="-9"/>
-      <point x="513" y="33"/>
+      <point x="301" y="-277" type="curve" smooth="yes"/>
+      <point x="457" y="-277"/>
+      <point x="551" y="-209"/>
+      <point x="551" y="-96" type="curve" smooth="yes"/>
+      <point x="551" y="-22"/>
+      <point x="512" y="27"/>
       <point x="442" y="42" type="curve"/>
       <point x="442" y="52" type="line"/>
-      <point x="491" y="66"/>
-      <point x="541" y="102"/>
-      <point x="541" y="194" type="curve" smooth="yes"/>
-      <point x="541" y="292"/>
-      <point x="482" y="348"/>
+      <point x="507" y="75"/>
+      <point x="541" y="121"/>
+      <point x="541" y="186" type="curve" smooth="yes"/>
+      <point x="541" y="291"/>
+      <point x="472" y="349"/>
       <point x="340" y="355" type="curve" smooth="yes"/>
       <point x="233" y="360" type="line" smooth="yes"/>
       <point x="161" y="363"/>
-      <point x="123" y="393"/>
-      <point x="123" y="446" type="curve" smooth="yes"/>
-      <point x="123" y="506"/>
-      <point x="180" y="531"/>
-      <point x="284" y="531" type="curve" smooth="yes"/>
-      <point x="355" y="531"/>
-      <point x="415" y="518"/>
-      <point x="479" y="492" type="curve"/>
-      <point x="511" y="566" type="line"/>
-      <point x="441" y="598"/>
-      <point x="370" y="612"/>
+      <point x="123" y="391"/>
+      <point x="123" y="441" type="curve" smooth="yes"/>
+      <point x="123" y="503"/>
+      <point x="176" y="534"/>
+      <point x="284" y="534" type="curve" smooth="yes"/>
+      <point x="358" y="534"/>
+      <point x="420" y="521"/>
+      <point x="480" y="494" type="curve"/>
+      <point x="511" y="563" type="line"/>
+      <point x="435" y="597"/>
+      <point x="365" y="612"/>
       <point x="284" y="612" type="curve" smooth="yes"/>
-      <point x="131" y="612"/>
-      <point x="38" y="550"/>
+      <point x="129" y="612"/>
+      <point x="38" y="547"/>
       <point x="38" y="435" type="curve" smooth="yes"/>
-      <point x="38" y="338"/>
-      <point x="107" y="280"/>
+      <point x="38" y="339"/>
+      <point x="106" y="280"/>
       <point x="223" y="273" type="curve" smooth="yes"/>
       <point x="330" y="267" type="line" smooth="yes"/>
-      <point x="418" y="262"/>
-      <point x="459" y="232"/>
-      <point x="459" y="180" type="curve" smooth="yes"/>
-      <point x="459" y="112"/>
-      <point x="405" y="80"/>
+      <point x="414" y="262"/>
+      <point x="456" y="232"/>
+      <point x="456" y="176" type="curve" smooth="yes"/>
+      <point x="456" y="111"/>
+      <point x="404" y="80"/>
       <point x="295" y="80" type="curve" smooth="yes"/>
       <point x="82" y="80" type="line"/>
       <point x="82" y="6" type="line"/>
-      <point x="305" y="6" type="line" smooth="yes"/>
-      <point x="431" y="6"/>
-      <point x="469" y="-17"/>
-      <point x="469" y="-68" type="curve" smooth="yes"/>
-      <point x="469" y="-126"/>
-      <point x="409" y="-147"/>
-      <point x="301" y="-147" type="curve" smooth="yes"/>
-      <point x="208" y="-147"/>
-      <point x="132" y="-125"/>
-      <point x="82" y="-98" type="curve"/>
-      <point x="48" y="-166" type="line"/>
-      <point x="99" y="-198"/>
-      <point x="192" y="-225"/>
+      <point x="319" y="6" type="line" smooth="yes"/>
+      <point x="426" y="6"/>
+      <point x="469" y="-23"/>
+      <point x="469" y="-94" type="curve" smooth="yes"/>
+      <point x="469" y="-162"/>
+      <point x="410" y="-199"/>
+      <point x="301" y="-199" type="curve" smooth="yes"/>
+      <point x="223" y="-199"/>
+      <point x="147" y="-177"/>
+      <point x="87" y="-136" type="curve"/>
+      <point x="46" y="-200" type="line"/>
+      <point x="119" y="-250"/>
+      <point x="209" y="-277"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/tta-malayalam.glif
@@ -8,45 +8,45 @@
   <outline>
     <contour>
       <point x="318" y="-16" type="curve" smooth="yes"/>
-      <point x="465" y="-16"/>
-      <point x="553" y="56"/>
+      <point x="464" y="-16"/>
+      <point x="553" y="55"/>
       <point x="553" y="170" type="curve" smooth="yes"/>
-      <point x="553" y="272"/>
-      <point x="481" y="336"/>
+      <point x="553" y="273"/>
+      <point x="480" y="336"/>
       <point x="352" y="342" type="curve" smooth="yes"/>
       <point x="245" y="347" type="line" smooth="yes"/>
-      <point x="168" y="351"/>
-      <point x="135" y="384"/>
+      <point x="173" y="350"/>
+      <point x="135" y="381"/>
       <point x="135" y="434" type="curve" smooth="yes"/>
       <point x="135" y="497"/>
       <point x="192" y="531"/>
       <point x="296" y="531" type="curve" smooth="yes"/>
-      <point x="365" y="531"/>
-      <point x="427" y="518"/>
+      <point x="364" y="531"/>
+      <point x="426" y="518"/>
       <point x="491" y="491" type="curve"/>
       <point x="523" y="565" type="line"/>
-      <point x="453" y="598"/>
-      <point x="382" y="612"/>
+      <point x="454" y="597"/>
+      <point x="384" y="612"/>
       <point x="296" y="612" type="curve" smooth="yes"/>
-      <point x="142" y="612"/>
-      <point x="50" y="541"/>
+      <point x="143" y="612"/>
+      <point x="50" y="542"/>
       <point x="50" y="427" type="curve" smooth="yes"/>
-      <point x="50" y="330"/>
-      <point x="119" y="264"/>
+      <point x="50" y="328"/>
+      <point x="121" y="264"/>
       <point x="235" y="259" type="curve" smooth="yes"/>
       <point x="342" y="254" type="line" smooth="yes"/>
-      <point x="430" y="250"/>
-      <point x="470" y="217"/>
-      <point x="470" y="162" type="curve" smooth="yes"/>
-      <point x="470" y="99"/>
+      <point x="426" y="250"/>
+      <point x="468" y="219"/>
+      <point x="468" y="162" type="curve" smooth="yes"/>
+      <point x="468" y="99"/>
       <point x="415" y="65"/>
       <point x="318" y="65" type="curve" smooth="yes"/>
-      <point x="236" y="65"/>
-      <point x="159" y="89"/>
+      <point x="237" y="65"/>
+      <point x="160" y="88"/>
       <point x="84" y="136" type="curve"/>
       <point x="38" y="61" type="line"/>
-      <point x="123" y="9"/>
-      <point x="216" y="-16"/>
+      <point x="122" y="10"/>
+      <point x="215" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="100" y="31" type="curve"/>
       <point x="184" y="31" type="line"/>
-      <point x="225" y="139"/>
-      <point x="248" y="251"/>
+      <point x="225" y="138"/>
+      <point x="248" y="250"/>
       <point x="248" y="339" type="curve" smooth="yes"/>
       <point x="248" y="515"/>
       <point x="170" y="612"/>
@@ -17,52 +17,58 @@
       <point x="120" y="534"/>
       <point x="166" y="478"/>
       <point x="166" y="337" type="curve" smooth="yes"/>
-      <point x="166" y="241"/>
-      <point x="143" y="133"/>
+      <point x="166" y="240"/>
+      <point x="143" y="132"/>
     </contour>
     <contour>
       <point x="144" y="-259" type="curve" smooth="yes"/>
-      <point x="249" y="-259"/>
-      <point x="323" y="-191"/>
-      <point x="323" y="-95" type="curve" smooth="yes"/>
-      <point x="323" y="3"/>
-      <point x="244" y="82"/>
+      <point x="248" y="-259"/>
+      <point x="323" y="-189"/>
+      <point x="323" y="-93" type="curve" smooth="yes"/>
+      <point x="323" y="6"/>
+      <point x="245" y="82"/>
       <point x="144" y="82" type="curve" smooth="yes"/>
-      <point x="45" y="82"/>
-      <point x="-32" y="5"/>
+      <point x="44" y="82"/>
+      <point x="-32" y="7"/>
       <point x="-32" y="-93" type="curve" smooth="yes"/>
-      <point x="-32" y="-191"/>
-      <point x="40" y="-259"/>
+      <point x="-32" y="-190"/>
+      <point x="41" y="-259"/>
     </contour>
     <contour>
-      <point x="145" y="-185" type="curve" smooth="yes"/>
-      <point x="77" y="-185"/>
-      <point x="40" y="-150"/>
-      <point x="40" y="-85" type="curve" smooth="yes"/>
-      <point x="40" y="-20"/>
-      <point x="79" y="17"/>
-      <point x="145" y="17" type="curve" smooth="yes"/>
-      <point x="211" y="17"/>
-      <point x="251" y="-21"/>
-      <point x="251" y="-85" type="curve" smooth="yes"/>
-      <point x="251" y="-149"/>
-      <point x="213" y="-185"/>
+      <point x="146" y="-185" type="curve" smooth="yes"/>
+      <point x="81" y="-185"/>
+      <point x="39" y="-146"/>
+      <point x="39" y="-85" type="curve" smooth="yes"/>
+      <point x="39" y="-78"/>
+      <point x="40" y="-71"/>
+      <point x="41" y="-65" type="curve"/>
+      <point x="47" y="-65" type="line"/>
+      <point x="62" y="-105"/>
+      <point x="96" y="-127"/>
+      <point x="146" y="-127" type="curve" smooth="yes"/>
+      <point x="196" y="-127"/>
+      <point x="229" y="-105"/>
+      <point x="245" y="-65" type="curve"/>
+      <point x="251" y="-65" type="line"/>
+      <point x="252" y="-71"/>
+      <point x="253" y="-78"/>
+      <point x="253" y="-85" type="curve" smooth="yes"/>
+      <point x="253" y="-145"/>
+      <point x="211" y="-185"/>
     </contour>
     <contour>
-      <point x="145" y="-115" type="curve" smooth="yes"/>
-      <point x="199" y="-115"/>
-      <point x="243" y="-101"/>
-      <point x="279" y="-78" type="curve"/>
-      <point x="256" y="-42" type="line"/>
-      <point x="229" y="-49"/>
-      <point x="192" y="-53"/>
-      <point x="145" y="-53" type="curve" smooth="yes"/>
-      <point x="98" y="-53"/>
-      <point x="60" y="-49"/>
-      <point x="34" y="-42" type="curve"/>
-      <point x="11" y="-78" type="line"/>
-      <point x="47" y="-101"/>
-      <point x="91" y="-115"/>
+      <point x="146" y="-57" type="curve" smooth="yes"/>
+      <point x="95" y="-57"/>
+      <point x="69" y="-35"/>
+      <point x="69" y="-10" type="curve" smooth="yes"/>
+      <point x="69" y="12"/>
+      <point x="98" y="24"/>
+      <point x="146" y="24" type="curve" smooth="yes"/>
+      <point x="194" y="24"/>
+      <point x="223" y="12"/>
+      <point x="223" y="-10" type="curve" smooth="yes"/>
+      <point x="223" y="-35"/>
+      <point x="197" y="-57"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/v_va-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/v_va-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="v_va-malayalam" format="2">
   <advance width="1053"/>
   <anchor x="699" y="-306" name="bottom"/>
-  <anchor x="944" y="0" name="bottomright"/>
   <anchor x="553" y="596" name="top"/>
   <anchor x="924" y="596" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/y_ya-malayalam.glif
@@ -1,97 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="1008"/>
-  <anchor x="614" y="-322" name="bottom"/>
-  <anchor x="859" y="-16" name="bottomright"/>
+  <anchor x="614" y="-306" name="bottom"/>
   <anchor x="515" y="596" name="top"/>
   <anchor x="821" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="309" y="-322" type="line"/>
-      <point x="879" y="-322" type="line"/>
+      <point x="309" y="-306" type="line"/>
+      <point x="879" y="-306" type="line"/>
       <point x="879" y="105" type="line"/>
-      <point x="865" y="55" type="line"/>
-      <point x="924" y="113"/>
-      <point x="954" y="203"/>
-      <point x="954" y="309" type="curve" smooth="yes"/>
-      <point x="954" y="413"/>
-      <point x="915" y="526"/>
-      <point x="843" y="612" type="curve"/>
-      <point x="775" y="563" type="line"/>
-      <point x="829" y="494"/>
-      <point x="872" y="410"/>
-      <point x="872" y="311" type="curve" smooth="yes"/>
-      <point x="872" y="165"/>
-      <point x="828" y="62"/>
-      <point x="677" y="62" type="curve" smooth="yes"/>
-      <point x="498" y="62"/>
-      <point x="417" y="212"/>
-      <point x="417" y="373" type="curve" smooth="yes"/>
-      <point x="417" y="473"/>
-      <point x="454" y="534"/>
-      <point x="516" y="534" type="curve" smooth="yes"/>
-      <point x="579" y="534"/>
-      <point x="616" y="472"/>
-      <point x="616" y="374" type="curve" smooth="yes"/>
-      <point x="616" y="257"/>
-      <point x="580" y="160"/>
-      <point x="506" y="105" type="curve"/>
-      <point x="559" y="51" type="line"/>
-      <point x="650" y="125"/>
-      <point x="698" y="244"/>
-      <point x="698" y="378" type="curve" smooth="yes"/>
-      <point x="698" y="515"/>
-      <point x="633" y="612"/>
-      <point x="516" y="612" type="curve" smooth="yes"/>
-      <point x="397" y="612"/>
-      <point x="335" y="512"/>
-      <point x="335" y="382" type="curve" smooth="yes"/>
-      <point x="335" y="197"/>
-      <point x="456" y="-13"/>
-      <point x="683" y="-13" type="curve" smooth="yes"/>
-      <point x="702" y="-13"/>
-      <point x="722" y="-11"/>
-      <point x="743" y="-8" type="curve"/>
-      <point x="662" y="25" type="line"/>
-      <point x="679" y="-27" type="line"/>
-      <point x="596" y="-72" type="line"/>
-      <point x="309" y="-264" type="line"/>
+      <point x="867" y="76" type="line"/>
+      <point x="922" y="134"/>
+      <point x="954" y="216"/>
+      <point x="954" y="313" type="curve" smooth="yes"/>
+      <point x="954" y="419"/>
+      <point x="910" y="527"/>
+      <point x="831" y="612" type="curve"/>
+      <point x="769" y="561" type="line"/>
+      <point x="840" y="486"/>
+      <point x="874" y="407"/>
+      <point x="874" y="315" type="curve" smooth="yes"/>
+      <point x="874" y="155"/>
+      <point x="793" y="62"/>
+      <point x="654" y="62" type="curve" smooth="yes"/>
+      <point x="491" y="62"/>
+      <point x="386" y="179"/>
+      <point x="386" y="354" type="curve" smooth="yes"/>
+      <point x="386" y="464"/>
+      <point x="436" y="534"/>
+      <point x="515" y="534" type="curve" smooth="yes"/>
+      <point x="588" y="534"/>
+      <point x="631" y="474"/>
+      <point x="631" y="372" type="curve" smooth="yes"/>
+      <point x="631" y="259"/>
+      <point x="578" y="152"/>
+      <point x="496" y="100" type="curve"/>
+      <point x="553" y="55" type="line"/>
+      <point x="650" y="117"/>
+      <point x="713" y="243"/>
+      <point x="713" y="374" type="curve" smooth="yes"/>
+      <point x="713" y="520"/>
+      <point x="637" y="612"/>
+      <point x="515" y="612" type="curve" smooth="yes"/>
+      <point x="391" y="612"/>
+      <point x="304" y="504"/>
+      <point x="304" y="350" type="curve" smooth="yes"/>
+      <point x="304" y="153"/>
+      <point x="461" y="-14"/>
+      <point x="655" y="-14" type="curve" smooth="yes"/>
+      <point x="685" y="-14"/>
+      <point x="713" y="-10"/>
+      <point x="739" y="-3" type="curve"/>
+      <point x="645" y="29" type="line"/>
+      <point x="651" y="-23" type="line"/>
+      <point x="579" y="-62" type="line"/>
+      <point x="309" y="-248" type="line"/>
     </contour>
     <contour>
-      <point x="392" y="-293" type="line"/>
-      <point x="815" y="-1" type="line"/>
-      <point x="797" y="-1" type="line"/>
-      <point x="797" y="-270" type="line"/>
-      <point x="832" y="-257" type="line"/>
-      <point x="392" y="-257" type="line"/>
+      <point x="392" y="-277" type="line"/>
+      <point x="815" y="15" type="line"/>
+      <point x="797" y="15" type="line"/>
+      <point x="797" y="-254" type="line"/>
+      <point x="832" y="-241" type="line"/>
+      <point x="392" y="-241" type="line"/>
     </contour>
     <contour>
-      <point x="358" y="-16" type="curve" smooth="yes"/>
-      <point x="430" y="-16"/>
-      <point x="487" y="3"/>
-      <point x="534" y="34" type="curve"/>
-      <point x="472" y="86" type="line"/>
-      <point x="442" y="71"/>
-      <point x="417" y="62"/>
-      <point x="362" y="62" type="curve" smooth="yes"/>
-      <point x="219" y="62"/>
-      <point x="136" y="171"/>
-      <point x="136" y="333" type="curve" smooth="yes"/>
-      <point x="136" y="444"/>
-      <point x="189" y="534"/>
-      <point x="286" y="534" type="curve" smooth="yes"/>
-      <point x="333" y="534"/>
-      <point x="361" y="517"/>
-      <point x="383" y="492" type="curve"/>
-      <point x="425" y="546" type="line"/>
-      <point x="392" y="588"/>
-      <point x="348" y="612"/>
-      <point x="283" y="612" type="curve" smooth="yes"/>
-      <point x="143" y="612"/>
-      <point x="54" y="492"/>
+      <point x="373" y="-16" type="curve" smooth="yes"/>
+      <point x="434" y="-16"/>
+      <point x="490" y="2"/>
+      <point x="530" y="37" type="curve"/>
+      <point x="473" y="88" type="line"/>
+      <point x="446" y="69"/>
+      <point x="418" y="62"/>
+      <point x="379" y="62" type="curve" smooth="yes"/>
+      <point x="230" y="62"/>
+      <point x="134" y="167"/>
+      <point x="134" y="333" type="curve" smooth="yes"/>
+      <point x="134" y="455"/>
+      <point x="194" y="534"/>
+      <point x="282" y="534" type="curve" smooth="yes"/>
+      <point x="322" y="534"/>
+      <point x="348" y="519"/>
+      <point x="375" y="491" type="curve"/>
+      <point x="431" y="545" type="line"/>
+      <point x="383" y="595"/>
+      <point x="346" y="612"/>
+      <point x="290" y="612" type="curve" smooth="yes"/>
+      <point x="150" y="612"/>
+      <point x="54" y="499"/>
       <point x="54" y="331" type="curve" smooth="yes"/>
       <point x="54" y="128"/>
-      <point x="172" y="-16"/>
+      <point x="187" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ya-malayalam.glif
@@ -8,72 +8,72 @@
   <anchor x="821" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="678" y="-16" type="curve" smooth="yes"/>
-      <point x="859" y="-16"/>
-      <point x="954" y="122"/>
-      <point x="954" y="309" type="curve" smooth="yes"/>
-      <point x="954" y="413"/>
-      <point x="915" y="526"/>
-      <point x="843" y="612" type="curve"/>
-      <point x="775" y="563" type="line"/>
-      <point x="829" y="494"/>
-      <point x="872" y="410"/>
-      <point x="872" y="311" type="curve" smooth="yes"/>
-      <point x="872" y="165"/>
-      <point x="808" y="62"/>
-      <point x="677" y="62" type="curve" smooth="yes"/>
-      <point x="498" y="62"/>
-      <point x="417" y="212"/>
-      <point x="417" y="373" type="curve" smooth="yes"/>
-      <point x="417" y="473"/>
-      <point x="454" y="534"/>
-      <point x="516" y="534" type="curve" smooth="yes"/>
-      <point x="579" y="534"/>
-      <point x="616" y="472"/>
-      <point x="616" y="374" type="curve" smooth="yes"/>
-      <point x="616" y="257"/>
-      <point x="580" y="160"/>
-      <point x="506" y="105" type="curve"/>
-      <point x="559" y="51" type="line"/>
-      <point x="650" y="125"/>
-      <point x="698" y="244"/>
-      <point x="698" y="378" type="curve" smooth="yes"/>
-      <point x="698" y="515"/>
-      <point x="633" y="612"/>
-      <point x="516" y="612" type="curve" smooth="yes"/>
-      <point x="397" y="612"/>
-      <point x="335" y="512"/>
-      <point x="335" y="382" type="curve" smooth="yes"/>
-      <point x="335" y="195"/>
-      <point x="458" y="-16"/>
+      <point x="655" y="-16" type="curve" smooth="yes"/>
+      <point x="832" y="-16"/>
+      <point x="954" y="118"/>
+      <point x="954" y="313" type="curve" smooth="yes"/>
+      <point x="954" y="419"/>
+      <point x="910" y="527"/>
+      <point x="831" y="612" type="curve"/>
+      <point x="769" y="561" type="line"/>
+      <point x="840" y="486"/>
+      <point x="874" y="407"/>
+      <point x="874" y="315" type="curve" smooth="yes"/>
+      <point x="874" y="159"/>
+      <point x="789" y="62"/>
+      <point x="654" y="62" type="curve" smooth="yes"/>
+      <point x="491" y="62"/>
+      <point x="386" y="179"/>
+      <point x="386" y="354" type="curve" smooth="yes"/>
+      <point x="386" y="464"/>
+      <point x="436" y="534"/>
+      <point x="515" y="534" type="curve" smooth="yes"/>
+      <point x="588" y="534"/>
+      <point x="631" y="474"/>
+      <point x="631" y="372" type="curve" smooth="yes"/>
+      <point x="631" y="259"/>
+      <point x="578" y="152"/>
+      <point x="496" y="100" type="curve"/>
+      <point x="553" y="55" type="line"/>
+      <point x="650" y="117"/>
+      <point x="713" y="243"/>
+      <point x="713" y="374" type="curve" smooth="yes"/>
+      <point x="713" y="520"/>
+      <point x="637" y="612"/>
+      <point x="515" y="612" type="curve" smooth="yes"/>
+      <point x="391" y="612"/>
+      <point x="304" y="504"/>
+      <point x="304" y="350" type="curve" smooth="yes"/>
+      <point x="304" y="152"/>
+      <point x="461" y="-16"/>
     </contour>
     <contour>
-      <point x="358" y="-16" type="curve" smooth="yes"/>
-      <point x="430" y="-16"/>
-      <point x="487" y="3"/>
-      <point x="534" y="34" type="curve"/>
-      <point x="472" y="86" type="line"/>
-      <point x="442" y="71"/>
-      <point x="417" y="62"/>
-      <point x="362" y="62" type="curve" smooth="yes"/>
-      <point x="219" y="62"/>
-      <point x="136" y="171"/>
-      <point x="136" y="333" type="curve" smooth="yes"/>
-      <point x="136" y="444"/>
-      <point x="189" y="534"/>
-      <point x="286" y="534" type="curve" smooth="yes"/>
-      <point x="333" y="534"/>
-      <point x="361" y="517"/>
-      <point x="383" y="492" type="curve"/>
-      <point x="425" y="546" type="line"/>
-      <point x="392" y="588"/>
-      <point x="348" y="612"/>
-      <point x="283" y="612" type="curve" smooth="yes"/>
-      <point x="143" y="612"/>
-      <point x="54" y="492"/>
+      <point x="373" y="-16" type="curve" smooth="yes"/>
+      <point x="434" y="-16"/>
+      <point x="490" y="2"/>
+      <point x="530" y="37" type="curve"/>
+      <point x="473" y="88" type="line"/>
+      <point x="446" y="69"/>
+      <point x="418" y="62"/>
+      <point x="379" y="62" type="curve" smooth="yes"/>
+      <point x="230" y="62"/>
+      <point x="134" y="167"/>
+      <point x="134" y="333" type="curve" smooth="yes"/>
+      <point x="134" y="455"/>
+      <point x="194" y="534"/>
+      <point x="282" y="534" type="curve" smooth="yes"/>
+      <point x="322" y="534"/>
+      <point x="348" y="519"/>
+      <point x="375" y="491" type="curve"/>
+      <point x="431" y="545" type="line"/>
+      <point x="383" y="595"/>
+      <point x="346" y="612"/>
+      <point x="290" y="612" type="curve" smooth="yes"/>
+      <point x="150" y="612"/>
+      <point x="54" y="499"/>
       <point x="54" y="331" type="curve" smooth="yes"/>
       <point x="54" y="128"/>
-      <point x="172" y="-16"/>
+      <point x="187" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/kerning.plist
@@ -45782,8 +45782,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -45893,7 +45891,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -45949,7 +45947,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>80</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46002,7 +46000,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>180</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -46049,7 +46047,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -46084,7 +46082,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -46112,8 +46110,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46148,7 +46144,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46217,7 +46213,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46277,7 +46273,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46326,7 +46322,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46384,7 +46380,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46425,7 +46421,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46561,8 +46557,6 @@
       <integer>-30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46591,7 +46585,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46639,8 +46633,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>10</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>0</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>0</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46726,8 +46718,6 @@
       <integer>50</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -46760,7 +46750,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -46835,8 +46825,6 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46880,8 +46868,6 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47001,8 +46987,6 @@
       <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47110,7 +47094,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47157,7 +47141,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47203,41 +47187,39 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>50</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_braceright.loclMALM_R</key>
-      <integer>40</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
       <integer>20</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>40</integer>
-      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>70</integer>
-      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
+      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
+      <integer>60</integer>
+      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
-      <integer>110</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
-      <integer>100</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
       <integer>20</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
       <integer>-20</integer>
-      <key>public.kern2.MAL_rVocalic-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
-      <integer>90</integer>
-      <key>public.kern2.MAL_uMatra-malayalam_L</key>
       <integer>80</integer>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>60</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>220</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
       <integer>150</integer>
     </dict>
@@ -47264,7 +47246,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47313,7 +47295,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47346,8 +47328,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -47387,7 +47367,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47590,7 +47570,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47616,8 +47596,6 @@
       <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47644,7 +47622,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47700,7 +47678,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -47732,8 +47710,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47843,8 +47819,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_p_pa-malayalam_L</key>
@@ -47911,7 +47885,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
@@ -47956,7 +47930,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47997,7 +47971,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48087,7 +48061,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>150</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48226,8 +48200,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48275,8 +48247,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48339,7 +48309,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48392,7 +48362,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>240</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>170</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -48477,7 +48447,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48516,7 +48486,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>130</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48612,8 +48582,6 @@
       <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
-      <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
@@ -48718,7 +48686,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_ng_ka-malayalam_L</key>
@@ -48770,6 +48738,24 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-30</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>-20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>50</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.ODI_a-oriya-L</key>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/c_cha-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/c_cha-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="c_cha-malayalam" format="2">
   <advance width="908"/>
   <anchor x="485" y="-361" name="bottom"/>
-  <anchor x="799" y="0" name="bottomright"/>
   <anchor x="452" y="596" name="top"/>
   <anchor x="778" y="596" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/d_da-malayalam.glif
@@ -1,23 +1,23 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
-  <advance width="689"/>
-  <anchor x="384" y="-209" name="bottom"/>
+  <advance width="679"/>
+  <anchor x="381" y="-269" name="bottom"/>
   <anchor x="376" y="596" name="top"/>
   <outline>
     <contour>
-      <point x="449" y="-225" type="curve" smooth="yes"/>
-      <point x="577" y="-225"/>
-      <point x="641" y="-177"/>
-      <point x="641" y="-86" type="curve" smooth="yes"/>
-      <point x="641" y="-27"/>
-      <point x="602" y="13"/>
-      <point x="532" y="23" type="curve"/>
-      <point x="532" y="33" type="line"/>
-      <point x="581" y="49"/>
-      <point x="631" y="85"/>
+      <point x="414" y="-285" type="curve" smooth="yes"/>
+      <point x="546" y="-285"/>
+      <point x="631" y="-220"/>
+      <point x="631" y="-119" type="curve" smooth="yes"/>
+      <point x="631" y="-47"/>
+      <point x="595" y="4"/>
+      <point x="531" y="22" type="curve"/>
+      <point x="531" y="32" type="line"/>
+      <point x="596" y="53"/>
+      <point x="631" y="100"/>
       <point x="631" y="166" type="curve" smooth="yes"/>
-      <point x="631" y="239"/>
-      <point x="586" y="284"/>
+      <point x="631" y="237"/>
+      <point x="588" y="284"/>
       <point x="511" y="298" type="curve"/>
       <point x="511" y="308" type="line"/>
       <point x="572" y="324"/>
@@ -48,27 +48,27 @@
       <point x="372" y="337" type="line"/>
       <point x="372" y="263" type="line"/>
       <point x="414" y="263" type="line" smooth="yes"/>
-      <point x="500" y="263"/>
-      <point x="549" y="228"/>
+      <point x="502" y="263"/>
+      <point x="549" y="227"/>
       <point x="549" y="159" type="curve" smooth="yes"/>
-      <point x="549" y="94"/>
-      <point x="495" y="62"/>
+      <point x="549" y="99"/>
+      <point x="502" y="62"/>
       <point x="425" y="62" type="curve" smooth="yes"/>
-      <point x="372" y="62" type="line"/>
-      <point x="372" y="-12" type="line"/>
-      <point x="435" y="-12" type="line" smooth="yes"/>
-      <point x="521" y="-12"/>
-      <point x="559" y="-35"/>
-      <point x="559" y="-77" type="curve" smooth="yes"/>
-      <point x="559" y="-126"/>
-      <point x="519" y="-147"/>
-      <point x="452" y="-147" type="curve" smooth="yes"/>
-      <point x="403" y="-147"/>
-      <point x="369" y="-140"/>
-      <point x="336" y="-129" type="curve"/>
-      <point x="308" y="-201" type="line"/>
-      <point x="344" y="-216"/>
-      <point x="397" y="-225"/>
+      <point x="352" y="62" type="line"/>
+      <point x="352" y="-12" type="line"/>
+      <point x="425" y="-12" type="line" smooth="yes"/>
+      <point x="508" y="-12"/>
+      <point x="549" y="-44"/>
+      <point x="549" y="-110" type="curve" smooth="yes"/>
+      <point x="549" y="-173"/>
+      <point x="502" y="-207"/>
+      <point x="416" y="-207" type="curve" smooth="yes"/>
+      <point x="360" y="-207"/>
+      <point x="313" y="-195"/>
+      <point x="261" y="-169" type="curve"/>
+      <point x="228" y="-238" type="line"/>
+      <point x="289" y="-269"/>
+      <point x="352" y="-285"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="987"/>
-  <anchor x="669" y="0" name="bottom"/>
+  <advance width="980"/>
+  <anchor x="662" y="0" name="bottom"/>
   <anchor x="493" y="596" name="top"/>
-  <anchor x="859" y="596" name="topright"/>
+  <anchor x="852" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="284" y="-16" type="curve" smooth="yes"/>
-      <point x="411" y="-16"/>
-      <point x="488" y="72"/>
-      <point x="507" y="240" type="curve" smooth="yes"/>
-      <point x="519" y="348" type="line" smooth="yes"/>
-      <point x="532" y="465"/>
-      <point x="581" y="532"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="463"/>
+      <point x="576" y="532"/>
       <point x="695" y="532" type="curve" smooth="yes"/>
-      <point x="794" y="532"/>
-      <point x="836" y="492"/>
-      <point x="836" y="429" type="curve" smooth="yes"/>
-      <point x="836" y="373"/>
-      <point x="792" y="337"/>
-      <point x="722" y="337" type="curve" smooth="yes"/>
-      <point x="670" y="337" type="line"/>
-      <point x="670" y="263" type="line"/>
-      <point x="722" y="263" type="line" smooth="yes"/>
-      <point x="813" y="263"/>
-      <point x="857" y="225"/>
-      <point x="857" y="161" type="curve" smooth="yes"/>
-      <point x="857" y="94"/>
-      <point x="815" y="62"/>
-      <point x="741" y="62" type="curve" smooth="yes"/>
-      <point x="707" y="62"/>
-      <point x="679" y="70"/>
-      <point x="650" y="83" type="curve"/>
-      <point x="614" y="10" type="line"/>
-      <point x="650" y="-7"/>
-      <point x="694" y="-16"/>
-      <point x="742" y="-16" type="curve" smooth="yes"/>
-      <point x="860" y="-16"/>
-      <point x="939" y="48"/>
-      <point x="939" y="155" type="curve" smooth="yes"/>
-      <point x="939" y="230"/>
-      <point x="893" y="284"/>
-      <point x="819" y="298" type="curve"/>
-      <point x="819" y="308" type="line"/>
-      <point x="882" y="325"/>
-      <point x="918" y="375"/>
-      <point x="918" y="439" type="curve" smooth="yes"/>
-      <point x="918" y="539"/>
-      <point x="842" y="612"/>
-      <point x="690" y="612" type="curve" smooth="yes"/>
-      <point x="533" y="612"/>
-      <point x="444" y="523"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="789" y="532"/>
+      <point x="829" y="493"/>
+      <point x="829" y="433" type="curve" smooth="yes"/>
+      <point x="829" y="375"/>
+      <point x="785" y="337"/>
+      <point x="715" y="337" type="curve" smooth="yes"/>
+      <point x="663" y="337" type="line"/>
+      <point x="663" y="263" type="line"/>
+      <point x="715" y="263" type="line" smooth="yes"/>
+      <point x="806" y="263"/>
+      <point x="850" y="225"/>
+      <point x="850" y="161" type="curve" smooth="yes"/>
+      <point x="850" y="94"/>
+      <point x="808" y="62"/>
+      <point x="734" y="62" type="curve" smooth="yes"/>
+      <point x="700" y="62"/>
+      <point x="672" y="70"/>
+      <point x="643" y="83" type="curve"/>
+      <point x="607" y="10" type="line"/>
+      <point x="643" y="-7"/>
+      <point x="687" y="-16"/>
+      <point x="735" y="-16" type="curve" smooth="yes"/>
+      <point x="853" y="-16"/>
+      <point x="932" y="48"/>
+      <point x="932" y="155" type="curve" smooth="yes"/>
+      <point x="932" y="230"/>
+      <point x="886" y="284"/>
+      <point x="812" y="298" type="curve"/>
+      <point x="812" y="308" type="line"/>
+      <point x="875" y="326"/>
+      <point x="911" y="378"/>
+      <point x="911" y="445" type="curve" smooth="yes"/>
+      <point x="911" y="542"/>
+      <point x="840" y="612"/>
+      <point x="697" y="612" type="curve" smooth="yes"/>
+      <point x="529" y="612"/>
+      <point x="421" y="515"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="92"/>
-      <point x="143" y="-16"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/g_ga-malayalam.glif
@@ -6,92 +6,96 @@
   <anchor x="763" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="403" y="-378" type="curve" smooth="yes"/>
-      <point x="519" y="-378"/>
-      <point x="561" y="-315"/>
-      <point x="569" y="-173" type="curve" smooth="yes"/>
-      <point x="570" y="-156" type="line" smooth="yes"/>
-      <point x="576" y="-52"/>
-      <point x="603" y="-22"/>
-      <point x="657" y="-22" type="curve" smooth="yes"/>
-      <point x="721" y="-22"/>
-      <point x="759" y="-67"/>
-      <point x="759" y="-160" type="curve" smooth="yes"/>
-      <point x="759" y="-241"/>
-      <point x="732" y="-291"/>
-      <point x="691" y="-338" type="curve"/>
-      <point x="747" y="-378" type="line"/>
-      <point x="808" y="-313"/>
-      <point x="833" y="-247"/>
-      <point x="833" y="-157" type="curve" smooth="yes"/>
-      <point x="833" y="-9"/>
-      <point x="756" y="48"/>
-      <point x="661" y="48" type="curve" smooth="yes"/>
-      <point x="547" y="48"/>
-      <point x="507" y="-14"/>
-      <point x="498" y="-152" type="curve" smooth="yes"/>
-      <point x="497" y="-168" type="line" smooth="yes"/>
-      <point x="490" y="-278"/>
-      <point x="463" y="-308"/>
-      <point x="407" y="-308" type="curve" smooth="yes"/>
-      <point x="349" y="-308"/>
-      <point x="307" y="-266"/>
-      <point x="307" y="-166" type="curve" smooth="yes"/>
-      <point x="307" y="-100"/>
-      <point x="330" y="-47"/>
-      <point x="376" y="7" type="curve"/>
-      <point x="360" y="-4" type="line"/>
-      <point x="442" y="26"/>
-      <point x="494" y="109"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="516" y="348" type="line" smooth="yes"/>
-      <point x="527" y="465"/>
-      <point x="579" y="528"/>
-      <point x="661" y="528" type="curve" smooth="yes"/>
-      <point x="757" y="528"/>
-      <point x="797" y="453"/>
-      <point x="797" y="330" type="curve" smooth="yes"/>
-      <point x="797" y="217"/>
-      <point x="773" y="122"/>
-      <point x="679" y="41" type="curve"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="460"/>
+      <point x="560" y="528"/>
+      <point x="653" y="528" type="curve" smooth="yes"/>
+      <point x="748" y="528"/>
+      <point x="796" y="462"/>
+      <point x="796" y="332" type="curve" smooth="yes"/>
+      <point x="796" y="200"/>
+      <point x="761" y="115"/>
+      <point x="678" y="44" type="curve"/>
       <point x="731" y="-16" type="line"/>
-      <point x="843" y="80"/>
-      <point x="880" y="187"/>
-      <point x="880" y="331" type="curve" smooth="yes"/>
-      <point x="880" y="505"/>
-      <point x="803" y="612"/>
-      <point x="655" y="612" type="curve" smooth="yes"/>
-      <point x="523" y="612"/>
-      <point x="444" y="525"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="836" y="74"/>
+      <point x="880" y="177"/>
+      <point x="880" y="332" type="curve" smooth="yes"/>
+      <point x="880" y="511"/>
+      <point x="797" y="612"/>
+      <point x="651" y="612" type="curve" smooth="yes"/>
+      <point x="507" y="612"/>
+      <point x="421" y="517"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="94"/>
-      <point x="142" y="-14"/>
-      <point x="285" y="-14" type="curve" smooth="yes"/>
-      <point x="301" y="-14"/>
-      <point x="316" y="-13"/>
-      <point x="333" y="-10" type="curve"/>
-      <point x="256" y="27" type="line"/>
-      <point x="288" y="-61" type="line"/>
-      <point x="294" y="-5" type="line"/>
-      <point x="262" y="-34"/>
-      <point x="233" y="-104"/>
-      <point x="233" y="-168" type="curve" smooth="yes"/>
-      <point x="233" y="-320"/>
-      <point x="311" y="-378"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
+    </contour>
+    <contour>
+      <point x="411" y="-378" type="curve" smooth="yes"/>
+      <point x="513" y="-378"/>
+      <point x="573" y="-310"/>
+      <point x="573" y="-198" type="curve" smooth="yes"/>
+      <point x="573" y="-178"/>
+      <point x="571" y="-157"/>
+      <point x="571" y="-137" type="curve" smooth="yes"/>
+      <point x="571" y="-56"/>
+      <point x="604" y="-24"/>
+      <point x="663" y="-24" type="curve" smooth="yes"/>
+      <point x="724" y="-24"/>
+      <point x="757" y="-71"/>
+      <point x="757" y="-157" type="curve" smooth="yes"/>
+      <point x="757" y="-228"/>
+      <point x="736" y="-280"/>
+      <point x="688" y="-331" type="curve"/>
+      <point x="741" y="-378" type="line"/>
+      <point x="806" y="-313"/>
+      <point x="833" y="-248"/>
+      <point x="833" y="-157" type="curve" smooth="yes"/>
+      <point x="833" y="-27"/>
+      <point x="771" y="48"/>
+      <point x="661" y="48" type="curve" smooth="yes"/>
+      <point x="561" y="48"/>
+      <point x="493" y="-10"/>
+      <point x="493" y="-131" type="curve" smooth="yes"/>
+      <point x="493" y="-151"/>
+      <point x="495" y="-172"/>
+      <point x="495" y="-192" type="curve" smooth="yes"/>
+      <point x="495" y="-267"/>
+      <point x="466" y="-306"/>
+      <point x="409" y="-306" type="curve" smooth="yes"/>
+      <point x="345" y="-306"/>
+      <point x="309" y="-257"/>
+      <point x="309" y="-169" type="curve" smooth="yes"/>
+      <point x="309" y="-102"/>
+      <point x="326" y="-44"/>
+      <point x="374" y="13" type="curve"/>
+      <point x="302" y="13" type="line"/>
+      <point x="258" y="-29"/>
+      <point x="233" y="-103"/>
+      <point x="233" y="-169" type="curve" smooth="yes"/>
+      <point x="233" y="-301"/>
+      <point x="299" y="-378"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/g_la-malayalam.glif
@@ -13,13 +13,13 @@
       <point x="425" y="-163"/>
       <point x="381" y="-121"/>
       <point x="311" y="-121" type="curve" smooth="yes"/>
-      <point x="258" y="-121"/>
+      <point x="260" y="-121"/>
       <point x="200" y="-154"/>
       <point x="200" y="-239" type="curve"/>
-      <point x="224" y="-172" type="line"/>
-      <point x="165" y="-172" type="line"/>
-      <point x="202" y="-198" type="line"/>
-      <point x="202" y="-84"/>
+      <point x="224" y="-175" type="line"/>
+      <point x="165" y="-175" type="line"/>
+      <point x="204" y="-198" type="line"/>
+      <point x="204" y="-84"/>
       <point x="256" y="-22"/>
       <point x="352" y="-22" type="curve" smooth="yes"/>
       <point x="448" y="-22"/>
@@ -36,31 +36,33 @@
       <point x="821" y="-7"/>
       <point x="771" y="48" type="curve"/>
       <point x="767" y="18" type="line"/>
-      <point x="851" y="106"/>
-      <point x="880" y="204"/>
-      <point x="880" y="331" type="curve" smooth="yes"/>
-      <point x="880" y="505"/>
-      <point x="803" y="612"/>
-      <point x="655" y="612" type="curve" smooth="yes"/>
-      <point x="523" y="612"/>
-      <point x="444" y="525"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="846" y="100"/>
+      <point x="880" y="196"/>
+      <point x="880" y="332" type="curve" smooth="yes"/>
+      <point x="880" y="511"/>
+      <point x="797" y="612"/>
+      <point x="651" y="612" type="curve" smooth="yes"/>
+      <point x="507" y="612"/>
+      <point x="421" y="517"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="132"/>
+      <point x="377" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="129"/>
-      <point x="113" y="38"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="138"/>
+      <point x="111" y="42"/>
       <point x="209" y="6" type="curve"/>
       <point x="211" y="-4" type="line"/>
       <point x="162" y="-47"/>
@@ -74,10 +76,10 @@
       <point x="234" y="-313"/>
       <point x="207" y="-256"/>
       <point x="207" y="-200" type="curve"/>
-      <point x="187" y="-208" type="line"/>
+      <point x="190" y="-218" type="line"/>
       <point x="208" y="-265" type="line"/>
       <point x="208" y="-221"/>
-      <point x="240" y="-181"/>
+      <point x="241" y="-181"/>
       <point x="294" y="-181" type="curve" smooth="yes"/>
       <point x="335" y="-181"/>
       <point x="355" y="-206"/>
@@ -91,25 +93,27 @@
       <point x="611" y="-271"/>
       <point x="587" y="-185" type="curve" smooth="yes"/>
       <point x="575" y="-142" type="line" smooth="yes"/>
-      <point x="548" y="-45"/>
-      <point x="501" y="17"/>
-      <point x="425" y="37" type="curve"/>
-      <point x="423" y="47" type="line"/>
-      <point x="474" y="90"/>
-      <point x="498" y="153"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="516" y="348" type="line" smooth="yes"/>
-      <point x="527" y="465"/>
-      <point x="579" y="528"/>
-      <point x="661" y="528" type="curve" smooth="yes"/>
-      <point x="757" y="528"/>
-      <point x="797" y="453"/>
-      <point x="797" y="330" type="curve" smooth="yes"/>
-      <point x="797" y="217"/>
-      <point x="773" y="126"/>
+      <point x="549" y="-47"/>
+      <point x="504" y="13"/>
+      <point x="431" y="33" type="curve"/>
+      <point x="429" y="43" type="line"/>
+      <point x="486" y="85"/>
+      <point x="513" y="148"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="460"/>
+      <point x="560" y="528"/>
+      <point x="653" y="528" type="curve" smooth="yes"/>
+      <point x="748" y="528"/>
+      <point x="796" y="462"/>
+      <point x="796" y="332" type="curve" smooth="yes"/>
+      <point x="796" y="200"/>
+      <point x="761" y="115"/>
       <point x="678" y="44" type="curve"/>
-      <point x="731" y="-8"/>
-      <point x="780" y="-72"/>
+      <point x="751" y="-24"/>
+      <point x="780" y="-94"/>
       <point x="780" y="-185" type="curve" smooth="yes"/>
       <point x="780" y="-262"/>
       <point x="753" y="-308"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/g_ma-malayalam.glif
@@ -6,16 +6,18 @@
   <anchor x="1312" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="284" y="-16" type="curve" smooth="yes"/>
-      <point x="411" y="-16"/>
-      <point x="492" y="72"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="515" y="346" type="line" smooth="yes"/>
-      <point x="525" y="460"/>
-      <point x="569" y="528"/>
-      <point x="660" y="528" type="curve" smooth="yes"/>
-      <point x="750" y="528"/>
-      <point x="796" y="456"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="460"/>
+      <point x="557" y="528"/>
+      <point x="653" y="528" type="curve" smooth="yes"/>
+      <point x="748" y="528"/>
+      <point x="796" y="462"/>
       <point x="796" y="331" type="curve" smooth="yes"/>
       <point x="796" y="0" type="line"/>
       <point x="1362" y="0" type="line"/>
@@ -27,28 +29,30 @@
       <point x="892" y="571"/>
       <point x="848" y="490" type="curve"/>
       <point x="838" y="490" type="line"/>
-      <point x="801" y="575"/>
-      <point x="738" y="612"/>
-      <point x="653" y="612" type="curve" smooth="yes"/>
-      <point x="521" y="612"/>
-      <point x="442" y="529"/>
-      <point x="427" y="353" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="408" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="803" y="571"/>
+      <point x="740" y="612"/>
+      <point x="651" y="612" type="curve" smooth="yes"/>
+      <point x="509" y="612"/>
+      <point x="421" y="517"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="92"/>
-      <point x="143" y="-16"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
     </contour>
     <contour>
       <point x="846" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/g_na-malayalam.glif
@@ -6,16 +6,18 @@
   <anchor x="1199" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="284" y="-16" type="curve" smooth="yes"/>
-      <point x="411" y="-16"/>
-      <point x="490" y="72"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="516" y="348" type="line" smooth="yes"/>
-      <point x="527" y="465"/>
-      <point x="576" y="528"/>
-      <point x="661" y="528" type="curve" smooth="yes"/>
-      <point x="757" y="528"/>
-      <point x="796" y="453"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="462"/>
+      <point x="562" y="528"/>
+      <point x="656" y="528" type="curve" smooth="yes"/>
+      <point x="750" y="528"/>
+      <point x="796" y="463"/>
       <point x="796" y="330" type="curve" smooth="yes"/>
       <point x="796" y="0" type="line"/>
       <point x="880" y="0" type="line"/>
@@ -37,31 +39,33 @@
       <point x="1186" y="612"/>
       <point x="1035" y="612" type="curve" smooth="yes"/>
       <point x="942" y="612"/>
-      <point x="876" y="570"/>
+      <point x="874" y="567"/>
       <point x="843" y="499" type="curve"/>
       <point x="833" y="499" type="line"/>
-      <point x="806" y="570"/>
-      <point x="745" y="612"/>
-      <point x="657" y="612" type="curve" smooth="yes"/>
-      <point x="523" y="612"/>
-      <point x="444" y="525"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="802" y="571"/>
+      <point x="737" y="612"/>
+      <point x="652" y="612" type="curve" smooth="yes"/>
+      <point x="506" y="612"/>
+      <point x="421" y="516"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="92"/>
-      <point x="143" y="-16"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ga-malayalam.glif
@@ -7,46 +7,50 @@
   <anchor x="763" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="284" y="-16" type="curve" smooth="yes"/>
-      <point x="411" y="-16"/>
-      <point x="490" y="72"/>
-      <point x="506" y="240" type="curve" smooth="yes"/>
-      <point x="516" y="348" type="line" smooth="yes"/>
-      <point x="527" y="465"/>
-      <point x="579" y="528"/>
-      <point x="661" y="528" type="curve" smooth="yes"/>
-      <point x="757" y="528"/>
-      <point x="797" y="453"/>
-      <point x="797" y="330" type="curve" smooth="yes"/>
-      <point x="797" y="217"/>
-      <point x="773" y="126"/>
-      <point x="679" y="45" type="curve"/>
+      <point x="292" y="-16" type="curve" smooth="yes"/>
+      <point x="428" y="-16"/>
+      <point x="513" y="81"/>
+      <point x="513" y="240" type="curve" smooth="yes"/>
+      <point x="513" y="275"/>
+      <point x="509" y="309"/>
+      <point x="509" y="344" type="curve" smooth="yes"/>
+      <point x="509" y="460"/>
+      <point x="560" y="528"/>
+      <point x="653" y="528" type="curve" smooth="yes"/>
+      <point x="748" y="528"/>
+      <point x="796" y="462"/>
+      <point x="796" y="332" type="curve" smooth="yes"/>
+      <point x="796" y="200"/>
+      <point x="761" y="115"/>
+      <point x="678" y="44" type="curve"/>
       <point x="731" y="-16" type="line"/>
-      <point x="843" y="80"/>
-      <point x="880" y="187"/>
-      <point x="880" y="331" type="curve" smooth="yes"/>
-      <point x="880" y="505"/>
-      <point x="803" y="612"/>
-      <point x="655" y="612" type="curve" smooth="yes"/>
-      <point x="523" y="612"/>
-      <point x="444" y="525"/>
-      <point x="428" y="355" type="curve" smooth="yes"/>
-      <point x="418" y="248" type="line" smooth="yes"/>
-      <point x="407" y="132"/>
-      <point x="357" y="68"/>
-      <point x="277" y="68" type="curve" smooth="yes"/>
-      <point x="189" y="68"/>
-      <point x="138" y="143"/>
-      <point x="138" y="270" type="curve" smooth="yes"/>
-      <point x="138" y="383"/>
-      <point x="175" y="478"/>
+      <point x="836" y="74"/>
+      <point x="880" y="177"/>
+      <point x="880" y="332" type="curve" smooth="yes"/>
+      <point x="880" y="511"/>
+      <point x="797" y="612"/>
+      <point x="651" y="612" type="curve" smooth="yes"/>
+      <point x="507" y="612"/>
+      <point x="421" y="517"/>
+      <point x="421" y="352" type="curve" smooth="yes"/>
+      <point x="421" y="317"/>
+      <point x="425" y="283"/>
+      <point x="425" y="248" type="curve" smooth="yes"/>
+      <point x="425" y="135"/>
+      <point x="380" y="68"/>
+      <point x="290" y="68" type="curve" smooth="yes"/>
+      <point x="194" y="68"/>
+      <point x="138" y="142"/>
+      <point x="138" y="268" type="curve" smooth="yes"/>
+      <point x="138" y="387"/>
+      <point x="179" y="481"/>
       <point x="262" y="553" type="curve"/>
       <point x="212" y="612" type="line"/>
-      <point x="98" y="521"/>
-      <point x="54" y="405"/>
-      <point x="54" y="270" type="curve" smooth="yes"/>
-      <point x="54" y="92"/>
-      <point x="143" y="-16"/>
+      <point x="106" y="527"/>
+      <point x="54" y="414"/>
+      <point x="54" y="268" type="curve" smooth="yes"/>
+      <point x="54" y="93"/>
+      <point x="146" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ga-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ga-malayalam.half" format="2">
   <advance width="934"/>
+  <anchor x="524" y="0" name="bottom"/>
+  <anchor x="469" y="596" name="top"/>
+  <anchor x="763" y="596" name="topright"/>
   <outline>
     <component base="ga-malayalam"/>
     <component base="halant-malayalam" xOffset="763"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/j_ja-malayalam.glif
@@ -1,224 +1,224 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1626"/>
-  <anchor x="1233" y="0" name="bottom"/>
-  <anchor x="828" y="596" name="top"/>
-  <anchor x="1471" y="596" name="topright"/>
+  <advance width="1700"/>
+  <anchor x="1275" y="-6" name="bottom"/>
+  <anchor x="850" y="596" name="top"/>
+  <anchor x="1536" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="348" y="-16" type="curve" smooth="yes"/>
-      <point x="627" y="-16"/>
-      <point x="782" y="87"/>
-      <point x="864" y="317" type="curve"/>
-      <point x="879" y="371" type="line"/>
-      <point x="884" y="371" type="line"/>
-      <point x="907" y="318"/>
-      <point x="944" y="300"/>
-      <point x="991" y="300" type="curve" smooth="yes"/>
-      <point x="1075" y="300"/>
-      <point x="1125" y="354"/>
-      <point x="1125" y="429" type="curve" smooth="yes"/>
-      <point x="1125" y="488"/>
-      <point x="1093" y="539"/>
-      <point x="1012" y="539" type="curve" smooth="yes"/>
-      <point x="990" y="539"/>
-      <point x="969" y="535"/>
-      <point x="958" y="529" type="curve"/>
-      <point x="981" y="504" type="line"/>
-      <point x="962" y="566" type="line"/>
-      <point x="935" y="528" type="line"/>
-      <point x="962" y="544"/>
-      <point x="983" y="552"/>
-      <point x="1029" y="552" type="curve" smooth="yes"/>
-      <point x="1146" y="552"/>
-      <point x="1184" y="466"/>
-      <point x="1184" y="392" type="curve" smooth="yes"/>
-      <point x="1184" y="353" type="line"/>
-      <point x="1268" y="353" type="line"/>
-      <point x="1268" y="388" type="line" smooth="yes"/>
-      <point x="1268" y="479"/>
-      <point x="1321" y="534"/>
-      <point x="1392" y="534" type="curve" smooth="yes"/>
-      <point x="1456" y="534"/>
-      <point x="1490" y="490"/>
-      <point x="1490" y="425" type="curve" smooth="yes"/>
-      <point x="1490" y="359"/>
-      <point x="1452" y="294"/>
-      <point x="1329" y="294" type="curve" smooth="yes"/>
-      <point x="1070" y="294" type="line" smooth="yes"/>
-      <point x="940" y="294"/>
-      <point x="872" y="230"/>
-      <point x="872" y="135" type="curve" smooth="yes"/>
-      <point x="872" y="46"/>
-      <point x="923" y="-16"/>
-      <point x="1023" y="-16" type="curve" smooth="yes"/>
-      <point x="1081" y="-16"/>
-      <point x="1133" y="0"/>
-      <point x="1203" y="51" type="curve" smooth="yes"/>
-      <point x="1265" y="96" type="line" smooth="yes"/>
-      <point x="1350" y="158"/>
-      <point x="1396" y="172"/>
-      <point x="1440" y="172" type="curve" smooth="yes"/>
-      <point x="1485" y="172"/>
-      <point x="1501" y="147"/>
-      <point x="1501" y="111" type="curve" smooth="yes"/>
-      <point x="1501" y="74"/>
-      <point x="1481" y="48"/>
-      <point x="1444" y="48" type="curve" smooth="yes"/>
-      <point x="1408" y="48"/>
-      <point x="1388" y="70"/>
-      <point x="1388" y="109" type="curve" smooth="yes"/>
-      <point x="1388" y="148"/>
-      <point x="1406" y="171"/>
-      <point x="1423" y="190" type="curve"/>
-      <point x="1323" y="157" type="line"/>
-      <point x="1342" y="135" type="line"/>
-      <point x="1336" y="121"/>
-      <point x="1332" y="107"/>
-      <point x="1332" y="90" type="curve" smooth="yes"/>
-      <point x="1332" y="34"/>
-      <point x="1369" y="-16"/>
-      <point x="1445" y="-16" type="curve" smooth="yes"/>
-      <point x="1525" y="-16"/>
-      <point x="1567" y="39"/>
-      <point x="1567" y="110" type="curve" smooth="yes"/>
-      <point x="1567" y="188"/>
-      <point x="1517" y="238"/>
-      <point x="1444" y="238" type="curve" smooth="yes"/>
-      <point x="1382" y="238"/>
-      <point x="1339" y="229"/>
-      <point x="1248" y="169" type="curve" smooth="yes"/>
-      <point x="1173" y="119" type="line" smooth="yes"/>
-      <point x="1102" y="72"/>
-      <point x="1067" y="61"/>
-      <point x="1032" y="61" type="curve" smooth="yes"/>
-      <point x="980" y="61"/>
-      <point x="950" y="82"/>
-      <point x="950" y="136" type="curve" smooth="yes"/>
-      <point x="950" y="189"/>
-      <point x="986" y="222"/>
-      <point x="1073" y="222" type="curve" smooth="yes"/>
-      <point x="1313" y="222" type="line" smooth="yes"/>
-      <point x="1506" y="222"/>
-      <point x="1572" y="320"/>
-      <point x="1572" y="428" type="curve" smooth="yes"/>
-      <point x="1572" y="534"/>
-      <point x="1502" y="612"/>
-      <point x="1390" y="612" type="curve" smooth="yes"/>
-      <point x="1309" y="612"/>
-      <point x="1254" y="567"/>
-      <point x="1233" y="490" type="curve"/>
-      <point x="1223" y="490" type="line"/>
-      <point x="1198" y="569"/>
-      <point x="1132" y="613"/>
-      <point x="1038" y="613" type="curve" smooth="yes"/>
-      <point x="944" y="613"/>
-      <point x="879" y="572"/>
-      <point x="841" y="460" type="curve" smooth="yes"/>
-      <point x="809" y="366" type="line" smooth="yes"/>
-      <point x="727" y="126"/>
-      <point x="573" y="61"/>
-      <point x="348" y="61" type="curve" smooth="yes"/>
-      <point x="214" y="61"/>
-      <point x="138" y="80"/>
-      <point x="138" y="149" type="curve" smooth="yes"/>
-      <point x="138" y="190"/>
-      <point x="170" y="222"/>
-      <point x="269" y="222" type="curve" smooth="yes"/>
-      <point x="521" y="222" type="line" smooth="yes"/>
-      <point x="704" y="222"/>
-      <point x="768" y="320"/>
-      <point x="768" y="432" type="curve" smooth="yes"/>
-      <point x="768" y="534"/>
-      <point x="709" y="612"/>
-      <point x="598" y="612" type="curve" smooth="yes"/>
-      <point x="510" y="612"/>
-      <point x="457" y="564"/>
-      <point x="438" y="490" type="curve"/>
-      <point x="428" y="490" type="line"/>
-      <point x="405" y="565"/>
-      <point x="340" y="612"/>
-      <point x="240" y="612" type="curve" smooth="yes"/>
-      <point x="128" y="612"/>
-      <point x="54" y="546"/>
-      <point x="54" y="448" type="curve" smooth="yes"/>
-      <point x="54" y="361"/>
-      <point x="110" y="300"/>
-      <point x="195" y="300" type="curve" smooth="yes"/>
-      <point x="281" y="300"/>
-      <point x="331" y="354"/>
-      <point x="331" y="429" type="curve" smooth="yes"/>
-      <point x="331" y="486"/>
-      <point x="299" y="540"/>
-      <point x="216" y="540" type="curve" smooth="yes"/>
-      <point x="196" y="540"/>
-      <point x="172" y="534"/>
-      <point x="159" y="524" type="curve"/>
-      <point x="191" y="502" type="line"/>
-      <point x="165" y="566" type="line"/>
-      <point x="149" y="530" type="line"/>
-      <point x="167" y="541"/>
-      <point x="193" y="552"/>
-      <point x="238" y="552" type="curve" smooth="yes"/>
-      <point x="352" y="552"/>
-      <point x="390" y="466"/>
-      <point x="390" y="392" type="curve" smooth="yes"/>
-      <point x="390" y="353" type="line"/>
-      <point x="474" y="353" type="line"/>
-      <point x="474" y="388" type="line" smooth="yes"/>
-      <point x="474" y="479"/>
-      <point x="523" y="534"/>
-      <point x="593" y="534" type="curve" smooth="yes"/>
-      <point x="658" y="534"/>
-      <point x="688" y="492"/>
-      <point x="688" y="425" type="curve" smooth="yes"/>
-      <point x="688" y="359"/>
-      <point x="650" y="294"/>
-      <point x="527" y="294" type="curve" smooth="yes"/>
-      <point x="265" y="294" type="line" smooth="yes"/>
-      <point x="124" y="294"/>
-      <point x="60" y="230"/>
-      <point x="60" y="147" type="curve" smooth="yes"/>
-      <point x="60" y="37"/>
-      <point x="157" y="-16"/>
+      <point x="336" y="-16" type="curve" smooth="yes"/>
+      <point x="636" y="-16"/>
+      <point x="804" y="75"/>
+      <point x="893" y="289" type="curve"/>
+      <point x="905" y="339" type="line"/>
+      <point x="910" y="339" type="line"/>
+      <point x="924" y="298"/>
+      <point x="966" y="274"/>
+      <point x="1024" y="274" type="curve" smooth="yes"/>
+      <point x="1103" y="274"/>
+      <point x="1153" y="323"/>
+      <point x="1153" y="399" type="curve" smooth="yes"/>
+      <point x="1153" y="469"/>
+      <point x="1115" y="512"/>
+      <point x="1041" y="512" type="curve" smooth="yes"/>
+      <point x="1011" y="512"/>
+      <point x="989" y="508"/>
+      <point x="966" y="499" type="curve"/>
+      <point x="947" y="527" type="line"/>
+      <point x="954" y="499" type="line"/>
+      <point x="977" y="531"/>
+      <point x="1020" y="552"/>
+      <point x="1079" y="552" type="curve" smooth="yes"/>
+      <point x="1180" y="552"/>
+      <point x="1228" y="499"/>
+      <point x="1228" y="392" type="curve" smooth="yes"/>
+      <point x="1228" y="333" type="line"/>
+      <point x="1312" y="333" type="line"/>
+      <point x="1312" y="392" type="line" smooth="yes"/>
+      <point x="1312" y="483"/>
+      <point x="1364" y="534"/>
+      <point x="1445" y="534" type="curve" smooth="yes"/>
+      <point x="1524" y="534"/>
+      <point x="1564" y="490"/>
+      <point x="1564" y="415" type="curve" smooth="yes"/>
+      <point x="1564" y="313"/>
+      <point x="1503" y="264"/>
+      <point x="1375" y="264" type="curve" smooth="yes"/>
+      <point x="1053" y="264" type="line" smooth="yes"/>
+      <point x="946" y="264"/>
+      <point x="878" y="209"/>
+      <point x="878" y="122" type="curve" smooth="yes"/>
+      <point x="878" y="37"/>
+      <point x="943" y="-16"/>
+      <point x="1036" y="-16" type="curve" smooth="yes"/>
+      <point x="1087" y="-16"/>
+      <point x="1129" y="-5"/>
+      <point x="1194" y="27" type="curve" smooth="yes"/>
+      <point x="1339" y="98" type="line"/>
+      <point x="1404" y="147" type="line"/>
+      <point x="1430" y="147" type="line"/>
+      <point x="1455" y="167"/>
+      <point x="1478" y="178"/>
+      <point x="1510" y="178" type="curve" smooth="yes"/>
+      <point x="1551" y="178"/>
+      <point x="1571" y="156"/>
+      <point x="1571" y="117" type="curve" smooth="yes"/>
+      <point x="1571" y="78"/>
+      <point x="1547" y="56"/>
+      <point x="1509" y="56" type="curve" smooth="yes"/>
+      <point x="1469" y="56"/>
+      <point x="1447" y="78"/>
+      <point x="1447" y="116" type="curve" smooth="yes"/>
+      <point x="1447" y="144"/>
+      <point x="1457" y="164"/>
+      <point x="1482" y="190" type="curve"/>
+      <point x="1378" y="150" type="line"/>
+      <point x="1399" y="129" type="line"/>
+      <point x="1394" y="117"/>
+      <point x="1391" y="103"/>
+      <point x="1391" y="86" type="curve" smooth="yes"/>
+      <point x="1391" y="24"/>
+      <point x="1441" y="-16"/>
+      <point x="1512" y="-16" type="curve" smooth="yes"/>
+      <point x="1592" y="-16"/>
+      <point x="1643" y="33"/>
+      <point x="1643" y="110" type="curve" smooth="yes"/>
+      <point x="1643" y="182"/>
+      <point x="1602" y="232"/>
+      <point x="1518" y="232" type="curve" smooth="yes"/>
+      <point x="1472" y="232"/>
+      <point x="1437" y="222"/>
+      <point x="1360" y="184" type="curve" smooth="yes"/>
+      <point x="1165" y="89" type="line" smooth="yes"/>
+      <point x="1122" y="68"/>
+      <point x="1084" y="58"/>
+      <point x="1041" y="58" type="curve" smooth="yes"/>
+      <point x="990" y="58"/>
+      <point x="960" y="80"/>
+      <point x="960" y="123" type="curve" smooth="yes"/>
+      <point x="960" y="168"/>
+      <point x="992" y="192"/>
+      <point x="1057" y="192" type="curve" smooth="yes"/>
+      <point x="1367" y="192" type="line" smooth="yes"/>
+      <point x="1538" y="192"/>
+      <point x="1646" y="279"/>
+      <point x="1646" y="417" type="curve" smooth="yes"/>
+      <point x="1646" y="532"/>
+      <point x="1576" y="612"/>
+      <point x="1458" y="612" type="curve" smooth="yes"/>
+      <point x="1367" y="612"/>
+      <point x="1307" y="567"/>
+      <point x="1281" y="494" type="curve"/>
+      <point x="1271" y="494" type="line"/>
+      <point x="1242" y="572"/>
+      <point x="1185" y="612"/>
+      <point x="1088" y="612" type="curve" smooth="yes"/>
+      <point x="977" y="612"/>
+      <point x="900" y="558"/>
+      <point x="871" y="454" type="curve" smooth="yes"/>
+      <point x="845" y="362" type="line" smooth="yes"/>
+      <point x="786" y="151"/>
+      <point x="628" y="61"/>
+      <point x="336" y="61" type="curve" smooth="yes"/>
+      <point x="213" y="61"/>
+      <point x="142" y="76"/>
+      <point x="142" y="131" type="curve" smooth="yes"/>
+      <point x="142" y="170"/>
+      <point x="175" y="192"/>
+      <point x="239" y="192" type="curve" smooth="yes"/>
+      <point x="517" y="192" type="line" smooth="yes"/>
+      <point x="694" y="192"/>
+      <point x="802" y="281"/>
+      <point x="802" y="422" type="curve" smooth="yes"/>
+      <point x="802" y="534"/>
+      <point x="740" y="612"/>
+      <point x="631" y="612" type="curve" smooth="yes"/>
+      <point x="545" y="612"/>
+      <point x="487" y="567"/>
+      <point x="463" y="494" type="curve"/>
+      <point x="453" y="494" type="line"/>
+      <point x="424" y="573"/>
+      <point x="367" y="612"/>
+      <point x="271" y="612" type="curve" smooth="yes"/>
+      <point x="143" y="612"/>
+      <point x="54" y="533"/>
+      <point x="54" y="423" type="curve" smooth="yes"/>
+      <point x="54" y="336"/>
+      <point x="114" y="274"/>
+      <point x="197" y="274" type="curve" smooth="yes"/>
+      <point x="281" y="274"/>
+      <point x="335" y="323"/>
+      <point x="335" y="399" type="curve" smooth="yes"/>
+      <point x="335" y="469"/>
+      <point x="297" y="512"/>
+      <point x="223" y="512" type="curve" smooth="yes"/>
+      <point x="193" y="512"/>
+      <point x="171" y="508"/>
+      <point x="148" y="499" type="curve"/>
+      <point x="129" y="527" type="line"/>
+      <point x="136" y="499" type="line"/>
+      <point x="157" y="529"/>
+      <point x="206" y="552"/>
+      <point x="269" y="552" type="curve" smooth="yes"/>
+      <point x="364" y="552"/>
+      <point x="410" y="499"/>
+      <point x="410" y="392" type="curve" smooth="yes"/>
+      <point x="410" y="333" type="line"/>
+      <point x="494" y="333" type="line"/>
+      <point x="494" y="392" type="line" smooth="yes"/>
+      <point x="494" y="483"/>
+      <point x="539" y="534"/>
+      <point x="618" y="534" type="curve" smooth="yes"/>
+      <point x="687" y="534"/>
+      <point x="720" y="493"/>
+      <point x="720" y="423" type="curve" smooth="yes"/>
+      <point x="720" y="315"/>
+      <point x="652" y="264"/>
+      <point x="513" y="264" type="curve" smooth="yes"/>
+      <point x="235" y="264" type="line" smooth="yes"/>
+      <point x="128" y="264"/>
+      <point x="60" y="212"/>
+      <point x="60" y="130" type="curve" smooth="yes"/>
+      <point x="60" y="33"/>
+      <point x="153" y="-16"/>
     </contour>
     <contour>
-      <point x="196" y="363" type="curve" smooth="yes"/>
-      <point x="149" y="363"/>
-      <point x="130" y="398"/>
-      <point x="130" y="445" type="curve" smooth="yes"/>
-      <point x="130" y="465"/>
-      <point x="133" y="483"/>
-      <point x="140" y="497" type="curve"/>
-      <point x="118" y="497" type="line"/>
-      <point x="95" y="455" type="line"/>
-      <point x="118" y="482"/>
-      <point x="160" y="496"/>
-      <point x="191" y="496" type="curve" smooth="yes"/>
-      <point x="248" y="496"/>
-      <point x="259" y="461"/>
-      <point x="259" y="434" type="curve" smooth="yes"/>
-      <point x="259" y="390"/>
-      <point x="236" y="363"/>
+      <point x="198" y="338" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="128" y="365"/>
+      <point x="128" y="418" type="curve" smooth="yes"/>
+      <point x="128" y="440"/>
+      <point x="131" y="457"/>
+      <point x="138" y="473" type="curve"/>
+      <point x="106" y="473" type="line"/>
+      <point x="95" y="433" type="line"/>
+      <point x="120" y="454"/>
+      <point x="155" y="468"/>
+      <point x="192" y="468" type="curve" smooth="yes"/>
+      <point x="240" y="468"/>
+      <point x="263" y="446"/>
+      <point x="263" y="401" type="curve" smooth="yes"/>
+      <point x="263" y="363"/>
+      <point x="240" y="338"/>
     </contour>
     <contour>
-      <point x="990" y="363" type="curve" smooth="yes"/>
-      <point x="943" y="363"/>
-      <point x="924" y="398"/>
-      <point x="924" y="447" type="curve" smooth="yes"/>
-      <point x="924" y="467"/>
-      <point x="927" y="485"/>
-      <point x="934" y="499" type="curve"/>
-      <point x="905" y="499" type="line"/>
-      <point x="889" y="465" type="line"/>
-      <point x="913" y="484"/>
-      <point x="954" y="496"/>
-      <point x="985" y="496" type="curve" smooth="yes"/>
-      <point x="1042" y="496"/>
-      <point x="1053" y="461"/>
-      <point x="1053" y="432" type="curve" smooth="yes"/>
-      <point x="1053" y="390"/>
-      <point x="1030" y="363"/>
+      <point x="1016" y="338" type="curve" smooth="yes"/>
+      <point x="971" y="338"/>
+      <point x="946" y="365"/>
+      <point x="946" y="418" type="curve" smooth="yes"/>
+      <point x="946" y="440"/>
+      <point x="949" y="457"/>
+      <point x="956" y="473" type="curve"/>
+      <point x="924" y="473" type="line"/>
+      <point x="913" y="433" type="line"/>
+      <point x="938" y="454"/>
+      <point x="973" y="468"/>
+      <point x="1010" y="468" type="curve" smooth="yes"/>
+      <point x="1058" y="468"/>
+      <point x="1081" y="446"/>
+      <point x="1081" y="401" type="curve" smooth="yes"/>
+      <point x="1081" y="363"/>
+      <point x="1058" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/j_nya-malayalam.glif
@@ -1,185 +1,184 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2219"/>
-  <anchor x="1809" y="0" name="bottom"/>
-  <anchor x="1103" y="596" name="top"/>
-  <anchor x="2069" y="596" name="topright"/>
+  <advance width="2252"/>
+  <anchor x="1842" y="0" name="bottom"/>
+  <anchor x="1126" y="596" name="top"/>
+  <anchor x="2102" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="358" y="-16" type="curve" smooth="yes"/>
-      <point x="578" y="-16"/>
-      <point x="734" y="47"/>
-      <point x="808" y="185" type="curve"/>
-      <point x="818" y="184" type="line"/>
-      <point x="843" y="63"/>
-      <point x="920" y="-16"/>
-      <point x="1035" y="-16" type="curve" smooth="yes"/>
-      <point x="1139" y="-16"/>
-      <point x="1207" y="59"/>
-      <point x="1207" y="175" type="curve" smooth="yes"/>
-      <point x="1207" y="284"/>
-      <point x="1142" y="356"/>
-      <point x="1042" y="356" type="curve" smooth="yes"/>
-      <point x="977" y="356"/>
-      <point x="921" y="324"/>
-      <point x="892" y="269" type="curve"/>
-      <point x="857" y="274" type="line"/>
-      <point x="890" y="141" type="line"/>
-      <point x="900" y="223"/>
-      <point x="959" y="282"/>
-      <point x="1030" y="282" type="curve" smooth="yes"/>
-      <point x="1090" y="282"/>
-      <point x="1125" y="241"/>
-      <point x="1125" y="172" type="curve" smooth="yes"/>
-      <point x="1125" y="102"/>
-      <point x="1091" y="62"/>
-      <point x="1031" y="62" type="curve" smooth="yes"/>
-      <point x="936" y="62"/>
-      <point x="883" y="151"/>
-      <point x="883" y="274" type="curve" smooth="yes"/>
-      <point x="883" y="429"/>
-      <point x="967" y="533"/>
-      <point x="1101" y="533" type="curve" smooth="yes"/>
-      <point x="1218" y="533"/>
-      <point x="1280" y="459"/>
-      <point x="1280" y="328" type="curve" smooth="yes"/>
-      <point x="1280" y="0" type="line"/>
-      <point x="1364" y="0" type="line"/>
-      <point x="1364" y="328" type="line" smooth="yes"/>
-      <point x="1364" y="457"/>
-      <point x="1434" y="534"/>
-      <point x="1557" y="534" type="curve" smooth="yes"/>
-      <point x="1729" y="534"/>
-      <point x="1820" y="411"/>
-      <point x="1820" y="249" type="curve" smooth="yes"/>
-      <point x="1820" y="135"/>
-      <point x="1782" y="62"/>
-      <point x="1706" y="62" type="curve" smooth="yes"/>
-      <point x="1637" y="62"/>
-      <point x="1595" y="126"/>
-      <point x="1595" y="224" type="curve" smooth="yes"/>
-      <point x="1595" y="398"/>
-      <point x="1706" y="534"/>
-      <point x="1868" y="534" type="curve" smooth="yes"/>
-      <point x="2005" y="534"/>
-      <point x="2082" y="449"/>
-      <point x="2082" y="309" type="curve" smooth="yes"/>
-      <point x="2082" y="201"/>
-      <point x="2042" y="116"/>
-      <point x="1978" y="41" type="curve"/>
-      <point x="2046" y="-14" type="line"/>
-      <point x="2120" y="77"/>
-      <point x="2165" y="177"/>
-      <point x="2165" y="304" type="curve" smooth="yes"/>
-      <point x="2165" y="494"/>
-      <point x="2053" y="612"/>
-      <point x="1871" y="612" type="curve" smooth="yes"/>
-      <point x="1663" y="612"/>
-      <point x="1513" y="434"/>
-      <point x="1513" y="223" type="curve" smooth="yes"/>
-      <point x="1513" y="78"/>
-      <point x="1590" y="-16"/>
-      <point x="1708" y="-16" type="curve" smooth="yes"/>
-      <point x="1831" y="-16"/>
-      <point x="1902" y="95"/>
-      <point x="1902" y="244" type="curve" smooth="yes"/>
-      <point x="1902" y="446"/>
-      <point x="1774" y="612"/>
-      <point x="1560" y="612" type="curve" smooth="yes"/>
-      <point x="1453" y="612"/>
-      <point x="1373" y="567"/>
-      <point x="1331" y="482" type="curve"/>
-      <point x="1321" y="482" type="line"/>
-      <point x="1281" y="568"/>
-      <point x="1207" y="612"/>
-      <point x="1104" y="612" type="curve" smooth="yes"/>
-      <point x="947" y="612"/>
-      <point x="848" y="528"/>
-      <point x="806" y="353" type="curve" smooth="yes"/>
-      <point x="751" y="123"/>
-      <point x="586" y="61"/>
-      <point x="358" y="61" type="curve" smooth="yes"/>
-      <point x="214" y="61"/>
-      <point x="138" y="80"/>
-      <point x="138" y="149" type="curve" smooth="yes"/>
-      <point x="138" y="190"/>
-      <point x="170" y="222"/>
-      <point x="269" y="222" type="curve" smooth="yes"/>
-      <point x="521" y="222" type="line" smooth="yes"/>
-      <point x="704" y="222"/>
-      <point x="768" y="320"/>
-      <point x="768" y="432" type="curve" smooth="yes"/>
-      <point x="768" y="534"/>
-      <point x="709" y="612"/>
-      <point x="600" y="612" type="curve" smooth="yes"/>
-      <point x="510" y="612"/>
-      <point x="457" y="564"/>
-      <point x="438" y="490" type="curve"/>
-      <point x="428" y="490" type="line"/>
-      <point x="405" y="565"/>
-      <point x="340" y="612"/>
-      <point x="240" y="612" type="curve" smooth="yes"/>
-      <point x="128" y="612"/>
-      <point x="54" y="546"/>
-      <point x="54" y="448" type="curve" smooth="yes"/>
-      <point x="54" y="361"/>
-      <point x="110" y="300"/>
-      <point x="195" y="300" type="curve" smooth="yes"/>
-      <point x="281" y="300"/>
-      <point x="331" y="354"/>
-      <point x="331" y="429" type="curve" smooth="yes"/>
-      <point x="331" y="486"/>
-      <point x="299" y="540"/>
-      <point x="216" y="540" type="curve" smooth="yes"/>
-      <point x="196" y="540"/>
-      <point x="172" y="534"/>
-      <point x="159" y="524" type="curve"/>
-      <point x="191" y="502" type="line"/>
-      <point x="165" y="566" type="line"/>
-      <point x="149" y="530" type="line"/>
-      <point x="167" y="541"/>
-      <point x="193" y="552"/>
-      <point x="240" y="552" type="curve" smooth="yes"/>
-      <point x="352" y="552"/>
-      <point x="390" y="466"/>
-      <point x="390" y="392" type="curve" smooth="yes"/>
-      <point x="390" y="353" type="line"/>
-      <point x="474" y="353" type="line"/>
-      <point x="474" y="388" type="line" smooth="yes"/>
-      <point x="474" y="479"/>
-      <point x="523" y="534"/>
-      <point x="593" y="534" type="curve" smooth="yes"/>
-      <point x="658" y="534"/>
-      <point x="688" y="492"/>
-      <point x="688" y="425" type="curve" smooth="yes"/>
-      <point x="688" y="359"/>
-      <point x="650" y="294"/>
-      <point x="527" y="294" type="curve" smooth="yes"/>
-      <point x="265" y="294" type="line" smooth="yes"/>
-      <point x="124" y="294"/>
-      <point x="60" y="230"/>
-      <point x="60" y="147" type="curve" smooth="yes"/>
-      <point x="60" y="37"/>
-      <point x="157" y="-16"/>
+      <point x="346" y="-16" type="curve" smooth="yes"/>
+      <point x="600" y="-16"/>
+      <point x="763" y="53"/>
+      <point x="842" y="194" type="curve"/>
+      <point x="852" y="193" type="line"/>
+      <point x="874" y="62"/>
+      <point x="958" y="-16"/>
+      <point x="1068" y="-16" type="curve" smooth="yes"/>
+      <point x="1172" y="-16"/>
+      <point x="1240" y="59"/>
+      <point x="1240" y="175" type="curve" smooth="yes"/>
+      <point x="1240" y="284"/>
+      <point x="1175" y="356"/>
+      <point x="1075" y="356" type="curve" smooth="yes"/>
+      <point x="1010" y="356"/>
+      <point x="954" y="324"/>
+      <point x="925" y="269" type="curve"/>
+      <point x="890" y="274" type="line"/>
+      <point x="923" y="141" type="line"/>
+      <point x="933" y="223"/>
+      <point x="992" y="282"/>
+      <point x="1063" y="282" type="curve" smooth="yes"/>
+      <point x="1123" y="282"/>
+      <point x="1158" y="241"/>
+      <point x="1158" y="172" type="curve" smooth="yes"/>
+      <point x="1158" y="102"/>
+      <point x="1124" y="62"/>
+      <point x="1064" y="62" type="curve" smooth="yes"/>
+      <point x="969" y="62"/>
+      <point x="916" y="151"/>
+      <point x="916" y="274" type="curve" smooth="yes"/>
+      <point x="916" y="429"/>
+      <point x="1000" y="533"/>
+      <point x="1134" y="533" type="curve" smooth="yes"/>
+      <point x="1251" y="533"/>
+      <point x="1313" y="459"/>
+      <point x="1313" y="328" type="curve" smooth="yes"/>
+      <point x="1313" y="0" type="line"/>
+      <point x="1397" y="0" type="line"/>
+      <point x="1397" y="328" type="line" smooth="yes"/>
+      <point x="1397" y="457"/>
+      <point x="1467" y="534"/>
+      <point x="1590" y="534" type="curve" smooth="yes"/>
+      <point x="1762" y="534"/>
+      <point x="1853" y="411"/>
+      <point x="1853" y="249" type="curve" smooth="yes"/>
+      <point x="1853" y="135"/>
+      <point x="1815" y="62"/>
+      <point x="1739" y="62" type="curve" smooth="yes"/>
+      <point x="1670" y="62"/>
+      <point x="1628" y="126"/>
+      <point x="1628" y="224" type="curve" smooth="yes"/>
+      <point x="1628" y="398"/>
+      <point x="1739" y="534"/>
+      <point x="1901" y="534" type="curve" smooth="yes"/>
+      <point x="2038" y="534"/>
+      <point x="2115" y="449"/>
+      <point x="2115" y="309" type="curve" smooth="yes"/>
+      <point x="2115" y="201"/>
+      <point x="2075" y="116"/>
+      <point x="2011" y="41" type="curve"/>
+      <point x="2079" y="-14" type="line"/>
+      <point x="2153" y="77"/>
+      <point x="2198" y="177"/>
+      <point x="2198" y="304" type="curve" smooth="yes"/>
+      <point x="2198" y="494"/>
+      <point x="2086" y="612"/>
+      <point x="1904" y="612" type="curve" smooth="yes"/>
+      <point x="1696" y="612"/>
+      <point x="1546" y="434"/>
+      <point x="1546" y="223" type="curve" smooth="yes"/>
+      <point x="1546" y="78"/>
+      <point x="1623" y="-16"/>
+      <point x="1741" y="-16" type="curve" smooth="yes"/>
+      <point x="1864" y="-16"/>
+      <point x="1935" y="95"/>
+      <point x="1935" y="244" type="curve" smooth="yes"/>
+      <point x="1935" y="446"/>
+      <point x="1807" y="612"/>
+      <point x="1593" y="612" type="curve" smooth="yes"/>
+      <point x="1486" y="612"/>
+      <point x="1406" y="567"/>
+      <point x="1364" y="482" type="curve"/>
+      <point x="1354" y="482" type="line"/>
+      <point x="1314" y="568"/>
+      <point x="1240" y="612"/>
+      <point x="1137" y="612" type="curve" smooth="yes"/>
+      <point x="980" y="612"/>
+      <point x="881" y="528"/>
+      <point x="839" y="353" type="curve" smooth="yes"/>
+      <point x="791" y="151"/>
+      <point x="639" y="61"/>
+      <point x="346" y="61" type="curve" smooth="yes"/>
+      <point x="216" y="61"/>
+      <point x="142" y="76"/>
+      <point x="142" y="131" type="curve" smooth="yes"/>
+      <point x="142" y="170"/>
+      <point x="175" y="192"/>
+      <point x="239" y="192" type="curve" smooth="yes"/>
+      <point x="517" y="192" type="line" smooth="yes"/>
+      <point x="693" y="192"/>
+      <point x="802" y="280"/>
+      <point x="802" y="420" type="curve" smooth="yes"/>
+      <point x="802" y="533"/>
+      <point x="740" y="612"/>
+      <point x="630" y="612" type="curve" smooth="yes"/>
+      <point x="544" y="612"/>
+      <point x="487" y="567"/>
+      <point x="463" y="494" type="curve"/>
+      <point x="453" y="494" type="line"/>
+      <point x="422" y="575"/>
+      <point x="362" y="612"/>
+      <point x="262" y="612" type="curve" smooth="yes"/>
+      <point x="141" y="612"/>
+      <point x="54" y="533"/>
+      <point x="54" y="423" type="curve" smooth="yes"/>
+      <point x="54" y="336"/>
+      <point x="114" y="274"/>
+      <point x="197" y="274" type="curve" smooth="yes"/>
+      <point x="281" y="274"/>
+      <point x="335" y="323"/>
+      <point x="335" y="399" type="curve" smooth="yes"/>
+      <point x="335" y="469"/>
+      <point x="297" y="512"/>
+      <point x="223" y="512" type="curve" smooth="yes"/>
+      <point x="193" y="512"/>
+      <point x="171" y="508"/>
+      <point x="148" y="499" type="curve"/>
+      <point x="129" y="527" type="line"/>
+      <point x="136" y="499" type="line"/>
+      <point x="156" y="529"/>
+      <point x="202" y="552"/>
+      <point x="261" y="552" type="curve" smooth="yes"/>
+      <point x="361" y="552"/>
+      <point x="410" y="499"/>
+      <point x="410" y="392" type="curve" smooth="yes"/>
+      <point x="410" y="333" type="line"/>
+      <point x="494" y="333" type="line"/>
+      <point x="494" y="392" type="line" smooth="yes"/>
+      <point x="494" y="483"/>
+      <point x="539" y="534"/>
+      <point x="616" y="534" type="curve" smooth="yes"/>
+      <point x="686" y="534"/>
+      <point x="720" y="492"/>
+      <point x="720" y="421" type="curve" smooth="yes"/>
+      <point x="720" y="314"/>
+      <point x="652" y="264"/>
+      <point x="513" y="264" type="curve" smooth="yes"/>
+      <point x="235" y="264" type="line" smooth="yes"/>
+      <point x="128" y="264"/>
+      <point x="60" y="212"/>
+      <point x="60" y="130" type="curve" smooth="yes"/>
+      <point x="60" y="33"/>
+      <point x="156" y="-16"/>
     </contour>
     <contour>
-      <point x="196" y="363" type="curve" smooth="yes"/>
-      <point x="149" y="363"/>
-      <point x="130" y="398"/>
-      <point x="130" y="445" type="curve" smooth="yes"/>
-      <point x="130" y="465"/>
-      <point x="133" y="483"/>
-      <point x="140" y="497" type="curve"/>
-      <point x="118" y="497" type="line"/>
-      <point x="95" y="455" type="line"/>
-      <point x="118" y="482"/>
-      <point x="160" y="496"/>
-      <point x="191" y="496" type="curve" smooth="yes"/>
-      <point x="248" y="496"/>
-      <point x="259" y="461"/>
-      <point x="259" y="434" type="curve" smooth="yes"/>
-      <point x="259" y="390"/>
-      <point x="236" y="363"/>
+      <point x="198" y="338" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="128" y="365"/>
+      <point x="128" y="418" type="curve" smooth="yes"/>
+      <point x="128" y="440"/>
+      <point x="131" y="457"/>
+      <point x="138" y="473" type="curve"/>
+      <point x="106" y="473" type="line"/>
+      <point x="95" y="433" type="line"/>
+      <point x="120" y="454"/>
+      <point x="155" y="468"/>
+      <point x="192" y="468" type="curve" smooth="yes"/>
+      <point x="240" y="468"/>
+      <point x="263" y="446"/>
+      <point x="263" y="401" type="curve" smooth="yes"/>
+      <point x="263" y="363"/>
+      <point x="240" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ja-malayalam.glif
@@ -1,135 +1,135 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <unicode hex="0D1C"/>
-  <anchor x="439" y="-4" name="bottom"/>
-  <anchor x="431" y="596" name="top"/>
-  <anchor x="677" y="596" name="topright"/>
+  <anchor x="457" y="-6" name="bottom"/>
+  <anchor x="441" y="596" name="top"/>
+  <anchor x="718" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="205" y="-16" type="curve" smooth="yes"/>
-      <point x="265" y="-16"/>
-      <point x="315" y="3"/>
-      <point x="409" y="59" type="curve" smooth="yes"/>
-      <point x="499" y="113" type="line"/>
-      <point x="546" y="145" type="line"/>
-      <point x="562" y="147" type="line"/>
-      <point x="601" y="167"/>
-      <point x="622" y="172"/>
-      <point x="646" y="172" type="curve" smooth="yes"/>
-      <point x="687" y="172"/>
-      <point x="707" y="152"/>
-      <point x="707" y="111" type="curve" smooth="yes"/>
-      <point x="707" y="72"/>
-      <point x="685" y="48"/>
-      <point x="650" y="48" type="curve" smooth="yes"/>
-      <point x="614" y="48"/>
-      <point x="594" y="70"/>
-      <point x="594" y="109" type="curve" smooth="yes"/>
-      <point x="594" y="139"/>
-      <point x="604" y="162"/>
-      <point x="629" y="190" type="curve"/>
-      <point x="527" y="155" type="line"/>
-      <point x="547" y="134" type="line"/>
-      <point x="543" y="125"/>
-      <point x="538" y="109"/>
-      <point x="538" y="90" type="curve" smooth="yes"/>
-      <point x="538" y="26"/>
-      <point x="583" y="-16"/>
-      <point x="651" y="-16" type="curve" smooth="yes"/>
-      <point x="725" y="-16"/>
-      <point x="773" y="33"/>
-      <point x="773" y="110" type="curve" smooth="yes"/>
-      <point x="773" y="187"/>
-      <point x="724" y="238"/>
-      <point x="650" y="238" type="curve" smooth="yes"/>
-      <point x="590" y="238"/>
-      <point x="552" y="224"/>
-      <point x="454" y="169" type="curve" smooth="yes"/>
-      <point x="379" y="127" type="line" smooth="yes"/>
-      <point x="278" y="71"/>
-      <point x="253" y="61"/>
-      <point x="214" y="61" type="curve" smooth="yes"/>
-      <point x="163" y="61"/>
-      <point x="138" y="85"/>
-      <point x="138" y="134" type="curve" smooth="yes"/>
-      <point x="138" y="192"/>
-      <point x="182" y="222"/>
-      <point x="269" y="222" type="curve" smooth="yes"/>
-      <point x="519" y="222" type="line" smooth="yes"/>
-      <point x="683" y="222"/>
-      <point x="778" y="299"/>
-      <point x="778" y="432" type="curve" smooth="yes"/>
-      <point x="778" y="542"/>
-      <point x="711" y="612"/>
-      <point x="606" y="612" type="curve" smooth="yes"/>
-      <point x="525" y="612"/>
-      <point x="464" y="567"/>
-      <point x="443" y="490" type="curve"/>
-      <point x="433" y="490" type="line"/>
-      <point x="414" y="569"/>
-      <point x="352" y="612"/>
-      <point x="255" y="612" type="curve" smooth="yes"/>
-      <point x="136" y="612"/>
-      <point x="54" y="545"/>
-      <point x="54" y="448" type="curve" smooth="yes"/>
-      <point x="54" y="360"/>
-      <point x="111" y="300"/>
-      <point x="195" y="300" type="curve" smooth="yes"/>
-      <point x="278" y="300"/>
-      <point x="331" y="349"/>
-      <point x="331" y="426" type="curve" smooth="yes"/>
-      <point x="331" y="492"/>
-      <point x="294" y="532"/>
-      <point x="226" y="532" type="curve" smooth="yes"/>
-      <point x="206" y="532"/>
-      <point x="186" y="529"/>
-      <point x="167" y="524" type="curve"/>
-      <point x="156" y="547" type="line"/>
-      <point x="150" y="525" type="line"/>
-      <point x="174" y="542"/>
-      <point x="210" y="552"/>
-      <point x="255" y="552" type="curve" smooth="yes"/>
-      <point x="345" y="552"/>
-      <point x="390" y="499"/>
-      <point x="390" y="392" type="curve" smooth="yes"/>
-      <point x="390" y="353" type="line"/>
-      <point x="474" y="353" type="line"/>
-      <point x="474" y="388" type="line" smooth="yes"/>
-      <point x="474" y="475"/>
-      <point x="524" y="534"/>
-      <point x="598" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="696" y="495"/>
-      <point x="696" y="429" type="curve" smooth="yes"/>
-      <point x="696" y="343"/>
-      <point x="637" y="294"/>
-      <point x="535" y="294" type="curve" smooth="yes"/>
-      <point x="266" y="294" type="line" smooth="yes"/>
-      <point x="138" y="294"/>
-      <point x="60" y="233"/>
-      <point x="60" y="133" type="curve" smooth="yes"/>
-      <point x="60" y="41"/>
-      <point x="116" y="-16"/>
+      <point x="218" y="-16" type="curve" smooth="yes"/>
+      <point x="269" y="-16"/>
+      <point x="311" y="-5"/>
+      <point x="376" y="27" type="curve" smooth="yes"/>
+      <point x="521" y="98" type="line"/>
+      <point x="586" y="147" type="line"/>
+      <point x="612" y="147" type="line"/>
+      <point x="637" y="167"/>
+      <point x="660" y="178"/>
+      <point x="692" y="178" type="curve" smooth="yes"/>
+      <point x="733" y="178"/>
+      <point x="753" y="156"/>
+      <point x="753" y="117" type="curve" smooth="yes"/>
+      <point x="753" y="78"/>
+      <point x="729" y="56"/>
+      <point x="691" y="56" type="curve" smooth="yes"/>
+      <point x="651" y="56"/>
+      <point x="629" y="78"/>
+      <point x="629" y="116" type="curve" smooth="yes"/>
+      <point x="629" y="144"/>
+      <point x="639" y="164"/>
+      <point x="664" y="190" type="curve"/>
+      <point x="560" y="150" type="line"/>
+      <point x="581" y="129" type="line"/>
+      <point x="576" y="117"/>
+      <point x="573" y="103"/>
+      <point x="573" y="86" type="curve" smooth="yes"/>
+      <point x="573" y="24"/>
+      <point x="623" y="-16"/>
+      <point x="694" y="-16" type="curve" smooth="yes"/>
+      <point x="774" y="-16"/>
+      <point x="825" y="33"/>
+      <point x="825" y="110" type="curve" smooth="yes"/>
+      <point x="825" y="182"/>
+      <point x="784" y="232"/>
+      <point x="700" y="232" type="curve" smooth="yes"/>
+      <point x="654" y="232"/>
+      <point x="619" y="222"/>
+      <point x="542" y="184" type="curve" smooth="yes"/>
+      <point x="347" y="89" type="line" smooth="yes"/>
+      <point x="304" y="68"/>
+      <point x="266" y="58"/>
+      <point x="223" y="58" type="curve" smooth="yes"/>
+      <point x="171" y="58"/>
+      <point x="142" y="81"/>
+      <point x="142" y="123" type="curve" smooth="yes"/>
+      <point x="142" y="168"/>
+      <point x="174" y="192"/>
+      <point x="239" y="192" type="curve" smooth="yes"/>
+      <point x="549" y="192" type="line" smooth="yes"/>
+      <point x="720" y="192"/>
+      <point x="828" y="279"/>
+      <point x="828" y="417" type="curve" smooth="yes"/>
+      <point x="828" y="532"/>
+      <point x="758" y="612"/>
+      <point x="640" y="612" type="curve" smooth="yes"/>
+      <point x="549" y="612"/>
+      <point x="489" y="567"/>
+      <point x="463" y="494" type="curve"/>
+      <point x="453" y="494" type="line"/>
+      <point x="422" y="575"/>
+      <point x="363" y="612"/>
+      <point x="262" y="612" type="curve" smooth="yes"/>
+      <point x="141" y="612"/>
+      <point x="54" y="533"/>
+      <point x="54" y="423" type="curve" smooth="yes"/>
+      <point x="54" y="336"/>
+      <point x="114" y="274"/>
+      <point x="197" y="274" type="curve" smooth="yes"/>
+      <point x="281" y="274"/>
+      <point x="335" y="323"/>
+      <point x="335" y="399" type="curve" smooth="yes"/>
+      <point x="335" y="469"/>
+      <point x="297" y="512"/>
+      <point x="223" y="512" type="curve" smooth="yes"/>
+      <point x="193" y="512"/>
+      <point x="171" y="508"/>
+      <point x="148" y="499" type="curve"/>
+      <point x="129" y="527" type="line"/>
+      <point x="136" y="499" type="line"/>
+      <point x="156" y="529"/>
+      <point x="202" y="552"/>
+      <point x="261" y="552" type="curve" smooth="yes"/>
+      <point x="362" y="552"/>
+      <point x="410" y="499"/>
+      <point x="410" y="392" type="curve" smooth="yes"/>
+      <point x="410" y="333" type="line"/>
+      <point x="494" y="333" type="line"/>
+      <point x="494" y="392" type="line" smooth="yes"/>
+      <point x="494" y="483"/>
+      <point x="546" y="534"/>
+      <point x="627" y="534" type="curve" smooth="yes"/>
+      <point x="706" y="534"/>
+      <point x="746" y="490"/>
+      <point x="746" y="415" type="curve" smooth="yes"/>
+      <point x="746" y="313"/>
+      <point x="685" y="264"/>
+      <point x="557" y="264" type="curve" smooth="yes"/>
+      <point x="235" y="264" type="line" smooth="yes"/>
+      <point x="128" y="264"/>
+      <point x="60" y="209"/>
+      <point x="60" y="122" type="curve" smooth="yes"/>
+      <point x="60" y="39"/>
+      <point x="123" y="-16"/>
     </contour>
     <contour>
-      <point x="196" y="363" type="curve" smooth="yes"/>
-      <point x="153" y="363"/>
-      <point x="130" y="393"/>
-      <point x="130" y="447" type="curve" smooth="yes"/>
-      <point x="130" y="471"/>
-      <point x="133" y="489"/>
-      <point x="140" y="499" type="curve"/>
-      <point x="118" y="499" type="line"/>
-      <point x="95" y="459" type="line"/>
-      <point x="119" y="477"/>
-      <point x="160" y="488"/>
-      <point x="193" y="488" type="curve" smooth="yes"/>
-      <point x="235" y="488"/>
-      <point x="259" y="467"/>
-      <point x="259" y="426" type="curve" smooth="yes"/>
-      <point x="259" y="387"/>
-      <point x="236" y="363"/>
+      <point x="198" y="338" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="128" y="365"/>
+      <point x="128" y="418" type="curve" smooth="yes"/>
+      <point x="128" y="440"/>
+      <point x="131" y="457"/>
+      <point x="138" y="473" type="curve"/>
+      <point x="106" y="473" type="line"/>
+      <point x="95" y="433" type="line"/>
+      <point x="120" y="454"/>
+      <point x="155" y="468"/>
+      <point x="192" y="468" type="curve" smooth="yes"/>
+      <point x="240" y="468"/>
+      <point x="263" y="446"/>
+      <point x="263" y="401" type="curve" smooth="yes"/>
+      <point x="263" y="363"/>
+      <point x="240" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
+  <anchor x="457" y="-6" name="bottom"/>
+  <anchor x="441" y="596" name="top"/>
+  <anchor x="718" y="596" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="677"/>
+    <component base="halant-malayalam" xOffset="718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
+  <anchor x="457" y="-6" name="bottom"/>
+  <anchor x="441" y="596" name="top"/>
+  <anchor x="718" y="596" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="439" yOffset="-4"/>
+    <component base="lVocalicMatra-malayalam" xOffset="457" yOffset="-6"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
+  <anchor x="457" y="-6" name="bottom"/>
+  <anchor x="441" y="596" name="top"/>
+  <anchor x="718" y="596" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="439" yOffset="-4"/>
+    <component base="llVocalicMatra-malayalam" xOffset="457" yOffset="-6"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/kC_hillu-malayalam.glif
@@ -2,96 +2,95 @@
 <glyph name="kChillu-malayalam" format="2">
   <advance width="1066"/>
   <unicode hex="0D7F"/>
-  <guideline x="1024"/>
   <anchor x="668" y="0" name="bottom"/>
   <anchor x="353" y="596" name="top"/>
   <outline>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
       <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="546" y="-16" type="curve" smooth="yes"/>
-      <point x="612" y="-16"/>
-      <point x="663" y="25"/>
+      <point x="608" y="-16"/>
+      <point x="661" y="21"/>
       <point x="691" y="85" type="curve"/>
       <point x="701" y="85" type="line"/>
-      <point x="724" y="28"/>
-      <point x="775" y="-16"/>
-      <point x="860" y="-16" type="curve" smooth="yes"/>
-      <point x="953" y="-16"/>
-      <point x="1023" y="44"/>
-      <point x="1023" y="154" type="curve" smooth="yes"/>
-      <point x="1023" y="261"/>
-      <point x="949" y="333"/>
-      <point x="815" y="333" type="curve" smooth="yes"/>
-      <point x="778" y="333" type="line"/>
-      <point x="744" y="259" type="line"/>
-      <point x="819" y="259" type="line" smooth="yes"/>
-      <point x="908" y="259"/>
-      <point x="938" y="216"/>
-      <point x="938" y="158" type="curve" smooth="yes"/>
-      <point x="938" y="99"/>
-      <point x="911" y="62"/>
-      <point x="852" y="62" type="curve" smooth="yes"/>
-      <point x="792" y="62"/>
-      <point x="750" y="107"/>
-      <point x="750" y="184" type="curve" smooth="yes"/>
-      <point x="750" y="265"/>
-      <point x="792" y="333"/>
+      <point x="726" y="20"/>
+      <point x="782" y="-16"/>
+      <point x="856" y="-16" type="curve" smooth="yes"/>
+      <point x="957" y="-16"/>
+      <point x="1023" y="55"/>
+      <point x="1023" y="165" type="curve" smooth="yes"/>
+      <point x="1023" y="282"/>
+      <point x="941" y="353"/>
+      <point x="806" y="353" type="curve" smooth="yes"/>
+      <point x="778" y="353" type="line"/>
+      <point x="744" y="279" type="line"/>
+      <point x="810" y="279" type="line" smooth="yes"/>
+      <point x="895" y="279"/>
+      <point x="939" y="242"/>
+      <point x="939" y="169" type="curve" smooth="yes"/>
+      <point x="939" y="102"/>
+      <point x="908" y="62"/>
+      <point x="847" y="62" type="curve" smooth="yes"/>
+      <point x="783" y="62"/>
+      <point x="746" y="103"/>
+      <point x="746" y="172" type="curve" smooth="yes"/>
+      <point x="746" y="241"/>
+      <point x="769" y="295"/>
       <point x="857" y="435" type="curve" smooth="yes"/>
-      <point x="908" y="516"/>
-      <point x="936" y="577"/>
+      <point x="915" y="527"/>
+      <point x="936" y="585"/>
       <point x="936" y="652" type="curve" smooth="yes"/>
-      <point x="936" y="743"/>
-      <point x="885" y="810"/>
+      <point x="936" y="751"/>
+      <point x="877" y="810"/>
       <point x="780" y="810" type="curve" smooth="yes"/>
-      <point x="722" y="810"/>
-      <point x="673" y="795"/>
+      <point x="720" y="810"/>
+      <point x="672" y="794"/>
       <point x="621" y="758" type="curve"/>
       <point x="659" y="691" type="line"/>
-      <point x="694" y="716"/>
-      <point x="731" y="731"/>
+      <point x="697" y="718"/>
+      <point x="734" y="731"/>
       <point x="774" y="731" type="curve" smooth="yes"/>
-      <point x="833" y="731"/>
-      <point x="853" y="697"/>
+      <point x="827" y="731"/>
+      <point x="853" y="704"/>
       <point x="853" y="649" type="curve" smooth="yes"/>
-      <point x="853" y="592"/>
-      <point x="832" y="545"/>
+      <point x="853" y="596"/>
+      <point x="836" y="552"/>
       <point x="783" y="464" type="curve" smooth="yes"/>
-      <point x="765" y="434"/>
-      <point x="752" y="407"/>
-      <point x="742" y="377" type="curve"/>
-      <point x="732" y="377" type="line"/>
-      <point x="721" y="515"/>
-      <point x="660" y="612"/>
+      <point x="760" y="426"/>
+      <point x="746" y="393"/>
+      <point x="739" y="361" type="curve"/>
+      <point x="731" y="361" type="line"/>
+      <point x="725" y="520"/>
+      <point x="656" y="612"/>
       <point x="543" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="330" y="495"/>
+      <point x="411" y="612"/>
+      <point x="330" y="500"/>
       <point x="330" y="318" type="curve" smooth="yes"/>
-      <point x="330" y="295"/>
-      <point x="333" y="248"/>
-      <point x="333" y="219" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="159" type="curve" smooth="yes"/>
-      <point x="123" y="220"/>
-      <point x="160" y="259"/>
-      <point x="247" y="259" type="curve" smooth="yes"/>
-      <point x="710" y="259" type="line"/>
-      <point x="717" y="333" type="line"/>
-      <point x="249" y="333" type="line" smooth="yes"/>
-      <point x="111" y="333"/>
-      <point x="41" y="263"/>
-      <point x="41" y="153" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="330" y="293"/>
+      <point x="333" y="242"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="710" y="279" type="line"/>
+      <point x="717" y="353" type="line"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/k_ka-malayalam.glif
@@ -1,102 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ka-malayalam" format="2">
   <advance width="1454"/>
-  <guideline x="1400"/>
   <anchor x="1044" y="0" name="bottom"/>
   <anchor x="793" y="596" name="top"/>
   <anchor x="1321" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
-      <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="377" y="94" type="line"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="756" y="106"/>
-      <point x="756" y="286" type="curve" smooth="yes"/>
-      <point x="756" y="310" type="line" smooth="yes"/>
-      <point x="756" y="489"/>
-      <point x="687" y="612"/>
-      <point x="544" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="330" y="495"/>
-      <point x="330" y="310" type="curve" smooth="yes"/>
-      <point x="330" y="287"/>
-      <point x="333" y="247"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="952" y="259" type="line" smooth="yes"/>
-      <point x="1050" y="259"/>
-      <point x="1075" y="209"/>
-      <point x="1075" y="144" type="curve" smooth="yes"/>
-      <point x="1075" y="86"/>
-      <point x="1050" y="62"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
+      <point x="759" y="287" type="curve" smooth="yes"/>
+      <point x="759" y="311" type="line" smooth="yes"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
+      <point x="546" y="612" type="curve" smooth="yes"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
+      <point x="329" y="311" type="curve" smooth="yes"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="960" y="279" type="line" smooth="yes"/>
+      <point x="1044" y="279"/>
+      <point x="1083" y="243"/>
+      <point x="1083" y="165" type="curve" smooth="yes"/>
+      <point x="1083" y="97"/>
+      <point x="1058" y="62"/>
       <point x="1010" y="62" type="curve" smooth="yes"/>
-      <point x="936" y="62"/>
-      <point x="911" y="146"/>
-      <point x="911" y="249" type="curve" smooth="yes"/>
-      <point x="911" y="421"/>
-      <point x="979" y="533"/>
+      <point x="946" y="62"/>
+      <point x="911" y="121"/>
+      <point x="911" y="230" type="curve" smooth="yes"/>
+      <point x="911" y="425"/>
+      <point x="988" y="533"/>
       <point x="1124" y="533" type="curve" smooth="yes"/>
-      <point x="1253" y="533"/>
-      <point x="1318" y="432"/>
+      <point x="1249" y="533"/>
+      <point x="1318" y="441"/>
       <point x="1318" y="286" type="curve" smooth="yes"/>
-      <point x="1318" y="194"/>
-      <point x="1285" y="106"/>
+      <point x="1318" y="197"/>
+      <point x="1287" y="109"/>
       <point x="1230" y="34" type="curve"/>
       <point x="1296" y="-16" type="line"/>
-      <point x="1367" y="68"/>
-      <point x="1400" y="182"/>
+      <point x="1362" y="62"/>
+      <point x="1400" y="173"/>
       <point x="1400" y="285" type="curve" smooth="yes"/>
-      <point x="1400" y="486"/>
-      <point x="1297" y="612"/>
+      <point x="1400" y="488"/>
+      <point x="1299" y="612"/>
       <point x="1126" y="612" type="curve" smooth="yes"/>
-      <point x="940" y="612"/>
-      <point x="829" y="465"/>
-      <point x="829" y="246" type="curve" smooth="yes"/>
-      <point x="829" y="116"/>
-      <point x="878" y="-16"/>
+      <point x="945" y="612"/>
+      <point x="829" y="463"/>
+      <point x="829" y="227" type="curve" smooth="yes"/>
+      <point x="829" y="77"/>
+      <point x="900" y="-16"/>
       <point x="1013" y="-16" type="curve" smooth="yes"/>
-      <point x="1111" y="-16"/>
-      <point x="1157" y="53"/>
-      <point x="1157" y="144" type="curve" smooth="yes"/>
-      <point x="1157" y="242"/>
-      <point x="1110" y="333"/>
-      <point x="948" y="333" type="curve" smooth="yes"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="1107" y="-16"/>
+      <point x="1165" y="54"/>
+      <point x="1165" y="165" type="curve" smooth="yes"/>
+      <point x="1165" y="288"/>
+      <point x="1092" y="353"/>
+      <point x="956" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="154"/>
-      <point x="412" y="288" type="curve" smooth="yes"/>
-      <point x="412" y="308" type="line" smooth="yes"/>
-      <point x="412" y="443"/>
-      <point x="453" y="534"/>
-      <point x="544" y="534" type="curve" smooth="yes"/>
-      <point x="636" y="534"/>
-      <point x="672" y="442"/>
-      <point x="672" y="308" type="curve" smooth="yes"/>
-      <point x="672" y="288" type="line" smooth="yes"/>
-      <point x="672" y="154"/>
-      <point x="633" y="62"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
+      <point x="412" y="289" type="curve" smooth="yes"/>
+      <point x="412" y="309" type="line" smooth="yes"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
+      <point x="545" y="534" type="curve" smooth="yes"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
+      <point x="672" y="309" type="curve" smooth="yes"/>
+      <point x="672" y="289" type="line" smooth="yes"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/k_la-malayalam.glif
@@ -54,29 +54,29 @@
       <point x="759" y="152"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="815" y="259" type="line" smooth="yes"/>
-      <point x="895" y="259"/>
-      <point x="936" y="223"/>
-      <point x="936" y="157" type="curve" smooth="yes"/>
-      <point x="936" y="94"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="806" y="279" type="line" smooth="yes"/>
+      <point x="893" y="279"/>
+      <point x="936" y="242"/>
+      <point x="936" y="168" type="curve" smooth="yes"/>
+      <point x="936" y="98"/>
       <point x="902" y="60"/>
       <point x="847" y="60" type="curve" smooth="yes"/>
       <point x="827" y="60"/>
@@ -87,20 +87,20 @@
       <point x="819" y="-16"/>
       <point x="850" y="-16" type="curve" smooth="yes"/>
       <point x="950" y="-16"/>
-      <point x="1018" y="53"/>
-      <point x="1018" y="155" type="curve" smooth="yes"/>
-      <point x="1018" y="264"/>
-      <point x="938" y="333"/>
-      <point x="811" y="333" type="curve" smooth="yes"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="1018" y="57"/>
+      <point x="1018" y="166" type="curve" smooth="yes"/>
+      <point x="1018" y="283"/>
+      <point x="937" y="353"/>
+      <point x="802" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
       <point x="377" y="94" type="line"/>
       <point x="388" y="72"/>
@@ -118,7 +118,7 @@
       <point x="381" y="-313"/>
       <point x="354" y="-256"/>
       <point x="354" y="-200" type="curve"/>
-      <point x="334" y="-208" type="line"/>
+      <point x="337" y="-218" type="line"/>
       <point x="355" y="-265" type="line"/>
       <point x="355" y="-221"/>
       <point x="387" y="-181"/>
@@ -131,19 +131,19 @@
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="442"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.glif
@@ -1,45 +1,44 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam" format="2">
   <advance width="1726"/>
-  <guideline x="1637"/>
   <anchor x="1281" y="0" name="bottom"/>
   <anchor x="879" y="596" name="top"/>
   <anchor x="1604" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
-      <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="377" y="94" type="line"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="759" y="104"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="159" type="curve" smooth="yes"/>
-      <point x="123" y="223"/>
-      <point x="166" y="265"/>
-      <point x="238" y="265" type="curve" smooth="yes"/>
-      <point x="815" y="265" type="line" smooth="yes"/>
-      <point x="905" y="265"/>
-      <point x="936" y="229"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="806" y="279" type="line" smooth="yes"/>
+      <point x="893" y="279"/>
+      <point x="936" y="244"/>
       <point x="936" y="175" type="curve" smooth="yes"/>
       <point x="936" y="129"/>
       <point x="919" y="95"/>
@@ -76,38 +75,38 @@
       <point x="1473" y="295"/>
       <point x="1543" y="391" type="curve"/>
       <point x="1553" y="389" type="line"/>
-      <point x="1552" y="40" type="line"/>
+      <point x="1553" y="40" type="line"/>
       <point x="1593" y="74" type="line"/>
       <point x="985" y="74" type="line"/>
       <point x="981" y="82" type="line"/>
       <point x="1009" y="112"/>
       <point x="1018" y="151"/>
       <point x="1018" y="182" type="curve" smooth="yes"/>
-      <point x="1018" y="274"/>
-      <point x="958" y="339"/>
-      <point x="811" y="339" type="curve" smooth="yes"/>
-      <point x="243" y="339" type="line" smooth="yes"/>
-      <point x="120" y="339"/>
-      <point x="41" y="266"/>
-      <point x="41" y="153" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="1018" y="289"/>
+      <point x="937" y="353"/>
+      <point x="802" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="442"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam.half" format="2">
   <advance width="1726"/>
+  <anchor x="1281" y="0" name="bottom"/>
+  <anchor x="879" y="596" name="top"/>
+  <anchor x="1604" y="596" name="topright"/>
   <outline>
     <component base="k_ssa-malayalam"/>
     <component base="halant-malayalam" xOffset="1604"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/k_ta-malayalam.glif
@@ -58,60 +58,60 @@
       <point x="908" y="73"/>
     </contour>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
-      <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="377" y="94" type="line"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="759" y="104"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="903" y="259" type="line"/>
-      <point x="903" y="333" type="line"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="904" y="279" type="line"/>
+      <point x="904" y="353" type="line"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="442"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/k_tta-malayalam.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_tta-malayalam" format="2">
   <advance width="1060"/>
-  <guideline x="1018" y="165" angle="90"/>
   <anchor x="852" y="-362" name="bottom"/>
   <anchor x="546" y="596" name="top"/>
   <anchor x="891" y="556" name="topright"/>
@@ -29,53 +28,53 @@
       <point x="973" y="27"/>
       <point x="955" y="31" type="curve"/>
       <point x="955" y="41" type="line"/>
-      <point x="1000" y="64"/>
-      <point x="1018" y="111"/>
-      <point x="1018" y="165" type="curve" smooth="yes"/>
-      <point x="1018" y="274"/>
-      <point x="938" y="333"/>
-      <point x="808" y="333" type="curve" smooth="yes"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="996" y="69"/>
+      <point x="1018" y="108"/>
+      <point x="1018" y="171" type="curve" smooth="yes"/>
+      <point x="1018" y="282"/>
+      <point x="940" y="353"/>
+      <point x="810" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
-      <point x="376" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="377" y="94" type="line"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="759" y="104"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="815" y="259" type="line" smooth="yes"/>
-      <point x="895" y="259"/>
-      <point x="936" y="223"/>
-      <point x="936" y="157" type="curve" smooth="yes"/>
-      <point x="936" y="94"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="806" y="279" type="line" smooth="yes"/>
+      <point x="894" y="279"/>
+      <point x="936" y="241"/>
+      <point x="936" y="166" type="curve" smooth="yes"/>
+      <point x="936" y="97"/>
       <point x="902" y="60"/>
       <point x="847" y="60" type="curve" smooth="yes"/>
       <point x="827" y="60"/>
@@ -105,19 +104,19 @@
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="440"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ka-malayalam.glif
@@ -7,78 +7,78 @@
   <anchor x="891" y="556" name="topright"/>
   <outline>
     <contour>
-      <point x="213" y="-16" type="curve" smooth="yes"/>
-      <point x="289" y="-16"/>
-      <point x="342" y="30"/>
+      <point x="217" y="-16" type="curve" smooth="yes"/>
+      <point x="287" y="-16"/>
+      <point x="340" y="23"/>
       <point x="367" y="94" type="curve"/>
       <point x="377" y="94" type="line"/>
-      <point x="410" y="24"/>
-      <point x="468" y="-16"/>
+      <point x="411" y="22"/>
+      <point x="470" y="-16"/>
       <point x="547" y="-16" type="curve" smooth="yes"/>
-      <point x="683" y="-16"/>
-      <point x="759" y="104"/>
+      <point x="679" y="-16"/>
+      <point x="759" y="98"/>
       <point x="759" y="287" type="curve" smooth="yes"/>
       <point x="759" y="311" type="line" smooth="yes"/>
-      <point x="759" y="486"/>
-      <point x="683" y="612"/>
+      <point x="759" y="495"/>
+      <point x="676" y="612"/>
       <point x="546" y="612" type="curve" smooth="yes"/>
-      <point x="407" y="612"/>
-      <point x="329" y="493"/>
+      <point x="411" y="612"/>
+      <point x="329" y="498"/>
       <point x="329" y="311" type="curve" smooth="yes"/>
-      <point x="329" y="287"/>
-      <point x="333" y="246"/>
-      <point x="333" y="221" type="curve" smooth="yes"/>
-      <point x="333" y="125"/>
-      <point x="289" y="62"/>
-      <point x="219" y="62" type="curve" smooth="yes"/>
-      <point x="162" y="62"/>
-      <point x="123" y="100"/>
-      <point x="123" y="156" type="curve" smooth="yes"/>
-      <point x="123" y="217"/>
-      <point x="166" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="815" y="259" type="line" smooth="yes"/>
-      <point x="895" y="259"/>
-      <point x="936" y="223"/>
-      <point x="936" y="157" type="curve" smooth="yes"/>
-      <point x="936" y="94"/>
-      <point x="902" y="60"/>
+      <point x="329" y="284"/>
+      <point x="333" y="239"/>
+      <point x="333" y="211" type="curve" smooth="yes"/>
+      <point x="333" y="113"/>
+      <point x="292" y="62"/>
+      <point x="223" y="62" type="curve" smooth="yes"/>
+      <point x="163" y="62"/>
+      <point x="123" y="103"/>
+      <point x="123" y="166" type="curve" smooth="yes"/>
+      <point x="123" y="235"/>
+      <point x="170" y="279"/>
+      <point x="244" y="279" type="curve" smooth="yes"/>
+      <point x="806" y="279" type="line" smooth="yes"/>
+      <point x="893" y="279"/>
+      <point x="936" y="242"/>
+      <point x="936" y="168" type="curve" smooth="yes"/>
+      <point x="936" y="100"/>
+      <point x="903" y="60"/>
       <point x="847" y="60" type="curve" smooth="yes"/>
-      <point x="827" y="60"/>
-      <point x="809" y="63"/>
+      <point x="828" y="60"/>
+      <point x="810" y="63"/>
       <point x="795" y="68" type="curve"/>
       <point x="774" y="-5" type="line"/>
-      <point x="797" y="-12"/>
-      <point x="819" y="-16"/>
+      <point x="800" y="-13"/>
+      <point x="822" y="-16"/>
       <point x="850" y="-16" type="curve" smooth="yes"/>
       <point x="950" y="-16"/>
-      <point x="1018" y="53"/>
-      <point x="1018" y="155" type="curve" smooth="yes"/>
-      <point x="1018" y="264"/>
-      <point x="938" y="333"/>
-      <point x="811" y="333" type="curve" smooth="yes"/>
-      <point x="243" y="333" type="line" smooth="yes"/>
-      <point x="120" y="333"/>
-      <point x="41" y="260"/>
-      <point x="41" y="150" type="curve" smooth="yes"/>
-      <point x="41" y="56"/>
-      <point x="114" y="-16"/>
+      <point x="1018" y="57"/>
+      <point x="1018" y="166" type="curve" smooth="yes"/>
+      <point x="1018" y="283"/>
+      <point x="937" y="353"/>
+      <point x="802" y="353" type="curve" smooth="yes"/>
+      <point x="249" y="353" type="line" smooth="yes"/>
+      <point x="123" y="353"/>
+      <point x="41" y="277"/>
+      <point x="41" y="160" type="curve" smooth="yes"/>
+      <point x="41" y="60"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
       <point x="545" y="62" type="curve" smooth="yes"/>
-      <point x="453" y="62"/>
-      <point x="412" y="152"/>
+      <point x="459" y="62"/>
+      <point x="412" y="142"/>
       <point x="412" y="289" type="curve" smooth="yes"/>
       <point x="412" y="309" type="line" smooth="yes"/>
-      <point x="412" y="442"/>
-      <point x="453" y="534"/>
+      <point x="412" y="453"/>
+      <point x="460" y="534"/>
       <point x="545" y="534" type="curve" smooth="yes"/>
-      <point x="633" y="534"/>
-      <point x="672" y="441"/>
+      <point x="626" y="534"/>
+      <point x="672" y="453"/>
       <point x="672" y="309" type="curve" smooth="yes"/>
       <point x="672" y="289" type="line" smooth="yes"/>
-      <point x="672" y="153"/>
-      <point x="633" y="62"/>
+      <point x="672" y="142"/>
+      <point x="627" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/m_la-malayalam.glif
@@ -1,56 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="m_la-malayalam" format="2">
   <advance width="692"/>
-  <anchor x="354" y="-362" name="bottom"/>
+  <anchor x="346" y="-362" name="bottom"/>
   <anchor x="349" y="596" name="top"/>
   <anchor x="577" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="129" y="-378" type="curve" smooth="yes"/>
-      <point x="211" y="-378"/>
-      <point x="259" y="-328"/>
-      <point x="259" y="-245" type="curve" smooth="yes"/>
-      <point x="259" y="-163"/>
-      <point x="215" y="-121"/>
-      <point x="145" y="-121" type="curve" smooth="yes"/>
-      <point x="92" y="-121"/>
-      <point x="34" y="-154"/>
-      <point x="34" y="-239" type="curve"/>
-      <point x="58" y="-172" type="line"/>
-      <point x="-1" y="-172" type="line"/>
-      <point x="38" y="-198" type="line"/>
-      <point x="38" y="-84"/>
-      <point x="90" y="-22"/>
-      <point x="186" y="-22" type="curve" smooth="yes"/>
-      <point x="282" y="-22"/>
-      <point x="318" y="-84"/>
-      <point x="339" y="-167" type="curve" smooth="yes"/>
-      <point x="349" y="-206" type="line" smooth="yes"/>
-      <point x="379" y="-322"/>
-      <point x="429" y="-378"/>
-      <point x="528" y="-378" type="curve" smooth="yes"/>
-      <point x="622" y="-378"/>
-      <point x="688" y="-319"/>
-      <point x="688" y="-185" type="curve" smooth="yes"/>
-      <point x="688" y="-80"/>
-      <point x="655" y="-7"/>
-      <point x="605" y="48" type="curve"/>
-      <point x="546" y="8" type="line"/>
-      <point x="586" y="-39"/>
-      <point x="614" y="-96"/>
-      <point x="614" y="-185" type="curve" smooth="yes"/>
-      <point x="614" y="-262"/>
-      <point x="587" y="-308"/>
-      <point x="527" y="-308" type="curve" smooth="yes"/>
-      <point x="472" y="-308"/>
-      <point x="445" y="-271"/>
-      <point x="421" y="-185" type="curve" smooth="yes"/>
-      <point x="409" y="-142" type="line" smooth="yes"/>
-      <point x="392" y="-83"/>
-      <point x="372" y="-36"/>
-      <point x="330" y="-10" type="curve"/>
-      <point x="333" y="0" type="line"/>
-      <point x="599" y="0" type="line"/>
+      <point x="63" y="0" type="line"/>
       <point x="629" y="0" type="line"/>
       <point x="629" y="340" type="line" smooth="yes"/>
       <point x="629" y="497"/>
@@ -59,29 +15,72 @@
       <point x="169" y="612"/>
       <point x="63" y="496"/>
       <point x="63" y="339" type="curve" smooth="yes"/>
-      <point x="63" y="3" type="line"/>
-      <point x="86" y="26" type="line"/>
-      <point x="14" y="-9"/>
-      <point x="-28" y="-85"/>
-      <point x="-28" y="-184" type="curve" smooth="yes"/>
-      <point x="-28" y="-316"/>
-      <point x="44" y="-378"/>
     </contour>
     <contour>
-      <point x="126" y="-313" type="curve" smooth="yes"/>
-      <point x="68" y="-313"/>
-      <point x="41" y="-256"/>
-      <point x="41" y="-200" type="curve"/>
-      <point x="21" y="-208" type="line"/>
-      <point x="42" y="-265" type="line"/>
-      <point x="42" y="-221"/>
-      <point x="74" y="-181"/>
-      <point x="128" y="-181" type="curve" smooth="yes"/>
-      <point x="169" y="-181"/>
-      <point x="189" y="-206"/>
-      <point x="189" y="-245" type="curve" smooth="yes"/>
-      <point x="189" y="-287"/>
-      <point x="168" y="-313"/>
+      <point x="201" y="-378" type="curve" smooth="yes"/>
+      <point x="279" y="-378"/>
+      <point x="328" y="-324"/>
+      <point x="328" y="-238" type="curve" smooth="yes"/>
+      <point x="328" y="-154"/>
+      <point x="289" y="-104"/>
+      <point x="224" y="-104" type="curve" smooth="yes"/>
+      <point x="167" y="-104"/>
+      <point x="120" y="-145"/>
+      <point x="115" y="-199" type="curve"/>
+      <point x="150" y="-158" type="line"/>
+      <point x="91" y="-158" type="line"/>
+      <point x="119" y="-198" type="line"/>
+      <point x="119" y="-84"/>
+      <point x="167" y="-18"/>
+      <point x="250" y="-18" type="curve" smooth="yes"/>
+      <point x="319" y="-18"/>
+      <point x="354" y="-58"/>
+      <point x="369" y="-155" type="curve" smooth="yes"/>
+      <point x="382" y="-238" type="line" smooth="yes"/>
+      <point x="396" y="-328"/>
+      <point x="443" y="-378"/>
+      <point x="515" y="-378" type="curve" smooth="yes"/>
+      <point x="601" y="-378"/>
+      <point x="649" y="-314"/>
+      <point x="649" y="-200" type="curve" smooth="yes"/>
+      <point x="649" y="-114"/>
+      <point x="618" y="-28"/>
+      <point x="560" y="47" type="curve"/>
+      <point x="500" y="6" type="line"/>
+      <point x="549" y="-54"/>
+      <point x="575" y="-126"/>
+      <point x="575" y="-204" type="curve" smooth="yes"/>
+      <point x="575" y="-273"/>
+      <point x="556" y="-308"/>
+      <point x="518" y="-308" type="curve" smooth="yes"/>
+      <point x="479" y="-308"/>
+      <point x="463" y="-281"/>
+      <point x="450" y="-201" type="curve" smooth="yes"/>
+      <point x="437" y="-118" type="line" smooth="yes"/>
+      <point x="421" y="-16"/>
+      <point x="361" y="32"/>
+      <point x="252" y="32" type="curve" smooth="yes"/>
+      <point x="129" y="32"/>
+      <point x="53" y="-50"/>
+      <point x="53" y="-184" type="curve" smooth="yes"/>
+      <point x="53" y="-302"/>
+      <point x="111" y="-378"/>
+    </contour>
+    <contour>
+      <point x="197" y="-312" type="curve" smooth="yes"/>
+      <point x="143" y="-312"/>
+      <point x="122" y="-267"/>
+      <point x="122" y="-213" type="curve"/>
+      <point x="102" y="-221" type="line"/>
+      <point x="123" y="-245" type="line"/>
+      <point x="123" y="-203"/>
+      <point x="154" y="-164"/>
+      <point x="199" y="-164" type="curve" smooth="yes"/>
+      <point x="238" y="-164"/>
+      <point x="258" y="-193"/>
+      <point x="258" y="-238" type="curve" smooth="yes"/>
+      <point x="258" y="-284"/>
+      <point x="237" y="-312"/>
     </contour>
     <contour>
       <point x="113" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ng_ka-malayalam.glif
@@ -6,13 +6,13 @@
   <anchor x="872" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="218" y="-16" type="curve" smooth="yes"/>
-      <point x="302" y="-16"/>
-      <point x="351" y="30"/>
-      <point x="375" y="96" type="curve"/>
-      <point x="385" y="96" type="line"/>
-      <point x="415" y="24"/>
-      <point x="473" y="-16"/>
+      <point x="222" y="-16" type="curve" smooth="yes"/>
+      <point x="292" y="-16"/>
+      <point x="345" y="23"/>
+      <point x="372" y="94" type="curve"/>
+      <point x="382" y="94" type="line"/>
+      <point x="414" y="25"/>
+      <point x="472" y="-16"/>
       <point x="552" y="-16" type="curve" smooth="yes"/>
       <point x="688" y="-16"/>
       <point x="764" y="104"/>
@@ -27,61 +27,61 @@
       <point x="374" y="498" type="line"/>
       <point x="352" y="566"/>
       <point x="301" y="612"/>
-      <point x="218" y="612" type="curve" smooth="yes"/>
+      <point x="217" y="612" type="curve" smooth="yes"/>
       <point x="112" y="612"/>
-      <point x="53" y="541"/>
-      <point x="53" y="450" type="curve" smooth="yes"/>
-      <point x="53" y="382"/>
-      <point x="88" y="327"/>
-      <point x="142" y="303" type="curve"/>
-      <point x="142" y="293" type="line"/>
-      <point x="86" y="272"/>
-      <point x="46" y="221"/>
-      <point x="46" y="150" type="curve" smooth="yes"/>
-      <point x="46" y="56"/>
-      <point x="111" y="-16"/>
+      <point x="53" y="543"/>
+      <point x="53" y="454" type="curve" smooth="yes"/>
+      <point x="53" y="393"/>
+      <point x="87" y="347"/>
+      <point x="142" y="323" type="curve"/>
+      <point x="142" y="313" type="line"/>
+      <point x="87" y="289"/>
+      <point x="46" y="233"/>
+      <point x="46" y="157" type="curve" smooth="yes"/>
+      <point x="46" y="59"/>
+      <point x="122" y="-16"/>
     </contour>
     <contour>
       <point x="855" y="-16" type="curve" smooth="yes"/>
       <point x="955" y="-16"/>
-      <point x="1023" y="53"/>
-      <point x="1023" y="155" type="curve" smooth="yes"/>
-      <point x="1023" y="264"/>
-      <point x="943" y="333"/>
-      <point x="816" y="333" type="curve" smooth="yes"/>
-      <point x="267" y="333" type="line" smooth="yes"/>
-      <point x="176" y="333"/>
-      <point x="135" y="381"/>
-      <point x="135" y="445" type="curve" smooth="yes"/>
-      <point x="135" y="498"/>
+      <point x="1023" y="57"/>
+      <point x="1023" y="166" type="curve" smooth="yes"/>
+      <point x="1023" y="283"/>
+      <point x="942" y="353"/>
+      <point x="807" y="353" type="curve" smooth="yes"/>
+      <point x="267" y="353" type="line" smooth="yes"/>
+      <point x="176" y="353"/>
+      <point x="135" y="394"/>
+      <point x="135" y="449" type="curve" smooth="yes"/>
+      <point x="135" y="500"/>
       <point x="169" y="534"/>
-      <point x="227" y="534" type="curve" smooth="yes"/>
+      <point x="226" y="534" type="curve" smooth="yes"/>
       <point x="306" y="534"/>
       <point x="338" y="475"/>
       <point x="338" y="375" type="curve" smooth="yes"/>
-      <point x="338" y="221" type="line" smooth="yes"/>
-      <point x="338" y="125"/>
-      <point x="294" y="62"/>
-      <point x="224" y="62" type="curve" smooth="yes"/>
-      <point x="163" y="62"/>
-      <point x="128" y="100"/>
-      <point x="128" y="156" type="curve" smooth="yes"/>
-      <point x="128" y="217"/>
-      <point x="171" y="259"/>
-      <point x="243" y="259" type="curve" smooth="yes"/>
-      <point x="820" y="259" type="line" smooth="yes"/>
-      <point x="900" y="259"/>
-      <point x="941" y="223"/>
-      <point x="941" y="157" type="curve" smooth="yes"/>
-      <point x="941" y="94"/>
-      <point x="907" y="60"/>
+      <point x="338" y="209" type="line" smooth="yes"/>
+      <point x="338" y="112"/>
+      <point x="296" y="62"/>
+      <point x="228" y="62" type="curve" smooth="yes"/>
+      <point x="168" y="62"/>
+      <point x="128" y="102"/>
+      <point x="128" y="163" type="curve" smooth="yes"/>
+      <point x="128" y="233"/>
+      <point x="173" y="279"/>
+      <point x="253" y="279" type="curve" smooth="yes"/>
+      <point x="811" y="279" type="line" smooth="yes"/>
+      <point x="898" y="279"/>
+      <point x="941" y="242"/>
+      <point x="941" y="168" type="curve" smooth="yes"/>
+      <point x="941" y="100"/>
+      <point x="908" y="60"/>
       <point x="852" y="60" type="curve" smooth="yes"/>
-      <point x="832" y="60"/>
-      <point x="814" y="63"/>
+      <point x="833" y="60"/>
+      <point x="815" y="63"/>
       <point x="800" y="68" type="curve"/>
       <point x="779" y="-5" type="line"/>
-      <point x="802" y="-12"/>
-      <point x="824" y="-16"/>
+      <point x="805" y="-13"/>
+      <point x="827" y="-16"/>
     </contour>
     <contour>
       <point x="550" y="62" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1542"/>
-  <anchor x="1141" y="-16" name="bottom"/>
-  <anchor x="801" y="596" name="top"/>
-  <anchor x="1409" y="596" name="topright"/>
+  <advance width="1592"/>
+  <anchor x="1167" y="-6" name="bottom"/>
+  <anchor x="796" y="596" name="top"/>
+  <anchor x="1428" y="596" name="topright"/>
   <outline>
     <contour>
       <point x="287" y="-16" type="curve" smooth="yes"/>
@@ -45,112 +45,112 @@
       <point x="821" y="548"/>
       <point x="833" y="547"/>
       <point x="845" y="546" type="curve"/>
-      <point x="801" y="586" type="line"/>
-      <point x="809" y="539" type="line"/>
-      <point x="778" y="512"/>
-      <point x="764" y="476"/>
-      <point x="764" y="435" type="curve" smooth="yes"/>
-      <point x="764" y="362"/>
-      <point x="819" y="306"/>
-      <point x="901" y="306" type="curve" smooth="yes"/>
-      <point x="994" y="306"/>
-      <point x="1041" y="363"/>
-      <point x="1041" y="443" type="curve" smooth="yes"/>
-      <point x="1041" y="476"/>
-      <point x="1027" y="519"/>
-      <point x="982" y="545" type="curve"/>
-      <point x="994" y="592" type="line"/>
-      <point x="900" y="555" type="line"/>
-      <point x="914" y="557"/>
-      <point x="927" y="557"/>
-      <point x="939" y="557" type="curve" smooth="yes"/>
-      <point x="1070" y="557"/>
-      <point x="1104" y="467"/>
-      <point x="1104" y="396" type="curve" smooth="yes"/>
-      <point x="1104" y="353" type="line"/>
-      <point x="1188" y="353" type="line"/>
-      <point x="1188" y="388" type="line" smooth="yes"/>
-      <point x="1188" y="479"/>
-      <point x="1232" y="534"/>
-      <point x="1307" y="534" type="curve" smooth="yes"/>
-      <point x="1371" y="534"/>
-      <point x="1406" y="490"/>
-      <point x="1406" y="425" type="curve" smooth="yes"/>
-      <point x="1406" y="359"/>
-      <point x="1368" y="294"/>
-      <point x="1245" y="294" type="curve" smooth="yes"/>
-      <point x="976" y="294" type="line" smooth="yes"/>
-      <point x="838" y="294"/>
-      <point x="770" y="226"/>
-      <point x="770" y="133" type="curve" smooth="yes"/>
-      <point x="770" y="46"/>
-      <point x="821" y="-16"/>
-      <point x="915" y="-16" type="curve" smooth="yes"/>
-      <point x="981" y="-16"/>
-      <point x="1035" y="9"/>
-      <point x="1119" y="59" type="curve" smooth="yes"/>
-      <point x="1209" y="113" type="line"/>
-      <point x="1256" y="145" type="line"/>
-      <point x="1272" y="147" type="line"/>
-      <point x="1311" y="167"/>
-      <point x="1332" y="172"/>
-      <point x="1356" y="172" type="curve" smooth="yes"/>
-      <point x="1397" y="172"/>
-      <point x="1417" y="152"/>
-      <point x="1417" y="111" type="curve" smooth="yes"/>
-      <point x="1417" y="72"/>
-      <point x="1395" y="48"/>
-      <point x="1360" y="48" type="curve" smooth="yes"/>
-      <point x="1324" y="48"/>
-      <point x="1304" y="70"/>
-      <point x="1304" y="109" type="curve" smooth="yes"/>
-      <point x="1304" y="139"/>
-      <point x="1314" y="162"/>
-      <point x="1339" y="190" type="curve"/>
-      <point x="1237" y="155" type="line"/>
-      <point x="1257" y="134" type="line"/>
-      <point x="1253" y="125"/>
-      <point x="1248" y="109"/>
-      <point x="1248" y="90" type="curve" smooth="yes"/>
-      <point x="1248" y="26"/>
-      <point x="1293" y="-16"/>
-      <point x="1361" y="-16" type="curve" smooth="yes"/>
-      <point x="1435" y="-16"/>
-      <point x="1483" y="33"/>
-      <point x="1483" y="110" type="curve" smooth="yes"/>
-      <point x="1483" y="187"/>
-      <point x="1434" y="238"/>
-      <point x="1360" y="238" type="curve" smooth="yes"/>
-      <point x="1300" y="238"/>
-      <point x="1262" y="224"/>
-      <point x="1164" y="169" type="curve" smooth="yes"/>
-      <point x="1089" y="127" type="line" smooth="yes"/>
-      <point x="1002" y="78"/>
-      <point x="969" y="61"/>
-      <point x="924" y="61" type="curve" smooth="yes"/>
-      <point x="878" y="61"/>
-      <point x="848" y="80"/>
-      <point x="848" y="134" type="curve" smooth="yes"/>
-      <point x="848" y="187"/>
-      <point x="884" y="222"/>
-      <point x="979" y="222" type="curve" smooth="yes"/>
-      <point x="1229" y="222" type="line" smooth="yes"/>
-      <point x="1422" y="222"/>
-      <point x="1488" y="320"/>
-      <point x="1488" y="428" type="curve" smooth="yes"/>
-      <point x="1488" y="534"/>
-      <point x="1416" y="612"/>
-      <point x="1309" y="612" type="curve" smooth="yes"/>
-      <point x="1225" y="612"/>
-      <point x="1168" y="565"/>
-      <point x="1150" y="490" type="curve"/>
-      <point x="1145" y="490" type="line"/>
-      <point x="1123" y="565"/>
-      <point x="1050" y="612"/>
-      <point x="957" y="612" type="curve" smooth="yes"/>
-      <point x="924" y="612"/>
-      <point x="897" y="605"/>
-      <point x="877" y="595" type="curve"/>
+      <point x="810" y="568" type="line"/>
+      <point x="817" y="539" type="line"/>
+      <point x="784" y="510"/>
+      <point x="764" y="469"/>
+      <point x="764" y="422" type="curve" smooth="yes"/>
+      <point x="764" y="346"/>
+      <point x="827" y="286"/>
+      <point x="909" y="286" type="curve" smooth="yes"/>
+      <point x="995" y="286"/>
+      <point x="1051" y="341"/>
+      <point x="1051" y="420" type="curve" smooth="yes"/>
+      <point x="1051" y="474"/>
+      <point x="1031" y="519"/>
+      <point x="993" y="544" type="curve"/>
+      <point x="1004" y="579" type="line"/>
+      <point x="945" y="550" type="line"/>
+      <point x="953" y="552"/>
+      <point x="965" y="554"/>
+      <point x="978" y="554" type="curve" smooth="yes"/>
+      <point x="1074" y="554"/>
+      <point x="1120" y="500"/>
+      <point x="1120" y="392" type="curve" smooth="yes"/>
+      <point x="1120" y="333" type="line"/>
+      <point x="1204" y="333" type="line"/>
+      <point x="1204" y="392" type="line" smooth="yes"/>
+      <point x="1204" y="483"/>
+      <point x="1256" y="534"/>
+      <point x="1337" y="534" type="curve" smooth="yes"/>
+      <point x="1416" y="534"/>
+      <point x="1456" y="490"/>
+      <point x="1456" y="415" type="curve" smooth="yes"/>
+      <point x="1456" y="313"/>
+      <point x="1395" y="264"/>
+      <point x="1267" y="264" type="curve" smooth="yes"/>
+      <point x="945" y="264" type="line" smooth="yes"/>
+      <point x="838" y="264"/>
+      <point x="770" y="209"/>
+      <point x="770" y="122" type="curve" smooth="yes"/>
+      <point x="770" y="37"/>
+      <point x="835" y="-16"/>
+      <point x="928" y="-16" type="curve" smooth="yes"/>
+      <point x="979" y="-16"/>
+      <point x="1021" y="-5"/>
+      <point x="1086" y="27" type="curve" smooth="yes"/>
+      <point x="1231" y="98" type="line"/>
+      <point x="1296" y="147" type="line"/>
+      <point x="1322" y="147" type="line"/>
+      <point x="1347" y="167"/>
+      <point x="1370" y="178"/>
+      <point x="1402" y="178" type="curve" smooth="yes"/>
+      <point x="1443" y="178"/>
+      <point x="1463" y="156"/>
+      <point x="1463" y="117" type="curve" smooth="yes"/>
+      <point x="1463" y="78"/>
+      <point x="1439" y="56"/>
+      <point x="1401" y="56" type="curve" smooth="yes"/>
+      <point x="1361" y="56"/>
+      <point x="1339" y="78"/>
+      <point x="1339" y="116" type="curve" smooth="yes"/>
+      <point x="1339" y="144"/>
+      <point x="1349" y="164"/>
+      <point x="1374" y="190" type="curve"/>
+      <point x="1270" y="150" type="line"/>
+      <point x="1291" y="129" type="line"/>
+      <point x="1286" y="117"/>
+      <point x="1283" y="103"/>
+      <point x="1283" y="86" type="curve" smooth="yes"/>
+      <point x="1283" y="24"/>
+      <point x="1333" y="-16"/>
+      <point x="1404" y="-16" type="curve" smooth="yes"/>
+      <point x="1484" y="-16"/>
+      <point x="1535" y="33"/>
+      <point x="1535" y="110" type="curve" smooth="yes"/>
+      <point x="1535" y="182"/>
+      <point x="1494" y="232"/>
+      <point x="1410" y="232" type="curve" smooth="yes"/>
+      <point x="1364" y="232"/>
+      <point x="1329" y="222"/>
+      <point x="1252" y="184" type="curve" smooth="yes"/>
+      <point x="1057" y="89" type="line" smooth="yes"/>
+      <point x="1014" y="68"/>
+      <point x="976" y="58"/>
+      <point x="933" y="58" type="curve" smooth="yes"/>
+      <point x="883" y="58"/>
+      <point x="852" y="80"/>
+      <point x="852" y="123" type="curve" smooth="yes"/>
+      <point x="852" y="168"/>
+      <point x="884" y="192"/>
+      <point x="949" y="192" type="curve" smooth="yes"/>
+      <point x="1259" y="192" type="line" smooth="yes"/>
+      <point x="1430" y="192"/>
+      <point x="1538" y="279"/>
+      <point x="1538" y="417" type="curve" smooth="yes"/>
+      <point x="1538" y="532"/>
+      <point x="1468" y="612"/>
+      <point x="1350" y="612" type="curve" smooth="yes"/>
+      <point x="1259" y="612"/>
+      <point x="1199" y="567"/>
+      <point x="1173" y="494" type="curve"/>
+      <point x="1163" y="494" type="line"/>
+      <point x="1132" y="574"/>
+      <point x="1073" y="612"/>
+      <point x="975" y="612" type="curve" smooth="yes"/>
+      <point x="941" y="612"/>
+      <point x="909" y="606"/>
+      <point x="881" y="595" type="curve"/>
       <point x="904" y="595" type="line"/>
       <point x="878" y="605"/>
       <point x="844" y="612"/>
@@ -169,19 +169,19 @@
       <point x="150" y="-16"/>
     </contour>
     <contour>
-      <point x="902" y="376" type="curve" smooth="yes"/>
-      <point x="865" y="376"/>
-      <point x="836" y="400"/>
-      <point x="836" y="450" type="curve" smooth="yes"/>
-      <point x="836" y="492"/>
-      <point x="862" y="541"/>
-      <point x="930" y="549" type="curve"/>
-      <point x="851" y="544" type="line"/>
-      <point x="927" y="543"/>
-      <point x="965" y="501"/>
-      <point x="965" y="448" type="curve" smooth="yes"/>
-      <point x="965" y="402"/>
-      <point x="943" y="376"/>
+      <point x="909" y="356" type="curve" smooth="yes"/>
+      <point x="866" y="356"/>
+      <point x="840" y="386"/>
+      <point x="840" y="431" type="curve" smooth="yes"/>
+      <point x="840" y="489"/>
+      <point x="867" y="530"/>
+      <point x="940" y="552" type="curve"/>
+      <point x="875" y="552" type="line"/>
+      <point x="948" y="530"/>
+      <point x="975" y="489"/>
+      <point x="975" y="431" type="curve" smooth="yes"/>
+      <point x="975" y="386"/>
+      <point x="952" y="356"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/t_la-malayalam.glif
@@ -56,22 +56,6 @@
       <point x="300" y="-378"/>
     </contour>
     <contour>
-      <point x="382" y="-313" type="curve" smooth="yes"/>
-      <point x="324" y="-313"/>
-      <point x="297" y="-256"/>
-      <point x="297" y="-200" type="curve"/>
-      <point x="277" y="-208" type="line"/>
-      <point x="298" y="-265" type="line"/>
-      <point x="298" y="-221"/>
-      <point x="330" y="-181"/>
-      <point x="384" y="-181" type="curve" smooth="yes"/>
-      <point x="425" y="-181"/>
-      <point x="445" y="-206"/>
-      <point x="445" y="-245" type="curve" smooth="yes"/>
-      <point x="445" y="-287"/>
-      <point x="424" y="-313"/>
-    </contour>
-    <contour>
       <point x="176" y="-16" type="curve"/>
       <point x="237" y="36" type="line"/>
       <point x="169" y="109"/>
@@ -94,6 +78,22 @@
       <point x="93" y="72"/>
     </contour>
     <contour>
+      <point x="382" y="-313" type="curve" smooth="yes"/>
+      <point x="324" y="-313"/>
+      <point x="297" y="-256"/>
+      <point x="297" y="-200" type="curve"/>
+      <point x="277" y="-208" type="line"/>
+      <point x="298" y="-265" type="line"/>
+      <point x="298" y="-221"/>
+      <point x="330" y="-181"/>
+      <point x="384" y="-181" type="curve" smooth="yes"/>
+      <point x="425" y="-181"/>
+      <point x="445" y="-206"/>
+      <point x="445" y="-245" type="curve" smooth="yes"/>
+      <point x="445" y="-287"/>
+      <point x="424" y="-313"/>
+    </contour>
+    <contour>
       <point x="783" y="-308" type="curve" smooth="yes"/>
       <point x="728" y="-308"/>
       <point x="701" y="-271"/>
@@ -106,11 +106,11 @@
       <point x="664" y="44"/>
       <point x="699" y="129"/>
       <point x="699" y="249" type="curve" smooth="yes"/>
-      <point x="699" y="370"/>
-      <point x="646" y="484"/>
-      <point x="555" y="551" type="curve"/>
-      <point x="483" y="505" type="line"/>
-      <point x="568" y="458"/>
+      <point x="699" y="369"/>
+      <point x="647" y="482"/>
+      <point x="557" y="549" type="curve"/>
+      <point x="485" y="504" type="line"/>
+      <point x="569" y="457"/>
       <point x="613" y="358"/>
       <point x="613" y="249" type="curve" smooth="yes"/>
       <point x="613" y="129"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="597"/>
-  <anchor x="331" y="-219" name="bottom"/>
+  <anchor x="329" y="-271" name="bottom"/>
   <anchor x="296" y="596" name="top"/>
   <anchor x="435" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="301" y="-225" type="curve" smooth="yes"/>
-      <point x="462" y="-225"/>
-      <point x="551" y="-171"/>
-      <point x="551" y="-69" type="curve" smooth="yes"/>
-      <point x="551" y="-9"/>
-      <point x="513" y="33"/>
+      <point x="301" y="-277" type="curve" smooth="yes"/>
+      <point x="457" y="-277"/>
+      <point x="551" y="-209"/>
+      <point x="551" y="-96" type="curve" smooth="yes"/>
+      <point x="551" y="-22"/>
+      <point x="512" y="27"/>
       <point x="442" y="42" type="curve"/>
       <point x="442" y="52" type="line"/>
-      <point x="491" y="66"/>
-      <point x="541" y="102"/>
-      <point x="541" y="194" type="curve" smooth="yes"/>
-      <point x="541" y="292"/>
-      <point x="482" y="348"/>
+      <point x="507" y="75"/>
+      <point x="541" y="121"/>
+      <point x="541" y="186" type="curve" smooth="yes"/>
+      <point x="541" y="291"/>
+      <point x="472" y="349"/>
       <point x="340" y="355" type="curve" smooth="yes"/>
       <point x="233" y="360" type="line" smooth="yes"/>
       <point x="161" y="363"/>
-      <point x="123" y="393"/>
-      <point x="123" y="446" type="curve" smooth="yes"/>
-      <point x="123" y="506"/>
-      <point x="180" y="531"/>
-      <point x="284" y="531" type="curve" smooth="yes"/>
-      <point x="355" y="531"/>
-      <point x="415" y="518"/>
-      <point x="479" y="492" type="curve"/>
-      <point x="511" y="566" type="line"/>
-      <point x="441" y="598"/>
-      <point x="370" y="612"/>
+      <point x="123" y="391"/>
+      <point x="123" y="441" type="curve" smooth="yes"/>
+      <point x="123" y="503"/>
+      <point x="176" y="534"/>
+      <point x="284" y="534" type="curve" smooth="yes"/>
+      <point x="358" y="534"/>
+      <point x="420" y="521"/>
+      <point x="480" y="494" type="curve"/>
+      <point x="511" y="563" type="line"/>
+      <point x="435" y="597"/>
+      <point x="365" y="612"/>
       <point x="284" y="612" type="curve" smooth="yes"/>
-      <point x="131" y="612"/>
-      <point x="38" y="550"/>
+      <point x="129" y="612"/>
+      <point x="38" y="547"/>
       <point x="38" y="435" type="curve" smooth="yes"/>
-      <point x="38" y="338"/>
-      <point x="107" y="280"/>
+      <point x="38" y="339"/>
+      <point x="106" y="280"/>
       <point x="223" y="273" type="curve" smooth="yes"/>
       <point x="330" y="267" type="line" smooth="yes"/>
-      <point x="418" y="262"/>
-      <point x="459" y="232"/>
-      <point x="459" y="180" type="curve" smooth="yes"/>
-      <point x="459" y="112"/>
-      <point x="405" y="80"/>
+      <point x="414" y="262"/>
+      <point x="456" y="232"/>
+      <point x="456" y="176" type="curve" smooth="yes"/>
+      <point x="456" y="111"/>
+      <point x="404" y="80"/>
       <point x="295" y="80" type="curve" smooth="yes"/>
       <point x="82" y="80" type="line"/>
       <point x="82" y="6" type="line"/>
-      <point x="305" y="6" type="line" smooth="yes"/>
-      <point x="431" y="6"/>
-      <point x="469" y="-17"/>
-      <point x="469" y="-68" type="curve" smooth="yes"/>
-      <point x="469" y="-126"/>
-      <point x="409" y="-147"/>
-      <point x="301" y="-147" type="curve" smooth="yes"/>
-      <point x="208" y="-147"/>
-      <point x="132" y="-125"/>
-      <point x="82" y="-98" type="curve"/>
-      <point x="48" y="-166" type="line"/>
-      <point x="99" y="-198"/>
-      <point x="192" y="-225"/>
+      <point x="319" y="6" type="line" smooth="yes"/>
+      <point x="426" y="6"/>
+      <point x="469" y="-23"/>
+      <point x="469" y="-94" type="curve" smooth="yes"/>
+      <point x="469" y="-162"/>
+      <point x="410" y="-199"/>
+      <point x="301" y="-199" type="curve" smooth="yes"/>
+      <point x="223" y="-199"/>
+      <point x="147" y="-177"/>
+      <point x="87" y="-136" type="curve"/>
+      <point x="46" y="-200" type="line"/>
+      <point x="119" y="-250"/>
+      <point x="209" y="-277"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/tta-malayalam.glif
@@ -8,45 +8,45 @@
   <outline>
     <contour>
       <point x="318" y="-16" type="curve" smooth="yes"/>
-      <point x="465" y="-16"/>
-      <point x="553" y="56"/>
+      <point x="464" y="-16"/>
+      <point x="553" y="55"/>
       <point x="553" y="170" type="curve" smooth="yes"/>
-      <point x="553" y="272"/>
-      <point x="481" y="336"/>
+      <point x="553" y="273"/>
+      <point x="480" y="336"/>
       <point x="352" y="342" type="curve" smooth="yes"/>
       <point x="245" y="347" type="line" smooth="yes"/>
-      <point x="168" y="351"/>
-      <point x="135" y="384"/>
+      <point x="173" y="350"/>
+      <point x="135" y="381"/>
       <point x="135" y="434" type="curve" smooth="yes"/>
       <point x="135" y="497"/>
       <point x="192" y="531"/>
       <point x="296" y="531" type="curve" smooth="yes"/>
-      <point x="365" y="531"/>
-      <point x="427" y="518"/>
+      <point x="364" y="531"/>
+      <point x="426" y="518"/>
       <point x="491" y="491" type="curve"/>
       <point x="523" y="565" type="line"/>
-      <point x="453" y="598"/>
-      <point x="382" y="612"/>
+      <point x="454" y="597"/>
+      <point x="384" y="612"/>
       <point x="296" y="612" type="curve" smooth="yes"/>
-      <point x="142" y="612"/>
-      <point x="50" y="541"/>
+      <point x="143" y="612"/>
+      <point x="50" y="542"/>
       <point x="50" y="427" type="curve" smooth="yes"/>
-      <point x="50" y="330"/>
-      <point x="119" y="264"/>
+      <point x="50" y="328"/>
+      <point x="121" y="264"/>
       <point x="235" y="259" type="curve" smooth="yes"/>
       <point x="342" y="254" type="line" smooth="yes"/>
-      <point x="430" y="250"/>
-      <point x="470" y="217"/>
-      <point x="470" y="162" type="curve" smooth="yes"/>
-      <point x="470" y="99"/>
+      <point x="426" y="250"/>
+      <point x="468" y="219"/>
+      <point x="468" y="162" type="curve" smooth="yes"/>
+      <point x="468" y="99"/>
       <point x="415" y="65"/>
       <point x="318" y="65" type="curve" smooth="yes"/>
-      <point x="236" y="65"/>
-      <point x="159" y="89"/>
+      <point x="237" y="65"/>
+      <point x="160" y="88"/>
       <point x="84" y="136" type="curve"/>
       <point x="38" y="61" type="line"/>
-      <point x="123" y="9"/>
-      <point x="216" y="-16"/>
+      <point x="122" y="10"/>
+      <point x="215" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/uuM_atra-malayalam.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="100" y="31" type="curve"/>
       <point x="184" y="31" type="line"/>
-      <point x="225" y="139"/>
-      <point x="248" y="251"/>
+      <point x="225" y="138"/>
+      <point x="248" y="250"/>
       <point x="248" y="339" type="curve" smooth="yes"/>
       <point x="248" y="515"/>
       <point x="170" y="612"/>
@@ -17,52 +17,58 @@
       <point x="120" y="534"/>
       <point x="166" y="478"/>
       <point x="166" y="337" type="curve" smooth="yes"/>
-      <point x="166" y="241"/>
-      <point x="143" y="133"/>
+      <point x="166" y="240"/>
+      <point x="143" y="132"/>
     </contour>
     <contour>
       <point x="144" y="-259" type="curve" smooth="yes"/>
-      <point x="249" y="-259"/>
-      <point x="323" y="-191"/>
-      <point x="323" y="-95" type="curve" smooth="yes"/>
-      <point x="323" y="3"/>
-      <point x="244" y="82"/>
+      <point x="248" y="-259"/>
+      <point x="323" y="-189"/>
+      <point x="323" y="-93" type="curve" smooth="yes"/>
+      <point x="323" y="6"/>
+      <point x="245" y="82"/>
       <point x="144" y="82" type="curve" smooth="yes"/>
-      <point x="45" y="82"/>
-      <point x="-32" y="5"/>
+      <point x="44" y="82"/>
+      <point x="-32" y="7"/>
       <point x="-32" y="-93" type="curve" smooth="yes"/>
-      <point x="-32" y="-191"/>
-      <point x="40" y="-259"/>
+      <point x="-32" y="-190"/>
+      <point x="41" y="-259"/>
     </contour>
     <contour>
-      <point x="145" y="-185" type="curve" smooth="yes"/>
-      <point x="77" y="-185"/>
-      <point x="40" y="-150"/>
-      <point x="40" y="-85" type="curve" smooth="yes"/>
-      <point x="40" y="-20"/>
-      <point x="79" y="17"/>
-      <point x="145" y="17" type="curve" smooth="yes"/>
-      <point x="211" y="17"/>
-      <point x="251" y="-21"/>
-      <point x="251" y="-85" type="curve" smooth="yes"/>
-      <point x="251" y="-149"/>
-      <point x="213" y="-185"/>
+      <point x="146" y="-185" type="curve" smooth="yes"/>
+      <point x="81" y="-185"/>
+      <point x="39" y="-146"/>
+      <point x="39" y="-85" type="curve" smooth="yes"/>
+      <point x="39" y="-78"/>
+      <point x="40" y="-71"/>
+      <point x="41" y="-65" type="curve"/>
+      <point x="47" y="-65" type="line"/>
+      <point x="62" y="-105"/>
+      <point x="96" y="-127"/>
+      <point x="146" y="-127" type="curve" smooth="yes"/>
+      <point x="196" y="-127"/>
+      <point x="229" y="-105"/>
+      <point x="245" y="-65" type="curve"/>
+      <point x="251" y="-65" type="line"/>
+      <point x="252" y="-71"/>
+      <point x="253" y="-78"/>
+      <point x="253" y="-85" type="curve" smooth="yes"/>
+      <point x="253" y="-145"/>
+      <point x="211" y="-185"/>
     </contour>
     <contour>
-      <point x="145" y="-115" type="curve" smooth="yes"/>
-      <point x="199" y="-115"/>
-      <point x="243" y="-101"/>
-      <point x="279" y="-78" type="curve"/>
-      <point x="256" y="-42" type="line"/>
-      <point x="229" y="-49"/>
-      <point x="192" y="-53"/>
-      <point x="145" y="-53" type="curve" smooth="yes"/>
-      <point x="98" y="-53"/>
-      <point x="60" y="-49"/>
-      <point x="34" y="-42" type="curve"/>
-      <point x="11" y="-78" type="line"/>
-      <point x="47" y="-101"/>
-      <point x="91" y="-115"/>
+      <point x="146" y="-57" type="curve" smooth="yes"/>
+      <point x="95" y="-57"/>
+      <point x="69" y="-35"/>
+      <point x="69" y="-10" type="curve" smooth="yes"/>
+      <point x="69" y="12"/>
+      <point x="98" y="24"/>
+      <point x="146" y="24" type="curve" smooth="yes"/>
+      <point x="194" y="24"/>
+      <point x="223" y="12"/>
+      <point x="223" y="-10" type="curve" smooth="yes"/>
+      <point x="223" y="-35"/>
+      <point x="197" y="-57"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/v_va-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/v_va-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="v_va-malayalam" format="2">
   <advance width="1053"/>
   <anchor x="699" y="-306" name="bottom"/>
-  <anchor x="944" y="0" name="bottomright"/>
   <anchor x="553" y="596" name="top"/>
   <anchor x="924" y="596" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/y_ya-malayalam.glif
@@ -1,97 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="1008"/>
-  <anchor x="614" y="-322" name="bottom"/>
-  <anchor x="859" y="-16" name="bottomright"/>
+  <anchor x="614" y="-306" name="bottom"/>
   <anchor x="515" y="596" name="top"/>
   <anchor x="821" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="309" y="-322" type="line"/>
-      <point x="879" y="-322" type="line"/>
+      <point x="309" y="-306" type="line"/>
+      <point x="879" y="-306" type="line"/>
       <point x="879" y="105" type="line"/>
-      <point x="865" y="55" type="line"/>
-      <point x="924" y="113"/>
-      <point x="954" y="203"/>
-      <point x="954" y="309" type="curve" smooth="yes"/>
-      <point x="954" y="413"/>
-      <point x="915" y="526"/>
-      <point x="843" y="612" type="curve"/>
-      <point x="775" y="563" type="line"/>
-      <point x="829" y="494"/>
-      <point x="872" y="410"/>
-      <point x="872" y="311" type="curve" smooth="yes"/>
-      <point x="872" y="165"/>
-      <point x="828" y="62"/>
-      <point x="677" y="62" type="curve" smooth="yes"/>
-      <point x="498" y="62"/>
-      <point x="417" y="212"/>
-      <point x="417" y="373" type="curve" smooth="yes"/>
-      <point x="417" y="473"/>
-      <point x="454" y="534"/>
-      <point x="516" y="534" type="curve" smooth="yes"/>
-      <point x="579" y="534"/>
-      <point x="616" y="472"/>
-      <point x="616" y="374" type="curve" smooth="yes"/>
-      <point x="616" y="257"/>
-      <point x="580" y="160"/>
-      <point x="506" y="105" type="curve"/>
-      <point x="559" y="51" type="line"/>
-      <point x="650" y="125"/>
-      <point x="698" y="244"/>
-      <point x="698" y="378" type="curve" smooth="yes"/>
-      <point x="698" y="515"/>
-      <point x="633" y="612"/>
-      <point x="516" y="612" type="curve" smooth="yes"/>
-      <point x="397" y="612"/>
-      <point x="335" y="512"/>
-      <point x="335" y="382" type="curve" smooth="yes"/>
-      <point x="335" y="197"/>
-      <point x="456" y="-13"/>
-      <point x="683" y="-13" type="curve" smooth="yes"/>
-      <point x="702" y="-13"/>
-      <point x="722" y="-11"/>
-      <point x="743" y="-8" type="curve"/>
-      <point x="662" y="25" type="line"/>
-      <point x="679" y="-27" type="line"/>
-      <point x="596" y="-72" type="line"/>
-      <point x="309" y="-264" type="line"/>
+      <point x="867" y="76" type="line"/>
+      <point x="922" y="134"/>
+      <point x="954" y="216"/>
+      <point x="954" y="313" type="curve" smooth="yes"/>
+      <point x="954" y="419"/>
+      <point x="910" y="527"/>
+      <point x="831" y="612" type="curve"/>
+      <point x="769" y="561" type="line"/>
+      <point x="840" y="486"/>
+      <point x="874" y="407"/>
+      <point x="874" y="315" type="curve" smooth="yes"/>
+      <point x="874" y="155"/>
+      <point x="793" y="62"/>
+      <point x="654" y="62" type="curve" smooth="yes"/>
+      <point x="491" y="62"/>
+      <point x="386" y="179"/>
+      <point x="386" y="354" type="curve" smooth="yes"/>
+      <point x="386" y="464"/>
+      <point x="436" y="534"/>
+      <point x="515" y="534" type="curve" smooth="yes"/>
+      <point x="588" y="534"/>
+      <point x="631" y="474"/>
+      <point x="631" y="372" type="curve" smooth="yes"/>
+      <point x="631" y="259"/>
+      <point x="578" y="152"/>
+      <point x="496" y="100" type="curve"/>
+      <point x="553" y="55" type="line"/>
+      <point x="650" y="117"/>
+      <point x="713" y="243"/>
+      <point x="713" y="374" type="curve" smooth="yes"/>
+      <point x="713" y="520"/>
+      <point x="637" y="612"/>
+      <point x="515" y="612" type="curve" smooth="yes"/>
+      <point x="391" y="612"/>
+      <point x="304" y="504"/>
+      <point x="304" y="350" type="curve" smooth="yes"/>
+      <point x="304" y="153"/>
+      <point x="461" y="-14"/>
+      <point x="655" y="-14" type="curve" smooth="yes"/>
+      <point x="685" y="-14"/>
+      <point x="713" y="-10"/>
+      <point x="739" y="-3" type="curve"/>
+      <point x="645" y="29" type="line"/>
+      <point x="651" y="-23" type="line"/>
+      <point x="579" y="-62" type="line"/>
+      <point x="309" y="-248" type="line"/>
     </contour>
     <contour>
-      <point x="392" y="-293" type="line"/>
-      <point x="815" y="-1" type="line"/>
-      <point x="797" y="-1" type="line"/>
-      <point x="797" y="-270" type="line"/>
-      <point x="832" y="-257" type="line"/>
-      <point x="392" y="-257" type="line"/>
+      <point x="392" y="-277" type="line"/>
+      <point x="815" y="15" type="line"/>
+      <point x="797" y="15" type="line"/>
+      <point x="797" y="-254" type="line"/>
+      <point x="832" y="-241" type="line"/>
+      <point x="392" y="-241" type="line"/>
     </contour>
     <contour>
-      <point x="358" y="-16" type="curve" smooth="yes"/>
-      <point x="430" y="-16"/>
-      <point x="487" y="3"/>
-      <point x="534" y="34" type="curve"/>
-      <point x="472" y="86" type="line"/>
-      <point x="442" y="71"/>
-      <point x="417" y="62"/>
-      <point x="362" y="62" type="curve" smooth="yes"/>
-      <point x="219" y="62"/>
-      <point x="136" y="171"/>
-      <point x="136" y="333" type="curve" smooth="yes"/>
-      <point x="136" y="444"/>
-      <point x="189" y="534"/>
-      <point x="286" y="534" type="curve" smooth="yes"/>
-      <point x="333" y="534"/>
-      <point x="361" y="517"/>
-      <point x="383" y="492" type="curve"/>
-      <point x="425" y="546" type="line"/>
-      <point x="392" y="588"/>
-      <point x="348" y="612"/>
-      <point x="283" y="612" type="curve" smooth="yes"/>
-      <point x="143" y="612"/>
-      <point x="54" y="492"/>
+      <point x="373" y="-16" type="curve" smooth="yes"/>
+      <point x="434" y="-16"/>
+      <point x="490" y="2"/>
+      <point x="530" y="37" type="curve"/>
+      <point x="473" y="88" type="line"/>
+      <point x="446" y="69"/>
+      <point x="418" y="62"/>
+      <point x="379" y="62" type="curve" smooth="yes"/>
+      <point x="230" y="62"/>
+      <point x="134" y="167"/>
+      <point x="134" y="333" type="curve" smooth="yes"/>
+      <point x="134" y="455"/>
+      <point x="194" y="534"/>
+      <point x="282" y="534" type="curve" smooth="yes"/>
+      <point x="322" y="534"/>
+      <point x="348" y="519"/>
+      <point x="375" y="491" type="curve"/>
+      <point x="431" y="545" type="line"/>
+      <point x="383" y="595"/>
+      <point x="346" y="612"/>
+      <point x="290" y="612" type="curve" smooth="yes"/>
+      <point x="150" y="612"/>
+      <point x="54" y="499"/>
       <point x="54" y="331" type="curve" smooth="yes"/>
       <point x="54" y="128"/>
-      <point x="172" y="-16"/>
+      <point x="187" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ya-malayalam.glif
@@ -8,72 +8,72 @@
   <anchor x="821" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="678" y="-16" type="curve" smooth="yes"/>
-      <point x="859" y="-16"/>
-      <point x="954" y="122"/>
-      <point x="954" y="309" type="curve" smooth="yes"/>
-      <point x="954" y="413"/>
-      <point x="915" y="526"/>
-      <point x="843" y="612" type="curve"/>
-      <point x="775" y="563" type="line"/>
-      <point x="829" y="494"/>
-      <point x="872" y="410"/>
-      <point x="872" y="311" type="curve" smooth="yes"/>
-      <point x="872" y="165"/>
-      <point x="808" y="62"/>
-      <point x="677" y="62" type="curve" smooth="yes"/>
-      <point x="498" y="62"/>
-      <point x="417" y="212"/>
-      <point x="417" y="373" type="curve" smooth="yes"/>
-      <point x="417" y="473"/>
-      <point x="454" y="534"/>
-      <point x="516" y="534" type="curve" smooth="yes"/>
-      <point x="579" y="534"/>
-      <point x="616" y="472"/>
-      <point x="616" y="374" type="curve" smooth="yes"/>
-      <point x="616" y="257"/>
-      <point x="580" y="160"/>
-      <point x="506" y="105" type="curve"/>
-      <point x="559" y="51" type="line"/>
-      <point x="650" y="125"/>
-      <point x="698" y="244"/>
-      <point x="698" y="378" type="curve" smooth="yes"/>
-      <point x="698" y="515"/>
-      <point x="633" y="612"/>
-      <point x="516" y="612" type="curve" smooth="yes"/>
-      <point x="397" y="612"/>
-      <point x="335" y="512"/>
-      <point x="335" y="382" type="curve" smooth="yes"/>
-      <point x="335" y="195"/>
-      <point x="458" y="-16"/>
+      <point x="655" y="-16" type="curve" smooth="yes"/>
+      <point x="832" y="-16"/>
+      <point x="954" y="118"/>
+      <point x="954" y="313" type="curve" smooth="yes"/>
+      <point x="954" y="419"/>
+      <point x="910" y="527"/>
+      <point x="831" y="612" type="curve"/>
+      <point x="769" y="561" type="line"/>
+      <point x="840" y="486"/>
+      <point x="874" y="407"/>
+      <point x="874" y="315" type="curve" smooth="yes"/>
+      <point x="874" y="159"/>
+      <point x="789" y="62"/>
+      <point x="654" y="62" type="curve" smooth="yes"/>
+      <point x="491" y="62"/>
+      <point x="386" y="179"/>
+      <point x="386" y="354" type="curve" smooth="yes"/>
+      <point x="386" y="464"/>
+      <point x="436" y="534"/>
+      <point x="515" y="534" type="curve" smooth="yes"/>
+      <point x="588" y="534"/>
+      <point x="631" y="474"/>
+      <point x="631" y="372" type="curve" smooth="yes"/>
+      <point x="631" y="259"/>
+      <point x="578" y="152"/>
+      <point x="496" y="100" type="curve"/>
+      <point x="553" y="55" type="line"/>
+      <point x="650" y="117"/>
+      <point x="713" y="243"/>
+      <point x="713" y="374" type="curve" smooth="yes"/>
+      <point x="713" y="520"/>
+      <point x="637" y="612"/>
+      <point x="515" y="612" type="curve" smooth="yes"/>
+      <point x="391" y="612"/>
+      <point x="304" y="504"/>
+      <point x="304" y="350" type="curve" smooth="yes"/>
+      <point x="304" y="152"/>
+      <point x="461" y="-16"/>
     </contour>
     <contour>
-      <point x="358" y="-16" type="curve" smooth="yes"/>
-      <point x="430" y="-16"/>
-      <point x="487" y="3"/>
-      <point x="534" y="34" type="curve"/>
-      <point x="472" y="86" type="line"/>
-      <point x="442" y="71"/>
-      <point x="417" y="62"/>
-      <point x="362" y="62" type="curve" smooth="yes"/>
-      <point x="219" y="62"/>
-      <point x="136" y="171"/>
-      <point x="136" y="333" type="curve" smooth="yes"/>
-      <point x="136" y="444"/>
-      <point x="189" y="534"/>
-      <point x="286" y="534" type="curve" smooth="yes"/>
-      <point x="333" y="534"/>
-      <point x="361" y="517"/>
-      <point x="383" y="492" type="curve"/>
-      <point x="425" y="546" type="line"/>
-      <point x="392" y="588"/>
-      <point x="348" y="612"/>
-      <point x="283" y="612" type="curve" smooth="yes"/>
-      <point x="143" y="612"/>
-      <point x="54" y="492"/>
+      <point x="373" y="-16" type="curve" smooth="yes"/>
+      <point x="434" y="-16"/>
+      <point x="490" y="2"/>
+      <point x="530" y="37" type="curve"/>
+      <point x="473" y="88" type="line"/>
+      <point x="446" y="69"/>
+      <point x="418" y="62"/>
+      <point x="379" y="62" type="curve" smooth="yes"/>
+      <point x="230" y="62"/>
+      <point x="134" y="167"/>
+      <point x="134" y="333" type="curve" smooth="yes"/>
+      <point x="134" y="455"/>
+      <point x="194" y="534"/>
+      <point x="282" y="534" type="curve" smooth="yes"/>
+      <point x="322" y="534"/>
+      <point x="348" y="519"/>
+      <point x="375" y="491" type="curve"/>
+      <point x="431" y="545" type="line"/>
+      <point x="383" y="595"/>
+      <point x="346" y="612"/>
+      <point x="290" y="612" type="curve" smooth="yes"/>
+      <point x="150" y="612"/>
+      <point x="54" y="499"/>
       <point x="54" y="331" type="curve" smooth="yes"/>
       <point x="54" y="128"/>
-      <point x="172" y="-16"/>
+      <point x="187" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/kerning.plist
@@ -45782,8 +45782,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -45893,7 +45891,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -45949,7 +45947,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>80</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46002,7 +46000,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>180</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -46049,7 +46047,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -46084,7 +46082,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -46112,8 +46110,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46148,7 +46144,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46217,7 +46213,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46277,7 +46273,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46326,7 +46322,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46384,7 +46380,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46425,7 +46421,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46561,8 +46557,6 @@
       <integer>-30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46591,7 +46585,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46639,8 +46633,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>10</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>0</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>0</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46726,8 +46718,6 @@
       <integer>50</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -46760,7 +46750,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -46835,8 +46825,6 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46880,8 +46868,6 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47001,8 +46987,6 @@
       <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47110,7 +47094,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47157,7 +47141,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47203,41 +47187,39 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>50</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_braceright.loclMALM_R</key>
-      <integer>40</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
       <integer>20</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>40</integer>
-      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>70</integer>
-      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
+      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
+      <integer>60</integer>
+      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
-      <integer>110</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
-      <integer>100</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
       <integer>20</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
       <integer>-20</integer>
-      <key>public.kern2.MAL_rVocalic-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
-      <integer>90</integer>
-      <key>public.kern2.MAL_uMatra-malayalam_L</key>
       <integer>80</integer>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>60</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>220</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
       <integer>150</integer>
     </dict>
@@ -47264,7 +47246,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47313,7 +47295,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47346,8 +47328,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -47387,7 +47367,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47590,7 +47570,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47616,8 +47596,6 @@
       <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47644,7 +47622,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47700,7 +47678,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -47732,8 +47710,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47843,8 +47819,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_p_pa-malayalam_L</key>
@@ -47911,7 +47885,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
@@ -47956,7 +47930,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47997,7 +47971,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48087,7 +48061,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>150</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48226,8 +48200,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48275,8 +48247,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48339,7 +48309,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48392,7 +48362,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>240</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>170</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -48477,7 +48447,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48516,7 +48486,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>130</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48612,8 +48582,6 @@
       <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
-      <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
@@ -48718,7 +48686,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_ng_ka-malayalam_L</key>
@@ -48770,6 +48738,24 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-30</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>-20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>50</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.ODI_a-oriya-L</key>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/c_cha-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/c_cha-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="c_cha-malayalam" format="2">
   <advance width="947"/>
   <anchor x="505" y="-357" name="bottom"/>
-  <anchor x="841" y="0" name="bottomright"/>
   <anchor x="452" y="613" name="top"/>
   <anchor x="804" y="613" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/d_da-malayalam.glif
@@ -1,22 +1,22 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
-  <advance width="728"/>
-  <anchor x="423" y="-213" name="bottom"/>
+  <advance width="718"/>
+  <anchor x="410" y="-255" name="bottom"/>
   <anchor x="392" y="613" name="top"/>
   <outline>
     <contour>
-      <point x="465" y="-229" type="curve" smooth="yes"/>
-      <point x="604" y="-229"/>
-      <point x="683" y="-174"/>
-      <point x="683" y="-76" type="curve" smooth="yes"/>
-      <point x="683" y="-5"/>
-      <point x="638" y="37"/>
-      <point x="559" y="49" type="curve"/>
-      <point x="559" y="61" type="line"/>
-      <point x="629" y="74"/>
-      <point x="673" y="112"/>
-      <point x="673" y="185" type="curve" smooth="yes"/>
-      <point x="673" y="253"/>
+      <point x="430" y="-271" type="curve" smooth="yes"/>
+      <point x="583" y="-271"/>
+      <point x="673" y="-207"/>
+      <point x="673" y="-99" type="curve" smooth="yes"/>
+      <point x="673" y="-25"/>
+      <point x="631" y="29"/>
+      <point x="559" y="48" type="curve"/>
+      <point x="559" y="60" type="line"/>
+      <point x="629" y="73"/>
+      <point x="673" y="111"/>
+      <point x="673" y="183" type="curve" smooth="yes"/>
+      <point x="673" y="252"/>
       <point x="634" y="298"/>
       <point x="538" y="309" type="curve"/>
       <point x="538" y="322" type="line"/>
@@ -54,21 +54,21 @@
       <point x="552" y="127"/>
       <point x="510" y="101"/>
       <point x="439" y="101" type="curve" smooth="yes"/>
-      <point x="382" y="101" type="line"/>
-      <point x="382" y="-4" type="line"/>
-      <point x="463" y="-4" type="line" smooth="yes"/>
-      <point x="531" y="-4"/>
-      <point x="562" y="-21"/>
-      <point x="562" y="-57" type="curve" smooth="yes"/>
-      <point x="562" y="-97"/>
-      <point x="528" y="-116"/>
-      <point x="461" y="-116" type="curve" smooth="yes"/>
-      <point x="411" y="-116"/>
-      <point x="379" y="-109"/>
-      <point x="345" y="-97" type="curve"/>
-      <point x="305" y="-200" type="line"/>
-      <point x="344" y="-217"/>
-      <point x="401" y="-229"/>
+      <point x="357" y="101" type="line"/>
+      <point x="357" y="-4" type="line"/>
+      <point x="444" y="-4" type="line" smooth="yes"/>
+      <point x="518" y="-4"/>
+      <point x="552" y="-28"/>
+      <point x="552" y="-80" type="curve" smooth="yes"/>
+      <point x="552" y="-134"/>
+      <point x="512" y="-160"/>
+      <point x="428" y="-160" type="curve" smooth="yes"/>
+      <point x="374" y="-160"/>
+      <point x="331" y="-149"/>
+      <point x="280" y="-122" type="curve"/>
+      <point x="233" y="-221" type="line"/>
+      <point x="295" y="-254"/>
+      <point x="363" y="-271"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="1026"/>
-  <anchor x="693" y="0" name="bottom"/>
-  <anchor x="511" y="613" name="top"/>
-  <anchor x="873" y="603" name="topright"/>
+  <advance width="1020"/>
+  <anchor x="687" y="0" name="bottom"/>
+  <anchor x="505" y="613" name="top"/>
+  <anchor x="867" y="603" name="topright"/>
   <outline>
     <contour>
-      <point x="306" y="-16" type="curve" smooth="yes"/>
-      <point x="438" y="-16"/>
-      <point x="523" y="65"/>
-      <point x="542" y="242" type="curve" smooth="yes"/>
-      <point x="554" y="347" type="line" smooth="yes"/>
-      <point x="566" y="458"/>
-      <point x="614" y="518"/>
-      <point x="717" y="518" type="curve" smooth="yes"/>
-      <point x="794" y="518"/>
-      <point x="839" y="489"/>
-      <point x="839" y="432" type="curve" smooth="yes"/>
-      <point x="839" y="382"/>
-      <point x="801" y="355"/>
-      <point x="741" y="355" type="curve" smooth="yes"/>
-      <point x="686" y="355" type="line"/>
-      <point x="686" y="250" type="line"/>
-      <point x="741" y="250" type="line" smooth="yes"/>
-      <point x="814" y="250"/>
-      <point x="860" y="228"/>
-      <point x="860" y="171" type="curve" smooth="yes"/>
-      <point x="860" y="120"/>
-      <point x="824" y="97"/>
-      <point x="765" y="97" type="curve" smooth="yes"/>
-      <point x="731" y="97"/>
-      <point x="702" y="104"/>
-      <point x="671" y="117" type="curve"/>
-      <point x="621" y="13" type="line"/>
-      <point x="660" y="-6"/>
-      <point x="712" y="-16"/>
-      <point x="768" y="-16" type="curve" smooth="yes"/>
-      <point x="897" y="-16"/>
-      <point x="981" y="51"/>
-      <point x="981" y="158" type="curve" smooth="yes"/>
-      <point x="981" y="237"/>
-      <point x="935" y="290"/>
-      <point x="846" y="303" type="curve"/>
-      <point x="846" y="315" type="line"/>
-      <point x="918" y="330"/>
-      <point x="960" y="378"/>
-      <point x="960" y="450" type="curve" smooth="yes"/>
-      <point x="960" y="555"/>
-      <point x="869" y="629"/>
-      <point x="716" y="629" type="curve" smooth="yes"/>
-      <point x="544" y="629"/>
-      <point x="448" y="533"/>
-      <point x="429" y="351" type="curve" smooth="yes"/>
-      <point x="419" y="261" type="line" smooth="yes"/>
-      <point x="408" y="153"/>
-      <point x="367" y="97"/>
-      <point x="295" y="97" type="curve" smooth="yes"/>
-      <point x="217" y="97"/>
-      <point x="168" y="160"/>
-      <point x="168" y="276" type="curve" smooth="yes"/>
-      <point x="168" y="385"/>
-      <point x="211" y="476"/>
-      <point x="292" y="554" type="curve"/>
-      <point x="213" y="629" type="line"/>
-      <point x="97" y="526"/>
-      <point x="51" y="408"/>
-      <point x="51" y="276" type="curve" smooth="yes"/>
+      <point x="313" y="-16" type="curve" smooth="yes"/>
+      <point x="457" y="-16"/>
+      <point x="552" y="77"/>
+      <point x="552" y="220" type="curve" smooth="yes"/>
+      <point x="552" y="266"/>
+      <point x="544" y="311"/>
+      <point x="544" y="356" type="curve" smooth="yes"/>
+      <point x="544" y="461"/>
+      <point x="609" y="518"/>
+      <point x="712" y="518" type="curve" smooth="yes"/>
+      <point x="788" y="518"/>
+      <point x="833" y="490"/>
+      <point x="833" y="436" type="curve" smooth="yes"/>
+      <point x="833" y="383"/>
+      <point x="795" y="355"/>
+      <point x="735" y="355" type="curve" smooth="yes"/>
+      <point x="680" y="355" type="line"/>
+      <point x="680" y="250" type="line"/>
+      <point x="735" y="250" type="line" smooth="yes"/>
+      <point x="808" y="250"/>
+      <point x="854" y="228"/>
+      <point x="854" y="171" type="curve" smooth="yes"/>
+      <point x="854" y="120"/>
+      <point x="818" y="97"/>
+      <point x="759" y="97" type="curve" smooth="yes"/>
+      <point x="725" y="97"/>
+      <point x="696" y="104"/>
+      <point x="665" y="117" type="curve"/>
+      <point x="615" y="13" type="line"/>
+      <point x="654" y="-6"/>
+      <point x="706" y="-16"/>
+      <point x="762" y="-16" type="curve" smooth="yes"/>
+      <point x="891" y="-16"/>
+      <point x="975" y="51"/>
+      <point x="975" y="158" type="curve" smooth="yes"/>
+      <point x="975" y="237"/>
+      <point x="929" y="290"/>
+      <point x="840" y="303" type="curve"/>
+      <point x="840" y="315" type="line"/>
+      <point x="910" y="331"/>
+      <point x="954" y="382"/>
+      <point x="954" y="456" type="curve" smooth="yes"/>
+      <point x="954" y="556"/>
+      <point x="867" y="629"/>
+      <point x="714" y="629" type="curve" smooth="yes"/>
+      <point x="540" y="629"/>
+      <point x="422" y="525"/>
+      <point x="422" y="367" type="curve" smooth="yes"/>
+      <point x="422" y="324"/>
+      <point x="430" y="281"/>
+      <point x="430" y="237" type="curve" smooth="yes"/>
+      <point x="430" y="148"/>
+      <point x="386" y="98"/>
+      <point x="309" y="98" type="curve" smooth="yes"/>
+      <point x="223" y="98"/>
+      <point x="173" y="161"/>
+      <point x="173" y="270" type="curve" smooth="yes"/>
+      <point x="173" y="378"/>
+      <point x="215" y="469"/>
+      <point x="301" y="543" type="curve"/>
+      <point x="222" y="629" type="line"/>
+      <point x="105" y="531"/>
+      <point x="51" y="416"/>
+      <point x="51" y="270" type="curve" smooth="yes"/>
       <point x="51" y="99"/>
-      <point x="155" y="-16"/>
+      <point x="157" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/g_ga-malayalam.glif
@@ -1,97 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ga-malayalam" format="2">
-  <advance width="973"/>
+  <advance width="974"/>
   <anchor x="589" y="-368" name="bottom"/>
   <anchor x="491" y="613" name="top"/>
   <anchor x="776" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="417" y="-382" type="curve" smooth="yes"/>
-      <point x="531" y="-382"/>
-      <point x="590" y="-323"/>
-      <point x="599" y="-189" type="curve" smooth="yes"/>
-      <point x="602" y="-149" type="line" smooth="yes"/>
-      <point x="608" y="-62"/>
-      <point x="636" y="-35"/>
-      <point x="686" y="-35" type="curve" smooth="yes"/>
-      <point x="744" y="-35"/>
-      <point x="777" y="-75"/>
-      <point x="777" y="-153" type="curve" smooth="yes"/>
-      <point x="777" y="-233"/>
-      <point x="746" y="-286"/>
-      <point x="711" y="-326" type="curve"/>
-      <point x="786" y="-382" type="line"/>
-      <point x="843" y="-320"/>
-      <point x="875" y="-247"/>
-      <point x="875" y="-154" type="curve" smooth="yes"/>
-      <point x="875" y="-19"/>
-      <point x="802" y="55"/>
-      <point x="683" y="55" type="curve" smooth="yes"/>
-      <point x="573" y="55"/>
-      <point x="516" y="-4"/>
-      <point x="506" y="-140" type="curve" smooth="yes"/>
-      <point x="504" y="-172" type="line" smooth="yes"/>
-      <point x="497" y="-262"/>
-      <point x="470" y="-292"/>
-      <point x="419" y="-292" type="curve" smooth="yes"/>
-      <point x="364" y="-292"/>
-      <point x="329" y="-252"/>
-      <point x="329" y="-170" type="curve" smooth="yes"/>
-      <point x="329" y="-101"/>
-      <point x="354" y="-42"/>
-      <point x="392" y="4" type="curve"/>
-      <point x="366" y="-9" type="line"/>
-      <point x="468" y="14"/>
-      <point x="528" y="99"/>
-      <point x="542" y="241" type="curve" smooth="yes"/>
-      <point x="553" y="349" type="line" smooth="yes"/>
-      <point x="564" y="463"/>
-      <point x="606" y="516"/>
-      <point x="682" y="516" type="curve" smooth="yes"/>
-      <point x="762" y="516"/>
-      <point x="800" y="453"/>
-      <point x="800" y="341" type="curve" smooth="yes"/>
-      <point x="800" y="220"/>
-      <point x="769" y="129"/>
-      <point x="678" y="42" type="curve"/>
-      <point x="774" y="-16" type="line"/>
-      <point x="877" y="79"/>
-      <point x="922" y="196"/>
-      <point x="922" y="340" type="curve" smooth="yes"/>
-      <point x="922" y="516"/>
-      <point x="829" y="629"/>
-      <point x="677" y="629" type="curve" smooth="yes"/>
-      <point x="532" y="629"/>
-      <point x="449" y="540"/>
-      <point x="431" y="362" type="curve" smooth="yes"/>
-      <point x="420" y="260" type="line" smooth="yes"/>
-      <point x="409" y="152"/>
-      <point x="366" y="97"/>
-      <point x="295" y="97" type="curve" smooth="yes"/>
-      <point x="218" y="97"/>
-      <point x="173" y="163"/>
-      <point x="173" y="276" type="curve" smooth="yes"/>
-      <point x="173" y="380"/>
-      <point x="214" y="471"/>
-      <point x="298" y="548" type="curve"/>
-      <point x="213" y="629" type="line"/>
-      <point x="101" y="530"/>
-      <point x="51" y="414"/>
-      <point x="51" y="276" type="curve" smooth="yes"/>
-      <point x="51" y="103"/>
-      <point x="154" y="-9"/>
-      <point x="312" y="-9" type="curve" smooth="yes"/>
-      <point x="326" y="-9"/>
-      <point x="340" y="-8"/>
-      <point x="354" y="-7" type="curve"/>
-      <point x="248" y="49" type="line"/>
-      <point x="292" y="-75" type="line"/>
-      <point x="296" y="12" type="line"/>
-      <point x="253" y="-34"/>
-      <point x="230" y="-102"/>
-      <point x="230" y="-173" type="curve" smooth="yes"/>
-      <point x="230" y="-310"/>
-      <point x="306" y="-382"/>
+      <point x="313" y="-16" type="curve" smooth="yes"/>
+      <point x="457" y="-16"/>
+      <point x="552" y="77"/>
+      <point x="552" y="220" type="curve" smooth="yes"/>
+      <point x="552" y="269"/>
+      <point x="544" y="318"/>
+      <point x="544" y="366" type="curve" smooth="yes"/>
+      <point x="544" y="461"/>
+      <point x="592" y="515"/>
+      <point x="671" y="515" type="curve" smooth="yes"/>
+      <point x="756" y="515"/>
+      <point x="801" y="453"/>
+      <point x="801" y="336" type="curve" smooth="yes"/>
+      <point x="801" y="208"/>
+      <point x="757" y="119"/>
+      <point x="661" y="41" type="curve"/>
+      <point x="766" y="-16" type="line"/>
+      <point x="870" y="75"/>
+      <point x="923" y="192"/>
+      <point x="923" y="336" type="curve" smooth="yes"/>
+      <point x="923" y="517"/>
+      <point x="825" y="629"/>
+      <point x="666" y="629" type="curve" smooth="yes"/>
+      <point x="521" y="629"/>
+      <point x="422" y="527"/>
+      <point x="422" y="377" type="curve" smooth="yes"/>
+      <point x="422" y="331"/>
+      <point x="430" y="284"/>
+      <point x="430" y="237" type="curve" smooth="yes"/>
+      <point x="430" y="148"/>
+      <point x="386" y="98"/>
+      <point x="309" y="98" type="curve" smooth="yes"/>
+      <point x="223" y="98"/>
+      <point x="173" y="161"/>
+      <point x="173" y="270" type="curve" smooth="yes"/>
+      <point x="173" y="378"/>
+      <point x="215" y="469"/>
+      <point x="301" y="543" type="curve"/>
+      <point x="222" y="629" type="line"/>
+      <point x="105" y="531"/>
+      <point x="51" y="416"/>
+      <point x="51" y="270" type="curve" smooth="yes"/>
+      <point x="51" y="99"/>
+      <point x="157" y="-16"/>
+    </contour>
+    <contour>
+      <point x="427" y="-382" type="curve" smooth="yes"/>
+      <point x="539" y="-382"/>
+      <point x="606" y="-314"/>
+      <point x="606" y="-206" type="curve" smooth="yes"/>
+      <point x="606" y="-181"/>
+      <point x="602" y="-156"/>
+      <point x="602" y="-131" type="curve" smooth="yes"/>
+      <point x="602" y="-68"/>
+      <point x="632" y="-35"/>
+      <point x="689" y="-35" type="curve" smooth="yes"/>
+      <point x="746" y="-35"/>
+      <point x="774" y="-74"/>
+      <point x="774" y="-153" type="curve" smooth="yes"/>
+      <point x="774" y="-219"/>
+      <point x="754" y="-275"/>
+      <point x="712" y="-326" type="curve"/>
+      <point x="787" y="-382" type="line"/>
+      <point x="847" y="-317"/>
+      <point x="876" y="-242"/>
+      <point x="876" y="-153" type="curve" smooth="yes"/>
+      <point x="876" y="-21"/>
+      <point x="807" y="55"/>
+      <point x="685" y="55" type="curve" smooth="yes"/>
+      <point x="571" y="55"/>
+      <point x="500" y="-14"/>
+      <point x="500" y="-121" type="curve" smooth="yes"/>
+      <point x="500" y="-146"/>
+      <point x="504" y="-171"/>
+      <point x="504" y="-196" type="curve" smooth="yes"/>
+      <point x="504" y="-256"/>
+      <point x="478" y="-290"/>
+      <point x="426" y="-290" type="curve" smooth="yes"/>
+      <point x="365" y="-290"/>
+      <point x="333" y="-246"/>
+      <point x="333" y="-169" type="curve" smooth="yes"/>
+      <point x="333" y="-103"/>
+      <point x="354" y="-41"/>
+      <point x="393" y="12" type="curve"/>
+      <point x="297" y="12" type="line"/>
+      <point x="255" y="-32"/>
+      <point x="231" y="-98"/>
+      <point x="231" y="-169" type="curve" smooth="yes"/>
+      <point x="231" y="-302"/>
+      <point x="304" y="-382"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/g_la-malayalam.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_la-malayalam" format="2">
-  <advance width="973"/>
+  <advance width="974"/>
   <anchor x="556" y="-366" name="bottom"/>
   <anchor x="491" y="613" name="top"/>
   <anchor x="776" y="613" name="topright"/>
@@ -8,25 +8,25 @@
     <contour>
       <point x="311" y="-382" type="curve" smooth="yes"/>
       <point x="406" y="-382"/>
-      <point x="452" y="-327"/>
-      <point x="452" y="-244" type="curve" smooth="yes"/>
-      <point x="452" y="-157"/>
-      <point x="405" y="-118"/>
+      <point x="453" y="-327"/>
+      <point x="453" y="-244" type="curve" smooth="yes"/>
+      <point x="453" y="-157"/>
+      <point x="406" y="-118"/>
       <point x="336" y="-118" type="curve" smooth="yes"/>
-      <point x="281" y="-118"/>
-      <point x="229" y="-147"/>
-      <point x="226" y="-229" type="curve"/>
-      <point x="259" y="-163" type="line"/>
-      <point x="206" y="-163" type="line"/>
-      <point x="229" y="-182" type="line"/>
-      <point x="229" y="-105"/>
-      <point x="275" y="-33"/>
+      <point x="282" y="-118"/>
+      <point x="230" y="-147"/>
+      <point x="227" y="-229" type="curve"/>
+      <point x="259" y="-164" type="line"/>
+      <point x="206" y="-164" type="line"/>
+      <point x="230" y="-182" type="line"/>
+      <point x="230" y="-105"/>
+      <point x="276" y="-33"/>
       <point x="372" y="-33" type="curve" smooth="yes"/>
-      <point x="462" y="-33"/>
+      <point x="463" y="-33"/>
       <point x="495" y="-82"/>
-      <point x="517" y="-166" type="curve" smooth="yes"/>
-      <point x="527" y="-203" type="line" smooth="yes"/>
-      <point x="559" y="-323"/>
+      <point x="518" y="-166" type="curve" smooth="yes"/>
+      <point x="528" y="-203" type="line" smooth="yes"/>
+      <point x="560" y="-323"/>
       <point x="611" y="-382"/>
       <point x="720" y="-382" type="curve" smooth="yes"/>
       <point x="832" y="-382"/>
@@ -35,39 +35,41 @@
       <point x="902" y="-79"/>
       <point x="869" y="-3"/>
       <point x="819" y="55" type="curve"/>
-      <point x="813" y="25" type="line"/>
-      <point x="888" y="113"/>
-      <point x="922" y="216"/>
-      <point x="922" y="340" type="curve" smooth="yes"/>
-      <point x="922" y="516"/>
-      <point x="829" y="629"/>
-      <point x="677" y="629" type="curve" smooth="yes"/>
-      <point x="532" y="629"/>
-      <point x="449" y="540"/>
-      <point x="431" y="362" type="curve" smooth="yes"/>
-      <point x="420" y="260" type="line" smooth="yes"/>
-      <point x="409" y="152"/>
-      <point x="366" y="97"/>
-      <point x="295" y="97" type="curve" smooth="yes"/>
-      <point x="218" y="97"/>
-      <point x="173" y="163"/>
-      <point x="173" y="276" type="curve" smooth="yes"/>
-      <point x="173" y="380"/>
-      <point x="214" y="471"/>
-      <point x="298" y="548" type="curve"/>
-      <point x="213" y="629" type="line"/>
-      <point x="101" y="530"/>
-      <point x="51" y="414"/>
-      <point x="51" y="276" type="curve" smooth="yes"/>
-      <point x="51" y="141"/>
-      <point x="112" y="45"/>
+      <point x="812" y="30" type="line"/>
+      <point x="886" y="114"/>
+      <point x="923" y="215"/>
+      <point x="923" y="336" type="curve" smooth="yes"/>
+      <point x="923" y="517"/>
+      <point x="825" y="629"/>
+      <point x="666" y="629" type="curve" smooth="yes"/>
+      <point x="521" y="629"/>
+      <point x="422" y="527"/>
+      <point x="422" y="377" type="curve" smooth="yes"/>
+      <point x="422" y="331"/>
+      <point x="430" y="284"/>
+      <point x="430" y="237" type="curve" smooth="yes"/>
+      <point x="430" y="148"/>
+      <point x="386" y="98"/>
+      <point x="309" y="98" type="curve" smooth="yes"/>
+      <point x="223" y="98"/>
+      <point x="173" y="161"/>
+      <point x="173" y="270" type="curve" smooth="yes"/>
+      <point x="173" y="378"/>
+      <point x="215" y="469"/>
+      <point x="301" y="543" type="curve"/>
+      <point x="222" y="629" type="line"/>
+      <point x="105" y="531"/>
+      <point x="51" y="416"/>
+      <point x="51" y="270" type="curve" smooth="yes"/>
+      <point x="51" y="140"/>
+      <point x="119" y="46"/>
       <point x="224" y="13" type="curve"/>
       <point x="225" y="1" type="line"/>
       <point x="167" y="-40"/>
       <point x="141" y="-108"/>
       <point x="141" y="-180" type="curve" smooth="yes"/>
       <point x="141" y="-318"/>
-      <point x="214" y="-382"/>
+      <point x="217" y="-382"/>
     </contour>
     <contour>
       <point x="308" y="-302" type="curve" smooth="yes"/>
@@ -82,34 +84,36 @@
       <point x="347" y="-191"/>
       <point x="364" y="-210"/>
       <point x="364" y="-246" type="curve" smooth="yes"/>
-      <point x="364" y="-282"/>
+      <point x="364" y="-283"/>
       <point x="344" y="-302"/>
     </contour>
     <contour>
-      <point x="720" y="-292" type="curve" smooth="yes"/>
-      <point x="669" y="-292"/>
+      <point x="721" y="-292" type="curve" smooth="yes"/>
+      <point x="670" y="-292"/>
       <point x="645" y="-257"/>
       <point x="623" y="-178" type="curve" smooth="yes"/>
       <point x="612" y="-140" type="line" smooth="yes"/>
-      <point x="587" y="-50"/>
-      <point x="548" y="14"/>
-      <point x="456" y="40" type="curve"/>
-      <point x="454" y="52" type="line"/>
-      <point x="511" y="91"/>
-      <point x="534" y="158"/>
-      <point x="542" y="241" type="curve" smooth="yes"/>
-      <point x="553" y="349" type="line" smooth="yes"/>
-      <point x="564" y="463"/>
-      <point x="606" y="516"/>
-      <point x="682" y="516" type="curve" smooth="yes"/>
-      <point x="762" y="516"/>
-      <point x="800" y="453"/>
-      <point x="800" y="341" type="curve" smooth="yes"/>
-      <point x="800" y="230"/>
-      <point x="770" y="146"/>
-      <point x="685" y="66" type="curve"/>
-      <point x="740" y="14"/>
-      <point x="804" y="-65"/>
+      <point x="583" y="-37"/>
+      <point x="540" y="14"/>
+      <point x="464" y="37" type="curve"/>
+      <point x="462" y="49" type="line"/>
+      <point x="519" y="85"/>
+      <point x="552" y="145"/>
+      <point x="552" y="220" type="curve" smooth="yes"/>
+      <point x="552" y="269"/>
+      <point x="544" y="318"/>
+      <point x="544" y="366" type="curve" smooth="yes"/>
+      <point x="544" y="461"/>
+      <point x="592" y="515"/>
+      <point x="671" y="515" type="curve" smooth="yes"/>
+      <point x="756" y="515"/>
+      <point x="801" y="453"/>
+      <point x="801" y="336" type="curve" smooth="yes"/>
+      <point x="801" y="221"/>
+      <point x="767" y="140"/>
+      <point x="685" y="70" type="curve"/>
+      <point x="763" y="-9"/>
+      <point x="804" y="-91"/>
       <point x="804" y="-182" type="curve" smooth="yes"/>
       <point x="804" y="-252"/>
       <point x="779" y="-292"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/g_ma-malayalam.glif
@@ -6,16 +6,18 @@
   <anchor x="1332" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="302" y="-16" type="curve" smooth="yes"/>
-      <point x="442" y="-16"/>
-      <point x="524" y="73"/>
-      <point x="540" y="243" type="curve" smooth="yes"/>
-      <point x="550" y="347" type="line" smooth="yes"/>
-      <point x="560" y="456"/>
-      <point x="598" y="516"/>
-      <point x="679" y="516" type="curve" smooth="yes"/>
-      <point x="762" y="516"/>
-      <point x="799" y="453"/>
+      <point x="313" y="-16" type="curve" smooth="yes"/>
+      <point x="457" y="-16"/>
+      <point x="552" y="77"/>
+      <point x="552" y="220" type="curve" smooth="yes"/>
+      <point x="552" y="269"/>
+      <point x="544" y="318"/>
+      <point x="544" y="366" type="curve" smooth="yes"/>
+      <point x="544" y="461"/>
+      <point x="592" y="515"/>
+      <point x="671" y="515" type="curve" smooth="yes"/>
+      <point x="763" y="515"/>
+      <point x="799" y="452"/>
       <point x="799" y="340" type="curve" smooth="yes"/>
       <point x="799" y="0" type="line"/>
       <point x="1404" y="0" type="line"/>
@@ -27,28 +29,30 @@
       <point x="915" y="592"/>
       <point x="866" y="519" type="curve"/>
       <point x="853" y="519" type="line"/>
-      <point x="813" y="596"/>
-      <point x="748" y="629"/>
-      <point x="665" y="629" type="curve" smooth="yes"/>
-      <point x="524" y="629"/>
-      <point x="445" y="539"/>
-      <point x="427" y="360" type="curve" smooth="yes"/>
-      <point x="417" y="262" type="line" smooth="yes"/>
-      <point x="407" y="157"/>
-      <point x="366" y="97"/>
-      <point x="294" y="97" type="curve" smooth="yes"/>
-      <point x="215" y="97"/>
-      <point x="168" y="160"/>
-      <point x="168" y="277" type="curve" smooth="yes"/>
-      <point x="168" y="388"/>
-      <point x="211" y="477"/>
-      <point x="285" y="562" type="curve"/>
-      <point x="202" y="629" type="line"/>
-      <point x="97" y="524"/>
-      <point x="51" y="409"/>
-      <point x="51" y="277" type="curve" smooth="yes"/>
-      <point x="51" y="92"/>
-      <point x="151" y="-16"/>
+      <point x="814" y="591"/>
+      <point x="751" y="629"/>
+      <point x="661" y="629" type="curve" smooth="yes"/>
+      <point x="518" y="629"/>
+      <point x="422" y="527"/>
+      <point x="422" y="377" type="curve" smooth="yes"/>
+      <point x="422" y="331"/>
+      <point x="430" y="284"/>
+      <point x="430" y="237" type="curve" smooth="yes"/>
+      <point x="430" y="148"/>
+      <point x="386" y="98"/>
+      <point x="309" y="98" type="curve" smooth="yes"/>
+      <point x="223" y="98"/>
+      <point x="173" y="161"/>
+      <point x="173" y="270" type="curve" smooth="yes"/>
+      <point x="173" y="378"/>
+      <point x="215" y="469"/>
+      <point x="301" y="543" type="curve"/>
+      <point x="222" y="629" type="line"/>
+      <point x="105" y="531"/>
+      <point x="51" y="416"/>
+      <point x="51" y="270" type="curve" smooth="yes"/>
+      <point x="51" y="99"/>
+      <point x="157" y="-16"/>
     </contour>
     <contour>
       <point x="865" y="48" type="line"/>
@@ -70,7 +74,7 @@
       <point x="954" y="104" type="line"/>
       <point x="1018" y="45" type="line"/>
       <point x="1116" y="161" type="line" smooth="yes"/>
-      <point x="1181" y="236"/>
+      <point x="1180" y="236"/>
       <point x="1212" y="303"/>
       <point x="1212" y="370" type="curve" smooth="yes"/>
       <point x="1212" y="464"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/g_na-malayalam.glif
@@ -6,16 +6,18 @@
   <anchor x="1225" y="603" name="topright"/>
   <outline>
     <contour>
-      <point x="298" y="-16" type="curve" smooth="yes"/>
-      <point x="435" y="-16"/>
-      <point x="520" y="67"/>
-      <point x="537" y="241" type="curve" smooth="yes"/>
-      <point x="548" y="349" type="line" smooth="yes"/>
-      <point x="558" y="453"/>
-      <point x="598" y="516"/>
-      <point x="678" y="516" type="curve" smooth="yes"/>
-      <point x="761" y="516"/>
-      <point x="799" y="450"/>
+      <point x="313" y="-16" type="curve" smooth="yes"/>
+      <point x="457" y="-16"/>
+      <point x="552" y="77"/>
+      <point x="552" y="220" type="curve" smooth="yes"/>
+      <point x="552" y="270"/>
+      <point x="544" y="319"/>
+      <point x="544" y="368" type="curve" smooth="yes"/>
+      <point x="544" y="462"/>
+      <point x="591" y="515"/>
+      <point x="674" y="515" type="curve" smooth="yes"/>
+      <point x="764" y="515"/>
+      <point x="799" y="452"/>
       <point x="799" y="341" type="curve" smooth="yes"/>
       <point x="799" y="0" type="line"/>
       <point x="921" y="0" type="line"/>
@@ -40,28 +42,30 @@
       <point x="905" y="588"/>
       <point x="869" y="516" type="curve"/>
       <point x="856" y="516" type="line"/>
-      <point x="824" y="586"/>
-      <point x="761" y="629"/>
-      <point x="670" y="629" type="curve" smooth="yes"/>
-      <point x="528" y="629"/>
-      <point x="446" y="540"/>
-      <point x="427" y="362" type="curve" smooth="yes"/>
-      <point x="417" y="260" type="line" smooth="yes"/>
-      <point x="406" y="153"/>
-      <point x="364" y="97"/>
-      <point x="293" y="97" type="curve" smooth="yes"/>
-      <point x="217" y="97"/>
-      <point x="168" y="160"/>
-      <point x="168" y="276" type="curve" smooth="yes"/>
-      <point x="168" y="385"/>
-      <point x="211" y="476"/>
-      <point x="292" y="554" type="curve"/>
-      <point x="213" y="629" type="line"/>
-      <point x="97" y="526"/>
-      <point x="51" y="408"/>
-      <point x="51" y="276" type="curve" smooth="yes"/>
+      <point x="823" y="587"/>
+      <point x="759" y="629"/>
+      <point x="663" y="629" type="curve" smooth="yes"/>
+      <point x="519" y="629"/>
+      <point x="422" y="528"/>
+      <point x="422" y="379" type="curve" smooth="yes"/>
+      <point x="422" y="332"/>
+      <point x="430" y="285"/>
+      <point x="430" y="237" type="curve" smooth="yes"/>
+      <point x="430" y="148"/>
+      <point x="386" y="98"/>
+      <point x="309" y="98" type="curve" smooth="yes"/>
+      <point x="223" y="98"/>
+      <point x="173" y="161"/>
+      <point x="173" y="270" type="curve" smooth="yes"/>
+      <point x="173" y="378"/>
+      <point x="215" y="469"/>
+      <point x="301" y="543" type="curve"/>
+      <point x="222" y="629" type="line"/>
+      <point x="105" y="531"/>
+      <point x="51" y="416"/>
+      <point x="51" y="270" type="curve" smooth="yes"/>
       <point x="51" y="99"/>
-      <point x="148" y="-16"/>
+      <point x="157" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ga-malayalam.glif
@@ -1,52 +1,56 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ga-malayalam" format="2">
-  <advance width="973"/>
+  <advance width="974"/>
   <unicode hex="0D17"/>
   <anchor x="545" y="0" name="bottom"/>
   <anchor x="491" y="613" name="top"/>
   <anchor x="776" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="306" y="-16" type="curve" smooth="yes"/>
-      <point x="444" y="-16"/>
-      <point x="525" y="72"/>
-      <point x="542" y="241" type="curve" smooth="yes"/>
-      <point x="553" y="349" type="line" smooth="yes"/>
-      <point x="564" y="463"/>
-      <point x="606" y="516"/>
-      <point x="682" y="516" type="curve" smooth="yes"/>
-      <point x="762" y="516"/>
-      <point x="800" y="453"/>
-      <point x="800" y="341" type="curve" smooth="yes"/>
-      <point x="800" y="230"/>
-      <point x="770" y="146"/>
-      <point x="685" y="67" type="curve"/>
-      <point x="774" y="-16" type="line"/>
-      <point x="877" y="79"/>
-      <point x="922" y="196"/>
-      <point x="922" y="340" type="curve" smooth="yes"/>
-      <point x="922" y="516"/>
-      <point x="829" y="629"/>
-      <point x="677" y="629" type="curve" smooth="yes"/>
-      <point x="532" y="629"/>
-      <point x="449" y="540"/>
-      <point x="431" y="362" type="curve" smooth="yes"/>
-      <point x="420" y="260" type="line" smooth="yes"/>
-      <point x="409" y="152"/>
-      <point x="366" y="97"/>
-      <point x="295" y="97" type="curve" smooth="yes"/>
-      <point x="218" y="97"/>
-      <point x="173" y="163"/>
-      <point x="173" y="276" type="curve" smooth="yes"/>
-      <point x="173" y="380"/>
-      <point x="214" y="471"/>
-      <point x="298" y="548" type="curve"/>
-      <point x="213" y="629" type="line"/>
-      <point x="101" y="530"/>
-      <point x="51" y="414"/>
-      <point x="51" y="276" type="curve" smooth="yes"/>
-      <point x="51" y="101"/>
-      <point x="154" y="-16"/>
+      <point x="313" y="-16" type="curve" smooth="yes"/>
+      <point x="457" y="-16"/>
+      <point x="552" y="77"/>
+      <point x="552" y="220" type="curve" smooth="yes"/>
+      <point x="552" y="269"/>
+      <point x="544" y="318"/>
+      <point x="544" y="366" type="curve" smooth="yes"/>
+      <point x="544" y="461"/>
+      <point x="592" y="515"/>
+      <point x="671" y="515" type="curve" smooth="yes"/>
+      <point x="756" y="515"/>
+      <point x="801" y="453"/>
+      <point x="801" y="336" type="curve" smooth="yes"/>
+      <point x="801" y="221"/>
+      <point x="767" y="140"/>
+      <point x="685" y="70" type="curve"/>
+      <point x="765" y="-16" type="line"/>
+      <point x="870" y="75"/>
+      <point x="923" y="192"/>
+      <point x="923" y="336" type="curve" smooth="yes"/>
+      <point x="923" y="517"/>
+      <point x="825" y="629"/>
+      <point x="666" y="629" type="curve" smooth="yes"/>
+      <point x="521" y="629"/>
+      <point x="422" y="527"/>
+      <point x="422" y="377" type="curve" smooth="yes"/>
+      <point x="422" y="331"/>
+      <point x="430" y="284"/>
+      <point x="430" y="237" type="curve" smooth="yes"/>
+      <point x="430" y="148"/>
+      <point x="386" y="98"/>
+      <point x="309" y="98" type="curve" smooth="yes"/>
+      <point x="223" y="98"/>
+      <point x="173" y="161"/>
+      <point x="173" y="270" type="curve" smooth="yes"/>
+      <point x="173" y="378"/>
+      <point x="215" y="469"/>
+      <point x="301" y="543" type="curve"/>
+      <point x="222" y="629" type="line"/>
+      <point x="105" y="531"/>
+      <point x="51" y="416"/>
+      <point x="51" y="270" type="curve" smooth="yes"/>
+      <point x="51" y="99"/>
+      <point x="157" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ga-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ga-malayalam.half" format="2">
-  <advance width="973"/>
+  <advance width="974"/>
+  <anchor x="545" y="0" name="bottom"/>
+  <anchor x="491" y="613" name="top"/>
+  <anchor x="776" y="613" name="topright"/>
   <outline>
     <component base="ga-malayalam"/>
     <component base="halant-malayalam" xOffset="776"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/j_ja-malayalam.glif
@@ -1,224 +1,224 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1665"/>
-  <anchor x="1251" y="0" name="bottom"/>
-  <anchor x="825" y="613" name="top"/>
-  <anchor x="1517" y="613" name="topright"/>
+  <advance width="1740"/>
+  <anchor x="1303" y="-1" name="bottom"/>
+  <anchor x="870" y="613" name="top"/>
+  <anchor x="1562" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="354" y="-16" type="curve" smooth="yes"/>
-      <point x="681" y="-16"/>
-      <point x="832" y="86"/>
-      <point x="898" y="324" type="curve"/>
-      <point x="905" y="357" type="line"/>
-      <point x="911" y="357" type="line"/>
-      <point x="931" y="328"/>
-      <point x="961" y="316"/>
-      <point x="997" y="316" type="curve" smooth="yes"/>
-      <point x="1087" y="316"/>
-      <point x="1138" y="369"/>
-      <point x="1138" y="436" type="curve" smooth="yes"/>
-      <point x="1138" y="494"/>
-      <point x="1111" y="540"/>
-      <point x="1027" y="540" type="curve" smooth="yes"/>
-      <point x="1003" y="540"/>
-      <point x="977" y="536"/>
-      <point x="959" y="526" type="curve"/>
-      <point x="992" y="516" type="line"/>
-      <point x="974" y="569" type="line"/>
-      <point x="959" y="537" type="line"/>
-      <point x="983" y="550"/>
-      <point x="1009" y="557"/>
-      <point x="1047" y="557" type="curve" smooth="yes"/>
-      <point x="1162" y="557"/>
-      <point x="1195" y="486"/>
-      <point x="1195" y="408" type="curve" smooth="yes"/>
-      <point x="1195" y="354" type="line"/>
-      <point x="1313" y="354" type="line"/>
-      <point x="1313" y="400" type="line" smooth="yes"/>
-      <point x="1313" y="480"/>
-      <point x="1353" y="526"/>
-      <point x="1414" y="526" type="curve" smooth="yes"/>
-      <point x="1472" y="526"/>
-      <point x="1497" y="487"/>
-      <point x="1497" y="428" type="curve" smooth="yes"/>
-      <point x="1497" y="349"/>
-      <point x="1457" y="307"/>
-      <point x="1354" y="307" type="curve" smooth="yes"/>
-      <point x="1102" y="307" type="line" smooth="yes"/>
-      <point x="962" y="307"/>
-      <point x="886" y="247"/>
-      <point x="886" y="142" type="curve" smooth="yes"/>
-      <point x="886" y="56"/>
-      <point x="935" y="-16"/>
-      <point x="1066" y="-16" type="curve" smooth="yes"/>
-      <point x="1139" y="-16"/>
-      <point x="1202" y="3"/>
-      <point x="1266" y="62" type="curve" smooth="yes"/>
-      <point x="1326" y="116" type="line" smooth="yes"/>
-      <point x="1377" y="159"/>
-      <point x="1432" y="176"/>
-      <point x="1472" y="176" type="curve" smooth="yes"/>
-      <point x="1511" y="176"/>
-      <point x="1523" y="155"/>
-      <point x="1523" y="125" type="curve" smooth="yes"/>
-      <point x="1523" y="95"/>
-      <point x="1508" y="73"/>
-      <point x="1475" y="73" type="curve" smooth="yes"/>
-      <point x="1445" y="73"/>
-      <point x="1427" y="92"/>
-      <point x="1427" y="123" type="curve" smooth="yes"/>
-      <point x="1427" y="146"/>
-      <point x="1436" y="163"/>
-      <point x="1449" y="182" type="curve"/>
-      <point x="1342" y="154" type="line"/>
-      <point x="1367" y="130" type="line"/>
-      <point x="1360" y="114"/>
-      <point x="1357" y="99"/>
-      <point x="1357" y="85" type="curve" smooth="yes"/>
-      <point x="1357" y="34"/>
-      <point x="1396" y="-16"/>
-      <point x="1476" y="-16" type="curve" smooth="yes"/>
-      <point x="1566" y="-16"/>
-      <point x="1612" y="42"/>
-      <point x="1612" y="122" type="curve" smooth="yes"/>
-      <point x="1612" y="206"/>
-      <point x="1554" y="260"/>
-      <point x="1471" y="260" type="curve" smooth="yes"/>
-      <point x="1417" y="260"/>
-      <point x="1348" y="255"/>
-      <point x="1275" y="193" type="curve" smooth="yes"/>
-      <point x="1220" y="146" type="line" smooth="yes"/>
-      <point x="1162" y="96"/>
-      <point x="1120" y="87"/>
-      <point x="1074" y="87" type="curve" smooth="yes"/>
-      <point x="1021" y="87"/>
-      <point x="995" y="106"/>
-      <point x="995" y="145" type="curve" smooth="yes"/>
-      <point x="995" y="186"/>
-      <point x="1025" y="208"/>
-      <point x="1095" y="208" type="curve" smooth="yes"/>
-      <point x="1376" y="208" type="line" smooth="yes"/>
-      <point x="1559" y="208"/>
-      <point x="1614" y="312"/>
-      <point x="1614" y="425" type="curve" smooth="yes"/>
-      <point x="1614" y="540"/>
-      <point x="1554" y="629"/>
-      <point x="1425" y="629" type="curve" smooth="yes"/>
-      <point x="1348" y="629"/>
-      <point x="1289" y="589"/>
-      <point x="1265" y="516" type="curve"/>
-      <point x="1252" y="516" type="line"/>
-      <point x="1220" y="590"/>
-      <point x="1155" y="629"/>
-      <point x="1054" y="629" type="curve" smooth="yes"/>
-      <point x="931" y="629"/>
-      <point x="864" y="573"/>
-      <point x="834" y="442" type="curve" smooth="yes"/>
-      <point x="815" y="367" type="line" smooth="yes"/>
-      <point x="762" y="155"/>
-      <point x="644" y="87"/>
-      <point x="357" y="87" type="curve" smooth="yes"/>
-      <point x="234" y="87"/>
-      <point x="173" y="105"/>
-      <point x="173" y="156" type="curve" smooth="yes"/>
-      <point x="173" y="188"/>
-      <point x="200" y="208"/>
-      <point x="268" y="208" type="curve" smooth="yes"/>
-      <point x="512" y="208" type="line" smooth="yes"/>
-      <point x="731" y="208"/>
-      <point x="787" y="312"/>
-      <point x="787" y="440" type="curve" smooth="yes"/>
-      <point x="787" y="544"/>
-      <point x="736" y="629"/>
-      <point x="618" y="629" type="curve" smooth="yes"/>
-      <point x="541" y="629"/>
-      <point x="484" y="590"/>
-      <point x="460" y="516" type="curve"/>
-      <point x="448" y="516" type="line"/>
-      <point x="418" y="589"/>
-      <point x="351" y="629"/>
-      <point x="255" y="629" type="curve" smooth="yes"/>
-      <point x="120" y="629"/>
-      <point x="51" y="555"/>
-      <point x="51" y="458" type="curve" smooth="yes"/>
-      <point x="51" y="376"/>
-      <point x="102" y="316"/>
-      <point x="198" y="316" type="curve" smooth="yes"/>
-      <point x="289" y="316"/>
-      <point x="340" y="369"/>
-      <point x="340" y="436" type="curve" smooth="yes"/>
-      <point x="340" y="493"/>
-      <point x="313" y="541"/>
-      <point x="228" y="541" type="curve" smooth="yes"/>
-      <point x="205" y="541"/>
-      <point x="177" y="535"/>
-      <point x="158" y="525" type="curve"/>
-      <point x="192" y="516" type="line"/>
-      <point x="174" y="569" type="line"/>
-      <point x="163" y="538" type="line"/>
-      <point x="184" y="549"/>
-      <point x="211" y="557"/>
-      <point x="249" y="557" type="curve" smooth="yes"/>
-      <point x="359" y="557"/>
-      <point x="391" y="486"/>
-      <point x="391" y="408" type="curve" smooth="yes"/>
-      <point x="391" y="354" type="line"/>
-      <point x="509" y="354" type="line"/>
-      <point x="509" y="400" type="line" smooth="yes"/>
-      <point x="509" y="480"/>
-      <point x="544" y="526"/>
-      <point x="603" y="526" type="curve" smooth="yes"/>
-      <point x="656" y="526"/>
-      <point x="678" y="487"/>
-      <point x="678" y="428" type="curve" smooth="yes"/>
-      <point x="678" y="349"/>
-      <point x="640" y="307"/>
-      <point x="539" y="307" type="curve" smooth="yes"/>
-      <point x="263" y="307" type="line" smooth="yes"/>
-      <point x="131" y="307"/>
-      <point x="57" y="254"/>
-      <point x="57" y="159" type="curve" smooth="yes"/>
-      <point x="57" y="53"/>
-      <point x="140" y="-16"/>
+      <point x="364" y="-16" type="curve" smooth="yes"/>
+      <point x="677" y="-16"/>
+      <point x="843" y="73"/>
+      <point x="914" y="278" type="curve"/>
+      <point x="921" y="343" type="line"/>
+      <point x="932" y="343" type="line"/>
+      <point x="945" y="308"/>
+      <point x="986" y="281"/>
+      <point x="1043" y="281" type="curve" smooth="yes"/>
+      <point x="1129" y="281"/>
+      <point x="1183" y="331"/>
+      <point x="1183" y="412" type="curve" smooth="yes"/>
+      <point x="1183" y="480"/>
+      <point x="1148" y="527"/>
+      <point x="1075" y="527" type="curve" smooth="yes"/>
+      <point x="1042" y="527"/>
+      <point x="1009" y="516"/>
+      <point x="980" y="500" type="curve"/>
+      <point x="957" y="523" type="line"/>
+      <point x="963" y="492" type="line"/>
+      <point x="988" y="531"/>
+      <point x="1037" y="555"/>
+      <point x="1108" y="555" type="curve" smooth="yes"/>
+      <point x="1200" y="555"/>
+      <point x="1236" y="513"/>
+      <point x="1236" y="409" type="curve" smooth="yes"/>
+      <point x="1236" y="330" type="line"/>
+      <point x="1350" y="330" type="line"/>
+      <point x="1350" y="402" type="line" smooth="yes"/>
+      <point x="1350" y="477"/>
+      <point x="1396" y="523"/>
+      <point x="1468" y="523" type="curve" smooth="yes"/>
+      <point x="1537" y="523"/>
+      <point x="1571" y="483"/>
+      <point x="1571" y="407" type="curve" smooth="yes"/>
+      <point x="1571" y="314"/>
+      <point x="1518" y="273"/>
+      <point x="1400" y="273" type="curve" smooth="yes"/>
+      <point x="1083" y="273" type="line" smooth="yes"/>
+      <point x="971" y="273"/>
+      <point x="900" y="212"/>
+      <point x="900" y="123" type="curve" smooth="yes"/>
+      <point x="900" y="37"/>
+      <point x="969" y="-16"/>
+      <point x="1065" y="-16" type="curve" smooth="yes"/>
+      <point x="1115" y="-16"/>
+      <point x="1160" y="-4"/>
+      <point x="1231" y="30" type="curve" smooth="yes"/>
+      <point x="1355" y="89" type="line"/>
+      <point x="1412" y="142" type="line"/>
+      <point x="1448" y="154" type="line"/>
+      <point x="1479" y="174"/>
+      <point x="1502" y="186"/>
+      <point x="1534" y="186" type="curve" smooth="yes"/>
+      <point x="1575" y="186"/>
+      <point x="1596" y="167"/>
+      <point x="1596" y="130" type="curve" smooth="yes"/>
+      <point x="1596" y="94"/>
+      <point x="1573" y="73"/>
+      <point x="1535" y="73" type="curve" smooth="yes"/>
+      <point x="1494" y="73"/>
+      <point x="1470" y="94"/>
+      <point x="1470" y="127" type="curve" smooth="yes"/>
+      <point x="1470" y="146"/>
+      <point x="1474" y="162"/>
+      <point x="1485" y="182" type="curve"/>
+      <point x="1387" y="148" type="line"/>
+      <point x="1411" y="126" type="line"/>
+      <point x="1405" y="115"/>
+      <point x="1402" y="102"/>
+      <point x="1402" y="86" type="curve" smooth="yes"/>
+      <point x="1402" y="27"/>
+      <point x="1455" y="-16"/>
+      <point x="1536" y="-16" type="curve" smooth="yes"/>
+      <point x="1628" y="-16"/>
+      <point x="1685" y="35"/>
+      <point x="1685" y="120" type="curve" smooth="yes"/>
+      <point x="1685" y="197"/>
+      <point x="1629" y="248"/>
+      <point x="1546" y="248" type="curve" smooth="yes"/>
+      <point x="1487" y="248"/>
+      <point x="1435" y="229"/>
+      <point x="1354" y="190" type="curve" smooth="yes"/>
+      <point x="1193" y="113" type="line" smooth="yes"/>
+      <point x="1152" y="94"/>
+      <point x="1118" y="84"/>
+      <point x="1078" y="84" type="curve" smooth="yes"/>
+      <point x="1036" y="84"/>
+      <point x="1014" y="100"/>
+      <point x="1014" y="130" type="curve" smooth="yes"/>
+      <point x="1014" y="162"/>
+      <point x="1036" y="178"/>
+      <point x="1076" y="178" type="curve" smooth="yes"/>
+      <point x="1393" y="178" type="line" smooth="yes"/>
+      <point x="1567" y="178"/>
+      <point x="1689" y="276"/>
+      <point x="1689" y="415" type="curve" smooth="yes"/>
+      <point x="1689" y="539"/>
+      <point x="1616" y="629"/>
+      <point x="1491" y="629" type="curve" smooth="yes"/>
+      <point x="1399" y="629"/>
+      <point x="1339" y="586"/>
+      <point x="1308" y="520" type="curve"/>
+      <point x="1296" y="520" type="line"/>
+      <point x="1273" y="585"/>
+      <point x="1211" y="629"/>
+      <point x="1110" y="629" type="curve" smooth="yes"/>
+      <point x="979" y="629"/>
+      <point x="888" y="565"/>
+      <point x="867" y="442" type="curve" smooth="yes"/>
+      <point x="854" y="367" type="line" smooth="yes"/>
+      <point x="820" y="174"/>
+      <point x="669" y="87"/>
+      <point x="367" y="87" type="curve" smooth="yes"/>
+      <point x="222" y="87"/>
+      <point x="175" y="98"/>
+      <point x="175" y="137" type="curve" smooth="yes"/>
+      <point x="175" y="162"/>
+      <point x="196" y="178"/>
+      <point x="234" y="178" type="curve" smooth="yes"/>
+      <point x="535" y="178" type="line" smooth="yes"/>
+      <point x="700" y="178"/>
+      <point x="820" y="275"/>
+      <point x="820" y="432" type="curve" smooth="yes"/>
+      <point x="820" y="554"/>
+      <point x="758" y="629"/>
+      <point x="652" y="629" type="curve" smooth="yes"/>
+      <point x="575" y="629"/>
+      <point x="514" y="589"/>
+      <point x="489" y="520" type="curve"/>
+      <point x="477" y="520" type="line"/>
+      <point x="452" y="586"/>
+      <point x="388" y="629"/>
+      <point x="287" y="629" type="curve" smooth="yes"/>
+      <point x="145" y="629"/>
+      <point x="51" y="553"/>
+      <point x="51" y="439" type="curve" smooth="yes"/>
+      <point x="51" y="344"/>
+      <point x="118" y="281"/>
+      <point x="215" y="281" type="curve" smooth="yes"/>
+      <point x="307" y="281"/>
+      <point x="364" y="331"/>
+      <point x="364" y="412" type="curve" smooth="yes"/>
+      <point x="364" y="480"/>
+      <point x="329" y="527"/>
+      <point x="256" y="527" type="curve" smooth="yes"/>
+      <point x="223" y="527"/>
+      <point x="190" y="516"/>
+      <point x="161" y="500" type="curve"/>
+      <point x="138" y="523" type="line"/>
+      <point x="144" y="492" type="line"/>
+      <point x="169" y="531"/>
+      <point x="218" y="555"/>
+      <point x="289" y="555" type="curve" smooth="yes"/>
+      <point x="381" y="555"/>
+      <point x="417" y="513"/>
+      <point x="417" y="409" type="curve" smooth="yes"/>
+      <point x="417" y="330" type="line"/>
+      <point x="531" y="330" type="line"/>
+      <point x="531" y="421" type="line" smooth="yes"/>
+      <point x="531" y="484"/>
+      <point x="566" y="523"/>
+      <point x="626" y="523" type="curve" smooth="yes"/>
+      <point x="685" y="523"/>
+      <point x="712" y="488"/>
+      <point x="712" y="422" type="curve" smooth="yes"/>
+      <point x="712" y="317"/>
+      <point x="654" y="273"/>
+      <point x="521" y="273" type="curve" smooth="yes"/>
+      <point x="231" y="273" type="line" smooth="yes"/>
+      <point x="123" y="273"/>
+      <point x="57" y="217"/>
+      <point x="57" y="135" type="curve" smooth="yes"/>
+      <point x="57" y="41"/>
+      <point x="132" y="-16"/>
     </contour>
     <contour>
-      <point x="203" y="394" type="curve" smooth="yes"/>
-      <point x="165" y="394"/>
-      <point x="147" y="422"/>
-      <point x="147" y="455" type="curve" smooth="yes"/>
-      <point x="147" y="474"/>
-      <point x="151" y="486"/>
-      <point x="160" y="500" type="curve"/>
-      <point x="128" y="500" type="line"/>
-      <point x="120" y="470" type="line"/>
-      <point x="142" y="485"/>
-      <point x="169" y="494"/>
-      <point x="198" y="494" type="curve" smooth="yes"/>
-      <point x="247" y="494"/>
-      <point x="258" y="470"/>
-      <point x="258" y="446" type="curve" smooth="yes"/>
-      <point x="258" y="416"/>
-      <point x="241" y="394"/>
+      <point x="213" y="368" type="curve" smooth="yes"/>
+      <point x="170" y="368"/>
+      <point x="143" y="389"/>
+      <point x="143" y="428" type="curve" smooth="yes"/>
+      <point x="143" y="445"/>
+      <point x="144" y="460"/>
+      <point x="147" y="470" type="curve"/>
+      <point x="128" y="470" type="line"/>
+      <point x="120" y="438" type="line"/>
+      <point x="149" y="455"/>
+      <point x="175" y="463"/>
+      <point x="210" y="463" type="curve" smooth="yes"/>
+      <point x="250" y="463"/>
+      <point x="268" y="447"/>
+      <point x="268" y="415" type="curve" smooth="yes"/>
+      <point x="268" y="385"/>
+      <point x="248" y="368"/>
     </contour>
     <contour>
-      <point x="1001" y="394" type="curve" smooth="yes"/>
-      <point x="963" y="394"/>
-      <point x="946" y="422"/>
-      <point x="946" y="456" type="curve" smooth="yes"/>
-      <point x="946" y="475"/>
-      <point x="949" y="487"/>
-      <point x="959" y="500" type="curve"/>
-      <point x="925" y="500" type="line"/>
-      <point x="918" y="474" type="line"/>
-      <point x="941" y="486"/>
-      <point x="967" y="494"/>
-      <point x="996" y="494" type="curve" smooth="yes"/>
-      <point x="1045" y="494"/>
-      <point x="1057" y="470"/>
-      <point x="1057" y="446" type="curve" smooth="yes"/>
-      <point x="1057" y="416"/>
-      <point x="1040" y="394"/>
+      <point x="1032" y="368" type="curve" smooth="yes"/>
+      <point x="989" y="368"/>
+      <point x="962" y="389"/>
+      <point x="962" y="428" type="curve" smooth="yes"/>
+      <point x="962" y="445"/>
+      <point x="963" y="460"/>
+      <point x="966" y="470" type="curve"/>
+      <point x="947" y="470" type="line"/>
+      <point x="939" y="438" type="line"/>
+      <point x="968" y="455"/>
+      <point x="994" y="463"/>
+      <point x="1029" y="463" type="curve" smooth="yes"/>
+      <point x="1069" y="463"/>
+      <point x="1087" y="447"/>
+      <point x="1087" y="415" type="curve" smooth="yes"/>
+      <point x="1087" y="385"/>
+      <point x="1067" y="368"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/j_nya-malayalam.glif
@@ -1,185 +1,184 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2278"/>
-  <anchor x="1850" y="0" name="bottom"/>
-  <anchor x="1132" y="613" name="top"/>
-  <anchor x="2115" y="613" name="topright"/>
+  <advance width="2312"/>
+  <anchor x="1884" y="0" name="bottom"/>
+  <anchor x="1156" y="613" name="top"/>
+  <anchor x="2149" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="370" y="-16" type="curve" smooth="yes"/>
-      <point x="605" y="-16"/>
-      <point x="755" y="37"/>
-      <point x="837" y="158" type="curve"/>
-      <point x="849" y="158" type="line"/>
-      <point x="882" y="50"/>
-      <point x="957" y="-16"/>
-      <point x="1066" y="-16" type="curve" smooth="yes"/>
-      <point x="1188" y="-16"/>
-      <point x="1256" y="71"/>
-      <point x="1256" y="186" type="curve" smooth="yes"/>
-      <point x="1256" y="302"/>
-      <point x="1192" y="372"/>
-      <point x="1089" y="372" type="curve" smooth="yes"/>
-      <point x="1027" y="372"/>
-      <point x="976" y="346"/>
-      <point x="945" y="298" type="curve"/>
-      <point x="918" y="305" type="line"/>
-      <point x="925" y="148" type="line"/>
-      <point x="943" y="227"/>
-      <point x="999" y="270"/>
-      <point x="1059" y="270" type="curve" smooth="yes"/>
-      <point x="1113" y="270"/>
-      <point x="1138" y="237"/>
-      <point x="1138" y="184" type="curve" smooth="yes"/>
-      <point x="1138" y="126"/>
-      <point x="1106" y="92"/>
-      <point x="1058" y="92" type="curve" smooth="yes"/>
-      <point x="979" y="92"/>
-      <point x="931" y="176"/>
-      <point x="931" y="283" type="curve" smooth="yes"/>
-      <point x="931" y="424"/>
-      <point x="1011" y="517"/>
-      <point x="1136" y="517" type="curve" smooth="yes"/>
-      <point x="1252" y="517"/>
-      <point x="1311" y="443"/>
-      <point x="1311" y="326" type="curve" smooth="yes"/>
-      <point x="1311" y="0" type="line"/>
-      <point x="1433" y="0" type="line"/>
-      <point x="1433" y="326" type="line" smooth="yes"/>
-      <point x="1433" y="449"/>
-      <point x="1486" y="518"/>
-      <point x="1604" y="518" type="curve" smooth="yes"/>
-      <point x="1766" y="518"/>
-      <point x="1844" y="398"/>
-      <point x="1844" y="246" type="curve" smooth="yes"/>
-      <point x="1844" y="145"/>
-      <point x="1809" y="95"/>
-      <point x="1750" y="95" type="curve" smooth="yes"/>
-      <point x="1697" y="95"/>
-      <point x="1657" y="140"/>
-      <point x="1657" y="233" type="curve" smooth="yes"/>
-      <point x="1657" y="391"/>
-      <point x="1762" y="518"/>
-      <point x="1911" y="518" type="curve" smooth="yes"/>
-      <point x="2035" y="518"/>
-      <point x="2109" y="444"/>
-      <point x="2109" y="316" type="curve" smooth="yes"/>
-      <point x="2109" y="214"/>
-      <point x="2079" y="140"/>
-      <point x="2011" y="59" type="curve"/>
-      <point x="2108" y="-14" type="line"/>
-      <point x="2185" y="80"/>
-      <point x="2227" y="186"/>
-      <point x="2227" y="316" type="curve" smooth="yes"/>
-      <point x="2227" y="508"/>
-      <point x="2107" y="628"/>
-      <point x="1914" y="628" type="curve" smooth="yes"/>
-      <point x="1706" y="628"/>
-      <point x="1546" y="449"/>
-      <point x="1546" y="230" type="curve" smooth="yes"/>
-      <point x="1546" y="70"/>
-      <point x="1628" y="-16"/>
-      <point x="1751" y="-16" type="curve" smooth="yes"/>
-      <point x="1875" y="-16"/>
-      <point x="1961" y="80"/>
-      <point x="1961" y="245" type="curve" smooth="yes"/>
-      <point x="1961" y="455"/>
-      <point x="1815" y="628"/>
-      <point x="1609" y="628" type="curve" smooth="yes"/>
-      <point x="1494" y="628"/>
-      <point x="1418" y="580"/>
-      <point x="1380" y="496" type="curve"/>
-      <point x="1367" y="496" type="line"/>
-      <point x="1327" y="577"/>
-      <point x="1252" y="628"/>
-      <point x="1132" y="628" type="curve" smooth="yes"/>
-      <point x="961" y="628"/>
-      <point x="863" y="535"/>
-      <point x="825" y="357" type="curve" smooth="yes"/>
-      <point x="780" y="149"/>
-      <point x="648" y="87"/>
-      <point x="373" y="87" type="curve" smooth="yes"/>
-      <point x="234" y="87"/>
-      <point x="173" y="105"/>
-      <point x="173" y="156" type="curve" smooth="yes"/>
-      <point x="173" y="188"/>
-      <point x="200" y="208"/>
-      <point x="268" y="208" type="curve" smooth="yes"/>
-      <point x="512" y="208" type="line" smooth="yes"/>
-      <point x="731" y="208"/>
-      <point x="787" y="312"/>
-      <point x="787" y="440" type="curve" smooth="yes"/>
-      <point x="787" y="544"/>
-      <point x="736" y="629"/>
-      <point x="618" y="629" type="curve" smooth="yes"/>
-      <point x="541" y="629"/>
-      <point x="484" y="590"/>
-      <point x="460" y="516" type="curve"/>
-      <point x="448" y="516" type="line"/>
-      <point x="418" y="589"/>
-      <point x="351" y="629"/>
-      <point x="255" y="629" type="curve" smooth="yes"/>
-      <point x="120" y="629"/>
-      <point x="51" y="555"/>
-      <point x="51" y="458" type="curve" smooth="yes"/>
-      <point x="51" y="376"/>
-      <point x="102" y="316"/>
-      <point x="198" y="316" type="curve" smooth="yes"/>
-      <point x="289" y="316"/>
-      <point x="340" y="369"/>
-      <point x="340" y="436" type="curve" smooth="yes"/>
-      <point x="340" y="493"/>
-      <point x="313" y="541"/>
-      <point x="228" y="541" type="curve" smooth="yes"/>
-      <point x="205" y="541"/>
-      <point x="177" y="535"/>
-      <point x="158" y="525" type="curve"/>
-      <point x="192" y="516" type="line"/>
-      <point x="174" y="569" type="line"/>
-      <point x="163" y="538" type="line"/>
-      <point x="184" y="549"/>
-      <point x="211" y="557"/>
-      <point x="250" y="557" type="curve" smooth="yes"/>
-      <point x="359" y="557"/>
-      <point x="391" y="486"/>
-      <point x="391" y="408" type="curve" smooth="yes"/>
-      <point x="391" y="354" type="line"/>
-      <point x="509" y="354" type="line"/>
-      <point x="509" y="400" type="line" smooth="yes"/>
-      <point x="509" y="480"/>
-      <point x="544" y="526"/>
-      <point x="603" y="526" type="curve" smooth="yes"/>
-      <point x="656" y="526"/>
-      <point x="678" y="487"/>
-      <point x="678" y="428" type="curve" smooth="yes"/>
-      <point x="678" y="349"/>
-      <point x="640" y="307"/>
-      <point x="539" y="307" type="curve" smooth="yes"/>
-      <point x="263" y="307" type="line" smooth="yes"/>
-      <point x="131" y="307"/>
-      <point x="57" y="254"/>
-      <point x="57" y="159" type="curve" smooth="yes"/>
-      <point x="57" y="53"/>
-      <point x="140" y="-16"/>
+      <point x="374" y="-16" type="curve" smooth="yes"/>
+      <point x="624" y="-16"/>
+      <point x="785" y="39"/>
+      <point x="871" y="170" type="curve"/>
+      <point x="883" y="170" type="line"/>
+      <point x="912" y="57"/>
+      <point x="989" y="-16"/>
+      <point x="1100" y="-16" type="curve" smooth="yes"/>
+      <point x="1222" y="-16"/>
+      <point x="1290" y="71"/>
+      <point x="1290" y="186" type="curve" smooth="yes"/>
+      <point x="1290" y="302"/>
+      <point x="1226" y="372"/>
+      <point x="1123" y="372" type="curve" smooth="yes"/>
+      <point x="1061" y="372"/>
+      <point x="1010" y="346"/>
+      <point x="979" y="298" type="curve"/>
+      <point x="952" y="305" type="line"/>
+      <point x="959" y="148" type="line"/>
+      <point x="977" y="227"/>
+      <point x="1033" y="270"/>
+      <point x="1093" y="270" type="curve" smooth="yes"/>
+      <point x="1147" y="270"/>
+      <point x="1172" y="237"/>
+      <point x="1172" y="184" type="curve" smooth="yes"/>
+      <point x="1172" y="126"/>
+      <point x="1140" y="92"/>
+      <point x="1092" y="92" type="curve" smooth="yes"/>
+      <point x="1013" y="92"/>
+      <point x="965" y="176"/>
+      <point x="965" y="283" type="curve" smooth="yes"/>
+      <point x="965" y="424"/>
+      <point x="1045" y="517"/>
+      <point x="1170" y="517" type="curve" smooth="yes"/>
+      <point x="1286" y="517"/>
+      <point x="1345" y="443"/>
+      <point x="1345" y="326" type="curve" smooth="yes"/>
+      <point x="1345" y="0" type="line"/>
+      <point x="1467" y="0" type="line"/>
+      <point x="1467" y="326" type="line" smooth="yes"/>
+      <point x="1467" y="449"/>
+      <point x="1520" y="518"/>
+      <point x="1638" y="518" type="curve" smooth="yes"/>
+      <point x="1800" y="518"/>
+      <point x="1878" y="398"/>
+      <point x="1878" y="246" type="curve" smooth="yes"/>
+      <point x="1878" y="145"/>
+      <point x="1843" y="95"/>
+      <point x="1784" y="95" type="curve" smooth="yes"/>
+      <point x="1731" y="95"/>
+      <point x="1691" y="140"/>
+      <point x="1691" y="233" type="curve" smooth="yes"/>
+      <point x="1691" y="391"/>
+      <point x="1796" y="518"/>
+      <point x="1945" y="518" type="curve" smooth="yes"/>
+      <point x="2069" y="518"/>
+      <point x="2143" y="444"/>
+      <point x="2143" y="316" type="curve" smooth="yes"/>
+      <point x="2143" y="214"/>
+      <point x="2113" y="140"/>
+      <point x="2045" y="59" type="curve"/>
+      <point x="2142" y="-14" type="line"/>
+      <point x="2219" y="80"/>
+      <point x="2261" y="186"/>
+      <point x="2261" y="316" type="curve" smooth="yes"/>
+      <point x="2261" y="508"/>
+      <point x="2141" y="628"/>
+      <point x="1948" y="628" type="curve" smooth="yes"/>
+      <point x="1740" y="628"/>
+      <point x="1580" y="449"/>
+      <point x="1580" y="230" type="curve" smooth="yes"/>
+      <point x="1580" y="70"/>
+      <point x="1662" y="-16"/>
+      <point x="1785" y="-16" type="curve" smooth="yes"/>
+      <point x="1909" y="-16"/>
+      <point x="1995" y="80"/>
+      <point x="1995" y="245" type="curve" smooth="yes"/>
+      <point x="1995" y="455"/>
+      <point x="1849" y="628"/>
+      <point x="1643" y="628" type="curve" smooth="yes"/>
+      <point x="1528" y="628"/>
+      <point x="1452" y="580"/>
+      <point x="1414" y="496" type="curve"/>
+      <point x="1401" y="496" type="line"/>
+      <point x="1361" y="577"/>
+      <point x="1286" y="628"/>
+      <point x="1166" y="628" type="curve" smooth="yes"/>
+      <point x="995" y="628"/>
+      <point x="897" y="535"/>
+      <point x="859" y="357" type="curve" smooth="yes"/>
+      <point x="814" y="148"/>
+      <point x="670" y="87"/>
+      <point x="377" y="87" type="curve" smooth="yes"/>
+      <point x="225" y="87"/>
+      <point x="175" y="100"/>
+      <point x="175" y="137" type="curve" smooth="yes"/>
+      <point x="175" y="164"/>
+      <point x="196" y="178"/>
+      <point x="234" y="178" type="curve" smooth="yes"/>
+      <point x="515" y="178" type="line" smooth="yes"/>
+      <point x="712" y="178"/>
+      <point x="820" y="274"/>
+      <point x="820" y="429" type="curve" smooth="yes"/>
+      <point x="820" y="553"/>
+      <point x="759" y="629"/>
+      <point x="654" y="629" type="curve" smooth="yes"/>
+      <point x="576" y="629"/>
+      <point x="514" y="589"/>
+      <point x="489" y="520" type="curve"/>
+      <point x="477" y="520" type="line"/>
+      <point x="453" y="585"/>
+      <point x="389" y="629"/>
+      <point x="287" y="629" type="curve" smooth="yes"/>
+      <point x="145" y="629"/>
+      <point x="51" y="553"/>
+      <point x="51" y="439" type="curve" smooth="yes"/>
+      <point x="51" y="344"/>
+      <point x="118" y="281"/>
+      <point x="215" y="281" type="curve" smooth="yes"/>
+      <point x="307" y="281"/>
+      <point x="364" y="331"/>
+      <point x="364" y="412" type="curve" smooth="yes"/>
+      <point x="364" y="480"/>
+      <point x="329" y="527"/>
+      <point x="256" y="527" type="curve" smooth="yes"/>
+      <point x="223" y="527"/>
+      <point x="190" y="516"/>
+      <point x="161" y="500" type="curve"/>
+      <point x="138" y="523" type="line"/>
+      <point x="144" y="492" type="line"/>
+      <point x="167" y="531"/>
+      <point x="218" y="555"/>
+      <point x="289" y="555" type="curve" smooth="yes"/>
+      <point x="381" y="555"/>
+      <point x="417" y="513"/>
+      <point x="417" y="409" type="curve" smooth="yes"/>
+      <point x="417" y="330" type="line"/>
+      <point x="531" y="330" type="line"/>
+      <point x="531" y="421" type="line" smooth="yes"/>
+      <point x="531" y="484"/>
+      <point x="569" y="523"/>
+      <point x="628" y="523" type="curve" smooth="yes"/>
+      <point x="685" y="523"/>
+      <point x="712" y="487"/>
+      <point x="712" y="418" type="curve" smooth="yes"/>
+      <point x="712" y="316"/>
+      <point x="651" y="273"/>
+      <point x="511" y="273" type="curve" smooth="yes"/>
+      <point x="231" y="273" type="line" smooth="yes"/>
+      <point x="123" y="273"/>
+      <point x="57" y="220"/>
+      <point x="57" y="135" type="curve" smooth="yes"/>
+      <point x="57" y="44"/>
+      <point x="135" y="-16"/>
     </contour>
     <contour>
-      <point x="203" y="394" type="curve" smooth="yes"/>
-      <point x="165" y="394"/>
-      <point x="147" y="422"/>
-      <point x="147" y="455" type="curve" smooth="yes"/>
-      <point x="147" y="474"/>
-      <point x="151" y="486"/>
-      <point x="160" y="500" type="curve"/>
-      <point x="128" y="500" type="line"/>
-      <point x="120" y="470" type="line"/>
-      <point x="142" y="485"/>
-      <point x="169" y="494"/>
-      <point x="198" y="494" type="curve" smooth="yes"/>
-      <point x="247" y="494"/>
-      <point x="258" y="470"/>
-      <point x="258" y="446" type="curve" smooth="yes"/>
-      <point x="258" y="416"/>
-      <point x="241" y="394"/>
+      <point x="213" y="368" type="curve" smooth="yes"/>
+      <point x="170" y="368"/>
+      <point x="143" y="389"/>
+      <point x="143" y="428" type="curve" smooth="yes"/>
+      <point x="143" y="445"/>
+      <point x="144" y="460"/>
+      <point x="147" y="470" type="curve"/>
+      <point x="128" y="470" type="line"/>
+      <point x="120" y="438" type="line"/>
+      <point x="149" y="455"/>
+      <point x="175" y="463"/>
+      <point x="210" y="463" type="curve" smooth="yes"/>
+      <point x="250" y="463"/>
+      <point x="268" y="447"/>
+      <point x="268" y="415" type="curve" smooth="yes"/>
+      <point x="268" y="385"/>
+      <point x="248" y="368"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ja-malayalam.glif
@@ -1,135 +1,135 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="871"/>
+  <advance width="921"/>
   <unicode hex="0D1C"/>
-  <anchor x="457" y="-1" name="bottom"/>
-  <anchor x="456" y="613" name="top"/>
-  <anchor x="723" y="613" name="topright"/>
+  <anchor x="484" y="-1" name="bottom"/>
+  <anchor x="461" y="613" name="top"/>
+  <anchor x="743" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="232" y="-16" type="curve" smooth="yes"/>
-      <point x="308" y="-16"/>
-      <point x="369" y="6"/>
-      <point x="453" y="61" type="curve" smooth="yes"/>
-      <point x="510" y="98" type="line"/>
-      <point x="570" y="148" type="line"/>
-      <point x="600" y="154" type="line"/>
-      <point x="631" y="169"/>
-      <point x="655" y="176"/>
-      <point x="675" y="176" type="curve" smooth="yes"/>
-      <point x="710" y="176"/>
-      <point x="727" y="159"/>
-      <point x="727" y="125" type="curve" smooth="yes"/>
-      <point x="727" y="92"/>
-      <point x="709" y="73"/>
-      <point x="680" y="73" type="curve" smooth="yes"/>
-      <point x="649" y="73"/>
-      <point x="631" y="92"/>
-      <point x="631" y="123" type="curve" smooth="yes"/>
-      <point x="631" y="143"/>
-      <point x="637" y="161"/>
-      <point x="652" y="182" type="curve"/>
-      <point x="543" y="153" type="line"/>
-      <point x="568" y="129" type="line"/>
-      <point x="562" y="118"/>
-      <point x="558" y="104"/>
-      <point x="558" y="87" type="curve" smooth="yes"/>
-      <point x="558" y="25"/>
-      <point x="604" y="-16"/>
-      <point x="680" y="-16" type="curve" smooth="yes"/>
-      <point x="764" y="-16"/>
-      <point x="816" y="36"/>
-      <point x="816" y="122" type="curve" smooth="yes"/>
-      <point x="816" y="205"/>
-      <point x="759" y="260"/>
-      <point x="675" y="260" type="curve" smooth="yes"/>
-      <point x="621" y="260"/>
-      <point x="576" y="242"/>
-      <point x="491" y="193" type="curve" smooth="yes"/>
-      <point x="420" y="151" type="line" smooth="yes"/>
-      <point x="338" y="103"/>
-      <point x="292" y="87"/>
-      <point x="243" y="87" type="curve" smooth="yes"/>
-      <point x="197" y="87"/>
-      <point x="173" y="107"/>
-      <point x="173" y="145" type="curve" smooth="yes"/>
-      <point x="173" y="186"/>
-      <point x="206" y="208"/>
-      <point x="268" y="208" type="curve" smooth="yes"/>
-      <point x="582" y="208" type="line" smooth="yes"/>
-      <point x="735" y="208"/>
-      <point x="820" y="287"/>
-      <point x="820" y="427" type="curve" smooth="yes"/>
-      <point x="820" y="554"/>
-      <point x="754" y="629"/>
-      <point x="643" y="629" type="curve" smooth="yes"/>
-      <point x="561" y="629"/>
-      <point x="497" y="588"/>
-      <point x="471" y="516" type="curve"/>
-      <point x="459" y="516" type="line"/>
-      <point x="437" y="591"/>
-      <point x="374" y="629"/>
-      <point x="275" y="629" type="curve" smooth="yes"/>
-      <point x="143" y="629"/>
-      <point x="51" y="560"/>
-      <point x="51" y="461" type="curve" smooth="yes"/>
-      <point x="51" y="374"/>
-      <point x="113" y="316"/>
-      <point x="205" y="316" type="curve" smooth="yes"/>
-      <point x="290" y="316"/>
-      <point x="343" y="362"/>
-      <point x="343" y="436" type="curve" smooth="yes"/>
-      <point x="343" y="497"/>
-      <point x="310" y="535"/>
-      <point x="242" y="535" type="curve" smooth="yes"/>
-      <point x="219" y="535"/>
-      <point x="196" y="531"/>
-      <point x="176" y="524" type="curve"/>
-      <point x="156" y="557" type="line"/>
-      <point x="150" y="523" type="line"/>
-      <point x="180" y="545"/>
-      <point x="221" y="557"/>
-      <point x="270" y="557" type="curve" smooth="yes"/>
-      <point x="360" y="557"/>
-      <point x="397" y="515"/>
-      <point x="397" y="408" type="curve" smooth="yes"/>
-      <point x="397" y="354" type="line"/>
-      <point x="515" y="354" type="line"/>
-      <point x="515" y="400" type="line" smooth="yes"/>
-      <point x="515" y="478"/>
-      <point x="554" y="526"/>
-      <point x="620" y="526" type="curve" smooth="yes"/>
-      <point x="674" y="526"/>
-      <point x="703" y="493"/>
-      <point x="703" y="429" type="curve" smooth="yes"/>
-      <point x="703" y="346"/>
-      <point x="657" y="307"/>
-      <point x="560" y="307" type="curve" smooth="yes"/>
-      <point x="263" y="307" type="line" smooth="yes"/>
-      <point x="133" y="307"/>
-      <point x="57" y="246"/>
-      <point x="57" y="142" type="curve" smooth="yes"/>
-      <point x="57" y="44"/>
-      <point x="125" y="-16"/>
+      <point x="250" y="-16" type="curve" smooth="yes"/>
+      <point x="297" y="-16"/>
+      <point x="342" y="-3"/>
+      <point x="412" y="30" type="curve" smooth="yes"/>
+      <point x="536" y="89" type="line"/>
+      <point x="593" y="142" type="line"/>
+      <point x="629" y="154" type="line"/>
+      <point x="660" y="174"/>
+      <point x="683" y="186"/>
+      <point x="715" y="186" type="curve" smooth="yes"/>
+      <point x="756" y="186"/>
+      <point x="777" y="167"/>
+      <point x="777" y="130" type="curve" smooth="yes"/>
+      <point x="777" y="94"/>
+      <point x="754" y="73"/>
+      <point x="716" y="73" type="curve" smooth="yes"/>
+      <point x="675" y="73"/>
+      <point x="651" y="94"/>
+      <point x="651" y="127" type="curve" smooth="yes"/>
+      <point x="651" y="146"/>
+      <point x="655" y="162"/>
+      <point x="666" y="182" type="curve"/>
+      <point x="568" y="148" type="line"/>
+      <point x="592" y="126" type="line"/>
+      <point x="586" y="115"/>
+      <point x="583" y="102"/>
+      <point x="583" y="86" type="curve" smooth="yes"/>
+      <point x="583" y="27"/>
+      <point x="636" y="-16"/>
+      <point x="717" y="-16" type="curve" smooth="yes"/>
+      <point x="809" y="-16"/>
+      <point x="866" y="35"/>
+      <point x="866" y="120" type="curve" smooth="yes"/>
+      <point x="866" y="197"/>
+      <point x="810" y="248"/>
+      <point x="727" y="248" type="curve" smooth="yes"/>
+      <point x="668" y="248"/>
+      <point x="616" y="229"/>
+      <point x="535" y="190" type="curve" smooth="yes"/>
+      <point x="374" y="113" type="line" smooth="yes"/>
+      <point x="331" y="93"/>
+      <point x="295" y="84"/>
+      <point x="252" y="84" type="curve" smooth="yes"/>
+      <point x="198" y="84"/>
+      <point x="175" y="100"/>
+      <point x="175" y="131" type="curve" smooth="yes"/>
+      <point x="175" y="162"/>
+      <point x="198" y="178"/>
+      <point x="237" y="178" type="curve" smooth="yes"/>
+      <point x="574" y="178" type="line" smooth="yes"/>
+      <point x="748" y="178"/>
+      <point x="870" y="276"/>
+      <point x="870" y="415" type="curve" smooth="yes"/>
+      <point x="870" y="539"/>
+      <point x="797" y="629"/>
+      <point x="672" y="629" type="curve" smooth="yes"/>
+      <point x="580" y="629"/>
+      <point x="520" y="586"/>
+      <point x="489" y="520" type="curve"/>
+      <point x="477" y="520" type="line"/>
+      <point x="453" y="585"/>
+      <point x="389" y="629"/>
+      <point x="287" y="629" type="curve" smooth="yes"/>
+      <point x="145" y="629"/>
+      <point x="51" y="553"/>
+      <point x="51" y="439" type="curve" smooth="yes"/>
+      <point x="51" y="344"/>
+      <point x="118" y="281"/>
+      <point x="215" y="281" type="curve" smooth="yes"/>
+      <point x="307" y="281"/>
+      <point x="364" y="331"/>
+      <point x="364" y="412" type="curve" smooth="yes"/>
+      <point x="364" y="480"/>
+      <point x="329" y="527"/>
+      <point x="256" y="527" type="curve" smooth="yes"/>
+      <point x="223" y="527"/>
+      <point x="190" y="516"/>
+      <point x="161" y="500" type="curve"/>
+      <point x="138" y="523" type="line"/>
+      <point x="144" y="492" type="line"/>
+      <point x="167" y="531"/>
+      <point x="218" y="555"/>
+      <point x="289" y="555" type="curve" smooth="yes"/>
+      <point x="381" y="555"/>
+      <point x="417" y="513"/>
+      <point x="417" y="409" type="curve" smooth="yes"/>
+      <point x="417" y="330" type="line"/>
+      <point x="531" y="330" type="line"/>
+      <point x="531" y="402" type="line" smooth="yes"/>
+      <point x="531" y="477"/>
+      <point x="577" y="523"/>
+      <point x="649" y="523" type="curve" smooth="yes"/>
+      <point x="718" y="523"/>
+      <point x="752" y="483"/>
+      <point x="752" y="407" type="curve" smooth="yes"/>
+      <point x="752" y="314"/>
+      <point x="699" y="273"/>
+      <point x="581" y="273" type="curve" smooth="yes"/>
+      <point x="234" y="273" type="line" smooth="yes"/>
+      <point x="124" y="273"/>
+      <point x="57" y="217"/>
+      <point x="57" y="129" type="curve" smooth="yes"/>
+      <point x="57" y="37"/>
+      <point x="134" y="-16"/>
     </contour>
     <contour>
-      <point x="206" y="394" type="curve" smooth="yes"/>
-      <point x="169" y="394"/>
-      <point x="147" y="418"/>
-      <point x="147" y="456" type="curve" smooth="yes"/>
-      <point x="147" y="476"/>
-      <point x="150" y="488"/>
-      <point x="160" y="500" type="curve"/>
-      <point x="128" y="500" type="line"/>
-      <point x="120" y="466" type="line"/>
-      <point x="146" y="481"/>
-      <point x="172" y="487"/>
-      <point x="202" y="487" type="curve" smooth="yes"/>
-      <point x="238" y="487"/>
-      <point x="258" y="472"/>
-      <point x="258" y="441" type="curve" smooth="yes"/>
-      <point x="258" y="411"/>
-      <point x="241" y="394"/>
+      <point x="213" y="368" type="curve" smooth="yes"/>
+      <point x="170" y="368"/>
+      <point x="143" y="389"/>
+      <point x="143" y="428" type="curve" smooth="yes"/>
+      <point x="143" y="445"/>
+      <point x="144" y="460"/>
+      <point x="147" y="470" type="curve"/>
+      <point x="128" y="470" type="line"/>
+      <point x="120" y="438" type="line"/>
+      <point x="149" y="455"/>
+      <point x="175" y="463"/>
+      <point x="210" y="463" type="curve" smooth="yes"/>
+      <point x="250" y="463"/>
+      <point x="268" y="447"/>
+      <point x="268" y="415" type="curve" smooth="yes"/>
+      <point x="268" y="385"/>
+      <point x="248" y="368"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="871"/>
+  <advance width="921"/>
+  <anchor x="484" y="-1" name="bottom"/>
+  <anchor x="461" y="613" name="top"/>
+  <anchor x="743" y="613" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="723"/>
+    <component base="halant-malayalam" xOffset="743"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="871"/>
+  <advance width="921"/>
+  <anchor x="484" y="-1" name="bottom"/>
+  <anchor x="461" y="613" name="top"/>
+  <anchor x="743" y="613" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="457" yOffset="-1"/>
+    <component base="lVocalicMatra-malayalam" xOffset="484" yOffset="-1"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="871"/>
+  <advance width="921"/>
+  <anchor x="484" y="-1" name="bottom"/>
+  <anchor x="461" y="613" name="top"/>
+  <anchor x="743" y="613" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="457" yOffset="-1"/>
+    <component base="llVocalicMatra-malayalam" xOffset="484" yOffset="-1"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
@@ -6,91 +6,91 @@
   <anchor x="360" y="613" name="top"/>
   <outline>
     <contour>
-      <point x="216" y="-16" type="curve" smooth="yes"/>
-      <point x="303" y="-16"/>
-      <point x="360" y="35"/>
+      <point x="219" y="-16" type="curve" smooth="yes"/>
+      <point x="299" y="-16"/>
+      <point x="358" y="27"/>
       <point x="380" y="102" type="curve"/>
-      <point x="392" y="102" type="line"/>
-      <point x="426" y="27"/>
-      <point x="487" y="-16"/>
-      <point x="567" y="-16" type="curve" smooth="yes"/>
-      <point x="626" y="-16"/>
-      <point x="681" y="20"/>
+      <point x="393" y="102" type="line"/>
+      <point x="426" y="26"/>
+      <point x="478" y="-16"/>
+      <point x="563" y="-16" type="curve" smooth="yes"/>
+      <point x="631" y="-16"/>
+      <point x="682" y="23"/>
       <point x="707" y="86" type="curve"/>
       <point x="720" y="86" type="line"/>
-      <point x="746" y="24"/>
-      <point x="795" y="-16"/>
-      <point x="880" y="-16" type="curve" smooth="yes"/>
-      <point x="999" y="-16"/>
-      <point x="1065" y="53"/>
-      <point x="1065" y="168" type="curve" smooth="yes"/>
-      <point x="1065" y="280"/>
-      <point x="985" y="353"/>
-      <point x="855" y="353" type="curve" smooth="yes"/>
-      <point x="805" y="353" type="line"/>
-      <point x="758" y="253" type="line"/>
-      <point x="848" y="253" type="line" smooth="yes"/>
-      <point x="916" y="253"/>
-      <point x="945" y="222"/>
-      <point x="945" y="174" type="curve" smooth="yes"/>
-      <point x="945" y="124"/>
-      <point x="919" y="95"/>
-      <point x="874" y="95" type="curve" smooth="yes"/>
-      <point x="820" y="95"/>
-      <point x="787" y="130"/>
-      <point x="787" y="201" type="curve" smooth="yes"/>
-      <point x="787" y="267"/>
-      <point x="814" y="330"/>
+      <point x="748" y="19"/>
+      <point x="803" y="-16"/>
+      <point x="881" y="-16" type="curve" smooth="yes"/>
+      <point x="992" y="-16"/>
+      <point x="1065" y="61"/>
+      <point x="1065" y="177" type="curve" smooth="yes"/>
+      <point x="1065" y="295"/>
+      <point x="980" y="373"/>
+      <point x="849" y="373" type="curve" smooth="yes"/>
+      <point x="805" y="373" type="line"/>
+      <point x="758" y="273" type="line"/>
+      <point x="840" y="273" type="line" smooth="yes"/>
+      <point x="912" y="273"/>
+      <point x="949" y="241"/>
+      <point x="949" y="181" type="curve" smooth="yes"/>
+      <point x="949" y="128"/>
+      <point x="918" y="95"/>
+      <point x="869" y="95" type="curve" smooth="yes"/>
+      <point x="816" y="95"/>
+      <point x="783" y="132"/>
+      <point x="783" y="191" type="curve" smooth="yes"/>
+      <point x="783" y="262"/>
+      <point x="813" y="328"/>
       <point x="892" y="436" type="curve" smooth="yes"/>
-      <point x="951" y="517"/>
-      <point x="984" y="585"/>
-      <point x="984" y="668" type="curve" smooth="yes"/>
-      <point x="984" y="772"/>
-      <point x="926" y="845"/>
+      <point x="958" y="527"/>
+      <point x="986" y="593"/>
+      <point x="986" y="668" type="curve" smooth="yes"/>
+      <point x="986" y="781"/>
+      <point x="918" y="845"/>
       <point x="800" y="845" type="curve" smooth="yes"/>
-      <point x="735" y="845"/>
-      <point x="682" y="828"/>
+      <point x="739" y="845"/>
+      <point x="686" y="830"/>
       <point x="630" y="798" type="curve"/>
       <point x="670" y="702" type="line"/>
-      <point x="706" y="723"/>
-      <point x="747" y="736"/>
+      <point x="708" y="724"/>
+      <point x="749" y="736"/>
       <point x="788" y="736" type="curve" smooth="yes"/>
-      <point x="851" y="736"/>
-      <point x="871" y="702"/>
-      <point x="871" y="661" type="curve" smooth="yes"/>
-      <point x="871" y="613"/>
-      <point x="847" y="573"/>
+      <point x="842" y="736"/>
+      <point x="870" y="710"/>
+      <point x="870" y="661" type="curve" smooth="yes"/>
+      <point x="870" y="621"/>
+      <point x="858" y="589"/>
       <point x="807" y="510" type="curve" smooth="yes"/>
-      <point x="791" y="484"/>
-      <point x="779" y="458"/>
-      <point x="773" y="437" type="curve"/>
-      <point x="760" y="437" type="line"/>
-      <point x="738" y="553"/>
-      <point x="668" y="629"/>
+      <point x="787" y="479"/>
+      <point x="774" y="444"/>
+      <point x="771" y="401" type="curve"/>
+      <point x="761" y="401" type="line"/>
+      <point x="744" y="547"/>
+      <point x="674" y="629"/>
       <point x="562" y="629" type="curve" smooth="yes"/>
-      <point x="422" y="629"/>
-      <point x="332" y="504"/>
+      <point x="424" y="629"/>
+      <point x="332" y="507"/>
       <point x="332" y="325" type="curve" smooth="yes"/>
-      <point x="332" y="296"/>
-      <point x="336" y="262"/>
-      <point x="336" y="232" type="curve" smooth="yes"/>
-      <point x="336" y="152"/>
-      <point x="299" y="95"/>
-      <point x="234" y="95" type="curve" smooth="yes"/>
-      <point x="185" y="95"/>
-      <point x="154" y="126"/>
-      <point x="154" y="173" type="curve" smooth="yes"/>
-      <point x="154" y="223"/>
-      <point x="187" y="253"/>
-      <point x="248" y="253" type="curve" smooth="yes"/>
-      <point x="740" y="253" type="line"/>
-      <point x="743" y="353" type="line"/>
-      <point x="252" y="353" type="line" smooth="yes"/>
-      <point x="117" y="353"/>
-      <point x="38" y="282"/>
-      <point x="38" y="163" type="curve" smooth="yes"/>
-      <point x="38" y="61"/>
-      <point x="110" y="-16"/>
+      <point x="332" y="293"/>
+      <point x="337" y="256"/>
+      <point x="337" y="223" type="curve" smooth="yes"/>
+      <point x="337" y="141"/>
+      <point x="300" y="95"/>
+      <point x="238" y="95" type="curve" smooth="yes"/>
+      <point x="187" y="95"/>
+      <point x="154" y="128"/>
+      <point x="154" y="179" type="curve" smooth="yes"/>
+      <point x="154" y="237"/>
+      <point x="196" y="273"/>
+      <point x="265" y="273" type="curve" smooth="yes"/>
+      <point x="740" y="273" type="line"/>
+      <point x="743" y="373" type="line"/>
+      <point x="270" y="373" type="line" smooth="yes"/>
+      <point x="126" y="373"/>
+      <point x="38" y="297"/>
+      <point x="38" y="171" type="curve" smooth="yes"/>
+      <point x="38" y="64"/>
+      <point x="115" y="-16"/>
     </contour>
     <contour>
       <point x="563" y="95" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/k_ka-malayalam.glif
@@ -6,96 +6,96 @@
   <anchor x="1338" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="216" y="-16" type="curve" smooth="yes"/>
-      <point x="303" y="-16"/>
+      <point x="219" y="-16" type="curve" smooth="yes"/>
+      <point x="307" y="-16"/>
       <point x="360" y="35"/>
       <point x="380" y="102" type="curve"/>
-      <point x="392" y="102" type="line"/>
+      <point x="393" y="102" type="line"/>
       <point x="426" y="27"/>
       <point x="487" y="-16"/>
       <point x="569" y="-16" type="curve" smooth="yes"/>
       <point x="707" y="-16"/>
-      <point x="795" y="109"/>
-      <point x="795" y="292" type="curve" smooth="yes"/>
-      <point x="795" y="322" type="line" smooth="yes"/>
-      <point x="795" y="502"/>
-      <point x="707" y="629"/>
+      <point x="796" y="109"/>
+      <point x="796" y="292" type="curve" smooth="yes"/>
+      <point x="796" y="323" type="line" smooth="yes"/>
+      <point x="796" y="501"/>
+      <point x="706" y="629"/>
       <point x="564" y="629" type="curve" smooth="yes"/>
       <point x="422" y="629"/>
-      <point x="332" y="504"/>
-      <point x="332" y="322" type="curve" smooth="yes"/>
-      <point x="332" y="293"/>
-      <point x="336" y="262"/>
-      <point x="336" y="233" type="curve" smooth="yes"/>
-      <point x="336" y="152"/>
-      <point x="299" y="95"/>
-      <point x="237" y="95" type="curve" smooth="yes"/>
-      <point x="185" y="95"/>
-      <point x="154" y="126"/>
-      <point x="154" y="172" type="curve" smooth="yes"/>
-      <point x="154" y="222"/>
-      <point x="190" y="253"/>
-      <point x="245" y="253" type="curve" smooth="yes"/>
-      <point x="983" y="253" type="line" smooth="yes"/>
-      <point x="1062" y="253"/>
-      <point x="1090" y="223"/>
-      <point x="1090" y="164" type="curve" smooth="yes"/>
-      <point x="1090" y="113"/>
-      <point x="1070" y="92"/>
-      <point x="1037" y="92" type="curve" smooth="yes"/>
-      <point x="985" y="92"/>
-      <point x="961" y="142"/>
-      <point x="961" y="240" type="curve" smooth="yes"/>
-      <point x="961" y="402"/>
-      <point x="1018" y="517"/>
-      <point x="1155" y="517" type="curve" smooth="yes"/>
-      <point x="1269" y="517"/>
-      <point x="1325" y="425"/>
+      <point x="332" y="503"/>
+      <point x="332" y="323" type="curve" smooth="yes"/>
+      <point x="332" y="290"/>
+      <point x="337" y="255"/>
+      <point x="337" y="223" type="curve" smooth="yes"/>
+      <point x="337" y="141"/>
+      <point x="300" y="95"/>
+      <point x="238" y="95" type="curve" smooth="yes"/>
+      <point x="187" y="95"/>
+      <point x="154" y="128"/>
+      <point x="154" y="179" type="curve" smooth="yes"/>
+      <point x="154" y="237"/>
+      <point x="196" y="273"/>
+      <point x="265" y="273" type="curve" smooth="yes"/>
+      <point x="982" y="273" type="line" smooth="yes"/>
+      <point x="1058" y="273"/>
+      <point x="1090" y="244"/>
+      <point x="1090" y="175" type="curve" smooth="yes"/>
+      <point x="1090" y="120"/>
+      <point x="1071" y="92"/>
+      <point x="1032" y="92" type="curve" smooth="yes"/>
+      <point x="984" y="92"/>
+      <point x="961" y="137"/>
+      <point x="961" y="231" type="curve" smooth="yes"/>
+      <point x="961" y="422"/>
+      <point x="1026" y="517"/>
+      <point x="1157" y="517" type="curve" smooth="yes"/>
+      <point x="1267" y="517"/>
+      <point x="1325" y="439"/>
       <point x="1325" y="293" type="curve" smooth="yes"/>
-      <point x="1325" y="206"/>
-      <point x="1301" y="126"/>
+      <point x="1325" y="203"/>
+      <point x="1299" y="124"/>
       <point x="1246" y="47" type="curve"/>
       <point x="1347" y="-16" type="line"/>
-      <point x="1416" y="75"/>
-      <point x="1446" y="188"/>
+      <point x="1411" y="68"/>
+      <point x="1446" y="178"/>
       <point x="1446" y="292" type="curve" smooth="yes"/>
-      <point x="1446" y="498"/>
-      <point x="1347" y="629"/>
-      <point x="1155" y="629" type="curve" smooth="yes"/>
-      <point x="954" y="629"/>
-      <point x="844" y="471"/>
-      <point x="844" y="264" type="curve" smooth="yes"/>
-      <point x="844" y="96"/>
-      <point x="905" y="-16"/>
-      <point x="1042" y="-16" type="curve" smooth="yes"/>
-      <point x="1163" y="-16"/>
-      <point x="1206" y="76"/>
-      <point x="1206" y="163" type="curve" smooth="yes"/>
-      <point x="1206" y="294"/>
-      <point x="1122" y="353"/>
-      <point x="979" y="353" type="curve" smooth="yes"/>
-      <point x="250" y="353" type="line" smooth="yes"/>
-      <point x="120" y="353"/>
-      <point x="38" y="281"/>
-      <point x="38" y="162" type="curve" smooth="yes"/>
-      <point x="38" y="61"/>
-      <point x="110" y="-16"/>
+      <point x="1446" y="510"/>
+      <point x="1344" y="629"/>
+      <point x="1157" y="629" type="curve" smooth="yes"/>
+      <point x="963" y="629"/>
+      <point x="844" y="476"/>
+      <point x="844" y="225" type="curve" smooth="yes"/>
+      <point x="844" y="74"/>
+      <point x="916" y="-16"/>
+      <point x="1037" y="-16" type="curve" smooth="yes"/>
+      <point x="1138" y="-16"/>
+      <point x="1206" y="58"/>
+      <point x="1206" y="174" type="curve" smooth="yes"/>
+      <point x="1206" y="295"/>
+      <point x="1127" y="373"/>
+      <point x="988" y="373" type="curve" smooth="yes"/>
+      <point x="270" y="373" type="line" smooth="yes"/>
+      <point x="126" y="373"/>
+      <point x="38" y="297"/>
+      <point x="38" y="171" type="curve" smooth="yes"/>
+      <point x="38" y="64"/>
+      <point x="115" y="-16"/>
     </contour>
     <contour>
       <point x="563" y="95" type="curve" smooth="yes"/>
-      <point x="488" y="95"/>
-      <point x="443" y="166"/>
+      <point x="487" y="95"/>
+      <point x="443" y="168"/>
       <point x="443" y="295" type="curve" smooth="yes"/>
       <point x="443" y="320" type="line" smooth="yes"/>
-      <point x="443" y="447"/>
-      <point x="488" y="518"/>
+      <point x="443" y="445"/>
+      <point x="487" y="518"/>
       <point x="563" y="518" type="curve" smooth="yes"/>
       <point x="635" y="518"/>
-      <point x="677" y="447"/>
+      <point x="677" y="445"/>
       <point x="677" y="320" type="curve" smooth="yes"/>
       <point x="677" y="295" type="line" smooth="yes"/>
-      <point x="677" y="166"/>
-      <point x="634" y="95"/>
+      <point x="677" y="168"/>
+      <point x="635" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/k_la-malayalam.glif
@@ -46,7 +46,7 @@
       <point x="786" y="-257"/>
       <point x="764" y="-178" type="curve" smooth="yes"/>
       <point x="753" y="-140" type="line" smooth="yes"/>
-      <point x="736" y="-78"/>
+      <point x="735" y="-78"/>
       <point x="712" y="-28"/>
       <point x="664" y="3" type="curve"/>
       <point x="664" y="16" type="line"/>
@@ -60,46 +60,46 @@
       <point x="422" y="629"/>
       <point x="332" y="503"/>
       <point x="332" y="323" type="curve" smooth="yes"/>
-      <point x="332" y="293"/>
-      <point x="336" y="262"/>
-      <point x="336" y="233" type="curve" smooth="yes"/>
-      <point x="336" y="152"/>
-      <point x="299" y="95"/>
-      <point x="237" y="95" type="curve" smooth="yes"/>
-      <point x="185" y="95"/>
-      <point x="154" y="126"/>
-      <point x="154" y="172" type="curve" smooth="yes"/>
-      <point x="154" y="222"/>
-      <point x="190" y="253"/>
-      <point x="245" y="253" type="curve" smooth="yes"/>
-      <point x="846" y="253" type="line" smooth="yes"/>
-      <point x="911" y="253"/>
-      <point x="943" y="226"/>
-      <point x="943" y="175" type="curve" smooth="yes"/>
-      <point x="943" y="123"/>
-      <point x="916" y="94"/>
-      <point x="869" y="94" type="curve" smooth="yes"/>
-      <point x="851" y="94"/>
-      <point x="835" y="96"/>
+      <point x="332" y="290"/>
+      <point x="337" y="255"/>
+      <point x="337" y="223" type="curve" smooth="yes"/>
+      <point x="337" y="141"/>
+      <point x="300" y="95"/>
+      <point x="238" y="95" type="curve" smooth="yes"/>
+      <point x="187" y="95"/>
+      <point x="154" y="128"/>
+      <point x="154" y="179" type="curve" smooth="yes"/>
+      <point x="154" y="237"/>
+      <point x="196" y="273"/>
+      <point x="265" y="273" type="curve" smooth="yes"/>
+      <point x="832" y="273" type="line" smooth="yes"/>
+      <point x="908" y="273"/>
+      <point x="943" y="244"/>
+      <point x="943" y="181" type="curve" smooth="yes"/>
+      <point x="943" y="131"/>
+      <point x="917" y="94"/>
+      <point x="866" y="94" type="curve" smooth="yes"/>
+      <point x="848" y="94"/>
+      <point x="833" y="96"/>
       <point x="819" y="101" type="curve"/>
       <point x="790" y="-3" type="line"/>
       <point x="815" y="-11"/>
       <point x="846" y="-16"/>
       <point x="878" y="-16" type="curve" smooth="yes"/>
       <point x="989" y="-16"/>
-      <point x="1060" y="55"/>
-      <point x="1060" y="167" type="curve" smooth="yes"/>
-      <point x="1060" y="279"/>
-      <point x="985" y="353"/>
-      <point x="844" y="353" type="curve" smooth="yes"/>
-      <point x="250" y="353" type="line" smooth="yes"/>
-      <point x="120" y="353"/>
-      <point x="38" y="281"/>
-      <point x="38" y="162" type="curve" smooth="yes"/>
-      <point x="38" y="61"/>
-      <point x="110" y="-16"/>
-      <point x="216" y="-16" type="curve" smooth="yes"/>
-      <point x="303" y="-16"/>
+      <point x="1060" y="59"/>
+      <point x="1060" y="177" type="curve" smooth="yes"/>
+      <point x="1060" y="302"/>
+      <point x="976" y="373"/>
+      <point x="830" y="373" type="curve" smooth="yes"/>
+      <point x="270" y="373" type="line" smooth="yes"/>
+      <point x="126" y="373"/>
+      <point x="38" y="297"/>
+      <point x="38" y="171" type="curve" smooth="yes"/>
+      <point x="38" y="64"/>
+      <point x="115" y="-16"/>
+      <point x="219" y="-16" type="curve" smooth="yes"/>
+      <point x="307" y="-16"/>
       <point x="360" y="35"/>
       <point x="380" y="102" type="curve"/>
       <point x="393" y="102" type="line"/>
@@ -110,13 +110,13 @@
       <point x="336" y="8"/>
       <point x="282" y="-74"/>
       <point x="282" y="-182" type="curve" smooth="yes"/>
-      <point x="282" y="-318"/>
-      <point x="355" y="-382"/>
+      <point x="282" y="-313"/>
+      <point x="354" y="-382"/>
     </contour>
     <contour>
       <point x="449" y="-302" type="curve" smooth="yes"/>
       <point x="401" y="-302"/>
-      <point x="380" y="-253"/>
+      <point x="379" y="-253"/>
       <point x="379" y="-215" type="curve"/>
       <point x="363" y="-220" type="line"/>
       <point x="377" y="-259" type="line"/>
@@ -131,19 +131,19 @@
     </contour>
     <contour>
       <point x="563" y="95" type="curve" smooth="yes"/>
-      <point x="488" y="95"/>
-      <point x="443" y="166"/>
+      <point x="487" y="95"/>
+      <point x="443" y="168"/>
       <point x="443" y="295" type="curve" smooth="yes"/>
       <point x="443" y="320" type="line" smooth="yes"/>
-      <point x="443" y="447"/>
-      <point x="488" y="518"/>
+      <point x="443" y="445"/>
+      <point x="487" y="518"/>
       <point x="563" y="518" type="curve" smooth="yes"/>
-      <point x="634" y="518"/>
-      <point x="677" y="446"/>
+      <point x="635" y="518"/>
+      <point x="677" y="445"/>
       <point x="677" y="320" type="curve" smooth="yes"/>
       <point x="677" y="295" type="line" smooth="yes"/>
-      <point x="677" y="166"/>
-      <point x="634" y="95"/>
+      <point x="677" y="168"/>
+      <point x="635" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
@@ -6,11 +6,11 @@
   <anchor x="1624" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="216" y="-16" type="curve" smooth="yes"/>
-      <point x="303" y="-16"/>
+      <point x="219" y="-16" type="curve" smooth="yes"/>
+      <point x="307" y="-16"/>
       <point x="360" y="35"/>
       <point x="380" y="102" type="curve"/>
-      <point x="392" y="102" type="line"/>
+      <point x="393" y="102" type="line"/>
       <point x="426" y="27"/>
       <point x="487" y="-16"/>
       <point x="569" y="-16" type="curve" smooth="yes"/>
@@ -24,21 +24,21 @@
       <point x="422" y="629"/>
       <point x="332" y="503"/>
       <point x="332" y="323" type="curve" smooth="yes"/>
-      <point x="332" y="293"/>
-      <point x="336" y="262"/>
-      <point x="336" y="233" type="curve" smooth="yes"/>
-      <point x="336" y="152"/>
-      <point x="299" y="95"/>
-      <point x="237" y="95" type="curve" smooth="yes"/>
-      <point x="185" y="95"/>
-      <point x="154" y="126"/>
-      <point x="154" y="175" type="curve" smooth="yes"/>
-      <point x="154" y="228"/>
-      <point x="190" y="259"/>
-      <point x="245" y="259" type="curve" smooth="yes"/>
-      <point x="836" y="259" type="line" smooth="yes"/>
-      <point x="902" y="259"/>
-      <point x="930" y="234"/>
+      <point x="332" y="290"/>
+      <point x="337" y="255"/>
+      <point x="337" y="223" type="curve" smooth="yes"/>
+      <point x="337" y="141"/>
+      <point x="300" y="95"/>
+      <point x="238" y="95" type="curve" smooth="yes"/>
+      <point x="187" y="95"/>
+      <point x="154" y="128"/>
+      <point x="154" y="179" type="curve" smooth="yes"/>
+      <point x="154" y="237"/>
+      <point x="196" y="273"/>
+      <point x="265" y="273" type="curve" smooth="yes"/>
+      <point x="830" y="273" type="line" smooth="yes"/>
+      <point x="898" y="273"/>
+      <point x="930" y="244"/>
       <point x="930" y="185" type="curve" smooth="yes"/>
       <point x="930" y="145"/>
       <point x="917" y="113"/>
@@ -79,34 +79,34 @@
       <point x="1627" y="105" type="line"/>
       <point x="1030" y="105" type="line"/>
       <point x="1024" y="116" type="line"/>
-      <point x="1040" y="136"/>
-      <point x="1049" y="166"/>
-      <point x="1049" y="194" type="curve" smooth="yes"/>
-      <point x="1049" y="300"/>
-      <point x="979" y="359"/>
-      <point x="834" y="359" type="curve" smooth="yes"/>
-      <point x="250" y="359" type="line" smooth="yes"/>
-      <point x="120" y="359"/>
-      <point x="38" y="287"/>
-      <point x="38" y="165" type="curve" smooth="yes"/>
-      <point x="38" y="61"/>
-      <point x="110" y="-16"/>
+      <point x="1040" y="140"/>
+      <point x="1049" y="172"/>
+      <point x="1049" y="204" type="curve" smooth="yes"/>
+      <point x="1049" y="310"/>
+      <point x="967" y="373"/>
+      <point x="828" y="373" type="curve" smooth="yes"/>
+      <point x="270" y="373" type="line" smooth="yes"/>
+      <point x="126" y="373"/>
+      <point x="38" y="297"/>
+      <point x="38" y="171" type="curve" smooth="yes"/>
+      <point x="38" y="64"/>
+      <point x="115" y="-16"/>
     </contour>
     <contour>
       <point x="563" y="95" type="curve" smooth="yes"/>
-      <point x="488" y="95"/>
-      <point x="443" y="166"/>
+      <point x="487" y="95"/>
+      <point x="443" y="168"/>
       <point x="443" y="295" type="curve" smooth="yes"/>
       <point x="443" y="320" type="line" smooth="yes"/>
-      <point x="443" y="447"/>
-      <point x="488" y="518"/>
+      <point x="443" y="445"/>
+      <point x="487" y="518"/>
       <point x="563" y="518" type="curve" smooth="yes"/>
-      <point x="634" y="518"/>
-      <point x="677" y="446"/>
+      <point x="635" y="518"/>
+      <point x="677" y="445"/>
       <point x="677" y="320" type="curve" smooth="yes"/>
       <point x="677" y="295" type="line" smooth="yes"/>
-      <point x="677" y="166"/>
-      <point x="634" y="95"/>
+      <point x="677" y="168"/>
+      <point x="635" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam.half" format="2">
   <advance width="1765"/>
+  <anchor x="1303" y="0" name="bottom"/>
+  <anchor x="899" y="613" name="top"/>
+  <anchor x="1624" y="613" name="topright"/>
   <outline>
     <component base="k_ssa-malayalam"/>
     <component base="halant-malayalam" xOffset="1624"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/k_ta-malayalam.glif
@@ -58,11 +58,11 @@
       <point x="905" y="74"/>
     </contour>
     <contour>
-      <point x="216" y="-16" type="curve" smooth="yes"/>
-      <point x="303" y="-16"/>
+      <point x="219" y="-16" type="curve" smooth="yes"/>
+      <point x="307" y="-16"/>
       <point x="360" y="35"/>
       <point x="380" y="102" type="curve"/>
-      <point x="392" y="102" type="line"/>
+      <point x="393" y="102" type="line"/>
       <point x="426" y="27"/>
       <point x="487" y="-16"/>
       <point x="569" y="-16" type="curve" smooth="yes"/>
@@ -76,42 +76,42 @@
       <point x="422" y="629"/>
       <point x="332" y="503"/>
       <point x="332" y="323" type="curve" smooth="yes"/>
-      <point x="332" y="293"/>
-      <point x="336" y="262"/>
-      <point x="336" y="233" type="curve" smooth="yes"/>
-      <point x="336" y="152"/>
-      <point x="299" y="95"/>
-      <point x="237" y="95" type="curve" smooth="yes"/>
-      <point x="185" y="95"/>
-      <point x="154" y="126"/>
-      <point x="154" y="172" type="curve" smooth="yes"/>
-      <point x="154" y="222"/>
-      <point x="190" y="253"/>
-      <point x="245" y="253" type="curve" smooth="yes"/>
-      <point x="916" y="253" type="line"/>
-      <point x="915" y="353" type="line"/>
-      <point x="250" y="353" type="line" smooth="yes"/>
-      <point x="120" y="353"/>
-      <point x="38" y="281"/>
-      <point x="38" y="162" type="curve" smooth="yes"/>
-      <point x="38" y="61"/>
-      <point x="110" y="-16"/>
+      <point x="332" y="290"/>
+      <point x="337" y="255"/>
+      <point x="337" y="223" type="curve" smooth="yes"/>
+      <point x="337" y="141"/>
+      <point x="300" y="95"/>
+      <point x="238" y="95" type="curve" smooth="yes"/>
+      <point x="187" y="95"/>
+      <point x="154" y="128"/>
+      <point x="154" y="179" type="curve" smooth="yes"/>
+      <point x="154" y="237"/>
+      <point x="196" y="273"/>
+      <point x="265" y="273" type="curve" smooth="yes"/>
+      <point x="931" y="273" type="line"/>
+      <point x="931" y="373" type="line"/>
+      <point x="270" y="373" type="line" smooth="yes"/>
+      <point x="126" y="373"/>
+      <point x="38" y="297"/>
+      <point x="38" y="171" type="curve" smooth="yes"/>
+      <point x="38" y="64"/>
+      <point x="115" y="-16"/>
     </contour>
     <contour>
       <point x="563" y="95" type="curve" smooth="yes"/>
-      <point x="488" y="95"/>
-      <point x="443" y="166"/>
+      <point x="487" y="95"/>
+      <point x="443" y="168"/>
       <point x="443" y="295" type="curve" smooth="yes"/>
       <point x="443" y="320" type="line" smooth="yes"/>
-      <point x="443" y="447"/>
-      <point x="488" y="518"/>
+      <point x="443" y="445"/>
+      <point x="487" y="518"/>
       <point x="563" y="518" type="curve" smooth="yes"/>
-      <point x="634" y="518"/>
-      <point x="677" y="446"/>
+      <point x="635" y="518"/>
+      <point x="677" y="445"/>
       <point x="677" y="320" type="curve" smooth="yes"/>
       <point x="677" y="295" type="line" smooth="yes"/>
-      <point x="677" y="166"/>
-      <point x="634" y="95"/>
+      <point x="677" y="168"/>
+      <point x="635" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/k_tta-malayalam.glif
@@ -14,7 +14,7 @@
       <point x="1012" y="-126"/>
       <point x="893" y="-120" type="curve" smooth="yes"/>
       <point x="822" y="-116" type="line" smooth="yes"/>
-      <point x="779" y="-113"/>
+      <point x="779" y="-114"/>
       <point x="752" y="-102"/>
       <point x="752" y="-76" type="curve" smooth="yes"/>
       <point x="752" y="-48"/>
@@ -28,23 +28,23 @@
       <point x="1012" y="32"/>
       <point x="994" y="36" type="curve"/>
       <point x="994" y="49" type="line"/>
-      <point x="1041" y="73"/>
-      <point x="1060" y="127"/>
-      <point x="1060" y="181" type="curve" smooth="yes"/>
-      <point x="1060" y="292"/>
-      <point x="985" y="353"/>
-      <point x="843" y="353" type="curve" smooth="yes"/>
-      <point x="250" y="353" type="line" smooth="yes"/>
-      <point x="120" y="353"/>
-      <point x="38" y="281"/>
-      <point x="38" y="162" type="curve" smooth="yes"/>
-      <point x="38" y="61"/>
-      <point x="110" y="-16"/>
-      <point x="216" y="-16" type="curve" smooth="yes"/>
-      <point x="303" y="-16"/>
+      <point x="1041" y="74"/>
+      <point x="1060" y="132"/>
+      <point x="1060" y="189" type="curve" smooth="yes"/>
+      <point x="1060" y="302"/>
+      <point x="979" y="373"/>
+      <point x="836" y="373" type="curve" smooth="yes"/>
+      <point x="270" y="373" type="line" smooth="yes"/>
+      <point x="126" y="373"/>
+      <point x="38" y="297"/>
+      <point x="38" y="171" type="curve" smooth="yes"/>
+      <point x="38" y="64"/>
+      <point x="115" y="-16"/>
+      <point x="219" y="-16" type="curve" smooth="yes"/>
+      <point x="307" y="-16"/>
       <point x="360" y="35"/>
       <point x="380" y="102" type="curve"/>
-      <point x="392" y="102" type="line"/>
+      <point x="393" y="102" type="line"/>
       <point x="426" y="27"/>
       <point x="487" y="-16"/>
       <point x="569" y="-16" type="curve" smooth="yes"/>
@@ -58,23 +58,23 @@
       <point x="422" y="629"/>
       <point x="332" y="503"/>
       <point x="332" y="323" type="curve" smooth="yes"/>
-      <point x="332" y="293"/>
-      <point x="336" y="262"/>
-      <point x="336" y="233" type="curve" smooth="yes"/>
-      <point x="336" y="152"/>
-      <point x="299" y="95"/>
-      <point x="237" y="95" type="curve" smooth="yes"/>
-      <point x="185" y="95"/>
-      <point x="154" y="126"/>
-      <point x="154" y="172" type="curve" smooth="yes"/>
-      <point x="154" y="222"/>
-      <point x="190" y="253"/>
-      <point x="245" y="253" type="curve" smooth="yes"/>
-      <point x="846" y="253" type="line" smooth="yes"/>
-      <point x="911" y="253"/>
-      <point x="943" y="226"/>
-      <point x="943" y="175" type="curve" smooth="yes"/>
-      <point x="943" y="123"/>
+      <point x="332" y="290"/>
+      <point x="337" y="255"/>
+      <point x="337" y="223" type="curve" smooth="yes"/>
+      <point x="337" y="141"/>
+      <point x="300" y="95"/>
+      <point x="238" y="95" type="curve" smooth="yes"/>
+      <point x="187" y="95"/>
+      <point x="154" y="128"/>
+      <point x="154" y="179" type="curve" smooth="yes"/>
+      <point x="154" y="237"/>
+      <point x="196" y="273"/>
+      <point x="265" y="273" type="curve" smooth="yes"/>
+      <point x="832" y="273" type="line" smooth="yes"/>
+      <point x="910" y="273"/>
+      <point x="943" y="242"/>
+      <point x="943" y="184" type="curve" smooth="yes"/>
+      <point x="943" y="128"/>
       <point x="916" y="94"/>
       <point x="869" y="94" type="curve" smooth="yes"/>
       <point x="851" y="94"/>
@@ -104,19 +104,19 @@
     </contour>
     <contour>
       <point x="563" y="95" type="curve" smooth="yes"/>
-      <point x="488" y="95"/>
-      <point x="443" y="166"/>
+      <point x="487" y="95"/>
+      <point x="443" y="168"/>
       <point x="443" y="295" type="curve" smooth="yes"/>
       <point x="443" y="320" type="line" smooth="yes"/>
-      <point x="443" y="446"/>
-      <point x="488" y="518"/>
+      <point x="443" y="445"/>
+      <point x="487" y="518"/>
       <point x="563" y="518" type="curve" smooth="yes"/>
-      <point x="634" y="518"/>
-      <point x="677" y="446"/>
+      <point x="635" y="518"/>
+      <point x="677" y="445"/>
       <point x="677" y="320" type="curve" smooth="yes"/>
       <point x="677" y="295" type="line" smooth="yes"/>
-      <point x="677" y="166"/>
-      <point x="634" y="95"/>
+      <point x="677" y="168"/>
+      <point x="635" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ka-malayalam.glif
@@ -7,8 +7,8 @@
   <anchor x="926" y="573" name="topright"/>
   <outline>
     <contour>
-      <point x="216" y="-16" type="curve" smooth="yes"/>
-      <point x="303" y="-16"/>
+      <point x="219" y="-16" type="curve" smooth="yes"/>
+      <point x="307" y="-16"/>
       <point x="360" y="35"/>
       <point x="380" y="102" type="curve"/>
       <point x="393" y="102" type="line"/>
@@ -25,60 +25,60 @@
       <point x="422" y="629"/>
       <point x="332" y="503"/>
       <point x="332" y="323" type="curve" smooth="yes"/>
-      <point x="332" y="293"/>
-      <point x="336" y="262"/>
-      <point x="336" y="233" type="curve" smooth="yes"/>
-      <point x="336" y="152"/>
-      <point x="299" y="95"/>
-      <point x="237" y="95" type="curve" smooth="yes"/>
-      <point x="185" y="95"/>
-      <point x="154" y="126"/>
-      <point x="154" y="172" type="curve" smooth="yes"/>
-      <point x="154" y="222"/>
-      <point x="190" y="253"/>
-      <point x="245" y="253" type="curve" smooth="yes"/>
-      <point x="846" y="253" type="line" smooth="yes"/>
-      <point x="911" y="253"/>
-      <point x="943" y="226"/>
-      <point x="943" y="175" type="curve" smooth="yes"/>
-      <point x="943" y="123"/>
-      <point x="916" y="94"/>
-      <point x="869" y="94" type="curve" smooth="yes"/>
-      <point x="851" y="94"/>
-      <point x="835" y="96"/>
+      <point x="332" y="290"/>
+      <point x="337" y="255"/>
+      <point x="337" y="223" type="curve" smooth="yes"/>
+      <point x="337" y="141"/>
+      <point x="300" y="95"/>
+      <point x="238" y="95" type="curve" smooth="yes"/>
+      <point x="187" y="95"/>
+      <point x="154" y="128"/>
+      <point x="154" y="179" type="curve" smooth="yes"/>
+      <point x="154" y="237"/>
+      <point x="196" y="273"/>
+      <point x="265" y="273" type="curve" smooth="yes"/>
+      <point x="832" y="273" type="line" smooth="yes"/>
+      <point x="908" y="273"/>
+      <point x="943" y="244"/>
+      <point x="943" y="181" type="curve" smooth="yes"/>
+      <point x="943" y="128"/>
+      <point x="914" y="94"/>
+      <point x="867" y="94" type="curve" smooth="yes"/>
+      <point x="848" y="94"/>
+      <point x="833" y="96"/>
       <point x="819" y="101" type="curve"/>
       <point x="790" y="-3" type="line"/>
-      <point x="815" y="-11"/>
-      <point x="846" y="-16"/>
+      <point x="816" y="-11"/>
+      <point x="847" y="-16"/>
       <point x="878" y="-16" type="curve" smooth="yes"/>
       <point x="989" y="-16"/>
-      <point x="1060" y="55"/>
-      <point x="1060" y="167" type="curve" smooth="yes"/>
-      <point x="1060" y="279"/>
-      <point x="985" y="353"/>
-      <point x="844" y="353" type="curve" smooth="yes"/>
-      <point x="250" y="353" type="line" smooth="yes"/>
-      <point x="120" y="353"/>
-      <point x="38" y="281"/>
-      <point x="38" y="162" type="curve" smooth="yes"/>
-      <point x="38" y="61"/>
-      <point x="110" y="-16"/>
+      <point x="1060" y="59"/>
+      <point x="1060" y="177" type="curve" smooth="yes"/>
+      <point x="1060" y="302"/>
+      <point x="976" y="373"/>
+      <point x="830" y="373" type="curve" smooth="yes"/>
+      <point x="270" y="373" type="line" smooth="yes"/>
+      <point x="126" y="373"/>
+      <point x="38" y="297"/>
+      <point x="38" y="171" type="curve" smooth="yes"/>
+      <point x="38" y="64"/>
+      <point x="115" y="-16"/>
     </contour>
     <contour>
       <point x="563" y="95" type="curve" smooth="yes"/>
-      <point x="488" y="95"/>
-      <point x="443" y="166"/>
+      <point x="487" y="95"/>
+      <point x="443" y="168"/>
       <point x="443" y="295" type="curve" smooth="yes"/>
       <point x="443" y="320" type="line" smooth="yes"/>
-      <point x="443" y="447"/>
-      <point x="488" y="518"/>
+      <point x="443" y="445"/>
+      <point x="487" y="518"/>
       <point x="563" y="518" type="curve" smooth="yes"/>
-      <point x="634" y="518"/>
-      <point x="677" y="446"/>
+      <point x="635" y="518"/>
+      <point x="677" y="445"/>
       <point x="677" y="320" type="curve" smooth="yes"/>
       <point x="677" y="295" type="line" smooth="yes"/>
-      <point x="677" y="166"/>
-      <point x="634" y="95"/>
+      <point x="677" y="168"/>
+      <point x="635" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/m_la-malayalam.glif
@@ -6,51 +6,7 @@
   <anchor x="597" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="141" y="-382" type="curve" smooth="yes"/>
-      <point x="237" y="-382"/>
-      <point x="283" y="-327"/>
-      <point x="283" y="-244" type="curve" smooth="yes"/>
-      <point x="283" y="-157"/>
-      <point x="235" y="-118"/>
-      <point x="167" y="-118" type="curve" smooth="yes"/>
-      <point x="112" y="-118"/>
-      <point x="60" y="-147"/>
-      <point x="56" y="-229" type="curve"/>
-      <point x="90" y="-163" type="line"/>
-      <point x="37" y="-163" type="line"/>
-      <point x="61" y="-182" type="line"/>
-      <point x="61" y="-105"/>
-      <point x="106" y="-33"/>
-      <point x="202" y="-33" type="curve" smooth="yes"/>
-      <point x="293" y="-33"/>
-      <point x="326" y="-82"/>
-      <point x="348" y="-166" type="curve" smooth="yes"/>
-      <point x="358" y="-203" type="line" smooth="yes"/>
-      <point x="390" y="-323"/>
-      <point x="441" y="-382"/>
-      <point x="550" y="-382" type="curve" smooth="yes"/>
-      <point x="663" y="-382"/>
-      <point x="732" y="-317"/>
-      <point x="732" y="-172" type="curve" smooth="yes"/>
-      <point x="732" y="-79"/>
-      <point x="700" y="-3"/>
-      <point x="650" y="55" type="curve"/>
-      <point x="560" y="15" type="line"/>
-      <point x="593" y="-19"/>
-      <point x="635" y="-88"/>
-      <point x="635" y="-182" type="curve" smooth="yes"/>
-      <point x="635" y="-252"/>
-      <point x="609" y="-292"/>
-      <point x="551" y="-292" type="curve" smooth="yes"/>
-      <point x="500" y="-292"/>
-      <point x="476" y="-257"/>
-      <point x="454" y="-178" type="curve" smooth="yes"/>
-      <point x="443" y="-140" type="line" smooth="yes"/>
-      <point x="428" y="-86"/>
-      <point x="408" y="-37"/>
-      <point x="369" y="-13" type="curve"/>
-      <point x="371" y="0" type="line"/>
-      <point x="638" y="0" type="line"/>
+      <point x="60" y="0" type="line"/>
       <point x="671" y="0" type="line"/>
       <point x="671" y="343" type="line" smooth="yes"/>
       <point x="671" y="521"/>
@@ -59,29 +15,72 @@
       <point x="172" y="629"/>
       <point x="60" y="520"/>
       <point x="60" y="344" type="curve" smooth="yes"/>
-      <point x="60" y="2" type="line"/>
-      <point x="83" y="25" type="line"/>
-      <point x="13" y="-14"/>
-      <point x="-28" y="-87"/>
-      <point x="-28" y="-180" type="curve" smooth="yes"/>
-      <point x="-28" y="-318"/>
-      <point x="45" y="-382"/>
     </contour>
     <contour>
-      <point x="139" y="-302" type="curve" smooth="yes"/>
-      <point x="91" y="-302"/>
-      <point x="69" y="-253"/>
-      <point x="68" y="-215" type="curve"/>
-      <point x="52" y="-220" type="line"/>
-      <point x="67" y="-259" type="line"/>
-      <point x="72" y="-216"/>
-      <point x="101" y="-191"/>
-      <point x="141" y="-191" type="curve" smooth="yes"/>
-      <point x="178" y="-191"/>
-      <point x="195" y="-210"/>
-      <point x="195" y="-246" type="curve" smooth="yes"/>
-      <point x="195" y="-282"/>
+      <point x="213" y="-382" type="curve" smooth="yes"/>
+      <point x="305" y="-382"/>
+      <point x="356" y="-326"/>
+      <point x="356" y="-230" type="curve" smooth="yes"/>
+      <point x="356" y="-140"/>
+      <point x="317" y="-86"/>
+      <point x="251" y="-86" type="curve" smooth="yes"/>
+      <point x="194" y="-86"/>
+      <point x="146" y="-119"/>
+      <point x="135" y="-204" type="curve"/>
+      <point x="168" y="-147" type="line"/>
+      <point x="115" y="-147" type="line"/>
+      <point x="139" y="-181" type="line"/>
+      <point x="139" y="-75"/>
+      <point x="183" y="-20"/>
+      <point x="267" y="-20" type="curve" smooth="yes"/>
+      <point x="343" y="-20"/>
+      <point x="371" y="-65"/>
+      <point x="381" y="-155" type="curve" smooth="yes"/>
+      <point x="391" y="-241" type="line" smooth="yes"/>
+      <point x="402" y="-332"/>
+      <point x="460" y="-382"/>
+      <point x="539" y="-382" type="curve" smooth="yes"/>
+      <point x="633" y="-382"/>
+      <point x="691" y="-319"/>
+      <point x="691" y="-197" type="curve" smooth="yes"/>
+      <point x="691" y="-105"/>
+      <point x="656" y="-8"/>
+      <point x="602" y="63" type="curve"/>
+      <point x="523" y="8" type="line"/>
+      <point x="567" y="-51"/>
+      <point x="593" y="-122"/>
+      <point x="593" y="-201" type="curve" smooth="yes"/>
+      <point x="593" y="-264"/>
+      <point x="577" y="-290"/>
+      <point x="544" y="-290" type="curve" smooth="yes"/>
+      <point x="510" y="-290"/>
+      <point x="492" y="-264"/>
+      <point x="485" y="-204" type="curve" smooth="yes"/>
+      <point x="475" y="-118" type="line" smooth="yes"/>
+      <point x="464" y="-22"/>
+      <point x="400" y="45"/>
+      <point x="269" y="45" type="curve" smooth="yes"/>
+      <point x="123" y="45"/>
+      <point x="50" y="-51"/>
+      <point x="50" y="-187" type="curve" smooth="yes"/>
+      <point x="50" y="-306"/>
+      <point x="112" y="-382"/>
+    </contour>
+    <contour>
+      <point x="212" y="-302" type="curve" smooth="yes"/>
       <point x="175" y="-302"/>
+      <point x="154" y="-275"/>
+      <point x="145" y="-215" type="curve"/>
+      <point x="131" y="-220" type="line"/>
+      <point x="145" y="-245" type="line"/>
+      <point x="154" y="-185"/>
+      <point x="175" y="-158"/>
+      <point x="214" y="-158" type="curve" smooth="yes"/>
+      <point x="253" y="-158"/>
+      <point x="267" y="-183"/>
+      <point x="267" y="-230" type="curve" smooth="yes"/>
+      <point x="267" y="-277"/>
+      <point x="250" y="-302"/>
     </contour>
     <contour>
       <point x="129" y="48" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
@@ -1,103 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng_ka-malayalam" format="2">
-  <advance width="1099"/>
-  <anchor x="683" y="0" name="bottom"/>
-  <anchor x="569" y="613" name="top"/>
-  <anchor x="923" y="613" name="topright"/>
+  <advance width="1104"/>
+  <anchor x="688" y="0" name="bottom"/>
+  <anchor x="574" y="613" name="top"/>
+  <anchor x="928" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="217" y="-16" type="curve" smooth="yes"/>
-      <point x="307" y="-16"/>
-      <point x="361" y="35"/>
-      <point x="382" y="103" type="curve"/>
-      <point x="394" y="103" type="line"/>
-      <point x="426" y="27"/>
-      <point x="487" y="-16"/>
-      <point x="570" y="-16" type="curve" smooth="yes"/>
-      <point x="708" y="-16"/>
-      <point x="796" y="109"/>
-      <point x="796" y="292" type="curve" smooth="yes"/>
-      <point x="796" y="323" type="line" smooth="yes"/>
-      <point x="796" y="501"/>
+      <point x="225" y="-16" type="curve" smooth="yes"/>
+      <point x="312" y="-16"/>
+      <point x="365" y="35"/>
+      <point x="385" y="102" type="curve"/>
+      <point x="398" y="102" type="line"/>
+      <point x="432" y="25"/>
+      <point x="493" y="-16"/>
+      <point x="575" y="-16" type="curve" smooth="yes"/>
+      <point x="711" y="-16"/>
+      <point x="801" y="106"/>
+      <point x="801" y="292" type="curve" smooth="yes"/>
+      <point x="801" y="323" type="line" smooth="yes"/>
+      <point x="801" y="507"/>
       <point x="709" y="629"/>
-      <point x="565" y="629" type="curve" smooth="yes"/>
-      <point x="484" y="629"/>
-      <point x="426" y="591"/>
-      <point x="394" y="524" type="curve"/>
-      <point x="381" y="524" type="line"/>
-      <point x="357" y="587"/>
-      <point x="302" y="629"/>
-      <point x="221" y="629" type="curve" smooth="yes"/>
-      <point x="107" y="629"/>
-      <point x="46" y="554"/>
-      <point x="46" y="462" type="curve" smooth="yes"/>
-      <point x="46" y="392"/>
-      <point x="80" y="339"/>
-      <point x="134" y="312" type="curve"/>
-      <point x="134" y="299" type="line"/>
-      <point x="76" y="275"/>
-      <point x="39" y="229"/>
-      <point x="39" y="153" type="curve" smooth="yes"/>
-      <point x="39" y="57"/>
-      <point x="108" y="-16"/>
+      <point x="570" y="629" type="curve" smooth="yes"/>
+      <point x="491" y="629"/>
+      <point x="432" y="593"/>
+      <point x="399" y="524" type="curve"/>
+      <point x="386" y="524" type="line"/>
+      <point x="360" y="591"/>
+      <point x="303" y="629"/>
+      <point x="226" y="629" type="curve" smooth="yes"/>
+      <point x="123" y="629"/>
+      <point x="51" y="565"/>
+      <point x="51" y="472" type="curve" smooth="yes"/>
+      <point x="51" y="408"/>
+      <point x="84" y="360"/>
+      <point x="139" y="332" type="curve"/>
+      <point x="139" y="319" type="line"/>
+      <point x="78" y="289"/>
+      <point x="44" y="234"/>
+      <point x="44" y="157" type="curve" smooth="yes"/>
+      <point x="44" y="56"/>
+      <point x="121" y="-16"/>
     </contour>
     <contour>
-      <point x="879" y="-16" type="curve" smooth="yes"/>
-      <point x="989" y="-16"/>
-      <point x="1060" y="55"/>
-      <point x="1060" y="167" type="curve" smooth="yes"/>
-      <point x="1060" y="279"/>
-      <point x="986" y="353"/>
-      <point x="845" y="353" type="curve" smooth="yes"/>
-      <point x="263" y="353" type="line" smooth="yes"/>
-      <point x="196" y="353"/>
-      <point x="163" y="390"/>
-      <point x="163" y="441" type="curve" smooth="yes"/>
-      <point x="163" y="488"/>
-      <point x="194" y="518"/>
-      <point x="243" y="518" type="curve" smooth="yes"/>
-      <point x="309" y="518"/>
-      <point x="336" y="468"/>
-      <point x="336" y="380" type="curve" smooth="yes"/>
-      <point x="336" y="233" type="line" smooth="yes"/>
-      <point x="336" y="152"/>
-      <point x="300" y="95"/>
-      <point x="237" y="95" type="curve" smooth="yes"/>
-      <point x="184" y="95"/>
-      <point x="155" y="127"/>
-      <point x="155" y="174" type="curve" smooth="yes"/>
-      <point x="155" y="222"/>
-      <point x="189" y="253"/>
-      <point x="250" y="253" type="curve" smooth="yes"/>
-      <point x="847" y="253" type="line" smooth="yes"/>
-      <point x="912" y="253"/>
-      <point x="944" y="226"/>
-      <point x="944" y="175" type="curve" smooth="yes"/>
-      <point x="944" y="123"/>
-      <point x="917" y="94"/>
-      <point x="870" y="94" type="curve" smooth="yes"/>
+      <point x="883" y="-16" type="curve" smooth="yes"/>
+      <point x="994" y="-16"/>
+      <point x="1065" y="59"/>
+      <point x="1065" y="177" type="curve" smooth="yes"/>
+      <point x="1065" y="302"/>
+      <point x="981" y="373"/>
+      <point x="835" y="373" type="curve" smooth="yes"/>
+      <point x="258" y="373" type="line" smooth="yes"/>
+      <point x="202" y="373"/>
+      <point x="168" y="401"/>
+      <point x="168" y="447" type="curve" smooth="yes"/>
+      <point x="168" y="490"/>
+      <point x="199" y="518"/>
+      <point x="246" y="518" type="curve" smooth="yes"/>
+      <point x="311" y="518"/>
+      <point x="341" y="473"/>
+      <point x="341" y="380" type="curve" smooth="yes"/>
+      <point x="341" y="223" type="line" smooth="yes"/>
+      <point x="341" y="141"/>
+      <point x="306" y="95"/>
+      <point x="244" y="95" type="curve" smooth="yes"/>
+      <point x="193" y="95"/>
+      <point x="161" y="127"/>
+      <point x="161" y="176" type="curve" smooth="yes"/>
+      <point x="161" y="237"/>
+      <point x="204" y="273"/>
+      <point x="274" y="273" type="curve" smooth="yes"/>
+      <point x="837" y="273" type="line" smooth="yes"/>
+      <point x="913" y="273"/>
+      <point x="948" y="244"/>
+      <point x="948" y="181" type="curve" smooth="yes"/>
+      <point x="948" y="128"/>
+      <point x="919" y="94"/>
+      <point x="872" y="94" type="curve" smooth="yes"/>
       <point x="852" y="94"/>
-      <point x="835" y="96"/>
-      <point x="819" y="101" type="curve"/>
-      <point x="790" y="-3" type="line"/>
-      <point x="816" y="-11"/>
-      <point x="846" y="-16"/>
+      <point x="838" y="96"/>
+      <point x="824" y="101" type="curve"/>
+      <point x="795" y="-3" type="line"/>
+      <point x="822" y="-11"/>
+      <point x="853" y="-16"/>
     </contour>
     <contour>
-      <point x="564" y="95" type="curve" smooth="yes"/>
-      <point x="489" y="95"/>
-      <point x="443" y="166"/>
-      <point x="443" y="295" type="curve" smooth="yes"/>
-      <point x="443" y="320" type="line" smooth="yes"/>
-      <point x="443" y="447"/>
-      <point x="489" y="518"/>
-      <point x="563" y="518" type="curve" smooth="yes"/>
-      <point x="634" y="518"/>
-      <point x="677" y="446"/>
-      <point x="677" y="320" type="curve" smooth="yes"/>
-      <point x="677" y="295" type="line" smooth="yes"/>
-      <point x="677" y="166"/>
-      <point x="634" y="95"/>
+      <point x="569" y="95" type="curve" smooth="yes"/>
+      <point x="492" y="95"/>
+      <point x="448" y="169"/>
+      <point x="448" y="295" type="curve" smooth="yes"/>
+      <point x="448" y="320" type="line" smooth="yes"/>
+      <point x="448" y="445"/>
+      <point x="493" y="518"/>
+      <point x="568" y="518" type="curve" smooth="yes"/>
+      <point x="640" y="518"/>
+      <point x="682" y="445"/>
+      <point x="682" y="320" type="curve" smooth="yes"/>
+      <point x="682" y="295" type="line" smooth="yes"/>
+      <point x="682" y="169"/>
+      <point x="640" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1581"/>
-  <anchor x="1165" y="-6" name="bottom"/>
-  <anchor x="830" y="613" name="top"/>
-  <anchor x="1440" y="613" name="topright"/>
+  <advance width="1630"/>
+  <anchor x="1193" y="-1" name="bottom"/>
+  <anchor x="815" y="613" name="top"/>
+  <anchor x="1452" y="613" name="topright"/>
   <outline>
     <contour>
       <point x="292" y="-16" type="curve" smooth="yes"/>
@@ -40,123 +40,123 @@
       <point x="664" y="0" type="line"/>
       <point x="664" y="344" type="line" smooth="yes"/>
       <point x="664" y="456"/>
-      <point x="715" y="549"/>
-      <point x="870" y="549" type="curve" smooth="yes"/>
-      <point x="888" y="549"/>
-      <point x="908" y="548"/>
-      <point x="930" y="545" type="curve"/>
-      <point x="765" y="584" type="line"/>
-      <point x="799" y="525" type="line"/>
-      <point x="772" y="504"/>
-      <point x="761" y="473"/>
-      <point x="761" y="444" type="curve" smooth="yes"/>
-      <point x="761" y="361"/>
-      <point x="829" y="314"/>
-      <point x="911" y="314" type="curve" smooth="yes"/>
-      <point x="993" y="314"/>
-      <point x="1061" y="357"/>
-      <point x="1061" y="444" type="curve" smooth="yes"/>
-      <point x="1061" y="475"/>
-      <point x="1047" y="517"/>
-      <point x="1012" y="537" type="curve"/>
-      <point x="1036" y="602" type="line"/>
-      <point x="943" y="547" type="line"/>
-      <point x="957" y="550"/>
-      <point x="970" y="550"/>
-      <point x="982" y="550" type="curve" smooth="yes"/>
-      <point x="1086" y="550"/>
-      <point x="1113" y="474"/>
-      <point x="1113" y="412" type="curve" smooth="yes"/>
-      <point x="1113" y="354" type="line"/>
-      <point x="1231" y="354" type="line"/>
-      <point x="1230" y="400" type="line" smooth="yes"/>
-      <point x="1228" y="480"/>
-      <point x="1266" y="526"/>
-      <point x="1328" y="526" type="curve" smooth="yes"/>
-      <point x="1387" y="526"/>
-      <point x="1413" y="487"/>
-      <point x="1413" y="428" type="curve" smooth="yes"/>
-      <point x="1413" y="349"/>
-      <point x="1373" y="307"/>
-      <point x="1270" y="307" type="curve" smooth="yes"/>
-      <point x="973" y="307" type="line" smooth="yes"/>
-      <point x="843" y="307"/>
-      <point x="767" y="247"/>
-      <point x="767" y="142" type="curve" smooth="yes"/>
-      <point x="767" y="56"/>
-      <point x="821" y="-16"/>
-      <point x="942" y="-16" type="curve" smooth="yes"/>
-      <point x="1020" y="-16"/>
-      <point x="1082" y="8"/>
-      <point x="1163" y="61" type="curve" smooth="yes"/>
-      <point x="1220" y="98" type="line"/>
-      <point x="1280" y="148" type="line"/>
-      <point x="1310" y="154" type="line"/>
-      <point x="1341" y="169"/>
-      <point x="1365" y="176"/>
-      <point x="1385" y="176" type="curve" smooth="yes"/>
-      <point x="1420" y="176"/>
-      <point x="1437" y="159"/>
-      <point x="1437" y="125" type="curve" smooth="yes"/>
-      <point x="1437" y="92"/>
-      <point x="1419" y="73"/>
-      <point x="1390" y="73" type="curve" smooth="yes"/>
-      <point x="1359" y="73"/>
-      <point x="1341" y="92"/>
-      <point x="1341" y="123" type="curve" smooth="yes"/>
-      <point x="1341" y="143"/>
-      <point x="1347" y="161"/>
-      <point x="1362" y="182" type="curve"/>
-      <point x="1253" y="153" type="line"/>
-      <point x="1278" y="129" type="line"/>
-      <point x="1272" y="118"/>
-      <point x="1268" y="104"/>
-      <point x="1268" y="87" type="curve" smooth="yes"/>
-      <point x="1268" y="25"/>
-      <point x="1314" y="-16"/>
-      <point x="1390" y="-16" type="curve" smooth="yes"/>
-      <point x="1474" y="-16"/>
-      <point x="1526" y="36"/>
-      <point x="1526" y="122" type="curve" smooth="yes"/>
-      <point x="1526" y="205"/>
-      <point x="1469" y="260"/>
-      <point x="1385" y="260" type="curve" smooth="yes"/>
-      <point x="1331" y="260"/>
-      <point x="1286" y="242"/>
-      <point x="1201" y="193" type="curve" smooth="yes"/>
-      <point x="1130" y="151" type="line" smooth="yes"/>
-      <point x="1053" y="105"/>
-      <point x="1004" y="87"/>
-      <point x="953" y="87" type="curve" smooth="yes"/>
-      <point x="909" y="87"/>
-      <point x="883" y="105"/>
-      <point x="883" y="145" type="curve" smooth="yes"/>
-      <point x="883" y="185"/>
-      <point x="914" y="208"/>
-      <point x="978" y="208" type="curve" smooth="yes"/>
-      <point x="1292" y="208" type="line" smooth="yes"/>
-      <point x="1472" y="208"/>
-      <point x="1530" y="312"/>
-      <point x="1530" y="425" type="curve" smooth="yes"/>
-      <point x="1530" y="540"/>
-      <point x="1469" y="629"/>
-      <point x="1341" y="629" type="curve" smooth="yes"/>
-      <point x="1262" y="629"/>
-      <point x="1199" y="589"/>
-      <point x="1180" y="516" type="curve"/>
-      <point x="1169" y="516" type="line"/>
-      <point x="1141" y="589"/>
-      <point x="1072" y="629"/>
-      <point x="974" y="629" type="curve" smooth="yes"/>
-      <point x="943" y="629"/>
-      <point x="915" y="623"/>
-      <point x="891" y="613" type="curve"/>
-      <point x="928" y="613" type="line"/>
-      <point x="902" y="623"/>
+      <point x="722" y="549"/>
+      <point x="860" y="549" type="curve" smooth="yes"/>
+      <point x="866" y="549"/>
+      <point x="872" y="549"/>
+      <point x="879" y="549" type="curve"/>
+      <point x="794" y="568" type="line"/>
+      <point x="812" y="532" type="line"/>
+      <point x="778" y="504"/>
+      <point x="760" y="468"/>
+      <point x="760" y="426" type="curve" smooth="yes"/>
+      <point x="760" y="345"/>
+      <point x="820" y="291"/>
+      <point x="917" y="291" type="curve" smooth="yes"/>
+      <point x="1015" y="291"/>
+      <point x="1074" y="345"/>
+      <point x="1074" y="426" type="curve" smooth="yes"/>
+      <point x="1074" y="477"/>
+      <point x="1055" y="515"/>
+      <point x="1018" y="540" type="curve"/>
+      <point x="1030" y="570" type="line"/>
+      <point x="962" y="553" type="line"/>
+      <point x="972" y="554"/>
+      <point x="985" y="555"/>
+      <point x="998" y="555" type="curve" smooth="yes"/>
+      <point x="1090" y="555"/>
+      <point x="1126" y="513"/>
+      <point x="1126" y="409" type="curve" smooth="yes"/>
+      <point x="1126" y="330" type="line"/>
+      <point x="1240" y="330" type="line"/>
+      <point x="1240" y="402" type="line" smooth="yes"/>
+      <point x="1240" y="477"/>
+      <point x="1286" y="523"/>
+      <point x="1358" y="523" type="curve" smooth="yes"/>
+      <point x="1427" y="523"/>
+      <point x="1461" y="483"/>
+      <point x="1461" y="407" type="curve" smooth="yes"/>
+      <point x="1461" y="314"/>
+      <point x="1408" y="273"/>
+      <point x="1290" y="273" type="curve" smooth="yes"/>
+      <point x="943" y="273" type="line" smooth="yes"/>
+      <point x="833" y="273"/>
+      <point x="766" y="217"/>
+      <point x="766" y="128" type="curve" smooth="yes"/>
+      <point x="766" y="37"/>
+      <point x="843" y="-16"/>
+      <point x="959" y="-16" type="curve" smooth="yes"/>
+      <point x="1006" y="-16"/>
+      <point x="1051" y="-3"/>
+      <point x="1121" y="30" type="curve" smooth="yes"/>
+      <point x="1245" y="89" type="line"/>
+      <point x="1302" y="142" type="line"/>
+      <point x="1338" y="154" type="line"/>
+      <point x="1369" y="174"/>
+      <point x="1392" y="186"/>
+      <point x="1424" y="186" type="curve" smooth="yes"/>
+      <point x="1465" y="186"/>
+      <point x="1486" y="167"/>
+      <point x="1486" y="130" type="curve" smooth="yes"/>
+      <point x="1486" y="94"/>
+      <point x="1463" y="73"/>
+      <point x="1425" y="73" type="curve" smooth="yes"/>
+      <point x="1384" y="73"/>
+      <point x="1360" y="94"/>
+      <point x="1360" y="127" type="curve" smooth="yes"/>
+      <point x="1360" y="146"/>
+      <point x="1364" y="162"/>
+      <point x="1375" y="182" type="curve"/>
+      <point x="1277" y="148" type="line"/>
+      <point x="1301" y="126" type="line"/>
+      <point x="1295" y="115"/>
+      <point x="1292" y="102"/>
+      <point x="1292" y="86" type="curve" smooth="yes"/>
+      <point x="1292" y="27"/>
+      <point x="1345" y="-16"/>
+      <point x="1426" y="-16" type="curve" smooth="yes"/>
+      <point x="1518" y="-16"/>
+      <point x="1575" y="35"/>
+      <point x="1575" y="120" type="curve" smooth="yes"/>
+      <point x="1575" y="197"/>
+      <point x="1519" y="248"/>
+      <point x="1436" y="248" type="curve" smooth="yes"/>
+      <point x="1377" y="248"/>
+      <point x="1325" y="229"/>
+      <point x="1244" y="190" type="curve" smooth="yes"/>
+      <point x="1083" y="113" type="line" smooth="yes"/>
+      <point x="1040" y="93"/>
+      <point x="1004" y="84"/>
+      <point x="961" y="84" type="curve" smooth="yes"/>
+      <point x="909" y="84"/>
+      <point x="884" y="100"/>
+      <point x="884" y="130" type="curve" smooth="yes"/>
+      <point x="884" y="162"/>
+      <point x="906" y="178"/>
+      <point x="946" y="178" type="curve" smooth="yes"/>
+      <point x="1283" y="178" type="line" smooth="yes"/>
+      <point x="1457" y="178"/>
+      <point x="1579" y="276"/>
+      <point x="1579" y="415" type="curve" smooth="yes"/>
+      <point x="1579" y="539"/>
+      <point x="1506" y="629"/>
+      <point x="1381" y="629" type="curve" smooth="yes"/>
+      <point x="1289" y="629"/>
+      <point x="1229" y="586"/>
+      <point x="1198" y="520" type="curve"/>
+      <point x="1186" y="520" type="line"/>
+      <point x="1162" y="585"/>
+      <point x="1098" y="629"/>
+      <point x="996" y="629" type="curve" smooth="yes"/>
+      <point x="955" y="629"/>
+      <point x="918" y="621"/>
+      <point x="886" y="607" type="curve"/>
+      <point x="931" y="607" type="line"/>
+      <point x="903" y="621"/>
       <point x="870" y="629"/>
-      <point x="832" y="629" type="curve" smooth="yes"/>
+      <point x="828" y="629" type="curve" smooth="yes"/>
       <point x="728" y="629"/>
-      <point x="647" y="581"/>
+      <point x="646" y="581"/>
       <point x="611" y="497" type="curve"/>
       <point x="599" y="497" type="line"/>
       <point x="558" y="577"/>
@@ -169,19 +169,19 @@
       <point x="148" y="-16"/>
     </contour>
     <contour>
-      <point x="912" y="397" type="curve" smooth="yes"/>
-      <point x="879" y="397"/>
-      <point x="852" y="418"/>
-      <point x="852" y="460" type="curve" smooth="yes"/>
-      <point x="852" y="493"/>
-      <point x="871" y="532"/>
-      <point x="923" y="544" type="curve"/>
-      <point x="884" y="542" type="line"/>
-      <point x="949" y="536"/>
-      <point x="968" y="490"/>
-      <point x="968" y="459" type="curve" smooth="yes"/>
-      <point x="968" y="421"/>
-      <point x="948" y="397"/>
+      <point x="917" y="379" type="curve" smooth="yes"/>
+      <point x="879" y="379"/>
+      <point x="856" y="404"/>
+      <point x="856" y="445" type="curve" smooth="yes"/>
+      <point x="856" y="492"/>
+      <point x="881" y="524"/>
+      <point x="937" y="550" type="curve"/>
+      <point x="896" y="550" type="line"/>
+      <point x="953" y="523"/>
+      <point x="978" y="491"/>
+      <point x="978" y="445" type="curve" smooth="yes"/>
+      <point x="978" y="403"/>
+      <point x="955" y="379"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/t_la-malayalam.glif
@@ -56,22 +56,6 @@
       <point x="302" y="-382"/>
     </contour>
     <contour>
-      <point x="396" y="-302" type="curve" smooth="yes"/>
-      <point x="348" y="-302"/>
-      <point x="326" y="-253"/>
-      <point x="326" y="-215" type="curve"/>
-      <point x="310" y="-220" type="line"/>
-      <point x="324" y="-259" type="line"/>
-      <point x="329" y="-216"/>
-      <point x="358" y="-191"/>
-      <point x="398" y="-191" type="curve" smooth="yes"/>
-      <point x="435" y="-191"/>
-      <point x="452" y="-210"/>
-      <point x="452" y="-246" type="curve" smooth="yes"/>
-      <point x="452" y="-282"/>
-      <point x="433" y="-302"/>
-    </contour>
-    <contour>
       <point x="175" y="-16" type="curve"/>
       <point x="264" y="59" type="line"/>
       <point x="204" y="124"/>
@@ -94,12 +78,28 @@
       <point x="91" y="73"/>
     </contour>
     <contour>
+      <point x="396" y="-302" type="curve" smooth="yes"/>
+      <point x="348" y="-302"/>
+      <point x="326" y="-253"/>
+      <point x="326" y="-215" type="curve"/>
+      <point x="310" y="-220" type="line"/>
+      <point x="324" y="-259" type="line"/>
+      <point x="329" y="-216"/>
+      <point x="358" y="-191"/>
+      <point x="398" y="-191" type="curve" smooth="yes"/>
+      <point x="435" y="-191"/>
+      <point x="452" y="-210"/>
+      <point x="452" y="-246" type="curve" smooth="yes"/>
+      <point x="452" y="-282"/>
+      <point x="433" y="-302"/>
+    </contour>
+    <contour>
       <point x="809" y="-292" type="curve" smooth="yes"/>
       <point x="757" y="-292"/>
       <point x="733" y="-257"/>
       <point x="711" y="-178" type="curve" smooth="yes"/>
       <point x="700" y="-140" type="line" smooth="yes"/>
-      <point x="684" y="-80"/>
+      <point x="683" y="-80"/>
       <point x="662" y="-25"/>
       <point x="611" y="6" type="curve"/>
       <point x="612" y="19" type="line"/>
@@ -107,10 +107,10 @@
       <point x="738" y="139"/>
       <point x="738" y="254" type="curve" smooth="yes"/>
       <point x="738" y="381"/>
-      <point x="679" y="498"/>
-      <point x="583" y="566" type="curve"/>
-      <point x="476" y="503" type="line"/>
-      <point x="563" y="464"/>
+      <point x="680" y="497"/>
+      <point x="585" y="565" type="curve"/>
+      <point x="478" y="502" type="line"/>
+      <point x="564" y="463"/>
       <point x="615" y="368"/>
       <point x="615" y="254" type="curve" smooth="yes"/>
       <point x="615" y="147"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="636"/>
-  <anchor x="354" y="-210" name="bottom"/>
+  <anchor x="353" y="-272" name="bottom"/>
   <anchor x="311" y="613" name="top"/>
   <anchor x="496" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="311" y="-229" type="curve" smooth="yes"/>
-      <point x="499" y="-229"/>
-      <point x="592" y="-166"/>
-      <point x="592" y="-55" type="curve" smooth="yes"/>
-      <point x="592" y="17"/>
-      <point x="548" y="53"/>
-      <point x="481" y="64" type="curve"/>
-      <point x="481" y="77" type="line"/>
-      <point x="539" y="88"/>
-      <point x="582" y="141"/>
-      <point x="582" y="214" type="curve" smooth="yes"/>
-      <point x="582" y="315"/>
-      <point x="524" y="369"/>
-      <point x="365" y="379" type="curve" smooth="yes"/>
-      <point x="247" y="386" type="line" smooth="yes"/>
-      <point x="183" y="389"/>
-      <point x="151" y="411"/>
-      <point x="151" y="451" type="curve" smooth="yes"/>
-      <point x="151" y="498"/>
+      <point x="320" y="-291" type="curve" smooth="yes"/>
+      <point x="491" y="-291"/>
+      <point x="592" y="-220"/>
+      <point x="592" y="-98" type="curve" smooth="yes"/>
+      <point x="592" y="-23"/>
+      <point x="551" y="31"/>
+      <point x="481" y="52" type="curve"/>
+      <point x="481" y="65" type="line"/>
+      <point x="541" y="83"/>
+      <point x="582" y="130"/>
+      <point x="582" y="204" type="curve" smooth="yes"/>
+      <point x="582" y="304"/>
+      <point x="521" y="364"/>
+      <point x="365" y="373" type="curve" smooth="yes"/>
+      <point x="247" y="380" type="line" smooth="yes"/>
+      <point x="183" y="384"/>
+      <point x="151" y="404"/>
+      <point x="151" y="448" type="curve" smooth="yes"/>
+      <point x="151" y="499"/>
       <point x="200" y="519"/>
       <point x="297" y="519" type="curve" smooth="yes"/>
-      <point x="376" y="519"/>
-      <point x="442" y="504"/>
+      <point x="370" y="519"/>
+      <point x="437" y="506"/>
       <point x="508" y="478" type="curve"/>
-      <point x="551" y="579" type="line"/>
-      <point x="474" y="614"/>
-      <point x="393" y="629"/>
+      <point x="551" y="577" type="line"/>
+      <point x="476" y="612"/>
+      <point x="395" y="629"/>
       <point x="301" y="629" type="curve" smooth="yes"/>
-      <point x="125" y="629"/>
+      <point x="127" y="629"/>
       <point x="35" y="555"/>
-      <point x="35" y="440" type="curve" smooth="yes"/>
-      <point x="35" y="335"/>
-      <point x="106" y="275"/>
-      <point x="232" y="268" type="curve" smooth="yes"/>
-      <point x="354" y="260" type="line" smooth="yes"/>
-      <point x="435" y="255"/>
-      <point x="467" y="232"/>
-      <point x="467" y="190" type="curve" smooth="yes"/>
-      <point x="467" y="141"/>
-      <point x="425" y="118"/>
-      <point x="341" y="118" type="curve" smooth="yes"/>
-      <point x="72" y="118" type="line"/>
-      <point x="72" y="13" type="line"/>
-      <point x="359" y="13" type="line" smooth="yes"/>
-      <point x="440" y="13"/>
-      <point x="471" y="-5"/>
-      <point x="471" y="-46" type="curve" smooth="yes"/>
-      <point x="471" y="-97"/>
-      <point x="418" y="-116"/>
-      <point x="313" y="-116" type="curve" smooth="yes"/>
-      <point x="216" y="-116"/>
-      <point x="133" y="-94"/>
-      <point x="89" y="-73" type="curve"/>
-      <point x="45" y="-175" type="line"/>
-      <point x="102" y="-205"/>
-      <point x="200" y="-229"/>
+      <point x="35" y="438" type="curve" smooth="yes"/>
+      <point x="35" y="331"/>
+      <point x="109" y="270"/>
+      <point x="232" y="262" type="curve" smooth="yes"/>
+      <point x="354" y="254" type="line" smooth="yes"/>
+      <point x="434" y="249"/>
+      <point x="466" y="225"/>
+      <point x="466" y="182" type="curve" smooth="yes"/>
+      <point x="466" y="130"/>
+      <point x="424" y="106"/>
+      <point x="341" y="106" type="curve" smooth="yes"/>
+      <point x="72" y="106" type="line"/>
+      <point x="72" y="1" type="line"/>
+      <point x="342" y="1" type="line" smooth="yes"/>
+      <point x="433" y="1"/>
+      <point x="471" y="-28"/>
+      <point x="471" y="-87" type="curve" smooth="yes"/>
+      <point x="471" y="-147"/>
+      <point x="419" y="-181"/>
+      <point x="320" y="-181" type="curve" smooth="yes"/>
+      <point x="242" y="-181"/>
+      <point x="160" y="-154"/>
+      <point x="97" y="-109" type="curve"/>
+      <point x="36" y="-198" type="line"/>
+      <point x="119" y="-257"/>
+      <point x="219" y="-291"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/tta-malayalam.glif
@@ -12,7 +12,7 @@
       <point x="594" y="58"/>
       <point x="594" y="177" type="curve" smooth="yes"/>
       <point x="594" y="283"/>
-      <point x="516" y="354"/>
+      <point x="516" y="355"/>
       <point x="377" y="362" type="curve" smooth="yes"/>
       <point x="258" y="368" type="line" smooth="yes"/>
       <point x="192" y="371"/>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
@@ -4,10 +4,10 @@
   <unicode hex="0D42"/>
   <outline>
     <contour>
-      <point x="101" y="24" type="curve"/>
-      <point x="208" y="24" type="line"/>
-      <point x="259" y="144"/>
-      <point x="286" y="254"/>
+      <point x="105" y="36" type="curve"/>
+      <point x="212" y="36" type="line"/>
+      <point x="260" y="152"/>
+      <point x="286" y="257"/>
       <point x="286" y="344" type="curve" smooth="yes"/>
       <point x="286" y="525"/>
       <point x="196" y="629"/>
@@ -17,52 +17,58 @@
       <point x="119" y="518"/>
       <point x="165" y="465"/>
       <point x="165" y="344" type="curve" smooth="yes"/>
-      <point x="165" y="249"/>
-      <point x="143" y="140"/>
+      <point x="165" y="253"/>
+      <point x="144" y="148"/>
     </contour>
     <contour>
       <point x="160" y="-287" type="curve" smooth="yes"/>
       <point x="280" y="-287"/>
-      <point x="360" y="-213"/>
-      <point x="360" y="-102" type="curve" smooth="yes"/>
-      <point x="360" y="7"/>
-      <point x="273" y="90"/>
+      <point x="360" y="-218"/>
+      <point x="360" y="-104" type="curve" smooth="yes"/>
+      <point x="360" y="2"/>
+      <point x="276" y="90"/>
       <point x="160" y="90" type="curve" smooth="yes"/>
-      <point x="48" y="90"/>
-      <point x="-38" y="7"/>
-      <point x="-38" y="-102" type="curve" smooth="yes"/>
-      <point x="-38" y="-213"/>
-      <point x="41" y="-287"/>
+      <point x="44" y="90"/>
+      <point x="-38" y="2"/>
+      <point x="-38" y="-104" type="curve" smooth="yes"/>
+      <point x="-38" y="-218"/>
+      <point x="40" y="-287"/>
     </contour>
     <contour>
       <point x="161" y="-192" type="curve" smooth="yes"/>
-      <point x="93" y="-192"/>
-      <point x="58" y="-157"/>
-      <point x="58" y="-89" type="curve" smooth="yes"/>
-      <point x="58" y="-23"/>
-      <point x="93" y="12"/>
-      <point x="161" y="12" type="curve" smooth="yes"/>
-      <point x="228" y="12"/>
-      <point x="264" y="-24"/>
-      <point x="264" y="-89" type="curve" smooth="yes"/>
-      <point x="264" y="-156"/>
-      <point x="228" y="-192"/>
+      <point x="87" y="-192"/>
+      <point x="52" y="-156"/>
+      <point x="52" y="-103" type="curve" smooth="yes"/>
+      <point x="52" y="-90"/>
+      <point x="53" y="-78"/>
+      <point x="55" y="-65" type="curve"/>
+      <point x="67" y="-65" type="line"/>
+      <point x="79" y="-109"/>
+      <point x="112" y="-134"/>
+      <point x="161" y="-134" type="curve" smooth="yes"/>
+      <point x="210" y="-134"/>
+      <point x="243" y="-109"/>
+      <point x="255" y="-65" type="curve"/>
+      <point x="267" y="-65" type="line"/>
+      <point x="269" y="-78"/>
+      <point x="270" y="-90"/>
+      <point x="270" y="-103" type="curve" smooth="yes"/>
+      <point x="270" y="-156"/>
+      <point x="235" y="-192"/>
     </contour>
     <contour>
-      <point x="161" y="-125" type="curve" smooth="yes"/>
-      <point x="218" y="-125"/>
-      <point x="265" y="-109"/>
-      <point x="298" y="-80" type="curve"/>
-      <point x="272" y="-44" type="line"/>
-      <point x="249" y="-53"/>
-      <point x="209" y="-58"/>
-      <point x="161" y="-58" type="curve" smooth="yes"/>
-      <point x="111" y="-58"/>
-      <point x="72" y="-53"/>
-      <point x="50" y="-45" type="curve"/>
-      <point x="23" y="-81" type="line"/>
-      <point x="56" y="-109"/>
-      <point x="103" y="-125"/>
+      <point x="161" y="-60" type="curve" smooth="yes"/>
+      <point x="111" y="-60"/>
+      <point x="87" y="-36"/>
+      <point x="87" y="-10" type="curve" smooth="yes"/>
+      <point x="87" y="9"/>
+      <point x="109" y="22"/>
+      <point x="161" y="22" type="curve" smooth="yes"/>
+      <point x="213" y="22"/>
+      <point x="235" y="9"/>
+      <point x="235" y="-10" type="curve" smooth="yes"/>
+      <point x="235" y="-36"/>
+      <point x="211" y="-60"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/v_va-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/v_va-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="v_va-malayalam" format="2">
   <advance width="1092"/>
   <anchor x="725" y="-299" name="bottom"/>
-  <anchor x="986" y="0" name="bottomright"/>
   <anchor x="565" y="613" name="top"/>
   <anchor x="948" y="613" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/y_ya-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="y_ya-malayalam" format="2">
   <advance width="1047"/>
   <anchor x="653" y="-305" name="bottom"/>
-  <anchor x="913" y="-6" name="bottomright"/>
   <anchor x="540" y="613" name="top"/>
   <anchor x="841" y="613" name="topright"/>
   <outline>
@@ -10,51 +9,51 @@
       <point x="319" y="-305" type="line"/>
       <point x="933" y="-305" type="line"/>
       <point x="933" y="122" type="line"/>
-      <point x="917" y="73" type="line"/>
-      <point x="968" y="131"/>
-      <point x="996" y="217"/>
-      <point x="996" y="322" type="curve" smooth="yes"/>
-      <point x="996" y="422"/>
-      <point x="961" y="535"/>
-      <point x="884" y="629" type="curve"/>
-      <point x="783" y="566" type="line"/>
-      <point x="833" y="502"/>
-      <point x="875" y="415"/>
-      <point x="875" y="314" type="curve" smooth="yes"/>
-      <point x="875" y="185"/>
-      <point x="828" y="95"/>
-      <point x="691" y="95" type="curve" smooth="yes"/>
-      <point x="535" y="95"/>
-      <point x="457" y="207"/>
-      <point x="457" y="372" type="curve" smooth="yes"/>
-      <point x="457" y="468"/>
-      <point x="487" y="520"/>
-      <point x="541" y="520" type="curve" smooth="yes"/>
-      <point x="595" y="520"/>
-      <point x="623" y="467"/>
-      <point x="623" y="369" type="curve" smooth="yes"/>
-      <point x="623" y="267"/>
-      <point x="594" y="173"/>
+      <point x="912" y="76" type="line"/>
+      <point x="966" y="134"/>
+      <point x="996" y="218"/>
+      <point x="996" y="324" type="curve" smooth="yes"/>
+      <point x="996" y="431"/>
+      <point x="954" y="542"/>
+      <point x="880" y="629" type="curve"/>
+      <point x="784" y="557" type="line"/>
+      <point x="844" y="488"/>
+      <point x="876" y="404"/>
+      <point x="876" y="318" type="curve" smooth="yes"/>
+      <point x="876" y="171"/>
+      <point x="810" y="94"/>
+      <point x="682" y="94" type="curve" smooth="yes"/>
+      <point x="508" y="94"/>
+      <point x="429" y="193"/>
+      <point x="429" y="353" type="curve" smooth="yes"/>
+      <point x="429" y="460"/>
+      <point x="466" y="519"/>
+      <point x="534" y="519" type="curve" smooth="yes"/>
+      <point x="595" y="519"/>
+      <point x="627" y="463"/>
+      <point x="627" y="358" type="curve" smooth="yes"/>
+      <point x="627" y="247"/>
+      <point x="592" y="168"/>
       <point x="524" y="125" type="curve"/>
       <point x="598" y="61" type="line"/>
-      <point x="696" y="139"/>
-      <point x="742" y="250"/>
-      <point x="742" y="375" type="curve" smooth="yes"/>
-      <point x="742" y="520"/>
-      <point x="680" y="629"/>
-      <point x="542" y="629" type="curve" smooth="yes"/>
-      <point x="407" y="629"/>
-      <point x="340" y="513"/>
-      <point x="340" y="377" type="curve" smooth="yes"/>
-      <point x="340" y="167"/>
-      <point x="476" y="-14"/>
-      <point x="712" y="-14" type="curve" smooth="yes"/>
-      <point x="735" y="-14"/>
-      <point x="759" y="-12"/>
-      <point x="783" y="-9" type="curve"/>
-      <point x="652" y="47" type="line"/>
-      <point x="657" y="-24" type="line"/>
-      <point x="548" y="-84" type="line"/>
+      <point x="693" y="126"/>
+      <point x="747" y="236"/>
+      <point x="747" y="364" type="curve" smooth="yes"/>
+      <point x="747" y="531"/>
+      <point x="670" y="629"/>
+      <point x="535" y="629" type="curve" smooth="yes"/>
+      <point x="402" y="629"/>
+      <point x="309" y="514"/>
+      <point x="309" y="349" type="curve" smooth="yes"/>
+      <point x="309" y="163"/>
+      <point x="462" y="-12"/>
+      <point x="690" y="-12" type="curve" smooth="yes"/>
+      <point x="718" y="-12"/>
+      <point x="744" y="-9"/>
+      <point x="768" y="-2" type="curve"/>
+      <point x="652" y="48" type="line"/>
+      <point x="657" y="-23" type="line"/>
+      <point x="554" y="-78" type="line"/>
       <point x="319" y="-235" type="line"/>
     </contour>
     <contour>
@@ -66,32 +65,32 @@
       <point x="465" y="-220" type="line"/>
     </contour>
     <contour>
-      <point x="372" y="-16" type="curve" smooth="yes"/>
-      <point x="451" y="-16"/>
-      <point x="513" y="4"/>
-      <point x="564" y="37" type="curve"/>
-      <point x="476" y="112" type="line"/>
-      <point x="451" y="102"/>
-      <point x="424" y="95"/>
-      <point x="382" y="95" type="curve" smooth="yes"/>
-      <point x="235" y="95"/>
-      <point x="173" y="200"/>
-      <point x="173" y="335" type="curve" smooth="yes"/>
-      <point x="173" y="447"/>
-      <point x="220" y="518"/>
-      <point x="305" y="518" type="curve" smooth="yes"/>
-      <point x="343" y="518"/>
-      <point x="365" y="507"/>
-      <point x="388" y="485" type="curve"/>
-      <point x="451" y="570" type="line"/>
-      <point x="414" y="608"/>
-      <point x="362" y="629"/>
-      <point x="298" y="629" type="curve" smooth="yes"/>
-      <point x="135" y="629"/>
-      <point x="51" y="491"/>
-      <point x="51" y="334" type="curve" smooth="yes"/>
-      <point x="51" y="127"/>
-      <point x="175" y="-16"/>
+      <point x="388" y="-16" type="curve" smooth="yes"/>
+      <point x="459" y="-16"/>
+      <point x="516" y="5"/>
+      <point x="562" y="39" type="curve"/>
+      <point x="478" y="112" type="line"/>
+      <point x="455" y="101"/>
+      <point x="430" y="94"/>
+      <point x="392" y="94" type="curve" smooth="yes"/>
+      <point x="249" y="94"/>
+      <point x="171" y="176"/>
+      <point x="171" y="330" type="curve" smooth="yes"/>
+      <point x="171" y="449"/>
+      <point x="221" y="519"/>
+      <point x="304" y="519" type="curve" smooth="yes"/>
+      <point x="336" y="519"/>
+      <point x="357" y="509"/>
+      <point x="383" y="480" type="curve"/>
+      <point x="455" y="571" type="line"/>
+      <point x="413" y="611"/>
+      <point x="370" y="629"/>
+      <point x="310" y="629" type="curve" smooth="yes"/>
+      <point x="155" y="629"/>
+      <point x="51" y="508"/>
+      <point x="51" y="329" type="curve" smooth="yes"/>
+      <point x="51" y="126"/>
+      <point x="188" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ya-malayalam.glif
@@ -8,72 +8,72 @@
   <anchor x="841" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="702" y="-16" type="curve" smooth="yes"/>
-      <point x="886" y="-16"/>
+      <point x="690" y="-16" type="curve" smooth="yes"/>
+      <point x="881" y="-16"/>
       <point x="996" y="112"/>
-      <point x="996" y="322" type="curve" smooth="yes"/>
-      <point x="996" y="422"/>
-      <point x="961" y="535"/>
-      <point x="884" y="629" type="curve"/>
-      <point x="783" y="566" type="line"/>
-      <point x="833" y="502"/>
-      <point x="875" y="415"/>
-      <point x="875" y="314" type="curve" smooth="yes"/>
-      <point x="875" y="185"/>
-      <point x="821" y="95"/>
-      <point x="691" y="95" type="curve" smooth="yes"/>
-      <point x="535" y="95"/>
-      <point x="457" y="207"/>
-      <point x="457" y="372" type="curve" smooth="yes"/>
-      <point x="457" y="468"/>
-      <point x="487" y="520"/>
-      <point x="541" y="520" type="curve" smooth="yes"/>
-      <point x="595" y="520"/>
-      <point x="623" y="467"/>
-      <point x="623" y="369" type="curve" smooth="yes"/>
-      <point x="623" y="267"/>
-      <point x="594" y="173"/>
+      <point x="996" y="324" type="curve" smooth="yes"/>
+      <point x="996" y="431"/>
+      <point x="954" y="542"/>
+      <point x="880" y="629" type="curve"/>
+      <point x="784" y="557" type="line"/>
+      <point x="844" y="488"/>
+      <point x="876" y="404"/>
+      <point x="876" y="318" type="curve" smooth="yes"/>
+      <point x="876" y="175"/>
+      <point x="806" y="94"/>
+      <point x="682" y="94" type="curve" smooth="yes"/>
+      <point x="508" y="94"/>
+      <point x="429" y="193"/>
+      <point x="429" y="353" type="curve" smooth="yes"/>
+      <point x="429" y="460"/>
+      <point x="466" y="519"/>
+      <point x="534" y="519" type="curve" smooth="yes"/>
+      <point x="595" y="519"/>
+      <point x="627" y="463"/>
+      <point x="627" y="358" type="curve" smooth="yes"/>
+      <point x="627" y="247"/>
+      <point x="592" y="168"/>
       <point x="524" y="125" type="curve"/>
       <point x="598" y="61" type="line"/>
-      <point x="696" y="139"/>
-      <point x="742" y="250"/>
-      <point x="742" y="375" type="curve" smooth="yes"/>
-      <point x="742" y="520"/>
-      <point x="680" y="629"/>
-      <point x="542" y="629" type="curve" smooth="yes"/>
-      <point x="407" y="629"/>
-      <point x="340" y="513"/>
-      <point x="340" y="377" type="curve" smooth="yes"/>
-      <point x="340" y="166"/>
-      <point x="476" y="-16"/>
+      <point x="693" y="126"/>
+      <point x="747" y="236"/>
+      <point x="747" y="364" type="curve" smooth="yes"/>
+      <point x="747" y="531"/>
+      <point x="670" y="629"/>
+      <point x="535" y="629" type="curve" smooth="yes"/>
+      <point x="402" y="629"/>
+      <point x="309" y="514"/>
+      <point x="309" y="349" type="curve" smooth="yes"/>
+      <point x="309" y="161"/>
+      <point x="462" y="-16"/>
     </contour>
     <contour>
-      <point x="372" y="-16" type="curve" smooth="yes"/>
-      <point x="451" y="-16"/>
-      <point x="513" y="4"/>
-      <point x="564" y="37" type="curve"/>
-      <point x="476" y="112" type="line"/>
-      <point x="451" y="102"/>
-      <point x="424" y="95"/>
-      <point x="382" y="95" type="curve" smooth="yes"/>
-      <point x="235" y="95"/>
-      <point x="173" y="200"/>
-      <point x="173" y="335" type="curve" smooth="yes"/>
-      <point x="173" y="447"/>
-      <point x="220" y="518"/>
-      <point x="305" y="518" type="curve" smooth="yes"/>
-      <point x="343" y="518"/>
-      <point x="365" y="507"/>
-      <point x="388" y="485" type="curve"/>
-      <point x="451" y="570" type="line"/>
-      <point x="414" y="608"/>
-      <point x="362" y="629"/>
-      <point x="298" y="629" type="curve" smooth="yes"/>
-      <point x="135" y="629"/>
-      <point x="51" y="491"/>
-      <point x="51" y="334" type="curve" smooth="yes"/>
-      <point x="51" y="127"/>
-      <point x="175" y="-16"/>
+      <point x="388" y="-16" type="curve" smooth="yes"/>
+      <point x="459" y="-16"/>
+      <point x="516" y="5"/>
+      <point x="562" y="39" type="curve"/>
+      <point x="478" y="112" type="line"/>
+      <point x="455" y="101"/>
+      <point x="430" y="94"/>
+      <point x="392" y="94" type="curve" smooth="yes"/>
+      <point x="249" y="94"/>
+      <point x="171" y="176"/>
+      <point x="171" y="330" type="curve" smooth="yes"/>
+      <point x="171" y="449"/>
+      <point x="221" y="519"/>
+      <point x="304" y="519" type="curve" smooth="yes"/>
+      <point x="336" y="519"/>
+      <point x="357" y="509"/>
+      <point x="383" y="480" type="curve"/>
+      <point x="455" y="571" type="line"/>
+      <point x="413" y="611"/>
+      <point x="370" y="629"/>
+      <point x="310" y="629" type="curve" smooth="yes"/>
+      <point x="155" y="629"/>
+      <point x="51" y="508"/>
+      <point x="51" y="329" type="curve" smooth="yes"/>
+      <point x="51" y="126"/>
+      <point x="188" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/kerning.plist
@@ -48863,8 +48863,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>67</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -48976,7 +48974,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>93</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49032,7 +49030,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>127</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49085,7 +49083,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>246</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>187</integer>
+      <integer>160</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>207</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -49132,7 +49130,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -49167,7 +49165,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>113</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>63</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -49195,8 +49193,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>47</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49231,7 +49227,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>133</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>93</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49300,7 +49296,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>63</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>17</integer>
+      <integer>14</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49360,7 +49356,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>127</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49411,7 +49407,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>226</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>177</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>197</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49469,7 +49465,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>77</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>27</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49510,7 +49506,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>133</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49646,8 +49642,6 @@
       <integer>-30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49725,7 +49719,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>56</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>13</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>26</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49819,8 +49813,6 @@
       <integer>50</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>87</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>47</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>57</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -49853,7 +49845,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>87</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -49928,8 +49920,6 @@
       <integer>-47</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49973,8 +49963,6 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>28</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -50094,8 +50082,6 @@
       <integer>3</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>53</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50205,7 +50191,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>157</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50256,7 +50242,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>157</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>177</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50302,43 +50288,43 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>43</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_braceright.loclMALM_R</key>
       <integer>40</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
-      <integer>27</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>40</integer>
-      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>77</integer>
-      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
+      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
+      <integer>70</integer>
+      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>130</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
-      <integer>107</integer>
+      <integer>80</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
       <integer>20</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
-      <integer>-27</integer>
-      <key>public.kern2.MAL_rVocalic-malayalam_L</key>
-      <integer>20</integer>
+      <integer>-20</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
-      <integer>57</integer>
+      <integer>70</integer>
+      <key>public.kern2.MAL_tt_tta-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
-      <integer>127</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_uMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>220</integer>
+      <integer>200</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
-      <integer>150</integer>
+      <integer>160</integer>
     </dict>
     <key>public.kern1.MAL_ma_lVocalicMatra-malayalam_R</key>
     <dict>
@@ -50363,7 +50349,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>153</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50412,7 +50398,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>167</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>173</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50447,8 +50433,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>66</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>27</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -50490,7 +50474,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>43</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -50695,7 +50679,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>113</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50722,7 +50706,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>43</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50749,7 +50733,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>33</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50805,7 +50789,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -50837,8 +50821,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50948,8 +50930,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_p_pa-malayalam_L</key>
@@ -51016,7 +50996,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>167</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
@@ -51061,7 +51041,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>133</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -51102,7 +51082,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>193</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>147</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -51192,7 +51172,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>197</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>137</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -51332,7 +51312,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>73</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>33</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -51382,8 +51362,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>63</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>33</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -51450,7 +51428,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>193</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>153</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -51503,7 +51481,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>266</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>197</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>226</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -51588,7 +51566,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>73</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -51633,7 +51611,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>130</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>153</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -51730,8 +51708,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>47</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -51835,7 +51811,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>127</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>87</integer>
       <key>public.kern2.MAL_ng_ka-malayalam_L</key>
@@ -51887,6 +51863,24 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-30</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>67</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>73</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>-20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>30</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.ODI_a-oriya-L</key>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/c_cha-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/c_cha-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="c_cha-malayalam" format="2">
   <advance width="884"/>
   <anchor x="485" y="-349" name="bottom"/>
-  <anchor x="787" y="0" name="bottomright"/>
   <anchor x="430" y="580" name="top"/>
   <anchor x="768" y="580" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/d_da-malayalam.glif
@@ -1,26 +1,23 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
-  <advance width="665"/>
-  <guideline x="1248" y="-225" angle="0"/>
-  <guideline x="619" y="162" angle="90"/>
-  <guideline x="1442" y="185" angle="90"/>
-  <anchor x="377" y="-209" name="bottom"/>
+  <advance width="655"/>
+  <anchor x="377" y="-263" name="bottom"/>
   <anchor x="363" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="437" y="-225" type="curve" smooth="yes"/>
-      <point x="564" y="-225"/>
-      <point x="629" y="-176"/>
-      <point x="629" y="-88" type="curve" smooth="yes"/>
-      <point x="629" y="-27"/>
-      <point x="591" y="12"/>
-      <point x="520" y="25" type="curve"/>
-      <point x="520" y="31" type="line"/>
-      <point x="569" y="49"/>
-      <point x="619" y="85"/>
+      <point x="400" y="-279" type="curve" smooth="yes"/>
+      <point x="535" y="-279"/>
+      <point x="619" y="-218"/>
+      <point x="619" y="-118" type="curve" smooth="yes"/>
+      <point x="619" y="-47"/>
+      <point x="587" y="1"/>
+      <point x="519" y="23" type="curve"/>
+      <point x="519" y="29" type="line"/>
+      <point x="583" y="52"/>
+      <point x="619" y="101"/>
       <point x="619" y="162" type="curve" smooth="yes"/>
-      <point x="619" y="231"/>
-      <point x="574" y="276"/>
+      <point x="619" y="229"/>
+      <point x="576" y="276"/>
       <point x="499" y="292" type="curve"/>
       <point x="499" y="298" type="line"/>
       <point x="560" y="316"/>
@@ -42,7 +39,7 @@
       <point x="124" y="426"/>
       <point x="214" y="518"/>
       <point x="361" y="518" type="curve" smooth="yes"/>
-      <point x="465" y="518"/>
+      <point x="466" y="518"/>
       <point x="516" y="480"/>
       <point x="516" y="416" type="curve" smooth="yes"/>
       <point x="516" y="361"/>
@@ -51,27 +48,27 @@
       <point x="360" y="329" type="line"/>
       <point x="360" y="255" type="line"/>
       <point x="402" y="255" type="line" smooth="yes"/>
-      <point x="488" y="255"/>
-      <point x="537" y="220"/>
+      <point x="489" y="255"/>
+      <point x="537" y="219"/>
       <point x="537" y="155" type="curve" smooth="yes"/>
-      <point x="537" y="94"/>
-      <point x="483" y="62"/>
+      <point x="537" y="98"/>
+      <point x="489" y="62"/>
       <point x="413" y="62" type="curve" smooth="yes"/>
-      <point x="360" y="62" type="line"/>
-      <point x="360" y="-12" type="line"/>
-      <point x="423" y="-12" type="line" smooth="yes"/>
-      <point x="509" y="-12"/>
-      <point x="547" y="-35"/>
-      <point x="547" y="-77" type="curve" smooth="yes"/>
-      <point x="547" y="-126"/>
-      <point x="507" y="-147"/>
-      <point x="440" y="-147" type="curve" smooth="yes"/>
-      <point x="391" y="-147"/>
-      <point x="357" y="-140"/>
-      <point x="324" y="-129" type="curve"/>
-      <point x="296" y="-201" type="line"/>
-      <point x="332" y="-216"/>
-      <point x="385" y="-225"/>
+      <point x="340" y="62" type="line"/>
+      <point x="340" y="-12" type="line"/>
+      <point x="413" y="-12" type="line" smooth="yes"/>
+      <point x="497" y="-12"/>
+      <point x="537" y="-47"/>
+      <point x="537" y="-106" type="curve" smooth="yes"/>
+      <point x="537" y="-166"/>
+      <point x="488" y="-201"/>
+      <point x="400" y="-201" type="curve" smooth="yes"/>
+      <point x="342" y="-201"/>
+      <point x="296" y="-190"/>
+      <point x="243" y="-164" type="curve"/>
+      <point x="210" y="-233" type="line"/>
+      <point x="270" y="-264"/>
+      <point x="335" y="-279"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="963"/>
-  <anchor x="657" y="0" name="bottom"/>
+  <advance width="956"/>
+  <anchor x="650" y="0" name="bottom"/>
   <anchor x="475" y="580" name="top"/>
-  <anchor x="847" y="580" name="topright"/>
+  <anchor x="840" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="272" y="-16" type="curve" smooth="yes"/>
+      <point x="282" y="-16" type="curve" smooth="yes"/>
       <point x="411" y="-16"/>
-      <point x="479" y="68"/>
-      <point x="494" y="232" type="curve" smooth="yes"/>
-      <point x="504" y="340" type="line" smooth="yes"/>
-      <point x="514" y="449"/>
-      <point x="569" y="516"/>
-      <point x="681" y="516" type="curve" smooth="yes"/>
-      <point x="782" y="516"/>
-      <point x="824" y="476"/>
-      <point x="824" y="416" type="curve" smooth="yes"/>
-      <point x="824" y="361"/>
-      <point x="780" y="329"/>
-      <point x="710" y="329" type="curve" smooth="yes"/>
-      <point x="668" y="329" type="line"/>
-      <point x="668" y="255" type="line"/>
-      <point x="710" y="255" type="line" smooth="yes"/>
-      <point x="796" y="255"/>
-      <point x="845" y="220"/>
-      <point x="845" y="158" type="curve" smooth="yes"/>
-      <point x="845" y="93"/>
-      <point x="805" y="62"/>
-      <point x="729" y="62" type="curve" smooth="yes"/>
-      <point x="697" y="62"/>
-      <point x="667" y="69"/>
-      <point x="634" y="82" type="curve"/>
-      <point x="602" y="10" type="line"/>
-      <point x="638" y="-7"/>
-      <point x="684" y="-16"/>
-      <point x="731" y="-16" type="curve" smooth="yes"/>
-      <point x="848" y="-16"/>
-      <point x="927" y="47"/>
-      <point x="927" y="153" type="curve" smooth="yes"/>
-      <point x="927" y="224"/>
-      <point x="882" y="276"/>
-      <point x="807" y="292" type="curve"/>
-      <point x="807" y="298" type="line"/>
-      <point x="868" y="316"/>
-      <point x="906" y="362"/>
-      <point x="906" y="427" type="curve" smooth="yes"/>
-      <point x="906" y="523"/>
-      <point x="833" y="596"/>
-      <point x="678" y="596" type="curve" smooth="yes"/>
-      <point x="521" y="596"/>
-      <point x="431" y="507"/>
-      <point x="416" y="347" type="curve" smooth="yes"/>
-      <point x="406" y="240" type="line" smooth="yes"/>
-      <point x="396" y="128"/>
-      <point x="355" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="89"/>
-      <point x="131" y="-16"/>
+      <point x="499" y="77"/>
+      <point x="499" y="214" type="curve" smooth="yes"/>
+      <point x="499" y="255"/>
+      <point x="495" y="297"/>
+      <point x="495" y="338" type="curve" smooth="yes"/>
+      <point x="495" y="457"/>
+      <point x="561" y="516"/>
+      <point x="679" y="516" type="curve" smooth="yes"/>
+      <point x="777" y="516"/>
+      <point x="817" y="479"/>
+      <point x="817" y="424" type="curve" smooth="yes"/>
+      <point x="817" y="365"/>
+      <point x="773" y="329"/>
+      <point x="703" y="329" type="curve" smooth="yes"/>
+      <point x="661" y="329" type="line"/>
+      <point x="661" y="255" type="line"/>
+      <point x="703" y="255" type="line" smooth="yes"/>
+      <point x="789" y="255"/>
+      <point x="838" y="220"/>
+      <point x="838" y="158" type="curve" smooth="yes"/>
+      <point x="838" y="93"/>
+      <point x="798" y="62"/>
+      <point x="722" y="62" type="curve" smooth="yes"/>
+      <point x="690" y="62"/>
+      <point x="660" y="69"/>
+      <point x="627" y="82" type="curve"/>
+      <point x="595" y="10" type="line"/>
+      <point x="631" y="-7"/>
+      <point x="677" y="-16"/>
+      <point x="724" y="-16" type="curve" smooth="yes"/>
+      <point x="841" y="-16"/>
+      <point x="920" y="47"/>
+      <point x="920" y="153" type="curve" smooth="yes"/>
+      <point x="920" y="224"/>
+      <point x="875" y="276"/>
+      <point x="800" y="292" type="curve"/>
+      <point x="800" y="298" type="line"/>
+      <point x="861" y="317"/>
+      <point x="899" y="365"/>
+      <point x="899" y="435" type="curve" smooth="yes"/>
+      <point x="899" y="524"/>
+      <point x="828" y="596"/>
+      <point x="680" y="596" type="curve" smooth="yes"/>
+      <point x="518" y="596"/>
+      <point x="411" y="503"/>
+      <point x="411" y="346" type="curve" smooth="yes"/>
+      <point x="411" y="305"/>
+      <point x="415" y="263"/>
+      <point x="415" y="222" type="curve" smooth="yes"/>
+      <point x="415" y="120"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="90"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/g_ga-malayalam.glif
@@ -6,91 +6,95 @@
   <anchor x="763" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="392" y="-367" type="curve" smooth="yes"/>
-      <point x="500" y="-367"/>
-      <point x="551" y="-308"/>
-      <point x="557" y="-175" type="curve" smooth="yes"/>
-      <point x="558" y="-152" type="line" smooth="yes"/>
-      <point x="562" y="-55"/>
-      <point x="593" y="-27"/>
-      <point x="648" y="-27" type="curve" smooth="yes"/>
-      <point x="709" y="-27"/>
-      <point x="747" y="-75"/>
-      <point x="747" y="-155" type="curve" smooth="yes"/>
-      <point x="747" y="-228"/>
-      <point x="719" y="-280"/>
-      <point x="681" y="-324" type="curve"/>
-      <point x="734" y="-367" type="line"/>
-      <point x="794" y="-304"/>
-      <point x="821" y="-235"/>
-      <point x="821" y="-153" type="curve" smooth="yes"/>
-      <point x="821" y="-23"/>
-      <point x="748" y="43"/>
-      <point x="650" y="43" type="curve" smooth="yes"/>
-      <point x="542" y="43"/>
-      <point x="492" y="-16"/>
-      <point x="486" y="-146" type="curve" smooth="yes"/>
-      <point x="485" y="-168" type="line" smooth="yes"/>
-      <point x="480" y="-270"/>
-      <point x="449" y="-297"/>
-      <point x="395" y="-297" type="curve" smooth="yes"/>
-      <point x="334" y="-297"/>
-      <point x="295" y="-250"/>
-      <point x="295" y="-165" type="curve" smooth="yes"/>
-      <point x="295" y="-90"/>
-      <point x="323" y="-35"/>
-      <point x="373" y="17" type="curve"/>
-      <point x="348" y="-4" type="line"/>
-      <point x="434" y="25"/>
-      <point x="481" y="107"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="563" y="512"/>
-      <point x="647" y="512" type="curve" smooth="yes"/>
-      <point x="734" y="512"/>
-      <point x="784" y="440"/>
-      <point x="784" y="326" type="curve" smooth="yes"/>
-      <point x="784" y="213"/>
-      <point x="748" y="113"/>
-      <point x="656" y="17" type="curve"/>
-      <point x="732" y="-16" type="line"/>
+      <point x="284" y="-12" type="curve" smooth="yes"/>
+      <point x="410" y="-12"/>
+      <point x="499" y="84"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="452"/>
+      <point x="550" y="514"/>
+      <point x="642" y="514" type="curve" smooth="yes"/>
+      <point x="734" y="514"/>
+      <point x="784" y="447"/>
+      <point x="784" y="324" type="curve" smooth="yes"/>
+      <point x="784" y="215"/>
+      <point x="741" y="120"/>
+      <point x="659" y="31" type="curve"/>
+      <point x="733" y="-12" type="line"/>
       <point x="823" y="85"/>
-      <point x="868" y="203"/>
+      <point x="868" y="198"/>
       <point x="868" y="327" type="curve" smooth="yes"/>
-      <point x="868" y="491"/>
+      <point x="868" y="495"/>
       <point x="781" y="596"/>
-      <point x="641" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
+      <point x="638" y="596" type="curve" smooth="yes"/>
+      <point x="503" y="596"/>
+      <point x="411" y="498"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
       <point x="42" y="92"/>
-      <point x="128" y="-13"/>
-      <point x="275" y="-13" type="curve" smooth="yes"/>
-      <point x="283" y="-13"/>
-      <point x="291" y="-13"/>
-      <point x="299" y="-12" type="curve"/>
-      <point x="248" y="27" type="line"/>
-      <point x="284" y="-57" type="line"/>
-      <point x="288" y="6" type="line"/>
-      <point x="240" y="-44"/>
-      <point x="221" y="-105"/>
-      <point x="221" y="-167" type="curve" smooth="yes"/>
-      <point x="221" y="-302"/>
+      <point x="139" y="-12"/>
+    </contour>
+    <contour>
+      <point x="398" y="-367" type="curve" smooth="yes"/>
+      <point x="500" y="-367"/>
+      <point x="559" y="-302"/>
+      <point x="559" y="-195" type="curve" smooth="yes"/>
+      <point x="559" y="-174"/>
+      <point x="557" y="-155"/>
+      <point x="557" y="-134" type="curve" smooth="yes"/>
+      <point x="557" y="-63"/>
+      <point x="588" y="-27"/>
+      <point x="648" y="-27" type="curve" smooth="yes"/>
+      <point x="710" y="-27"/>
+      <point x="747" y="-74"/>
+      <point x="747" y="-155" type="curve" smooth="yes"/>
+      <point x="747" y="-220"/>
+      <point x="725" y="-272"/>
+      <point x="678" y="-319" type="curve"/>
+      <point x="729" y="-367" type="line"/>
+      <point x="792" y="-305"/>
+      <point x="821" y="-238"/>
+      <point x="821" y="-155" type="curve" smooth="yes"/>
+      <point x="821" y="-41"/>
+      <point x="746" y="43"/>
+      <point x="646" y="43" type="curve" smooth="yes"/>
+      <point x="545" y="43"/>
+      <point x="483" y="-22"/>
+      <point x="483" y="-127" type="curve" smooth="yes"/>
+      <point x="483" y="-147"/>
+      <point x="485" y="-169"/>
+      <point x="485" y="-188" type="curve" smooth="yes"/>
+      <point x="485" y="-261"/>
+      <point x="454" y="-297"/>
+      <point x="396" y="-297" type="curve" smooth="yes"/>
+      <point x="334" y="-297"/>
+      <point x="295" y="-252"/>
+      <point x="295" y="-175" type="curve" smooth="yes"/>
+      <point x="295" y="-102"/>
+      <point x="314" y="-48"/>
+      <point x="359" y="6" type="curve"/>
+      <point x="284" y="6" type="line"/>
+      <point x="243" y="-42"/>
+      <point x="221" y="-106"/>
+      <point x="221" y="-175" type="curve" smooth="yes"/>
+      <point x="221" y="-291"/>
       <point x="295" y="-367"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/g_la-malayalam.glif
@@ -32,38 +32,40 @@
       <point x="786" y="-367"/>
       <point x="852" y="-308"/>
       <point x="852" y="-182" type="curve" smooth="yes"/>
-      <point x="852" y="-74"/>
-      <point x="811" y="4"/>
-      <point x="752" y="61" type="curve"/>
-      <point x="757" y="13" type="line"/>
-      <point x="831" y="108"/>
-      <point x="868" y="215"/>
+      <point x="852" y="-84"/>
+      <point x="819" y="-4"/>
+      <point x="753" y="60" type="curve"/>
+      <point x="753" y="10" type="line"/>
+      <point x="830" y="102"/>
+      <point x="868" y="208"/>
       <point x="868" y="327" type="curve" smooth="yes"/>
-      <point x="868" y="491"/>
+      <point x="868" y="495"/>
       <point x="781" y="596"/>
-      <point x="641" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="119"/>
-      <point x="100" y="20"/>
+      <point x="638" y="596" type="curve" smooth="yes"/>
+      <point x="503" y="596"/>
+      <point x="411" y="498"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="121"/>
+      <point x="108" y="29"/>
       <point x="213" y="2" type="curve"/>
       <point x="214" y="-3" type="line"/>
-      <point x="160" y="-47"/>
+      <point x="159" y="-48"/>
       <point x="136" y="-111"/>
       <point x="136" y="-181" type="curve" smooth="yes"/>
       <point x="136" y="-305"/>
@@ -91,25 +93,27 @@
       <point x="606" y="-261"/>
       <point x="584" y="-182" type="curve" smooth="yes"/>
       <point x="572" y="-139" type="line" smooth="yes"/>
-      <point x="546" y="-44"/>
-      <point x="496" y="21"/>
-      <point x="408" y="35" type="curve"/>
-      <point x="408" y="40" type="line"/>
-      <point x="466" y="78"/>
-      <point x="485" y="150"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="563" y="512"/>
-      <point x="647" y="512" type="curve" smooth="yes"/>
-      <point x="734" y="512"/>
-      <point x="784" y="440"/>
-      <point x="784" y="326" type="curve" smooth="yes"/>
-      <point x="784" y="222"/>
-      <point x="744" y="130"/>
-      <point x="666" y="41" type="curve"/>
-      <point x="729" y="-12"/>
-      <point x="778" y="-79"/>
+      <point x="546" y="-45"/>
+      <point x="498" y="19"/>
+      <point x="413" y="33" type="curve"/>
+      <point x="413" y="38" type="line"/>
+      <point x="467" y="77"/>
+      <point x="499" y="142"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="452"/>
+      <point x="550" y="514"/>
+      <point x="642" y="514" type="curve" smooth="yes"/>
+      <point x="734" y="514"/>
+      <point x="784" y="447"/>
+      <point x="784" y="324" type="curve" smooth="yes"/>
+      <point x="784" y="220"/>
+      <point x="745" y="128"/>
+      <point x="665" y="44" type="curve"/>
+      <point x="745" y="-21"/>
+      <point x="778" y="-93"/>
       <point x="778" y="-182" type="curve" smooth="yes"/>
       <point x="778" y="-251"/>
       <point x="751" y="-297"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/g_ma-malayalam.glif
@@ -6,16 +6,18 @@
   <anchor x="1300" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="272" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="478" y="74"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="557" y="512"/>
-      <point x="648" y="512" type="curve" smooth="yes"/>
-      <point x="738" y="512"/>
-      <point x="784" y="440"/>
+      <point x="282" y="-16" type="curve" smooth="yes"/>
+      <point x="411" y="-16"/>
+      <point x="499" y="81"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="454"/>
+      <point x="547" y="514"/>
+      <point x="640" y="514" type="curve" smooth="yes"/>
+      <point x="733" y="514"/>
+      <point x="784" y="446"/>
       <point x="784" y="323" type="curve" smooth="yes"/>
       <point x="784" y="0" type="line"/>
       <point x="1350" y="0" type="line"/>
@@ -27,28 +29,30 @@
       <point x="880" y="555"/>
       <point x="834" y="474" type="curve"/>
       <point x="829" y="474" type="line"/>
-      <point x="792" y="559"/>
-      <point x="726" y="596"/>
-      <point x="639" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="89"/>
-      <point x="131" y="-16"/>
+      <point x="794" y="551"/>
+      <point x="728" y="596"/>
+      <point x="634" y="596" type="curve" smooth="yes"/>
+      <point x="500" y="596"/>
+      <point x="411" y="500"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="90"/>
+      <point x="137" y="-16"/>
     </contour>
     <contour>
       <point x="834" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/g_na-malayalam.glif
@@ -6,16 +6,18 @@
   <anchor x="1187" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="272" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="478" y="74"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="558" y="512"/>
-      <point x="648" y="512" type="curve" smooth="yes"/>
-      <point x="740" y="512"/>
-      <point x="784" y="450"/>
+      <point x="282" y="-16" type="curve" smooth="yes"/>
+      <point x="411" y="-16"/>
+      <point x="499" y="81"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="455"/>
+      <point x="551" y="518"/>
+      <point x="641" y="518" type="curve" smooth="yes"/>
+      <point x="736" y="518"/>
+      <point x="784" y="454"/>
       <point x="784" y="326" type="curve" smooth="yes"/>
       <point x="784" y="0" type="line"/>
       <point x="868" y="0" type="line"/>
@@ -40,28 +42,30 @@
       <point x="865" y="554"/>
       <point x="829" y="485" type="curve"/>
       <point x="824" y="485" type="line"/>
-      <point x="791" y="554"/>
-      <point x="729" y="596"/>
-      <point x="641" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="89"/>
-      <point x="131" y="-16"/>
+      <point x="789" y="552"/>
+      <point x="726" y="596"/>
+      <point x="637" y="596" type="curve" smooth="yes"/>
+      <point x="504" y="596"/>
+      <point x="411" y="498"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="90"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ga-malayalam.glif
@@ -7,46 +7,50 @@
   <anchor x="763" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="272" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="478" y="74"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="563" y="512"/>
-      <point x="647" y="512" type="curve" smooth="yes"/>
-      <point x="734" y="512"/>
-      <point x="784" y="440"/>
-      <point x="784" y="326" type="curve" smooth="yes"/>
-      <point x="784" y="222"/>
-      <point x="744" y="130"/>
-      <point x="666" y="41" type="curve"/>
-      <point x="732" y="-16" type="line"/>
-      <point x="823" y="85"/>
-      <point x="868" y="203"/>
+      <point x="282" y="-16" type="curve" smooth="yes"/>
+      <point x="411" y="-16"/>
+      <point x="499" y="81"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="452"/>
+      <point x="550" y="514"/>
+      <point x="642" y="514" type="curve" smooth="yes"/>
+      <point x="734" y="514"/>
+      <point x="784" y="447"/>
+      <point x="784" y="324" type="curve" smooth="yes"/>
+      <point x="784" y="220"/>
+      <point x="745" y="128"/>
+      <point x="665" y="44" type="curve"/>
+      <point x="730" y="-16" type="line"/>
+      <point x="822" y="82"/>
+      <point x="868" y="197"/>
       <point x="868" y="327" type="curve" smooth="yes"/>
-      <point x="868" y="491"/>
+      <point x="868" y="495"/>
       <point x="781" y="596"/>
-      <point x="641" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="89"/>
-      <point x="131" y="-16"/>
+      <point x="638" y="596" type="curve" smooth="yes"/>
+      <point x="503" y="596"/>
+      <point x="411" y="498"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="90"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ga-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ga-malayalam.half" format="2">
   <advance width="910"/>
+  <anchor x="502" y="0" name="bottom"/>
+  <anchor x="459" y="580" name="top"/>
+  <anchor x="763" y="580" name="topright"/>
   <outline>
     <component base="ga-malayalam"/>
     <component base="halant-malayalam" xOffset="763"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/j_ja-malayalam.glif
@@ -1,224 +1,224 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1602"/>
-  <anchor x="1213" y="0" name="bottom"/>
-  <anchor x="793" y="580" name="top"/>
-  <anchor x="1481" y="580" name="topright"/>
+  <advance width="1668"/>
+  <anchor x="1258" y="0" name="bottom"/>
+  <anchor x="834" y="580" name="top"/>
+  <anchor x="1527" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="326" y="-16" type="curve" smooth="yes"/>
-      <point x="623" y="-16"/>
-      <point x="779" y="95"/>
-      <point x="854" y="317" type="curve"/>
-      <point x="867" y="374" type="line"/>
-      <point x="872" y="374" type="line"/>
-      <point x="890" y="316"/>
-      <point x="931" y="294"/>
-      <point x="982" y="294" type="curve" smooth="yes"/>
-      <point x="1069" y="294"/>
-      <point x="1113" y="348"/>
-      <point x="1113" y="417" type="curve" smooth="yes"/>
-      <point x="1113" y="478"/>
-      <point x="1081" y="524"/>
-      <point x="1000" y="524" type="curve" smooth="yes"/>
-      <point x="978" y="524"/>
-      <point x="957" y="520"/>
-      <point x="946" y="514" type="curve"/>
-      <point x="973" y="488" type="line"/>
-      <point x="947" y="550" type="line"/>
-      <point x="941" y="511" type="line"/>
-      <point x="959" y="526"/>
-      <point x="986" y="535"/>
-      <point x="1026" y="535" type="curve" smooth="yes"/>
-      <point x="1134" y="535"/>
-      <point x="1172" y="454"/>
-      <point x="1172" y="380" type="curve" smooth="yes"/>
-      <point x="1172" y="343" type="line"/>
-      <point x="1256" y="343" type="line"/>
-      <point x="1256" y="376" type="line" smooth="yes"/>
-      <point x="1256" y="467"/>
-      <point x="1309" y="518"/>
-      <point x="1380" y="518" type="curve" smooth="yes"/>
-      <point x="1444" y="518"/>
-      <point x="1478" y="478"/>
-      <point x="1478" y="413" type="curve" smooth="yes"/>
-      <point x="1478" y="349"/>
-      <point x="1440" y="287"/>
-      <point x="1317" y="287" type="curve" smooth="yes"/>
-      <point x="1062" y="287" type="line" smooth="yes"/>
-      <point x="923" y="287"/>
-      <point x="852" y="221"/>
-      <point x="852" y="133" type="curve" smooth="yes"/>
-      <point x="852" y="54"/>
-      <point x="901" y="-16"/>
-      <point x="1009" y="-16" type="curve" smooth="yes"/>
-      <point x="1063" y="-16"/>
-      <point x="1122" y="1"/>
-      <point x="1202" y="54" type="curve" smooth="yes"/>
-      <point x="1256" y="90" type="line" smooth="yes"/>
-      <point x="1345" y="150"/>
-      <point x="1384" y="167"/>
-      <point x="1428" y="167" type="curve" smooth="yes"/>
-      <point x="1473" y="167"/>
-      <point x="1489" y="142"/>
-      <point x="1489" y="106" type="curve" smooth="yes"/>
-      <point x="1489" y="72"/>
-      <point x="1469" y="48"/>
-      <point x="1432" y="48" type="curve" smooth="yes"/>
-      <point x="1396" y="48"/>
-      <point x="1376" y="70"/>
-      <point x="1376" y="110" type="curve" smooth="yes"/>
-      <point x="1376" y="145"/>
-      <point x="1392" y="166"/>
-      <point x="1409" y="185" type="curve"/>
-      <point x="1311" y="152" type="line"/>
-      <point x="1328" y="130" type="line"/>
-      <point x="1323" y="116"/>
-      <point x="1320" y="107"/>
-      <point x="1320" y="90" type="curve" smooth="yes"/>
-      <point x="1320" y="34"/>
-      <point x="1357" y="-16"/>
-      <point x="1434" y="-16" type="curve" smooth="yes"/>
-      <point x="1513" y="-16"/>
-      <point x="1555" y="37"/>
-      <point x="1555" y="105" type="curve" smooth="yes"/>
-      <point x="1555" y="183"/>
-      <point x="1505" y="233"/>
-      <point x="1432" y="233" type="curve" smooth="yes"/>
-      <point x="1372" y="233"/>
-      <point x="1329" y="216"/>
-      <point x="1239" y="161" type="curve" smooth="yes"/>
-      <point x="1172" y="120" type="line" smooth="yes"/>
-      <point x="1095" y="73"/>
-      <point x="1062" y="61"/>
-      <point x="1016" y="61" type="curve" smooth="yes"/>
-      <point x="963" y="61"/>
-      <point x="931" y="88"/>
-      <point x="931" y="133" type="curve" smooth="yes"/>
-      <point x="931" y="183"/>
-      <point x="971" y="215"/>
-      <point x="1065" y="215" type="curve" smooth="yes"/>
-      <point x="1301" y="215" type="line" smooth="yes"/>
-      <point x="1494" y="215"/>
-      <point x="1560" y="312"/>
-      <point x="1560" y="416" type="curve" smooth="yes"/>
-      <point x="1560" y="526"/>
-      <point x="1488" y="596"/>
-      <point x="1381" y="596" type="curve" smooth="yes"/>
-      <point x="1297" y="596"/>
-      <point x="1236" y="549"/>
-      <point x="1218" y="478" type="curve"/>
-      <point x="1213" y="478" type="line"/>
-      <point x="1191" y="549"/>
-      <point x="1118" y="596"/>
-      <point x="1021" y="596" type="curve" smooth="yes"/>
-      <point x="931" y="596"/>
-      <point x="860" y="555"/>
-      <point x="824" y="444" type="curve" smooth="yes"/>
-      <point x="799" y="366" type="line" smooth="yes"/>
-      <point x="723" y="128"/>
-      <point x="569" y="61"/>
-      <point x="326" y="61" type="curve" smooth="yes"/>
-      <point x="182" y="61"/>
-      <point x="126" y="91"/>
-      <point x="126" y="147" type="curve" smooth="yes"/>
-      <point x="126" y="191"/>
-      <point x="157" y="215"/>
-      <point x="257" y="215" type="curve" smooth="yes"/>
-      <point x="498" y="215" type="line" smooth="yes"/>
-      <point x="695" y="215"/>
-      <point x="757" y="312"/>
-      <point x="757" y="424" type="curve" smooth="yes"/>
-      <point x="757" y="530"/>
-      <point x="689" y="596"/>
-      <point x="585" y="596" type="curve" smooth="yes"/>
-      <point x="505" y="596"/>
-      <point x="442" y="549"/>
-      <point x="424" y="478" type="curve"/>
-      <point x="419" y="478" type="line"/>
-      <point x="397" y="549"/>
-      <point x="324" y="596"/>
-      <point x="227" y="596" type="curve" smooth="yes"/>
-      <point x="118" y="596"/>
-      <point x="42" y="532"/>
-      <point x="42" y="432" type="curve" smooth="yes"/>
-      <point x="42" y="353"/>
-      <point x="98" y="294"/>
-      <point x="183" y="294" type="curve" smooth="yes"/>
-      <point x="269" y="294"/>
-      <point x="319" y="348"/>
-      <point x="319" y="417" type="curve" smooth="yes"/>
-      <point x="319" y="478"/>
-      <point x="287" y="524"/>
-      <point x="206" y="524" type="curve" smooth="yes"/>
-      <point x="184" y="524"/>
-      <point x="163" y="520"/>
-      <point x="152" y="514" type="curve"/>
-      <point x="179" y="488" type="line"/>
-      <point x="153" y="550" type="line"/>
-      <point x="147" y="511" type="line"/>
-      <point x="165" y="526"/>
-      <point x="192" y="535"/>
-      <point x="232" y="535" type="curve" smooth="yes"/>
-      <point x="340" y="535"/>
-      <point x="378" y="454"/>
-      <point x="378" y="380" type="curve" smooth="yes"/>
-      <point x="378" y="343" type="line"/>
-      <point x="462" y="343" type="line"/>
-      <point x="462" y="376" type="line" smooth="yes"/>
-      <point x="462" y="467"/>
-      <point x="511" y="518"/>
-      <point x="581" y="518" type="curve" smooth="yes"/>
-      <point x="645" y="518"/>
-      <point x="675" y="478"/>
-      <point x="675" y="413" type="curve" smooth="yes"/>
-      <point x="675" y="349"/>
-      <point x="641" y="287"/>
-      <point x="514" y="287" type="curve" smooth="yes"/>
-      <point x="254" y="287" type="line" smooth="yes"/>
-      <point x="105" y="287"/>
-      <point x="48" y="229"/>
-      <point x="48" y="147" type="curve" smooth="yes"/>
-      <point x="48" y="39"/>
-      <point x="134" y="-16"/>
+      <point x="308" y="-16" type="curve" smooth="yes"/>
+      <point x="604" y="-16"/>
+      <point x="783" y="86"/>
+      <point x="879" y="287" type="curve"/>
+      <point x="892" y="344" type="line"/>
+      <point x="897" y="344" type="line"/>
+      <point x="909" y="302"/>
+      <point x="949" y="273"/>
+      <point x="1012" y="273" type="curve" smooth="yes"/>
+      <point x="1090" y="273"/>
+      <point x="1145" y="324"/>
+      <point x="1145" y="402" type="curve" smooth="yes"/>
+      <point x="1145" y="470"/>
+      <point x="1103" y="515"/>
+      <point x="1032" y="515" type="curve" smooth="yes"/>
+      <point x="1006" y="515"/>
+      <point x="983" y="510"/>
+      <point x="961" y="499" type="curve"/>
+      <point x="946" y="523" type="line"/>
+      <point x="946" y="491" type="line"/>
+      <point x="976" y="520"/>
+      <point x="1018" y="536"/>
+      <point x="1073" y="536" type="curve" smooth="yes"/>
+      <point x="1169" y="536"/>
+      <point x="1212" y="484"/>
+      <point x="1212" y="382" type="curve" smooth="yes"/>
+      <point x="1212" y="324" type="line"/>
+      <point x="1296" y="324" type="line"/>
+      <point x="1296" y="380" type="line" smooth="yes"/>
+      <point x="1296" y="469"/>
+      <point x="1349" y="518"/>
+      <point x="1430" y="518" type="curve" smooth="yes"/>
+      <point x="1503" y="518"/>
+      <point x="1544" y="475"/>
+      <point x="1544" y="403" type="curve" smooth="yes"/>
+      <point x="1544" y="316"/>
+      <point x="1481" y="267"/>
+      <point x="1365" y="267" type="curve" smooth="yes"/>
+      <point x="1040" y="267" type="line" smooth="yes"/>
+      <point x="937" y="267"/>
+      <point x="864" y="212"/>
+      <point x="864" y="122" type="curve" smooth="yes"/>
+      <point x="864" y="41"/>
+      <point x="930" y="-16"/>
+      <point x="1020" y="-16" type="curve" smooth="yes"/>
+      <point x="1070" y="-16"/>
+      <point x="1105" y="-5"/>
+      <point x="1189" y="36" type="curve" smooth="yes"/>
+      <point x="1309" y="95" type="line"/>
+      <point x="1378" y="138" type="line"/>
+      <point x="1410" y="146" type="line"/>
+      <point x="1434" y="168"/>
+      <point x="1457" y="176"/>
+      <point x="1486" y="176" type="curve" smooth="yes"/>
+      <point x="1525" y="176"/>
+      <point x="1548" y="154"/>
+      <point x="1548" y="115" type="curve" smooth="yes"/>
+      <point x="1548" y="78"/>
+      <point x="1523" y="54"/>
+      <point x="1485" y="54" type="curve" smooth="yes"/>
+      <point x="1447" y="54"/>
+      <point x="1421" y="79"/>
+      <point x="1421" y="115" type="curve" smooth="yes"/>
+      <point x="1421" y="143"/>
+      <point x="1435" y="168"/>
+      <point x="1458" y="181" type="curve"/>
+      <point x="1351" y="145" type="line"/>
+      <point x="1370" y="128" type="line"/>
+      <point x="1366" y="116"/>
+      <point x="1365" y="106"/>
+      <point x="1365" y="94" type="curve" smooth="yes"/>
+      <point x="1365" y="32"/>
+      <point x="1416" y="-16"/>
+      <point x="1490" y="-16" type="curve" smooth="yes"/>
+      <point x="1571" y="-16"/>
+      <point x="1622" y="38"/>
+      <point x="1622" y="114" type="curve" smooth="yes"/>
+      <point x="1622" y="185"/>
+      <point x="1571" y="236"/>
+      <point x="1492" y="236" type="curve" smooth="yes"/>
+      <point x="1453" y="236"/>
+      <point x="1408" y="220"/>
+      <point x="1334" y="184" type="curve" smooth="yes"/>
+      <point x="1161" y="99" type="line" smooth="yes"/>
+      <point x="1103" y="71"/>
+      <point x="1066" y="60"/>
+      <point x="1024" y="60" type="curve" smooth="yes"/>
+      <point x="977" y="60"/>
+      <point x="946" y="85"/>
+      <point x="946" y="125" type="curve" smooth="yes"/>
+      <point x="946" y="170"/>
+      <point x="981" y="195"/>
+      <point x="1043" y="195" type="curve" smooth="yes"/>
+      <point x="1355" y="195" type="line" smooth="yes"/>
+      <point x="1520" y="195"/>
+      <point x="1626" y="277"/>
+      <point x="1626" y="405" type="curve" smooth="yes"/>
+      <point x="1626" y="521"/>
+      <point x="1556" y="596"/>
+      <point x="1443" y="596" type="curve" smooth="yes"/>
+      <point x="1354" y="596"/>
+      <point x="1290" y="552"/>
+      <point x="1258" y="478" type="curve"/>
+      <point x="1253" y="478" type="line"/>
+      <point x="1227" y="553"/>
+      <point x="1168" y="596"/>
+      <point x="1073" y="596" type="curve" smooth="yes"/>
+      <point x="966" y="596"/>
+      <point x="888" y="543"/>
+      <point x="856" y="444" type="curve" smooth="yes"/>
+      <point x="831" y="366" type="line" smooth="yes"/>
+      <point x="764" y="156"/>
+      <point x="600" y="61"/>
+      <point x="308" y="61" type="curve" smooth="yes"/>
+      <point x="175" y="61"/>
+      <point x="128" y="84"/>
+      <point x="128" y="132" type="curve" smooth="yes"/>
+      <point x="128" y="173"/>
+      <point x="165" y="195"/>
+      <point x="231" y="195" type="curve" smooth="yes"/>
+      <point x="507" y="195" type="line" smooth="yes"/>
+      <point x="673" y="195"/>
+      <point x="776" y="285"/>
+      <point x="776" y="410" type="curve" smooth="yes"/>
+      <point x="776" y="521"/>
+      <point x="710" y="596"/>
+      <point x="604" y="596" type="curve" smooth="yes"/>
+      <point x="524" y="596"/>
+      <point x="464" y="550"/>
+      <point x="440" y="478" type="curve"/>
+      <point x="435" y="478" type="line"/>
+      <point x="408" y="556"/>
+      <point x="346" y="596"/>
+      <point x="254" y="596" type="curve" smooth="yes"/>
+      <point x="137" y="596"/>
+      <point x="42" y="525"/>
+      <point x="42" y="420" type="curve" smooth="yes"/>
+      <point x="42" y="332"/>
+      <point x="100" y="273"/>
+      <point x="188" y="273" type="curve" smooth="yes"/>
+      <point x="270" y="273"/>
+      <point x="327" y="324"/>
+      <point x="327" y="402" type="curve" smooth="yes"/>
+      <point x="327" y="470"/>
+      <point x="285" y="515"/>
+      <point x="214" y="515" type="curve" smooth="yes"/>
+      <point x="188" y="515"/>
+      <point x="165" y="510"/>
+      <point x="143" y="499" type="curve"/>
+      <point x="128" y="523" type="line"/>
+      <point x="128" y="491" type="line"/>
+      <point x="158" y="520"/>
+      <point x="198" y="536"/>
+      <point x="254" y="536" type="curve" smooth="yes"/>
+      <point x="352" y="536"/>
+      <point x="394" y="483"/>
+      <point x="394" y="382" type="curve" smooth="yes"/>
+      <point x="394" y="324" type="line"/>
+      <point x="478" y="324" type="line"/>
+      <point x="478" y="380" type="line" smooth="yes"/>
+      <point x="478" y="467"/>
+      <point x="521" y="518"/>
+      <point x="596" y="518" type="curve" smooth="yes"/>
+      <point x="658" y="518"/>
+      <point x="694" y="479"/>
+      <point x="694" y="410" type="curve" smooth="yes"/>
+      <point x="694" y="316"/>
+      <point x="629" y="267"/>
+      <point x="503" y="267" type="curve" smooth="yes"/>
+      <point x="228" y="267" type="line" smooth="yes"/>
+      <point x="121" y="267"/>
+      <point x="46" y="214"/>
+      <point x="46" y="129" type="curve" smooth="yes"/>
+      <point x="46" y="36"/>
+      <point x="128" y="-16"/>
     </contour>
     <contour>
-      <point x="184" y="357" type="curve" smooth="yes"/>
-      <point x="137" y="357"/>
-      <point x="118" y="392"/>
-      <point x="118" y="441" type="curve" smooth="yes"/>
-      <point x="118" y="457"/>
-      <point x="120" y="472"/>
-      <point x="126" y="484" type="curve"/>
-      <point x="107" y="484" type="line"/>
-      <point x="83" y="451" type="line"/>
-      <point x="107" y="470"/>
-      <point x="144" y="482"/>
-      <point x="178" y="482" type="curve" smooth="yes"/>
-      <point x="236" y="482"/>
-      <point x="247" y="447"/>
-      <point x="247" y="422" type="curve" smooth="yes"/>
-      <point x="247" y="384"/>
-      <point x="227" y="357"/>
+      <point x="183" y="341" type="curve" smooth="yes"/>
+      <point x="139" y="341"/>
+      <point x="110" y="370"/>
+      <point x="110" y="416" type="curve" smooth="yes"/>
+      <point x="110" y="439"/>
+      <point x="114" y="454"/>
+      <point x="126" y="475" type="curve"/>
+      <point x="98" y="475" type="line"/>
+      <point x="90" y="427" type="line"/>
+      <point x="113" y="453"/>
+      <point x="148" y="467"/>
+      <point x="183" y="467" type="curve" smooth="yes"/>
+      <point x="227" y="467"/>
+      <point x="251" y="442"/>
+      <point x="251" y="404" type="curve" smooth="yes"/>
+      <point x="251" y="366"/>
+      <point x="226" y="341"/>
     </contour>
     <contour>
-      <point x="978" y="357" type="curve" smooth="yes"/>
-      <point x="931" y="357"/>
-      <point x="912" y="392"/>
-      <point x="912" y="441" type="curve" smooth="yes"/>
-      <point x="912" y="457"/>
-      <point x="914" y="472"/>
-      <point x="920" y="484" type="curve"/>
-      <point x="901" y="484" type="line"/>
-      <point x="877" y="451" type="line"/>
-      <point x="901" y="470"/>
-      <point x="938" y="482"/>
-      <point x="972" y="482" type="curve" smooth="yes"/>
-      <point x="1030" y="482"/>
-      <point x="1041" y="447"/>
-      <point x="1041" y="422" type="curve" smooth="yes"/>
-      <point x="1041" y="384"/>
-      <point x="1021" y="357"/>
+      <point x="1001" y="341" type="curve" smooth="yes"/>
+      <point x="957" y="341"/>
+      <point x="928" y="370"/>
+      <point x="928" y="416" type="curve" smooth="yes"/>
+      <point x="928" y="439"/>
+      <point x="932" y="454"/>
+      <point x="944" y="475" type="curve"/>
+      <point x="916" y="475" type="line"/>
+      <point x="908" y="427" type="line"/>
+      <point x="931" y="453"/>
+      <point x="966" y="467"/>
+      <point x="1001" y="467" type="curve" smooth="yes"/>
+      <point x="1045" y="467"/>
+      <point x="1069" y="442"/>
+      <point x="1069" y="404" type="curve" smooth="yes"/>
+      <point x="1069" y="366"/>
+      <point x="1044" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/j_nya-malayalam.glif
@@ -1,185 +1,184 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2195"/>
-  <anchor x="1786" y="0" name="bottom"/>
-  <anchor x="1091" y="580" name="top"/>
-  <anchor x="2059" y="580" name="topright"/>
+  <advance width="2228"/>
+  <anchor x="1819" y="0" name="bottom"/>
+  <anchor x="1114" y="580" name="top"/>
+  <anchor x="2092" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="336" y="-16" type="curve" smooth="yes"/>
-      <point x="560" y="-16"/>
-      <point x="712" y="43"/>
-      <point x="800" y="189" type="curve"/>
-      <point x="806" y="189" type="line"/>
-      <point x="829" y="69"/>
-      <point x="904" y="-16"/>
-      <point x="1019" y="-16" type="curve" smooth="yes"/>
-      <point x="1129" y="-16"/>
-      <point x="1195" y="65"/>
-      <point x="1195" y="175" type="curve" smooth="yes"/>
-      <point x="1195" y="272"/>
-      <point x="1138" y="347"/>
-      <point x="1026" y="347" type="curve" smooth="yes"/>
-      <point x="962" y="347"/>
-      <point x="906" y="314"/>
-      <point x="876" y="264" type="curve"/>
-      <point x="864" y="268" type="line"/>
-      <point x="878" y="138" type="line"/>
-      <point x="893" y="223"/>
-      <point x="947" y="273"/>
-      <point x="1016" y="273" type="curve" smooth="yes"/>
-      <point x="1079" y="273"/>
-      <point x="1113" y="239"/>
-      <point x="1113" y="171" type="curve" smooth="yes"/>
-      <point x="1113" y="101"/>
-      <point x="1074" y="62"/>
-      <point x="1014" y="62" type="curve" smooth="yes"/>
-      <point x="923" y="62"/>
-      <point x="871" y="163"/>
-      <point x="871" y="266" type="curve" smooth="yes"/>
-      <point x="871" y="413"/>
-      <point x="961" y="518"/>
-      <point x="1091" y="518" type="curve" smooth="yes"/>
-      <point x="1206" y="518"/>
-      <point x="1268" y="441"/>
-      <point x="1268" y="318" type="curve" smooth="yes"/>
-      <point x="1268" y="0" type="line"/>
-      <point x="1352" y="0" type="line"/>
-      <point x="1352" y="318" type="line" smooth="yes"/>
-      <point x="1352" y="441"/>
-      <point x="1420" y="518"/>
-      <point x="1545" y="518" type="curve" smooth="yes"/>
-      <point x="1716" y="518"/>
-      <point x="1807" y="397"/>
-      <point x="1807" y="241" type="curve" smooth="yes"/>
-      <point x="1807" y="130"/>
-      <point x="1767" y="64"/>
-      <point x="1693" y="64" type="curve" smooth="yes"/>
-      <point x="1621" y="64"/>
-      <point x="1582" y="124"/>
-      <point x="1582" y="216" type="curve" smooth="yes"/>
-      <point x="1582" y="383"/>
-      <point x="1693" y="518"/>
-      <point x="1855" y="518" type="curve" smooth="yes"/>
-      <point x="1995" y="518"/>
-      <point x="2071" y="435"/>
-      <point x="2071" y="305" type="curve" smooth="yes"/>
-      <point x="2071" y="208"/>
-      <point x="2033" y="120"/>
-      <point x="1965" y="42" type="curve"/>
-      <point x="2034" y="-14" type="line"/>
-      <point x="2108" y="78"/>
-      <point x="2153" y="174"/>
-      <point x="2153" y="296" type="curve" smooth="yes"/>
-      <point x="2153" y="484"/>
-      <point x="2047" y="596"/>
-      <point x="1858" y="596" type="curve" smooth="yes"/>
-      <point x="1651" y="596"/>
-      <point x="1500" y="423"/>
-      <point x="1500" y="217" type="curve" smooth="yes"/>
-      <point x="1500" y="79"/>
-      <point x="1575" y="-14"/>
-      <point x="1697" y="-14" type="curve" smooth="yes"/>
-      <point x="1822" y="-14"/>
-      <point x="1889" y="85"/>
-      <point x="1889" y="235" type="curve" smooth="yes"/>
-      <point x="1889" y="432"/>
-      <point x="1761" y="596"/>
-      <point x="1548" y="596" type="curve" smooth="yes"/>
-      <point x="1436" y="596"/>
-      <point x="1359" y="548"/>
-      <point x="1319" y="470" type="curve"/>
-      <point x="1314" y="470" type="line"/>
-      <point x="1274" y="548"/>
-      <point x="1199" y="596"/>
-      <point x="1090" y="596" type="curve" smooth="yes"/>
-      <point x="933" y="596"/>
-      <point x="843" y="506"/>
-      <point x="793" y="348" type="curve" smooth="yes"/>
-      <point x="721" y="117"/>
-      <point x="579" y="61"/>
-      <point x="336" y="61" type="curve" smooth="yes"/>
-      <point x="182" y="61"/>
-      <point x="126" y="91"/>
-      <point x="126" y="147" type="curve" smooth="yes"/>
-      <point x="126" y="191"/>
-      <point x="157" y="215"/>
-      <point x="257" y="215" type="curve" smooth="yes"/>
-      <point x="498" y="215" type="line" smooth="yes"/>
-      <point x="695" y="215"/>
-      <point x="759" y="312"/>
-      <point x="757" y="424" type="curve" smooth="yes"/>
-      <point x="755" y="530"/>
-      <point x="689" y="596"/>
-      <point x="585" y="596" type="curve" smooth="yes"/>
-      <point x="505" y="596"/>
-      <point x="442" y="549"/>
-      <point x="424" y="478" type="curve"/>
-      <point x="419" y="478" type="line"/>
-      <point x="397" y="549"/>
-      <point x="324" y="596"/>
-      <point x="227" y="596" type="curve" smooth="yes"/>
-      <point x="118" y="596"/>
-      <point x="42" y="532"/>
-      <point x="42" y="432" type="curve" smooth="yes"/>
-      <point x="42" y="353"/>
-      <point x="98" y="294"/>
-      <point x="183" y="294" type="curve" smooth="yes"/>
-      <point x="269" y="294"/>
-      <point x="319" y="348"/>
-      <point x="319" y="417" type="curve" smooth="yes"/>
-      <point x="319" y="478"/>
-      <point x="287" y="524"/>
-      <point x="206" y="524" type="curve" smooth="yes"/>
-      <point x="184" y="524"/>
-      <point x="163" y="520"/>
-      <point x="152" y="514" type="curve"/>
-      <point x="179" y="488" type="line"/>
-      <point x="153" y="550" type="line"/>
-      <point x="147" y="511" type="line"/>
-      <point x="165" y="526"/>
-      <point x="192" y="535"/>
-      <point x="232" y="535" type="curve" smooth="yes"/>
-      <point x="340" y="535"/>
-      <point x="378" y="454"/>
-      <point x="378" y="380" type="curve" smooth="yes"/>
-      <point x="378" y="343" type="line"/>
-      <point x="462" y="343" type="line"/>
-      <point x="462" y="376" type="line" smooth="yes"/>
-      <point x="462" y="467"/>
-      <point x="511" y="518"/>
-      <point x="581" y="518" type="curve" smooth="yes"/>
-      <point x="645" y="518"/>
-      <point x="675" y="478"/>
-      <point x="675" y="413" type="curve" smooth="yes"/>
-      <point x="675" y="349"/>
-      <point x="641" y="287"/>
-      <point x="514" y="287" type="curve" smooth="yes"/>
-      <point x="254" y="287" type="line" smooth="yes"/>
-      <point x="105" y="287"/>
-      <point x="48" y="229"/>
-      <point x="48" y="147" type="curve" smooth="yes"/>
-      <point x="48" y="39"/>
-      <point x="134" y="-16"/>
+      <point x="316" y="-16" type="curve" smooth="yes"/>
+      <point x="570" y="-16"/>
+      <point x="740" y="53"/>
+      <point x="830" y="200" type="curve"/>
+      <point x="836" y="200" type="line"/>
+      <point x="856" y="67"/>
+      <point x="935" y="-16"/>
+      <point x="1052" y="-16" type="curve" smooth="yes"/>
+      <point x="1162" y="-16"/>
+      <point x="1228" y="65"/>
+      <point x="1228" y="175" type="curve" smooth="yes"/>
+      <point x="1228" y="272"/>
+      <point x="1171" y="347"/>
+      <point x="1059" y="347" type="curve" smooth="yes"/>
+      <point x="995" y="347"/>
+      <point x="939" y="314"/>
+      <point x="909" y="264" type="curve"/>
+      <point x="897" y="268" type="line"/>
+      <point x="911" y="138" type="line"/>
+      <point x="926" y="223"/>
+      <point x="982" y="273"/>
+      <point x="1049" y="273" type="curve" smooth="yes"/>
+      <point x="1112" y="273"/>
+      <point x="1146" y="239"/>
+      <point x="1146" y="171" type="curve" smooth="yes"/>
+      <point x="1146" y="101"/>
+      <point x="1107" y="62"/>
+      <point x="1047" y="62" type="curve" smooth="yes"/>
+      <point x="954" y="62"/>
+      <point x="904" y="163"/>
+      <point x="904" y="266" type="curve" smooth="yes"/>
+      <point x="904" y="413"/>
+      <point x="994" y="518"/>
+      <point x="1124" y="518" type="curve" smooth="yes"/>
+      <point x="1239" y="518"/>
+      <point x="1301" y="441"/>
+      <point x="1301" y="318" type="curve" smooth="yes"/>
+      <point x="1301" y="0" type="line"/>
+      <point x="1385" y="0" type="line"/>
+      <point x="1385" y="318" type="line" smooth="yes"/>
+      <point x="1385" y="441"/>
+      <point x="1453" y="518"/>
+      <point x="1578" y="518" type="curve" smooth="yes"/>
+      <point x="1749" y="518"/>
+      <point x="1840" y="397"/>
+      <point x="1840" y="241" type="curve" smooth="yes"/>
+      <point x="1840" y="130"/>
+      <point x="1800" y="64"/>
+      <point x="1726" y="64" type="curve" smooth="yes"/>
+      <point x="1654" y="64"/>
+      <point x="1615" y="124"/>
+      <point x="1615" y="216" type="curve" smooth="yes"/>
+      <point x="1615" y="383"/>
+      <point x="1726" y="518"/>
+      <point x="1888" y="518" type="curve" smooth="yes"/>
+      <point x="2028" y="518"/>
+      <point x="2104" y="435"/>
+      <point x="2104" y="305" type="curve" smooth="yes"/>
+      <point x="2104" y="208"/>
+      <point x="2066" y="120"/>
+      <point x="1998" y="42" type="curve"/>
+      <point x="2067" y="-14" type="line"/>
+      <point x="2141" y="78"/>
+      <point x="2186" y="174"/>
+      <point x="2186" y="296" type="curve" smooth="yes"/>
+      <point x="2186" y="484"/>
+      <point x="2080" y="596"/>
+      <point x="1891" y="596" type="curve" smooth="yes"/>
+      <point x="1684" y="596"/>
+      <point x="1533" y="423"/>
+      <point x="1533" y="217" type="curve" smooth="yes"/>
+      <point x="1533" y="79"/>
+      <point x="1608" y="-14"/>
+      <point x="1730" y="-14" type="curve" smooth="yes"/>
+      <point x="1855" y="-14"/>
+      <point x="1922" y="85"/>
+      <point x="1922" y="235" type="curve" smooth="yes"/>
+      <point x="1922" y="432"/>
+      <point x="1794" y="596"/>
+      <point x="1581" y="596" type="curve" smooth="yes"/>
+      <point x="1469" y="596"/>
+      <point x="1392" y="548"/>
+      <point x="1352" y="470" type="curve"/>
+      <point x="1347" y="470" type="line"/>
+      <point x="1307" y="548"/>
+      <point x="1232" y="596"/>
+      <point x="1123" y="596" type="curve" smooth="yes"/>
+      <point x="977" y="596"/>
+      <point x="878" y="514"/>
+      <point x="826" y="348" type="curve" smooth="yes"/>
+      <point x="761" y="142"/>
+      <point x="616" y="61"/>
+      <point x="316" y="61" type="curve" smooth="yes"/>
+      <point x="177" y="61"/>
+      <point x="128" y="85"/>
+      <point x="128" y="131" type="curve" smooth="yes"/>
+      <point x="128" y="172"/>
+      <point x="165" y="195"/>
+      <point x="231" y="195" type="curve" smooth="yes"/>
+      <point x="507" y="195" type="line" smooth="yes"/>
+      <point x="673" y="195"/>
+      <point x="776" y="285"/>
+      <point x="776" y="410" type="curve" smooth="yes"/>
+      <point x="776" y="521"/>
+      <point x="710" y="596"/>
+      <point x="605" y="596" type="curve" smooth="yes"/>
+      <point x="525" y="596"/>
+      <point x="464" y="550"/>
+      <point x="440" y="478" type="curve"/>
+      <point x="435" y="478" type="line"/>
+      <point x="408" y="556"/>
+      <point x="346" y="596"/>
+      <point x="256" y="596" type="curve" smooth="yes"/>
+      <point x="137" y="596"/>
+      <point x="42" y="525"/>
+      <point x="42" y="420" type="curve" smooth="yes"/>
+      <point x="42" y="332"/>
+      <point x="100" y="273"/>
+      <point x="188" y="273" type="curve" smooth="yes"/>
+      <point x="270" y="273"/>
+      <point x="327" y="324"/>
+      <point x="327" y="402" type="curve" smooth="yes"/>
+      <point x="327" y="470"/>
+      <point x="285" y="515"/>
+      <point x="214" y="515" type="curve" smooth="yes"/>
+      <point x="188" y="515"/>
+      <point x="165" y="510"/>
+      <point x="143" y="499" type="curve"/>
+      <point x="128" y="523" type="line"/>
+      <point x="128" y="491" type="line"/>
+      <point x="159" y="520"/>
+      <point x="197" y="536"/>
+      <point x="256" y="536" type="curve" smooth="yes"/>
+      <point x="351" y="536"/>
+      <point x="394" y="483"/>
+      <point x="394" y="382" type="curve" smooth="yes"/>
+      <point x="394" y="324" type="line"/>
+      <point x="478" y="324" type="line"/>
+      <point x="478" y="380" type="line" smooth="yes"/>
+      <point x="478" y="467"/>
+      <point x="522" y="518"/>
+      <point x="597" y="518" type="curve" smooth="yes"/>
+      <point x="658" y="518"/>
+      <point x="694" y="479"/>
+      <point x="694" y="410" type="curve" smooth="yes"/>
+      <point x="694" y="316"/>
+      <point x="629" y="267"/>
+      <point x="503" y="267" type="curve" smooth="yes"/>
+      <point x="228" y="267" type="line" smooth="yes"/>
+      <point x="121" y="267"/>
+      <point x="46" y="214"/>
+      <point x="46" y="128" type="curve" smooth="yes"/>
+      <point x="46" y="38"/>
+      <point x="131" y="-16"/>
     </contour>
     <contour>
-      <point x="184" y="357" type="curve" smooth="yes"/>
-      <point x="137" y="357"/>
-      <point x="118" y="392"/>
-      <point x="118" y="441" type="curve" smooth="yes"/>
-      <point x="118" y="457"/>
-      <point x="120" y="472"/>
-      <point x="126" y="484" type="curve"/>
-      <point x="107" y="484" type="line"/>
-      <point x="83" y="451" type="line"/>
-      <point x="107" y="470"/>
-      <point x="144" y="482"/>
-      <point x="178" y="482" type="curve" smooth="yes"/>
-      <point x="236" y="482"/>
-      <point x="247" y="447"/>
-      <point x="247" y="422" type="curve" smooth="yes"/>
-      <point x="247" y="384"/>
-      <point x="227" y="357"/>
+      <point x="183" y="341" type="curve" smooth="yes"/>
+      <point x="139" y="341"/>
+      <point x="110" y="370"/>
+      <point x="110" y="416" type="curve" smooth="yes"/>
+      <point x="110" y="439"/>
+      <point x="114" y="454"/>
+      <point x="126" y="475" type="curve"/>
+      <point x="98" y="475" type="line"/>
+      <point x="90" y="427" type="line"/>
+      <point x="113" y="453"/>
+      <point x="148" y="467"/>
+      <point x="183" y="467" type="curve" smooth="yes"/>
+      <point x="227" y="467"/>
+      <point x="251" y="442"/>
+      <point x="251" y="404" type="curve" smooth="yes"/>
+      <point x="251" y="366"/>
+      <point x="226" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ja-malayalam.glif
@@ -1,137 +1,135 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <unicode hex="0D1C"/>
-  <guideline x="48" y="133" angle="91.1496"/>
-  <guideline x="766" y="416" angle="269.0789"/>
-  <anchor x="419" y="0" name="bottom"/>
-  <anchor x="419" y="580" name="top"/>
-  <anchor x="687" y="580" name="topright"/>
+  <anchor x="440" y="0" name="bottom"/>
+  <anchor x="425" y="580" name="top"/>
+  <anchor x="709" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="258" y="-16"/>
-      <point x="307" y="2"/>
-      <point x="396" y="54" type="curve" smooth="yes"/>
-      <point x="459" y="91" type="line"/>
-      <point x="546" y="142" type="line"/>
-      <point x="562" y="148" type="line"/>
-      <point x="594" y="163"/>
-      <point x="612" y="167"/>
-      <point x="634" y="167" type="curve" smooth="yes"/>
-      <point x="675" y="167"/>
-      <point x="695" y="147"/>
-      <point x="695" y="106" type="curve" smooth="yes"/>
-      <point x="695" y="70"/>
-      <point x="673" y="48"/>
-      <point x="638" y="48" type="curve" smooth="yes"/>
-      <point x="602" y="48"/>
-      <point x="582" y="70"/>
-      <point x="582" y="110" type="curve" smooth="yes"/>
-      <point x="582" y="137"/>
-      <point x="591" y="159"/>
-      <point x="615" y="185" type="curve"/>
-      <point x="517" y="152" type="line"/>
-      <point x="534" y="130" type="line"/>
-      <point x="528" y="112"/>
-      <point x="526" y="104"/>
-      <point x="526" y="90" type="curve" smooth="yes"/>
-      <point x="526" y="26"/>
-      <point x="571" y="-16"/>
-      <point x="640" y="-16" type="curve" smooth="yes"/>
-      <point x="714" y="-16"/>
-      <point x="761" y="31"/>
-      <point x="761" y="105" type="curve" smooth="yes"/>
-      <point x="761" y="182"/>
-      <point x="712" y="233"/>
-      <point x="638" y="233" type="curve" smooth="yes"/>
-      <point x="586" y="233"/>
-      <point x="556" y="222"/>
-      <point x="442" y="162" type="curve" smooth="yes"/>
-      <point x="366" y="122" type="line" smooth="yes"/>
-      <point x="268" y="70"/>
-      <point x="244" y="61"/>
-      <point x="202" y="61" type="curve" smooth="yes"/>
-      <point x="155" y="61"/>
-      <point x="127" y="88"/>
-      <point x="127" y="133" type="curve" smooth="yes"/>
-      <point x="127" y="188"/>
-      <point x="170" y="215"/>
-      <point x="257" y="215" type="curve" smooth="yes"/>
-      <point x="507" y="215" type="line" smooth="yes"/>
-      <point x="671" y="215"/>
-      <point x="766" y="289"/>
-      <point x="766" y="416" type="curve" smooth="yes"/>
-      <point x="766" y="525"/>
-      <point x="695" y="596"/>
-      <point x="587" y="596" type="curve" smooth="yes"/>
-      <point x="505" y="596"/>
-      <point x="442" y="551"/>
-      <point x="424" y="478" type="curve"/>
-      <point x="419" y="478" type="line"/>
-      <point x="398" y="550"/>
-      <point x="337" y="596"/>
-      <point x="240" y="596" type="curve" smooth="yes"/>
-      <point x="123" y="596"/>
-      <point x="42" y="526"/>
-      <point x="42" y="432" type="curve" smooth="yes"/>
-      <point x="42" y="351"/>
-      <point x="100" y="294"/>
-      <point x="183" y="294" type="curve" smooth="yes"/>
-      <point x="264" y="294"/>
-      <point x="319" y="340"/>
-      <point x="319" y="409" type="curve" smooth="yes"/>
-      <point x="319" y="477"/>
-      <point x="281" y="515"/>
-      <point x="215" y="515" type="curve" smooth="yes"/>
-      <point x="190" y="515"/>
-      <point x="166" y="510"/>
-      <point x="144" y="500" type="curve"/>
-      <point x="128" y="522" type="line"/>
-      <point x="137" y="498" type="line"/>
-      <point x="161" y="523"/>
-      <point x="197" y="536"/>
-      <point x="240" y="536" type="curve" smooth="yes"/>
-      <point x="333" y="536"/>
-      <point x="378" y="475"/>
-      <point x="378" y="380" type="curve" smooth="yes"/>
-      <point x="378" y="343" type="line"/>
-      <point x="462" y="343" type="line"/>
-      <point x="462" y="376" type="line" smooth="yes"/>
-      <point x="462" y="462"/>
-      <point x="511" y="518"/>
-      <point x="586" y="518" type="curve" smooth="yes"/>
-      <point x="648" y="518"/>
-      <point x="684" y="480"/>
-      <point x="684" y="413" type="curve" smooth="yes"/>
-      <point x="684" y="333"/>
-      <point x="625" y="287"/>
-      <point x="523" y="287" type="curve" smooth="yes"/>
-      <point x="254" y="287" type="line" smooth="yes"/>
-      <point x="126" y="287"/>
-      <point x="48" y="229"/>
-      <point x="48" y="133" type="curve" smooth="yes"/>
-      <point x="48" y="39"/>
-      <point x="104" y="-16"/>
+      <point x="202" y="-16" type="curve" smooth="yes"/>
+      <point x="252" y="-16"/>
+      <point x="287" y="-5"/>
+      <point x="371" y="36" type="curve" smooth="yes"/>
+      <point x="491" y="95" type="line"/>
+      <point x="560" y="138" type="line"/>
+      <point x="592" y="146" type="line"/>
+      <point x="616" y="168"/>
+      <point x="639" y="176"/>
+      <point x="668" y="176" type="curve" smooth="yes"/>
+      <point x="707" y="176"/>
+      <point x="730" y="154"/>
+      <point x="730" y="115" type="curve" smooth="yes"/>
+      <point x="730" y="78"/>
+      <point x="705" y="54"/>
+      <point x="667" y="54" type="curve" smooth="yes"/>
+      <point x="629" y="54"/>
+      <point x="603" y="79"/>
+      <point x="603" y="115" type="curve" smooth="yes"/>
+      <point x="603" y="143"/>
+      <point x="617" y="168"/>
+      <point x="640" y="181" type="curve"/>
+      <point x="533" y="145" type="line"/>
+      <point x="552" y="128" type="line"/>
+      <point x="548" y="116"/>
+      <point x="547" y="106"/>
+      <point x="547" y="94" type="curve" smooth="yes"/>
+      <point x="547" y="32"/>
+      <point x="598" y="-16"/>
+      <point x="672" y="-16" type="curve" smooth="yes"/>
+      <point x="753" y="-16"/>
+      <point x="804" y="38"/>
+      <point x="804" y="114" type="curve" smooth="yes"/>
+      <point x="804" y="185"/>
+      <point x="753" y="236"/>
+      <point x="674" y="236" type="curve" smooth="yes"/>
+      <point x="635" y="236"/>
+      <point x="590" y="220"/>
+      <point x="516" y="184" type="curve" smooth="yes"/>
+      <point x="343" y="99" type="line" smooth="yes"/>
+      <point x="285" y="71"/>
+      <point x="248" y="60"/>
+      <point x="206" y="60" type="curve" smooth="yes"/>
+      <point x="159" y="60"/>
+      <point x="128" y="85"/>
+      <point x="128" y="125" type="curve" smooth="yes"/>
+      <point x="128" y="170"/>
+      <point x="163" y="195"/>
+      <point x="225" y="195" type="curve" smooth="yes"/>
+      <point x="537" y="195" type="line" smooth="yes"/>
+      <point x="702" y="195"/>
+      <point x="808" y="277"/>
+      <point x="808" y="405" type="curve" smooth="yes"/>
+      <point x="808" y="521"/>
+      <point x="738" y="596"/>
+      <point x="625" y="596" type="curve" smooth="yes"/>
+      <point x="536" y="596"/>
+      <point x="472" y="552"/>
+      <point x="440" y="478" type="curve"/>
+      <point x="435" y="478" type="line"/>
+      <point x="409" y="553"/>
+      <point x="350" y="596"/>
+      <point x="255" y="596" type="curve" smooth="yes"/>
+      <point x="137" y="596"/>
+      <point x="42" y="525"/>
+      <point x="42" y="420" type="curve" smooth="yes"/>
+      <point x="42" y="332"/>
+      <point x="101" y="273"/>
+      <point x="190" y="273" type="curve" smooth="yes"/>
+      <point x="271" y="273"/>
+      <point x="327" y="324"/>
+      <point x="327" y="401" type="curve" smooth="yes"/>
+      <point x="327" y="470"/>
+      <point x="285" y="515"/>
+      <point x="214" y="515" type="curve" smooth="yes"/>
+      <point x="188" y="515"/>
+      <point x="165" y="510"/>
+      <point x="143" y="499" type="curve"/>
+      <point x="128" y="523" type="line"/>
+      <point x="128" y="491" type="line"/>
+      <point x="158" y="520"/>
+      <point x="198" y="536"/>
+      <point x="255" y="536" type="curve" smooth="yes"/>
+      <point x="351" y="536"/>
+      <point x="394" y="484"/>
+      <point x="394" y="382" type="curve" smooth="yes"/>
+      <point x="394" y="324" type="line"/>
+      <point x="478" y="324" type="line"/>
+      <point x="478" y="380" type="line" smooth="yes"/>
+      <point x="478" y="469"/>
+      <point x="531" y="518"/>
+      <point x="612" y="518" type="curve" smooth="yes"/>
+      <point x="685" y="518"/>
+      <point x="726" y="475"/>
+      <point x="726" y="403" type="curve" smooth="yes"/>
+      <point x="726" y="316"/>
+      <point x="663" y="267"/>
+      <point x="547" y="267" type="curve" smooth="yes"/>
+      <point x="222" y="267" type="line" smooth="yes"/>
+      <point x="119" y="267"/>
+      <point x="46" y="212"/>
+      <point x="46" y="122" type="curve" smooth="yes"/>
+      <point x="46" y="41"/>
+      <point x="112" y="-16"/>
     </contour>
     <contour>
-      <point x="184" y="357" type="curve" smooth="yes"/>
-      <point x="141" y="357"/>
-      <point x="118" y="384"/>
-      <point x="118" y="433" type="curve" smooth="yes"/>
-      <point x="118" y="449"/>
-      <point x="120" y="460"/>
+      <point x="185" y="341" type="curve" smooth="yes"/>
+      <point x="139" y="341"/>
+      <point x="110" y="370"/>
+      <point x="110" y="416" type="curve" smooth="yes"/>
+      <point x="110" y="439"/>
+      <point x="114" y="454"/>
       <point x="126" y="475" type="curve"/>
-      <point x="107" y="475" type="line"/>
+      <point x="98" y="475" type="line"/>
       <point x="90" y="427" type="line"/>
-      <point x="117" y="454"/>
-      <point x="151" y="467"/>
-      <point x="189" y="467" type="curve" smooth="yes"/>
-      <point x="225" y="467"/>
-      <point x="247" y="447"/>
-      <point x="247" y="413" type="curve" smooth="yes"/>
-      <point x="247" y="378"/>
-      <point x="224" y="357"/>
+      <point x="113" y="453"/>
+      <point x="148" y="467"/>
+      <point x="183" y="467" type="curve" smooth="yes"/>
+      <point x="228" y="467"/>
+      <point x="251" y="442"/>
+      <point x="251" y="403" type="curve" smooth="yes"/>
+      <point x="251" y="366"/>
+      <point x="227" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
+  <anchor x="440" y="0" name="bottom"/>
+  <anchor x="425" y="580" name="top"/>
+  <anchor x="709" y="580" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="687"/>
+    <component base="halant-malayalam" xOffset="709"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="808"/>
-  <guideline x="48" y="133" angle="91.1496"/>
-  <guideline x="766" y="416" angle="269.0789"/>
+  <advance width="850"/>
+  <anchor x="440" y="0" name="bottom"/>
+  <anchor x="425" y="580" name="top"/>
+  <anchor x="709" y="580" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="419"/>
+    <component base="lVocalicMatra-malayalam" xOffset="440"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="808"/>
-  <guideline x="48" y="133" angle="91.1496"/>
-  <guideline x="766" y="416" angle="269.0789"/>
+  <advance width="850"/>
+  <anchor x="440" y="0" name="bottom"/>
+  <anchor x="425" y="580" name="top"/>
+  <anchor x="709" y="580" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="419"/>
+    <component base="llVocalicMatra-malayalam" xOffset="440"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/kC_hillu-malayalam.glif
@@ -2,96 +2,95 @@
 <glyph name="kChillu-malayalam" format="2">
   <advance width="1040"/>
   <unicode hex="0D7F"/>
-  <guideline x="1011"/>
   <anchor x="644" y="0" name="bottom"/>
   <anchor x="367" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="397" y="22"/>
+      <point x="457" y="-16"/>
       <point x="532" y="-16" type="curve" smooth="yes"/>
       <point x="600" y="-16"/>
-      <point x="651" y="25"/>
-      <point x="679" y="85" type="curve"/>
-      <point x="686" y="85" type="line"/>
-      <point x="709" y="28"/>
-      <point x="763" y="-16"/>
-      <point x="848" y="-16" type="curve" smooth="yes"/>
-      <point x="941" y="-16"/>
-      <point x="1011" y="44"/>
-      <point x="1011" y="150" type="curve" smooth="yes"/>
-      <point x="1011" y="252"/>
-      <point x="937" y="324"/>
-      <point x="803" y="324" type="curve" smooth="yes"/>
-      <point x="766" y="324" type="line"/>
-      <point x="732" y="250" type="line"/>
-      <point x="807" y="250" type="line" smooth="yes"/>
-      <point x="896" y="250"/>
-      <point x="926" y="207"/>
-      <point x="926" y="154" type="curve" smooth="yes"/>
-      <point x="926" y="99"/>
-      <point x="899" y="62"/>
-      <point x="840" y="62" type="curve" smooth="yes"/>
-      <point x="780" y="62"/>
-      <point x="738" y="107"/>
-      <point x="738" y="180" type="curve" smooth="yes"/>
-      <point x="738" y="256"/>
-      <point x="781" y="328"/>
+      <point x="653" y="22"/>
+      <point x="683" y="85" type="curve"/>
+      <point x="690" y="85" type="line"/>
+      <point x="715" y="21"/>
+      <point x="772" y="-16"/>
+      <point x="846" y="-16" type="curve" smooth="yes"/>
+      <point x="946" y="-16"/>
+      <point x="1011" y="52"/>
+      <point x="1011" y="156" type="curve" smooth="yes"/>
+      <point x="1011" y="272"/>
+      <point x="931" y="344"/>
+      <point x="803" y="344" type="curve" smooth="yes"/>
+      <point x="766" y="344" type="line"/>
+      <point x="732" y="270" type="line"/>
+      <point x="807" y="270" type="line" smooth="yes"/>
+      <point x="885" y="270"/>
+      <point x="926" y="232"/>
+      <point x="926" y="160" type="curve" smooth="yes"/>
+      <point x="926" y="100"/>
+      <point x="892" y="62"/>
+      <point x="839" y="62" type="curve" smooth="yes"/>
+      <point x="777" y="62"/>
+      <point x="738" y="103"/>
+      <point x="738" y="170" type="curve" smooth="yes"/>
+      <point x="738" y="248"/>
+      <point x="762" y="305"/>
       <point x="845" y="426" type="curve" smooth="yes"/>
-      <point x="898" y="508"/>
-      <point x="924" y="554"/>
+      <point x="906" y="515"/>
+      <point x="924" y="561"/>
       <point x="924" y="632" type="curve" smooth="yes"/>
-      <point x="924" y="718"/>
-      <point x="873" y="789"/>
+      <point x="924" y="728"/>
+      <point x="863" y="789"/>
       <point x="768" y="789" type="curve" smooth="yes"/>
-      <point x="710" y="789"/>
-      <point x="661" y="774"/>
+      <point x="708" y="789"/>
+      <point x="660" y="773"/>
       <point x="609" y="737" type="curve"/>
       <point x="647" y="670" type="line"/>
-      <point x="682" y="695"/>
-      <point x="719" y="710"/>
+      <point x="685" y="697"/>
+      <point x="722" y="710"/>
       <point x="762" y="710" type="curve" smooth="yes"/>
-      <point x="821" y="710"/>
-      <point x="841" y="676"/>
+      <point x="814" y="710"/>
+      <point x="841" y="683"/>
       <point x="841" y="632" type="curve" smooth="yes"/>
-      <point x="841" y="583"/>
-      <point x="820" y="536"/>
+      <point x="841" y="586"/>
+      <point x="823" y="542"/>
       <point x="771" y="455" type="curve" smooth="yes"/>
-      <point x="753" y="425"/>
-      <point x="738" y="400"/>
+      <point x="746" y="413"/>
+      <point x="736" y="393"/>
       <point x="728" y="368" type="curve"/>
       <point x="722" y="368" type="line"/>
-      <point x="711" y="499"/>
-      <point x="648" y="596"/>
+      <point x="710" y="511"/>
+      <point x="639" y="596"/>
       <point x="531" y="596" type="curve" smooth="yes"/>
-      <point x="394" y="596"/>
-      <point x="317" y="479"/>
+      <point x="398" y="596"/>
+      <point x="317" y="485"/>
       <point x="317" y="302" type="curve" smooth="yes"/>
-      <point x="317" y="279"/>
-      <point x="320" y="239"/>
-      <point x="320" y="215" type="curve" smooth="yes"/>
-      <point x="320" y="121"/>
-      <point x="276" y="62"/>
-      <point x="205" y="62" type="curve" smooth="yes"/>
-      <point x="144" y="62"/>
-      <point x="110" y="95"/>
-      <point x="110" y="153" type="curve" smooth="yes"/>
-      <point x="110" y="211"/>
-      <point x="147" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="698" y="250" type="line"/>
-      <point x="705" y="324" type="line"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="317" y="276"/>
+      <point x="322" y="236"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="698" y="270" type="line"/>
+      <point x="705" y="344" type="line"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/k_ka-malayalam.glif
@@ -1,102 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ka-malayalam" format="2">
   <advance width="1437"/>
-  <guideline x="1394"/>
   <anchor x="1027" y="0" name="bottom"/>
   <anchor x="810" y="580" name="top"/>
   <anchor x="1309" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="940" y="250" type="line" smooth="yes"/>
-      <point x="1038" y="250"/>
-      <point x="1063" y="201"/>
-      <point x="1063" y="140" type="curve" smooth="yes"/>
-      <point x="1063" y="86"/>
-      <point x="1038" y="62"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="942" y="270" type="line" smooth="yes"/>
+      <point x="1030" y="270"/>
+      <point x="1073" y="233"/>
+      <point x="1073" y="156" type="curve" smooth="yes"/>
+      <point x="1073" y="94"/>
+      <point x="1047" y="62"/>
       <point x="998" y="62" type="curve" smooth="yes"/>
-      <point x="924" y="62"/>
-      <point x="899" y="146"/>
-      <point x="899" y="241" type="curve" smooth="yes"/>
-      <point x="899" y="405"/>
-      <point x="967" y="517"/>
+      <point x="933" y="62"/>
+      <point x="899" y="120"/>
+      <point x="899" y="231" type="curve" smooth="yes"/>
+      <point x="899" y="416"/>
+      <point x="975" y="517"/>
       <point x="1116" y="517" type="curve" smooth="yes"/>
-      <point x="1248" y="517"/>
-      <point x="1313" y="416"/>
+      <point x="1240" y="517"/>
+      <point x="1313" y="428"/>
       <point x="1313" y="278" type="curve" smooth="yes"/>
-      <point x="1313" y="186"/>
-      <point x="1280" y="106"/>
+      <point x="1313" y="192"/>
+      <point x="1284" y="111"/>
       <point x="1225" y="34" type="curve"/>
       <point x="1291" y="-16" type="line"/>
-      <point x="1362" y="68"/>
-      <point x="1395" y="174"/>
+      <point x="1358" y="63"/>
+      <point x="1395" y="167"/>
       <point x="1395" y="277" type="curve" smooth="yes"/>
-      <point x="1395" y="470"/>
-      <point x="1292" y="596"/>
+      <point x="1395" y="475"/>
+      <point x="1290" y="596"/>
       <point x="1118" y="596" type="curve" smooth="yes"/>
-      <point x="928" y="596"/>
-      <point x="817" y="449"/>
-      <point x="817" y="238" type="curve" smooth="yes"/>
-      <point x="817" y="116"/>
-      <point x="866" y="-16"/>
-      <point x="1001" y="-16" type="curve" smooth="yes"/>
-      <point x="1099" y="-16"/>
-      <point x="1145" y="53"/>
-      <point x="1145" y="140" type="curve" smooth="yes"/>
-      <point x="1145" y="234"/>
-      <point x="1098" y="324"/>
-      <point x="936" y="324" type="curve" smooth="yes"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="932" y="596"/>
+      <point x="817" y="455"/>
+      <point x="817" y="228" type="curve" smooth="yes"/>
+      <point x="817" y="78"/>
+      <point x="887" y="-16"/>
+      <point x="999" y="-16" type="curve" smooth="yes"/>
+      <point x="1095" y="-16"/>
+      <point x="1155" y="50"/>
+      <point x="1155" y="156" type="curve" smooth="yes"/>
+      <point x="1155" y="278"/>
+      <point x="1079" y="344"/>
+      <point x="940" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/k_la-malayalam.glif
@@ -54,29 +54,29 @@
       <point x="744" y="153"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="805" y="250" type="line" smooth="yes"/>
-      <point x="883" y="250"/>
-      <point x="924" y="215"/>
-      <point x="924" y="153" type="curve" smooth="yes"/>
-      <point x="924" y="95"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="799" y="270" type="line" smooth="yes"/>
+      <point x="881" y="270"/>
+      <point x="924" y="233"/>
+      <point x="924" y="164" type="curve" smooth="yes"/>
+      <point x="924" y="99"/>
       <point x="891" y="62"/>
       <point x="835" y="62" type="curve" smooth="yes"/>
       <point x="818" y="62"/>
@@ -87,23 +87,23 @@
       <point x="809" y="-16"/>
       <point x="838" y="-16" type="curve" smooth="yes"/>
       <point x="937" y="-16"/>
-      <point x="1006" y="51"/>
-      <point x="1006" y="151" type="curve" smooth="yes"/>
-      <point x="1006" y="257"/>
-      <point x="927" y="324"/>
-      <point x="799" y="324" type="curve" smooth="yes"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="375" y="68"/>
+      <point x="1006" y="55"/>
+      <point x="1006" y="162" type="curve" smooth="yes"/>
+      <point x="1006" y="274"/>
+      <point x="930" y="344"/>
+      <point x="797" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="375" y="69"/>
       <point x="392" y="48"/>
       <point x="413" y="31" type="curve"/>
       <point x="413" y="23" type="line"/>
@@ -131,19 +131,19 @@
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.glif
@@ -1,48 +1,47 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam" format="2">
   <advance width="1702"/>
-  <guideline x="1626"/>
   <anchor x="1259" y="0" name="bottom"/>
   <anchor x="876" y="580" name="top"/>
   <anchor x="1581" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="156" type="curve" smooth="yes"/>
-      <point x="111" y="217"/>
-      <point x="148" y="256"/>
-      <point x="235" y="256" type="curve" smooth="yes"/>
-      <point x="814" y="256" type="line" smooth="yes"/>
-      <point x="895" y="256"/>
-      <point x="924" y="221"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="799" y="270" type="line" smooth="yes"/>
+      <point x="881" y="270"/>
+      <point x="924" y="236"/>
       <point x="924" y="172" type="curve" smooth="yes"/>
-      <point x="924" y="129"/>
-      <point x="901" y="95"/>
+      <point x="924" y="134"/>
+      <point x="906" y="100"/>
       <point x="862" y="56" type="curve"/>
       <point x="881" y="0" type="line"/>
       <point x="1625" y="0" type="line"/>
@@ -51,26 +50,26 @@
       <point x="1500" y="402"/>
       <point x="1392" y="312"/>
       <point x="1254" y="312" type="curve" smooth="yes"/>
-      <point x="1157" y="312"/>
-      <point x="1102" y="363"/>
+      <point x="1161" y="312"/>
+      <point x="1102" y="360"/>
       <point x="1102" y="436" type="curve" smooth="yes"/>
       <point x="1102" y="486"/>
       <point x="1131" y="518"/>
       <point x="1178" y="518" type="curve" smooth="yes"/>
-      <point x="1226" y="518"/>
-      <point x="1252" y="482"/>
+      <point x="1225" y="518"/>
+      <point x="1252" y="484"/>
       <point x="1252" y="425" type="curve" smooth="yes"/>
       <point x="1252" y="61" type="line"/>
       <point x="1334" y="61" type="line"/>
       <point x="1334" y="431" type="line" smooth="yes"/>
-      <point x="1334" y="529"/>
-      <point x="1279" y="596"/>
+      <point x="1334" y="532"/>
+      <point x="1276" y="596"/>
       <point x="1183" y="596" type="curve" smooth="yes"/>
-      <point x="1084" y="596"/>
-      <point x="1020" y="526"/>
+      <point x="1087" y="596"/>
+      <point x="1020" y="529"/>
       <point x="1020" y="435" type="curve" smooth="yes"/>
-      <point x="1020" y="320"/>
-      <point x="1113" y="236"/>
+      <point x="1020" y="317"/>
+      <point x="1116" y="236"/>
       <point x="1256" y="236" type="curve" smooth="yes"/>
       <point x="1366" y="236"/>
       <point x="1464" y="289"/>
@@ -80,34 +79,34 @@
       <point x="1581" y="74" type="line"/>
       <point x="967" y="74" type="line"/>
       <point x="965" y="79" type="line"/>
-      <point x="996" y="114"/>
-      <point x="1006" y="152"/>
+      <point x="991" y="108"/>
+      <point x="1006" y="145"/>
       <point x="1006" y="180" type="curve" smooth="yes"/>
-      <point x="1006" y="267"/>
-      <point x="949" y="330"/>
-      <point x="810" y="330" type="curve" smooth="yes"/>
-      <point x="237" y="330" type="line" smooth="yes"/>
-      <point x="99" y="330"/>
-      <point x="29" y="260"/>
-      <point x="29" y="151" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="1006" y="281"/>
+      <point x="930" y="344"/>
+      <point x="797" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam.half" format="2">
   <advance width="1702"/>
+  <anchor x="1259" y="0" name="bottom"/>
+  <anchor x="876" y="580" name="top"/>
+  <anchor x="1581" y="580" name="topright"/>
   <outline>
     <component base="k_ssa-malayalam"/>
     <component base="halant-malayalam" xOffset="1581"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/k_ta-malayalam.glif
@@ -58,60 +58,60 @@
       <point x="896" y="73"/>
     </contour>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="882" y="250" type="line"/>
-      <point x="882" y="324" type="line"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="898" y="270" type="line"/>
+      <point x="898" y="344" type="line"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/k_tta-malayalam.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_tta-malayalam" format="2">
   <advance width="1035"/>
-  <guideline x="1006" y="158" angle="90"/>
   <anchor x="840" y="-351" name="bottom"/>
   <anchor x="532" y="580" name="top"/>
   <anchor x="879" y="540" name="topright"/>
@@ -29,54 +28,54 @@
       <point x="964" y="22"/>
       <point x="945" y="27" type="curve"/>
       <point x="945" y="35" type="line"/>
-      <point x="984" y="59"/>
-      <point x="1006" y="104"/>
-      <point x="1006" y="158" type="curve" smooth="yes"/>
-      <point x="1006" y="265"/>
-      <point x="927" y="324"/>
-      <point x="799" y="324" type="curve" smooth="yes"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="984" y="62"/>
+      <point x="1006" y="111"/>
+      <point x="1006" y="169" type="curve" smooth="yes"/>
+      <point x="1006" y="278"/>
+      <point x="928" y="344"/>
+      <point x="799" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="805" y="250" type="line" smooth="yes"/>
-      <point x="883" y="250"/>
-      <point x="924" y="215"/>
-      <point x="924" y="153" type="curve" smooth="yes"/>
-      <point x="924" y="95"/>
-      <point x="894" y="62"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="799" y="270" type="line" smooth="yes"/>
+      <point x="881" y="270"/>
+      <point x="924" y="233"/>
+      <point x="924" y="165" type="curve" smooth="yes"/>
+      <point x="924" y="98"/>
+      <point x="892" y="62"/>
       <point x="835" y="62" type="curve" smooth="yes"/>
       <point x="818" y="62"/>
       <point x="799" y="64"/>
@@ -105,19 +104,19 @@
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ka-malayalam.glif
@@ -7,78 +7,78 @@
   <anchor x="879" y="540" name="topright"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="805" y="250" type="line" smooth="yes"/>
-      <point x="883" y="250"/>
-      <point x="924" y="215"/>
-      <point x="924" y="153" type="curve" smooth="yes"/>
-      <point x="924" y="95"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="799" y="270" type="line" smooth="yes"/>
+      <point x="881" y="270"/>
+      <point x="924" y="233"/>
+      <point x="924" y="164" type="curve" smooth="yes"/>
+      <point x="924" y="99"/>
       <point x="891" y="62"/>
       <point x="835" y="62" type="curve" smooth="yes"/>
-      <point x="818" y="62"/>
-      <point x="799" y="64"/>
+      <point x="815" y="62"/>
+      <point x="797" y="65"/>
       <point x="783" y="70" type="curve"/>
       <point x="762" y="-5" type="line"/>
-      <point x="785" y="-12"/>
-      <point x="809" y="-16"/>
+      <point x="787" y="-13"/>
+      <point x="811" y="-16"/>
       <point x="838" y="-16" type="curve" smooth="yes"/>
-      <point x="937" y="-16"/>
-      <point x="1006" y="51"/>
-      <point x="1006" y="151" type="curve" smooth="yes"/>
-      <point x="1006" y="257"/>
-      <point x="927" y="324"/>
-      <point x="799" y="324" type="curve" smooth="yes"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="938" y="-16"/>
+      <point x="1006" y="56"/>
+      <point x="1006" y="162" type="curve" smooth="yes"/>
+      <point x="1006" y="274"/>
+      <point x="930" y="344"/>
+      <point x="797" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/m_la-malayalam.glif
@@ -6,51 +6,7 @@
   <anchor x="567" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="120" y="-367" type="curve" smooth="yes"/>
-      <point x="202" y="-367"/>
-      <point x="250" y="-317"/>
-      <point x="250" y="-238" type="curve" smooth="yes"/>
-      <point x="250" y="-160"/>
-      <point x="206" y="-118"/>
-      <point x="136" y="-118" type="curve" smooth="yes"/>
-      <point x="81" y="-118"/>
-      <point x="21" y="-151"/>
-      <point x="21" y="-236" type="curve"/>
-      <point x="49" y="-169" type="line"/>
-      <point x="-10" y="-166" type="line"/>
-      <point x="31" y="-195" type="line"/>
-      <point x="31" y="-89"/>
-      <point x="81" y="-27"/>
-      <point x="177" y="-27" type="curve" smooth="yes"/>
-      <point x="273" y="-27"/>
-      <point x="310" y="-89"/>
-      <point x="329" y="-164" type="curve" smooth="yes"/>
-      <point x="339" y="-203" type="line" smooth="yes"/>
-      <point x="367" y="-311"/>
-      <point x="420" y="-367"/>
-      <point x="519" y="-367" type="curve" smooth="yes"/>
-      <point x="613" y="-367"/>
-      <point x="679" y="-308"/>
-      <point x="679" y="-182" type="curve" smooth="yes"/>
-      <point x="679" y="-85"/>
-      <point x="646" y="-12"/>
-      <point x="596" y="43" type="curve"/>
-      <point x="537" y="3" type="line"/>
-      <point x="577" y="-44"/>
-      <point x="605" y="-101"/>
-      <point x="605" y="-182" type="curve" smooth="yes"/>
-      <point x="605" y="-251"/>
-      <point x="578" y="-297"/>
-      <point x="518" y="-297" type="curve" smooth="yes"/>
-      <point x="463" y="-297"/>
-      <point x="433" y="-261"/>
-      <point x="411" y="-182" type="curve" smooth="yes"/>
-      <point x="399" y="-139" type="line" smooth="yes"/>
-      <point x="384" y="-84"/>
-      <point x="363" y="-33"/>
-      <point x="322" y="-5" type="curve"/>
-      <point x="323" y="0" type="line"/>
-      <point x="583" y="0" type="line"/>
+      <point x="51" y="0" type="line"/>
       <point x="617" y="0" type="line"/>
       <point x="617" y="324" type="line" smooth="yes"/>
       <point x="617" y="481"/>
@@ -59,29 +15,72 @@
       <point x="157" y="596"/>
       <point x="51" y="480"/>
       <point x="51" y="323" type="curve" smooth="yes"/>
-      <point x="51" y="0" type="line"/>
-      <point x="97" y="30" type="line"/>
-      <point x="13" y="-1"/>
-      <point x="-37" y="-79"/>
-      <point x="-37" y="-181" type="curve" smooth="yes"/>
-      <point x="-37" y="-305"/>
-      <point x="35" y="-367"/>
     </contour>
     <contour>
-      <point x="117" y="-302" type="curve" smooth="yes"/>
-      <point x="59" y="-302"/>
-      <point x="32" y="-253"/>
-      <point x="32" y="-197" type="curve"/>
-      <point x="12" y="-205" type="line"/>
-      <point x="33" y="-262" type="line"/>
-      <point x="33" y="-218"/>
-      <point x="65" y="-178"/>
-      <point x="119" y="-178" type="curve" smooth="yes"/>
-      <point x="160" y="-178"/>
-      <point x="180" y="-203"/>
-      <point x="180" y="-238" type="curve" smooth="yes"/>
-      <point x="180" y="-276"/>
-      <point x="159" y="-302"/>
+      <point x="185" y="-367" type="curve" smooth="yes"/>
+      <point x="264" y="-367"/>
+      <point x="312" y="-317"/>
+      <point x="312" y="-235" type="curve" smooth="yes"/>
+      <point x="312" y="-157"/>
+      <point x="271" y="-109"/>
+      <point x="206" y="-109" type="curve" smooth="yes"/>
+      <point x="140" y="-109"/>
+      <point x="93" y="-162"/>
+      <point x="93" y="-236" type="curve"/>
+      <point x="117" y="-169" type="line"/>
+      <point x="58" y="-169" type="line"/>
+      <point x="95" y="-195" type="line"/>
+      <point x="95" y="-87"/>
+      <point x="148" y="-23"/>
+      <point x="233" y="-23" type="curve" smooth="yes"/>
+      <point x="304" y="-23"/>
+      <point x="343" y="-66"/>
+      <point x="357" y="-152" type="curve" smooth="yes"/>
+      <point x="369" y="-225" type="line" smooth="yes"/>
+      <point x="385" y="-320"/>
+      <point x="430" y="-367"/>
+      <point x="506" y="-367" type="curve" smooth="yes"/>
+      <point x="593" y="-367"/>
+      <point x="643" y="-306"/>
+      <point x="643" y="-199" type="curve" smooth="yes"/>
+      <point x="643" y="-105"/>
+      <point x="613" y="-23"/>
+      <point x="553" y="49" type="curve"/>
+      <point x="498" y="6" type="line"/>
+      <point x="547" y="-52"/>
+      <point x="569" y="-116"/>
+      <point x="569" y="-197" type="curve" smooth="yes"/>
+      <point x="569" y="-263"/>
+      <point x="548" y="-297"/>
+      <point x="508" y="-297" type="curve" smooth="yes"/>
+      <point x="470" y="-297"/>
+      <point x="450" y="-268"/>
+      <point x="438" y="-198" type="curve" smooth="yes"/>
+      <point x="426" y="-125" type="line" smooth="yes"/>
+      <point x="409" y="-23"/>
+      <point x="345" y="37"/>
+      <point x="235" y="37" type="curve" smooth="yes"/>
+      <point x="110" y="37"/>
+      <point x="31" y="-51"/>
+      <point x="31" y="-183" type="curve" smooth="yes"/>
+      <point x="31" y="-293"/>
+      <point x="93" y="-367"/>
+    </contour>
+    <contour>
+      <point x="181" y="-303" type="curve" smooth="yes"/>
+      <point x="126" y="-303"/>
+      <point x="100" y="-254"/>
+      <point x="100" y="-197" type="curve"/>
+      <point x="80" y="-205" type="line"/>
+      <point x="101" y="-262" type="line"/>
+      <point x="101" y="-212"/>
+      <point x="132" y="-167"/>
+      <point x="183" y="-167" type="curve" smooth="yes"/>
+      <point x="220" y="-167"/>
+      <point x="242" y="-192"/>
+      <point x="242" y="-235" type="curve" smooth="yes"/>
+      <point x="242" y="-278"/>
+      <point x="219" y="-303"/>
     </contour>
     <contour>
       <point x="101" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ng_ka-malayalam.glif
@@ -6,98 +6,98 @@
   <anchor x="860" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="203" y="-16" type="curve" smooth="yes"/>
-      <point x="281" y="-16"/>
-      <point x="337" y="27"/>
-      <point x="362" y="92" type="curve"/>
-      <point x="367" y="92" type="line"/>
-      <point x="402" y="23"/>
-      <point x="461" y="-16"/>
+      <point x="211" y="-16" type="curve" smooth="yes"/>
+      <point x="280" y="-16"/>
+      <point x="336" y="25"/>
+      <point x="362" y="93" type="curve"/>
+      <point x="367" y="93" type="line"/>
+      <point x="404" y="21"/>
+      <point x="463" y="-16"/>
       <point x="540" y="-16" type="curve" smooth="yes"/>
-      <point x="676" y="-16"/>
-      <point x="749" y="106"/>
+      <point x="669" y="-16"/>
+      <point x="749" y="96"/>
       <point x="749" y="278" type="curve" smooth="yes"/>
       <point x="749" y="302" type="line" smooth="yes"/>
-      <point x="749" y="473"/>
-      <point x="680" y="596"/>
+      <point x="749" y="487"/>
+      <point x="670" y="596"/>
       <point x="537" y="596" type="curve" smooth="yes"/>
-      <point x="456" y="596"/>
-      <point x="398" y="554"/>
+      <point x="459" y="596"/>
+      <point x="399" y="557"/>
       <point x="367" y="484" type="curve"/>
       <point x="362" y="484" type="line"/>
-      <point x="340" y="549"/>
-      <point x="289" y="596"/>
-      <point x="205" y="596" type="curve" smooth="yes"/>
-      <point x="98" y="596"/>
-      <point x="41" y="527"/>
-      <point x="41" y="441" type="curve" smooth="yes"/>
-      <point x="41" y="376"/>
-      <point x="76" y="318"/>
-      <point x="134" y="292" type="curve"/>
-      <point x="134" y="287" type="line"/>
-      <point x="73" y="265"/>
-      <point x="34" y="214"/>
-      <point x="34" y="145" type="curve" smooth="yes"/>
-      <point x="34" y="46"/>
-      <point x="99" y="-16"/>
+      <point x="337" y="556"/>
+      <point x="281" y="596"/>
+      <point x="203" y="596" type="curve" smooth="yes"/>
+      <point x="107" y="596"/>
+      <point x="41" y="535"/>
+      <point x="41" y="446" type="curve" smooth="yes"/>
+      <point x="41" y="388"/>
+      <point x="78" y="335"/>
+      <point x="134" y="313" type="curve"/>
+      <point x="134" y="308" type="line"/>
+      <point x="71" y="283"/>
+      <point x="34" y="226"/>
+      <point x="34" y="154" type="curve" smooth="yes"/>
+      <point x="34" y="54"/>
+      <point x="106" y="-16"/>
     </contour>
     <contour>
       <point x="843" y="-16" type="curve" smooth="yes"/>
-      <point x="942" y="-16"/>
-      <point x="1011" y="51"/>
-      <point x="1011" y="151" type="curve" smooth="yes"/>
-      <point x="1011" y="257"/>
-      <point x="944" y="324"/>
-      <point x="804" y="324" type="curve" smooth="yes"/>
-      <point x="255" y="324" type="line" smooth="yes"/>
-      <point x="164" y="324"/>
-      <point x="123" y="373"/>
-      <point x="123" y="433" type="curve" smooth="yes"/>
-      <point x="123" y="482"/>
-      <point x="155" y="518"/>
-      <point x="215" y="518" type="curve" smooth="yes"/>
-      <point x="294" y="518"/>
-      <point x="326" y="459"/>
+      <point x="943" y="-16"/>
+      <point x="1011" y="56"/>
+      <point x="1011" y="162" type="curve" smooth="yes"/>
+      <point x="1011" y="276"/>
+      <point x="933" y="344"/>
+      <point x="802" y="344" type="curve" smooth="yes"/>
+      <point x="251" y="344" type="line" smooth="yes"/>
+      <point x="172" y="344"/>
+      <point x="123" y="379"/>
+      <point x="123" y="437" type="curve" smooth="yes"/>
+      <point x="123" y="486"/>
+      <point x="158" y="518"/>
+      <point x="213" y="518" type="curve" smooth="yes"/>
+      <point x="289" y="518"/>
+      <point x="326" y="467"/>
       <point x="326" y="363" type="curve" smooth="yes"/>
-      <point x="326" y="215" type="line" smooth="yes"/>
-      <point x="326" y="121"/>
-      <point x="284" y="62"/>
-      <point x="211" y="62" type="curve" smooth="yes"/>
-      <point x="150" y="62"/>
-      <point x="116" y="97"/>
-      <point x="116" y="153" type="curve" smooth="yes"/>
-      <point x="116" y="211"/>
-      <point x="153" y="250"/>
-      <point x="240" y="250" type="curve" smooth="yes"/>
-      <point x="810" y="250" type="line" smooth="yes"/>
-      <point x="892" y="250"/>
-      <point x="929" y="215"/>
-      <point x="929" y="153" type="curve" smooth="yes"/>
-      <point x="929" y="95"/>
+      <point x="326" y="203" type="line" smooth="yes"/>
+      <point x="326" y="113"/>
+      <point x="286" y="62"/>
+      <point x="216" y="62" type="curve" smooth="yes"/>
+      <point x="154" y="62"/>
+      <point x="116" y="99"/>
+      <point x="116" y="158" type="curve" smooth="yes"/>
+      <point x="116" y="231"/>
+      <point x="159" y="270"/>
+      <point x="240" y="270" type="curve" smooth="yes"/>
+      <point x="804" y="270" type="line" smooth="yes"/>
+      <point x="886" y="270"/>
+      <point x="929" y="233"/>
+      <point x="929" y="164" type="curve" smooth="yes"/>
+      <point x="929" y="99"/>
       <point x="896" y="62"/>
       <point x="840" y="62" type="curve" smooth="yes"/>
-      <point x="823" y="62"/>
-      <point x="804" y="64"/>
+      <point x="822" y="62"/>
+      <point x="804" y="65"/>
       <point x="788" y="70" type="curve"/>
       <point x="767" y="-5" type="line"/>
-      <point x="790" y="-12"/>
-      <point x="814" y="-16"/>
+      <point x="790" y="-13"/>
+      <point x="813" y="-16"/>
     </contour>
     <contour>
       <point x="538" y="62" type="curve" smooth="yes"/>
-      <point x="446" y="62"/>
-      <point x="405" y="146"/>
+      <point x="451" y="62"/>
+      <point x="405" y="138"/>
       <point x="405" y="280" type="curve" smooth="yes"/>
       <point x="405" y="300" type="line" smooth="yes"/>
-      <point x="405" y="427"/>
-      <point x="446" y="518"/>
+      <point x="405" y="439"/>
+      <point x="453" y="518"/>
       <point x="537" y="518" type="curve" smooth="yes"/>
-      <point x="629" y="518"/>
-      <point x="665" y="426"/>
+      <point x="620" y="518"/>
+      <point x="665" y="441"/>
       <point x="665" y="300" type="curve" smooth="yes"/>
       <point x="665" y="280" type="line" smooth="yes"/>
-      <point x="665" y="146"/>
-      <point x="626" y="62"/>
+      <point x="665" y="137"/>
+      <point x="621" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1518"/>
-  <anchor x="1129" y="0" name="bottom"/>
-  <anchor x="790" y="580" name="top"/>
-  <anchor x="1397" y="580" name="topright"/>
+  <advance width="1560"/>
+  <anchor x="1150" y="0" name="bottom"/>
+  <anchor x="780" y="580" name="top"/>
+  <anchor x="1419" y="580" name="topright"/>
   <outline>
     <contour>
       <point x="271" y="-16" type="curve" smooth="yes"/>
@@ -45,117 +45,117 @@
       <point x="811" y="529"/>
       <point x="816" y="529"/>
       <point x="833" y="527" type="curve"/>
-      <point x="789" y="570" type="line"/>
-      <point x="797" y="523" type="line"/>
-      <point x="766" y="496"/>
-      <point x="752" y="462"/>
-      <point x="752" y="427" type="curve" smooth="yes"/>
-      <point x="752" y="361"/>
-      <point x="807" y="309"/>
-      <point x="889" y="309" type="curve" smooth="yes"/>
-      <point x="982" y="309"/>
-      <point x="1029" y="362"/>
-      <point x="1029" y="435" type="curve" smooth="yes"/>
-      <point x="1029" y="462"/>
-      <point x="1015" y="503"/>
-      <point x="971" y="532" type="curve"/>
-      <point x="982" y="576" type="line"/>
-      <point x="888" y="538" type="line"/>
-      <point x="902" y="540"/>
-      <point x="915" y="540"/>
-      <point x="927" y="540" type="curve" smooth="yes"/>
-      <point x="1058" y="540"/>
-      <point x="1092" y="451"/>
-      <point x="1092" y="380" type="curve" smooth="yes"/>
-      <point x="1092" y="343" type="line"/>
-      <point x="1176" y="343" type="line"/>
-      <point x="1176" y="376" type="line" smooth="yes"/>
-      <point x="1176" y="467"/>
-      <point x="1229" y="518"/>
-      <point x="1298" y="518" type="curve" smooth="yes"/>
-      <point x="1360" y="518"/>
-      <point x="1394" y="478"/>
-      <point x="1394" y="413" type="curve" smooth="yes"/>
-      <point x="1394" y="349"/>
-      <point x="1356" y="283"/>
-      <point x="1233" y="283" type="curve" smooth="yes"/>
-      <point x="964" y="283" type="line" smooth="yes"/>
-      <point x="825" y="283"/>
-      <point x="758" y="221"/>
-      <point x="758" y="133" type="curve" smooth="yes"/>
-      <point x="758" y="54"/>
-      <point x="799" y="-16"/>
-      <point x="911" y="-16" type="curve" smooth="yes"/>
-      <point x="971" y="-16"/>
-      <point x="1021" y="4"/>
-      <point x="1106" y="54" type="curve" smooth="yes"/>
-      <point x="1169" y="91" type="line"/>
-      <point x="1256" y="142" type="line"/>
-      <point x="1272" y="148" type="line"/>
-      <point x="1304" y="163"/>
-      <point x="1322" y="167"/>
-      <point x="1344" y="167" type="curve" smooth="yes"/>
-      <point x="1385" y="167"/>
-      <point x="1405" y="147"/>
-      <point x="1405" y="106" type="curve" smooth="yes"/>
-      <point x="1405" y="70"/>
-      <point x="1383" y="48"/>
-      <point x="1348" y="48" type="curve" smooth="yes"/>
-      <point x="1312" y="48"/>
-      <point x="1292" y="70"/>
-      <point x="1292" y="110" type="curve" smooth="yes"/>
-      <point x="1292" y="137"/>
-      <point x="1301" y="159"/>
-      <point x="1325" y="185" type="curve"/>
-      <point x="1227" y="152" type="line"/>
-      <point x="1244" y="130" type="line"/>
-      <point x="1238" y="112"/>
-      <point x="1236" y="104"/>
-      <point x="1236" y="90" type="curve" smooth="yes"/>
-      <point x="1236" y="26"/>
-      <point x="1281" y="-16"/>
-      <point x="1350" y="-16" type="curve" smooth="yes"/>
-      <point x="1424" y="-16"/>
-      <point x="1471" y="31"/>
-      <point x="1471" y="105" type="curve" smooth="yes"/>
-      <point x="1471" y="182"/>
-      <point x="1422" y="233"/>
-      <point x="1348" y="233" type="curve" smooth="yes"/>
-      <point x="1296" y="233"/>
-      <point x="1266" y="222"/>
-      <point x="1152" y="162" type="curve" smooth="yes"/>
-      <point x="1076" y="122" type="line" smooth="yes"/>
-      <point x="993" y="78"/>
-      <point x="960" y="61"/>
-      <point x="912" y="61" type="curve" smooth="yes"/>
-      <point x="865" y="61"/>
-      <point x="837" y="88"/>
-      <point x="837" y="133" type="curve" smooth="yes"/>
-      <point x="837" y="183"/>
-      <point x="873" y="211"/>
-      <point x="967" y="211" type="curve" smooth="yes"/>
-      <point x="1217" y="211" type="line" smooth="yes"/>
-      <point x="1410" y="211"/>
-      <point x="1476" y="312"/>
-      <point x="1476" y="416" type="curve" smooth="yes"/>
-      <point x="1476" y="526"/>
-      <point x="1404" y="596"/>
-      <point x="1299" y="596" type="curve" smooth="yes"/>
-      <point x="1217" y="596"/>
-      <point x="1156" y="549"/>
-      <point x="1138" y="478" type="curve"/>
-      <point x="1133" y="478" type="line"/>
-      <point x="1111" y="549"/>
-      <point x="1038" y="596"/>
-      <point x="945" y="596" type="curve" smooth="yes"/>
-      <point x="911" y="596"/>
-      <point x="884" y="589"/>
-      <point x="863" y="578" type="curve"/>
-      <point x="895" y="578" type="line"/>
+      <point x="798" y="546" type="line"/>
+      <point x="803" y="524" type="line"/>
+      <point x="768" y="497"/>
+      <point x="748" y="460"/>
+      <point x="748" y="417" type="curve" smooth="yes"/>
+      <point x="748" y="339"/>
+      <point x="804" y="287"/>
+      <point x="890" y="287" type="curve" smooth="yes"/>
+      <point x="975" y="287"/>
+      <point x="1032" y="340"/>
+      <point x="1032" y="417" type="curve" smooth="yes"/>
+      <point x="1032" y="463"/>
+      <point x="1010" y="503"/>
+      <point x="973" y="530" type="curve"/>
+      <point x="984" y="560" type="line"/>
+      <point x="933" y="534" type="line"/>
+      <point x="940" y="535"/>
+      <point x="952" y="536"/>
+      <point x="964" y="536" type="curve" smooth="yes"/>
+      <point x="1061" y="536"/>
+      <point x="1104" y="484"/>
+      <point x="1104" y="382" type="curve" smooth="yes"/>
+      <point x="1104" y="324" type="line"/>
+      <point x="1188" y="324" type="line"/>
+      <point x="1188" y="380" type="line" smooth="yes"/>
+      <point x="1188" y="469"/>
+      <point x="1241" y="518"/>
+      <point x="1322" y="518" type="curve" smooth="yes"/>
+      <point x="1395" y="518"/>
+      <point x="1436" y="475"/>
+      <point x="1436" y="403" type="curve" smooth="yes"/>
+      <point x="1436" y="316"/>
+      <point x="1373" y="267"/>
+      <point x="1257" y="267" type="curve" smooth="yes"/>
+      <point x="932" y="267" type="line" smooth="yes"/>
+      <point x="829" y="267"/>
+      <point x="756" y="212"/>
+      <point x="756" y="122" type="curve" smooth="yes"/>
+      <point x="756" y="41"/>
+      <point x="822" y="-16"/>
+      <point x="912" y="-16" type="curve" smooth="yes"/>
+      <point x="962" y="-16"/>
+      <point x="997" y="-5"/>
+      <point x="1081" y="36" type="curve" smooth="yes"/>
+      <point x="1201" y="95" type="line"/>
+      <point x="1270" y="138" type="line"/>
+      <point x="1302" y="146" type="line"/>
+      <point x="1326" y="168"/>
+      <point x="1349" y="176"/>
+      <point x="1378" y="176" type="curve" smooth="yes"/>
+      <point x="1417" y="176"/>
+      <point x="1440" y="154"/>
+      <point x="1440" y="115" type="curve" smooth="yes"/>
+      <point x="1440" y="78"/>
+      <point x="1415" y="54"/>
+      <point x="1377" y="54" type="curve" smooth="yes"/>
+      <point x="1339" y="54"/>
+      <point x="1313" y="79"/>
+      <point x="1313" y="115" type="curve" smooth="yes"/>
+      <point x="1313" y="143"/>
+      <point x="1327" y="168"/>
+      <point x="1350" y="181" type="curve"/>
+      <point x="1243" y="145" type="line"/>
+      <point x="1262" y="128" type="line"/>
+      <point x="1258" y="116"/>
+      <point x="1257" y="106"/>
+      <point x="1257" y="94" type="curve" smooth="yes"/>
+      <point x="1257" y="32"/>
+      <point x="1308" y="-16"/>
+      <point x="1382" y="-16" type="curve" smooth="yes"/>
+      <point x="1463" y="-16"/>
+      <point x="1514" y="38"/>
+      <point x="1514" y="114" type="curve" smooth="yes"/>
+      <point x="1514" y="185"/>
+      <point x="1463" y="236"/>
+      <point x="1384" y="236" type="curve" smooth="yes"/>
+      <point x="1345" y="236"/>
+      <point x="1300" y="220"/>
+      <point x="1226" y="184" type="curve" smooth="yes"/>
+      <point x="1053" y="99" type="line" smooth="yes"/>
+      <point x="995" y="71"/>
+      <point x="958" y="60"/>
+      <point x="916" y="60" type="curve" smooth="yes"/>
+      <point x="869" y="60"/>
+      <point x="838" y="85"/>
+      <point x="838" y="125" type="curve" smooth="yes"/>
+      <point x="838" y="170"/>
+      <point x="873" y="195"/>
+      <point x="935" y="195" type="curve" smooth="yes"/>
+      <point x="1247" y="195" type="line" smooth="yes"/>
+      <point x="1412" y="195"/>
+      <point x="1518" y="277"/>
+      <point x="1518" y="405" type="curve" smooth="yes"/>
+      <point x="1518" y="521"/>
+      <point x="1448" y="596"/>
+      <point x="1335" y="596" type="curve" smooth="yes"/>
+      <point x="1246" y="596"/>
+      <point x="1182" y="552"/>
+      <point x="1150" y="478" type="curve"/>
+      <point x="1145" y="478" type="line"/>
+      <point x="1119" y="553"/>
+      <point x="1060" y="596"/>
+      <point x="965" y="596" type="curve" smooth="yes"/>
+      <point x="935" y="596"/>
+      <point x="891" y="589"/>
+      <point x="861" y="576" type="curve"/>
+      <point x="895" y="576" type="line"/>
       <point x="867" y="589"/>
-      <point x="831" y="596"/>
-      <point x="790" y="596" type="curve" smooth="yes"/>
-      <point x="685" y="596"/>
+      <point x="830" y="596"/>
+      <point x="791" y="596" type="curve" smooth="yes"/>
+      <point x="686" y="596"/>
       <point x="611" y="548"/>
       <point x="571" y="470" type="curve"/>
       <point x="566" y="470" type="line"/>
@@ -169,19 +169,19 @@
       <point x="133" y="-16"/>
     </contour>
     <contour>
-      <point x="890" y="379" type="curve" smooth="yes"/>
-      <point x="853" y="379"/>
-      <point x="824" y="399"/>
-      <point x="824" y="442" type="curve" smooth="yes"/>
+      <point x="890" y="357" type="curve" smooth="yes"/>
+      <point x="850" y="357"/>
+      <point x="824" y="386"/>
+      <point x="824" y="426" type="curve" smooth="yes"/>
       <point x="824" y="478"/>
-      <point x="850" y="526"/>
-      <point x="920" y="532" type="curve"/>
-      <point x="837" y="528" type="line"/>
-      <point x="915" y="527"/>
-      <point x="953" y="487"/>
-      <point x="953" y="440" type="curve" smooth="yes"/>
-      <point x="953" y="401"/>
-      <point x="931" y="379"/>
+      <point x="860" y="517"/>
+      <point x="923" y="534" type="curve"/>
+      <point x="858" y="534" type="line"/>
+      <point x="921" y="517"/>
+      <point x="956" y="479"/>
+      <point x="956" y="426" type="curve" smooth="yes"/>
+      <point x="956" y="386"/>
+      <point x="930" y="357"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/t_la-malayalam.glif
@@ -56,22 +56,6 @@
       <point x="294" y="-367"/>
     </contour>
     <contour>
-      <point x="376" y="-302" type="curve" smooth="yes"/>
-      <point x="318" y="-302"/>
-      <point x="291" y="-253"/>
-      <point x="291" y="-197" type="curve"/>
-      <point x="271" y="-205" type="line"/>
-      <point x="292" y="-262" type="line"/>
-      <point x="292" y="-218"/>
-      <point x="324" y="-178"/>
-      <point x="378" y="-178" type="curve" smooth="yes"/>
-      <point x="419" y="-178"/>
-      <point x="439" y="-203"/>
-      <point x="439" y="-238" type="curve" smooth="yes"/>
-      <point x="439" y="-276"/>
-      <point x="418" y="-302"/>
-    </contour>
-    <contour>
       <point x="164" y="-16" type="curve"/>
       <point x="224" y="35" type="line"/>
       <point x="158" y="108"/>
@@ -94,6 +78,22 @@
       <point x="81" y="72"/>
     </contour>
     <contour>
+      <point x="376" y="-302" type="curve" smooth="yes"/>
+      <point x="318" y="-302"/>
+      <point x="291" y="-253"/>
+      <point x="291" y="-197" type="curve"/>
+      <point x="271" y="-205" type="line"/>
+      <point x="292" y="-262" type="line"/>
+      <point x="292" y="-218"/>
+      <point x="324" y="-178"/>
+      <point x="378" y="-178" type="curve" smooth="yes"/>
+      <point x="419" y="-178"/>
+      <point x="439" y="-203"/>
+      <point x="439" y="-238" type="curve" smooth="yes"/>
+      <point x="439" y="-276"/>
+      <point x="418" y="-302"/>
+    </contour>
+    <contour>
       <point x="777" y="-297" type="curve" smooth="yes"/>
       <point x="722" y="-297"/>
       <point x="692" y="-261"/>
@@ -106,11 +106,11 @@
       <point x="652" y="43"/>
       <point x="687" y="129"/>
       <point x="687" y="241" type="curve" smooth="yes"/>
-      <point x="687" y="358"/>
-      <point x="631" y="472"/>
-      <point x="538" y="538" type="curve"/>
-      <point x="463" y="495" type="line"/>
-      <point x="556" y="450"/>
+      <point x="687" y="357"/>
+      <point x="632" y="470"/>
+      <point x="540" y="536" type="curve"/>
+      <point x="465" y="494" type="line"/>
+      <point x="557" y="449"/>
       <point x="601" y="348"/>
       <point x="601" y="241" type="curve" smooth="yes"/>
       <point x="601" y="129"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="572"/>
-  <anchor x="308" y="-209" name="bottom"/>
+  <anchor x="308" y="-235" name="bottom"/>
   <anchor x="283" y="580" name="top"/>
   <anchor x="434" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="288" y="-225" type="curve" smooth="yes"/>
-      <point x="449" y="-225"/>
-      <point x="538" y="-171"/>
-      <point x="538" y="-69" type="curve" smooth="yes"/>
-      <point x="538" y="-9"/>
-      <point x="500" y="29"/>
-      <point x="429" y="42" type="curve"/>
-      <point x="429" y="48" type="line"/>
-      <point x="478" y="66"/>
-      <point x="528" y="102"/>
-      <point x="528" y="190" type="curve" smooth="yes"/>
-      <point x="528" y="284"/>
-      <point x="469" y="340"/>
+      <point x="288" y="-251" type="curve" smooth="yes"/>
+      <point x="449" y="-251"/>
+      <point x="538" y="-190"/>
+      <point x="538" y="-86" type="curve" smooth="yes"/>
+      <point x="538" y="-17"/>
+      <point x="501" y="30"/>
+      <point x="431" y="47" type="curve"/>
+      <point x="431" y="53" type="line"/>
+      <point x="493" y="76"/>
+      <point x="528" y="123"/>
+      <point x="528" y="189" type="curve" smooth="yes"/>
+      <point x="528" y="289"/>
+      <point x="462" y="341"/>
       <point x="327" y="347" type="curve" smooth="yes"/>
       <point x="220" y="352" type="line" smooth="yes"/>
-      <point x="148" y="355"/>
-      <point x="110" y="385"/>
-      <point x="110" y="434" type="curve" smooth="yes"/>
-      <point x="110" y="490"/>
-      <point x="167" y="515"/>
-      <point x="271" y="515" type="curve" smooth="yes"/>
-      <point x="342" y="515"/>
-      <point x="402" y="502"/>
-      <point x="466" y="476" type="curve"/>
+      <point x="149" y="355"/>
+      <point x="110" y="383"/>
+      <point x="110" y="432" type="curve" smooth="yes"/>
+      <point x="110" y="488"/>
+      <point x="163" y="516"/>
+      <point x="271" y="516" type="curve" smooth="yes"/>
+      <point x="340" y="516"/>
+      <point x="400" y="504"/>
+      <point x="466" y="477" type="curve"/>
       <point x="498" y="550" type="line"/>
-      <point x="428" y="582"/>
-      <point x="357" y="596"/>
+      <point x="430" y="582"/>
+      <point x="359" y="596"/>
       <point x="271" y="596" type="curve" smooth="yes"/>
-      <point x="118" y="596"/>
-      <point x="25" y="534"/>
+      <point x="116" y="596"/>
+      <point x="25" y="532"/>
       <point x="25" y="423" type="curve" smooth="yes"/>
-      <point x="25" y="330"/>
-      <point x="94" y="272"/>
-      <point x="210" y="265" type="curve" smooth="yes"/>
+      <point x="25" y="328"/>
+      <point x="94" y="269"/>
+      <point x="210" y="264" type="curve" smooth="yes"/>
       <point x="317" y="259" type="line" smooth="yes"/>
-      <point x="405" y="254"/>
-      <point x="446" y="224"/>
-      <point x="446" y="176" type="curve" smooth="yes"/>
-      <point x="446" y="112"/>
-      <point x="392" y="80"/>
-      <point x="282" y="80" type="curve" smooth="yes"/>
-      <point x="69" y="80" type="line"/>
-      <point x="69" y="6" type="line"/>
-      <point x="292" y="6" type="line" smooth="yes"/>
-      <point x="418" y="6"/>
-      <point x="456" y="-17"/>
-      <point x="456" y="-68" type="curve" smooth="yes"/>
-      <point x="456" y="-126"/>
-      <point x="396" y="-147"/>
-      <point x="288" y="-147" type="curve" smooth="yes"/>
-      <point x="195" y="-147"/>
-      <point x="119" y="-125"/>
-      <point x="69" y="-98" type="curve"/>
-      <point x="35" y="-166" type="line"/>
-      <point x="86" y="-198"/>
-      <point x="179" y="-225"/>
+      <point x="400" y="255"/>
+      <point x="443" y="226"/>
+      <point x="443" y="175" type="curve" smooth="yes"/>
+      <point x="443" y="118"/>
+      <point x="389" y="86"/>
+      <point x="293" y="86" type="curve" smooth="yes"/>
+      <point x="69" y="86" type="line"/>
+      <point x="69" y="12" type="line"/>
+      <point x="314" y="12" type="line" smooth="yes"/>
+      <point x="410" y="12"/>
+      <point x="453" y="-16"/>
+      <point x="453" y="-78" type="curve" smooth="yes"/>
+      <point x="453" y="-140"/>
+      <point x="399" y="-171"/>
+      <point x="288" y="-171" type="curve" smooth="yes"/>
+      <point x="210" y="-171"/>
+      <point x="135" y="-147"/>
+      <point x="79" y="-104" type="curve"/>
+      <point x="33" y="-169" type="line"/>
+      <point x="101" y="-222"/>
+      <point x="192" y="-251"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/tta-malayalam.glif
@@ -8,45 +8,45 @@
   <outline>
     <contour>
       <point x="305" y="-16" type="curve" smooth="yes"/>
-      <point x="451" y="-16"/>
-      <point x="540" y="54"/>
-      <point x="540" y="165" type="curve" smooth="yes"/>
-      <point x="540" y="263"/>
-      <point x="471" y="328"/>
+      <point x="452" y="-16"/>
+      <point x="540" y="50"/>
+      <point x="540" y="162" type="curve" smooth="yes"/>
+      <point x="540" y="267"/>
+      <point x="469" y="328"/>
       <point x="339" y="334" type="curve" smooth="yes"/>
       <point x="232" y="339" type="line" smooth="yes"/>
       <point x="160" y="342"/>
       <point x="122" y="371"/>
-      <point x="122" y="421" type="curve" smooth="yes"/>
-      <point x="122" y="483"/>
-      <point x="179" y="515"/>
-      <point x="283" y="515" type="curve" smooth="yes"/>
-      <point x="354" y="515"/>
-      <point x="414" y="502"/>
-      <point x="478" y="476" type="curve"/>
+      <point x="122" y="422" type="curve" smooth="yes"/>
+      <point x="122" y="484"/>
+      <point x="179" y="516"/>
+      <point x="291" y="516" type="curve" smooth="yes"/>
+      <point x="357" y="516"/>
+      <point x="415" y="504"/>
+      <point x="478" y="477" type="curve"/>
       <point x="510" y="550" type="line"/>
-      <point x="440" y="582"/>
-      <point x="369" y="596"/>
-      <point x="283" y="596" type="curve" smooth="yes"/>
-      <point x="130" y="596"/>
-      <point x="37" y="527"/>
-      <point x="37" y="414" type="curve" smooth="yes"/>
-      <point x="37" y="320"/>
-      <point x="106" y="257"/>
-      <point x="222" y="250" type="curve" smooth="yes"/>
+      <point x="443" y="582"/>
+      <point x="375" y="596"/>
+      <point x="291" y="596" type="curve" smooth="yes"/>
+      <point x="133" y="596"/>
+      <point x="37" y="529"/>
+      <point x="37" y="416" type="curve" smooth="yes"/>
+      <point x="37" y="318"/>
+      <point x="110" y="254"/>
+      <point x="222" y="249" type="curve" smooth="yes"/>
       <point x="329" y="244" type="line" smooth="yes"/>
-      <point x="417" y="239"/>
-      <point x="457" y="210"/>
-      <point x="457" y="158" type="curve" smooth="yes"/>
-      <point x="457" y="98"/>
-      <point x="403" y="65"/>
-      <point x="305" y="65" type="curve" smooth="yes"/>
-      <point x="223" y="65"/>
-      <point x="146" y="89"/>
-      <point x="71" y="135" type="curve"/>
-      <point x="25" y="59" type="line"/>
-      <point x="110" y="9"/>
-      <point x="201" y="-16"/>
+      <point x="415" y="240"/>
+      <point x="455" y="211"/>
+      <point x="455" y="156" type="curve" smooth="yes"/>
+      <point x="455" y="97"/>
+      <point x="402" y="64"/>
+      <point x="305" y="64" type="curve" smooth="yes"/>
+      <point x="215" y="64"/>
+      <point x="140" y="86"/>
+      <point x="67" y="133" type="curve"/>
+      <point x="25" y="65" type="line"/>
+      <point x="112" y="9"/>
+      <point x="198" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/uuM_atra-malayalam.glif
@@ -36,33 +36,39 @@
     </contour>
     <contour>
       <point x="126" y="-185" type="curve" smooth="yes"/>
-      <point x="74" y="-185"/>
-      <point x="38" y="-151"/>
-      <point x="38" y="-100" type="curve" smooth="yes"/>
-      <point x="38" y="-49"/>
-      <point x="73" y="-15"/>
-      <point x="126" y="-15" type="curve" smooth="yes"/>
-      <point x="178" y="-15"/>
-      <point x="214" y="-49"/>
-      <point x="214" y="-100" type="curve" smooth="yes"/>
-      <point x="214" y="-151"/>
-      <point x="178" y="-185"/>
+      <point x="70" y="-185"/>
+      <point x="34" y="-151"/>
+      <point x="34" y="-103" type="curve" smooth="yes"/>
+      <point x="34" y="-85"/>
+      <point x="37" y="-72"/>
+      <point x="42" y="-60" type="curve"/>
+      <point x="46" y="-60" type="line"/>
+      <point x="55" y="-103"/>
+      <point x="84" y="-127"/>
+      <point x="126" y="-127" type="curve" smooth="yes"/>
+      <point x="168" y="-127"/>
+      <point x="197" y="-103"/>
+      <point x="206" y="-60" type="curve"/>
+      <point x="210" y="-60" type="line"/>
+      <point x="215" y="-72"/>
+      <point x="218" y="-85"/>
+      <point x="218" y="-103" type="curve" smooth="yes"/>
+      <point x="218" y="-151"/>
+      <point x="182" y="-185"/>
     </contour>
     <contour>
-      <point x="125" y="-119" type="curve" smooth="yes"/>
-      <point x="171" y="-119"/>
-      <point x="208" y="-106"/>
-      <point x="239" y="-78" type="curve"/>
-      <point x="216" y="-38" type="line"/>
-      <point x="192" y="-60"/>
-      <point x="164" y="-70"/>
-      <point x="125" y="-70" type="curve" smooth="yes"/>
-      <point x="86" y="-70"/>
-      <point x="57" y="-60"/>
-      <point x="34" y="-38" type="curve"/>
-      <point x="11" y="-78" type="line"/>
-      <point x="42" y="-106"/>
-      <point x="79" y="-119"/>
+      <point x="126" y="-63" type="curve" smooth="yes"/>
+      <point x="86" y="-63"/>
+      <point x="63" y="-48"/>
+      <point x="63" y="-29" type="curve" smooth="yes"/>
+      <point x="63" y="-12"/>
+      <point x="86" y="0"/>
+      <point x="126" y="0" type="curve" smooth="yes"/>
+      <point x="166" y="0"/>
+      <point x="189" y="-12"/>
+      <point x="189" y="-29" type="curve" smooth="yes"/>
+      <point x="189" y="-48"/>
+      <point x="166" y="-63"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/v_va-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/v_va-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="v_va-malayalam" format="2">
   <advance width="1029"/>
   <anchor x="699" y="-281" name="bottom"/>
-  <anchor x="932" y="0" name="bottomright"/>
   <anchor x="548" y="580" name="top"/>
   <anchor x="912" y="580" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/y_ya-malayalam.glif
@@ -1,97 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="984"/>
-  <anchor x="622" y="-281" name="bottom"/>
-  <anchor x="855" y="0" name="bottomright"/>
+  <anchor x="622" y="-268" name="bottom"/>
   <anchor x="505" y="580" name="top"/>
   <anchor x="811" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="305" y="-291" type="line"/>
-      <point x="875" y="-291" type="line"/>
+      <point x="305" y="-278" type="line"/>
+      <point x="875" y="-278" type="line"/>
       <point x="875" y="121" type="line"/>
-      <point x="863" y="66" type="line"/>
-      <point x="915" y="122"/>
-      <point x="942" y="204"/>
-      <point x="942" y="300" type="curve" smooth="yes"/>
-      <point x="942" y="399"/>
-      <point x="904" y="510"/>
-      <point x="831" y="596" type="curve"/>
-      <point x="763" y="548" type="line"/>
-      <point x="817" y="480"/>
-      <point x="860" y="398"/>
-      <point x="860" y="302" type="curve" smooth="yes"/>
-      <point x="860" y="161"/>
-      <point x="796" y="62"/>
-      <point x="655" y="62" type="curve" smooth="yes"/>
-      <point x="486" y="62"/>
-      <point x="405" y="195"/>
-      <point x="405" y="362" type="curve" smooth="yes"/>
-      <point x="405" y="459"/>
-      <point x="442" y="518"/>
-      <point x="506" y="518" type="curve" smooth="yes"/>
-      <point x="567" y="518"/>
-      <point x="604" y="459"/>
-      <point x="604" y="362" type="curve" smooth="yes"/>
-      <point x="604" y="244"/>
-      <point x="565" y="154"/>
-      <point x="494" y="104" type="curve"/>
+      <point x="857" y="71" type="line"/>
+      <point x="912" y="126"/>
+      <point x="942" y="206"/>
+      <point x="942" y="303" type="curve" smooth="yes"/>
+      <point x="942" y="405"/>
+      <point x="900" y="514"/>
+      <point x="828" y="596" type="curve"/>
+      <point x="765" y="547" type="line"/>
+      <point x="830" y="473"/>
+      <point x="862" y="390"/>
+      <point x="862" y="299" type="curve" smooth="yes"/>
+      <point x="862" y="151"/>
+      <point x="778" y="62"/>
+      <point x="648" y="62" type="curve" smooth="yes"/>
+      <point x="462" y="62"/>
+      <point x="373" y="190"/>
+      <point x="373" y="338" type="curve" smooth="yes"/>
+      <point x="373" y="453"/>
+      <point x="426" y="518"/>
+      <point x="508" y="518" type="curve" smooth="yes"/>
+      <point x="585" y="518"/>
+      <point x="628" y="453"/>
+      <point x="628" y="346" type="curve" smooth="yes"/>
+      <point x="628" y="233"/>
+      <point x="577" y="146"/>
+      <point x="492" y="95" type="curve"/>
       <point x="547" y="50" type="line"/>
-      <point x="638" y="121"/>
-      <point x="686" y="240"/>
-      <point x="686" y="367" type="curve" smooth="yes"/>
-      <point x="686" y="500"/>
-      <point x="621" y="596"/>
-      <point x="504" y="596" type="curve" smooth="yes"/>
-      <point x="385" y="596"/>
-      <point x="323" y="497"/>
-      <point x="323" y="370" type="curve" smooth="yes"/>
-      <point x="323" y="181"/>
-      <point x="444" y="-13"/>
-      <point x="663" y="-13" type="curve" smooth="yes"/>
-      <point x="680" y="-13"/>
-      <point x="698" y="-12"/>
-      <point x="717" y="-9" type="curve"/>
-      <point x="652" y="29" type="line"/>
-      <point x="652" y="-18" type="line"/>
-      <point x="565" y="-70" type="line"/>
-      <point x="305" y="-235" type="line"/>
+      <point x="649" y="110"/>
+      <point x="710" y="224"/>
+      <point x="710" y="352" type="curve" smooth="yes"/>
+      <point x="710" y="500"/>
+      <point x="632" y="596"/>
+      <point x="508" y="596" type="curve" smooth="yes"/>
+      <point x="374" y="596"/>
+      <point x="291" y="479"/>
+      <point x="291" y="334" type="curve" smooth="yes"/>
+      <point x="291" y="143"/>
+      <point x="448" y="-12"/>
+      <point x="650" y="-12" type="curve" smooth="yes"/>
+      <point x="674" y="-12"/>
+      <point x="697" y="-10"/>
+      <point x="719" y="-5" type="curve"/>
+      <point x="629" y="33" type="line"/>
+      <point x="629" y="-14" type="line"/>
+      <point x="551" y="-58" type="line"/>
+      <point x="305" y="-222" type="line"/>
     </contour>
     <contour>
-      <point x="401" y="-258" type="line"/>
-      <point x="807" y="13" type="line"/>
-      <point x="793" y="13" type="line"/>
-      <point x="793" y="-244" type="line"/>
-      <point x="831" y="-226" type="line"/>
-      <point x="401" y="-226" type="line"/>
+      <point x="401" y="-243" type="line"/>
+      <point x="807" y="26" type="line"/>
+      <point x="793" y="26" type="line"/>
+      <point x="793" y="-231" type="line"/>
+      <point x="831" y="-213" type="line"/>
+      <point x="401" y="-213" type="line"/>
     </contour>
     <contour>
-      <point x="348" y="-16" type="curve" smooth="yes"/>
-      <point x="418" y="-16"/>
-      <point x="474" y="2"/>
-      <point x="522" y="32" type="curve"/>
-      <point x="460" y="84" type="line"/>
-      <point x="431" y="71"/>
+      <point x="349" y="-16" type="curve" smooth="yes"/>
+      <point x="414" y="-16"/>
+      <point x="467" y="0"/>
+      <point x="519" y="35" type="curve"/>
+      <point x="461" y="83" type="line"/>
+      <point x="430" y="69"/>
       <point x="396" y="62"/>
-      <point x="352" y="62" type="curve" smooth="yes"/>
-      <point x="215" y="62"/>
-      <point x="124" y="167"/>
-      <point x="124" y="323" type="curve" smooth="yes"/>
-      <point x="124" y="430"/>
+      <point x="353" y="62" type="curve" smooth="yes"/>
+      <point x="212" y="62"/>
+      <point x="122" y="167"/>
+      <point x="122" y="323" type="curve" smooth="yes"/>
+      <point x="122" y="430"/>
       <point x="176" y="518"/>
-      <point x="274" y="518" type="curve" smooth="yes"/>
-      <point x="320" y="518"/>
-      <point x="349" y="502"/>
-      <point x="371" y="478" type="curve"/>
-      <point x="413" y="532" type="line"/>
-      <point x="378" y="575"/>
-      <point x="334" y="596"/>
-      <point x="271" y="596" type="curve" smooth="yes"/>
-      <point x="131" y="596"/>
-      <point x="42" y="478"/>
-      <point x="42" y="323" type="curve" smooth="yes"/>
-      <point x="42" y="125"/>
-      <point x="168" y="-16"/>
+      <point x="278" y="518" type="curve" smooth="yes"/>
+      <point x="319" y="518"/>
+      <point x="350" y="506"/>
+      <point x="375" y="479" type="curve"/>
+      <point x="427" y="537" type="line"/>
+      <point x="386" y="578"/>
+      <point x="342" y="596"/>
+      <point x="282" y="596" type="curve" smooth="yes"/>
+      <point x="135" y="596"/>
+      <point x="42" y="476"/>
+      <point x="42" y="321" type="curve" smooth="yes"/>
+      <point x="42" y="126"/>
+      <point x="170" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ya-malayalam.glif
@@ -8,72 +8,72 @@
   <anchor x="811" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="658" y="-16" type="curve" smooth="yes"/>
-      <point x="843" y="-16"/>
-      <point x="942" y="117"/>
-      <point x="942" y="300" type="curve" smooth="yes"/>
-      <point x="942" y="399"/>
-      <point x="904" y="510"/>
-      <point x="831" y="596" type="curve"/>
-      <point x="763" y="548" type="line"/>
-      <point x="817" y="480"/>
-      <point x="860" y="398"/>
-      <point x="860" y="302" type="curve" smooth="yes"/>
-      <point x="860" y="161"/>
-      <point x="796" y="62"/>
-      <point x="655" y="62" type="curve" smooth="yes"/>
-      <point x="486" y="62"/>
-      <point x="405" y="195"/>
-      <point x="405" y="362" type="curve" smooth="yes"/>
-      <point x="405" y="459"/>
-      <point x="442" y="518"/>
-      <point x="506" y="518" type="curve" smooth="yes"/>
-      <point x="567" y="518"/>
-      <point x="604" y="459"/>
-      <point x="604" y="362" type="curve" smooth="yes"/>
-      <point x="604" y="244"/>
-      <point x="565" y="154"/>
-      <point x="494" y="104" type="curve"/>
+      <point x="650" y="-16" type="curve" smooth="yes"/>
+      <point x="824" y="-16"/>
+      <point x="942" y="108"/>
+      <point x="942" y="303" type="curve" smooth="yes"/>
+      <point x="942" y="405"/>
+      <point x="900" y="514"/>
+      <point x="828" y="596" type="curve"/>
+      <point x="765" y="547" type="line"/>
+      <point x="830" y="473"/>
+      <point x="862" y="390"/>
+      <point x="862" y="299" type="curve" smooth="yes"/>
+      <point x="862" y="151"/>
+      <point x="778" y="62"/>
+      <point x="648" y="62" type="curve" smooth="yes"/>
+      <point x="462" y="62"/>
+      <point x="373" y="190"/>
+      <point x="373" y="338" type="curve" smooth="yes"/>
+      <point x="373" y="453"/>
+      <point x="426" y="518"/>
+      <point x="508" y="518" type="curve" smooth="yes"/>
+      <point x="585" y="518"/>
+      <point x="628" y="453"/>
+      <point x="628" y="346" type="curve" smooth="yes"/>
+      <point x="628" y="233"/>
+      <point x="577" y="146"/>
+      <point x="492" y="95" type="curve"/>
       <point x="547" y="50" type="line"/>
-      <point x="638" y="121"/>
-      <point x="686" y="240"/>
-      <point x="686" y="367" type="curve" smooth="yes"/>
-      <point x="686" y="500"/>
-      <point x="621" y="596"/>
-      <point x="504" y="596" type="curve" smooth="yes"/>
-      <point x="385" y="596"/>
-      <point x="323" y="497"/>
-      <point x="323" y="370" type="curve" smooth="yes"/>
-      <point x="323" y="179"/>
-      <point x="446" y="-16"/>
+      <point x="649" y="110"/>
+      <point x="710" y="224"/>
+      <point x="710" y="352" type="curve" smooth="yes"/>
+      <point x="710" y="500"/>
+      <point x="632" y="596"/>
+      <point x="508" y="596" type="curve" smooth="yes"/>
+      <point x="374" y="596"/>
+      <point x="291" y="479"/>
+      <point x="291" y="334" type="curve" smooth="yes"/>
+      <point x="291" y="141"/>
+      <point x="448" y="-16"/>
     </contour>
     <contour>
-      <point x="348" y="-16" type="curve" smooth="yes"/>
-      <point x="418" y="-16"/>
-      <point x="474" y="2"/>
-      <point x="522" y="32" type="curve"/>
-      <point x="460" y="84" type="line"/>
-      <point x="431" y="71"/>
+      <point x="349" y="-16" type="curve" smooth="yes"/>
+      <point x="414" y="-16"/>
+      <point x="467" y="0"/>
+      <point x="519" y="35" type="curve"/>
+      <point x="461" y="83" type="line"/>
+      <point x="430" y="69"/>
       <point x="396" y="62"/>
-      <point x="352" y="62" type="curve" smooth="yes"/>
-      <point x="215" y="62"/>
-      <point x="124" y="167"/>
-      <point x="124" y="323" type="curve" smooth="yes"/>
-      <point x="124" y="430"/>
+      <point x="353" y="62" type="curve" smooth="yes"/>
+      <point x="212" y="62"/>
+      <point x="122" y="167"/>
+      <point x="122" y="323" type="curve" smooth="yes"/>
+      <point x="122" y="430"/>
       <point x="176" y="518"/>
-      <point x="274" y="518" type="curve" smooth="yes"/>
-      <point x="320" y="518"/>
-      <point x="349" y="502"/>
-      <point x="371" y="478" type="curve"/>
-      <point x="413" y="532" type="line"/>
-      <point x="378" y="575"/>
-      <point x="334" y="596"/>
-      <point x="271" y="596" type="curve" smooth="yes"/>
-      <point x="131" y="596"/>
-      <point x="42" y="478"/>
-      <point x="42" y="323" type="curve" smooth="yes"/>
-      <point x="42" y="125"/>
-      <point x="168" y="-16"/>
+      <point x="278" y="518" type="curve" smooth="yes"/>
+      <point x="319" y="518"/>
+      <point x="350" y="506"/>
+      <point x="375" y="479" type="curve"/>
+      <point x="427" y="537" type="line"/>
+      <point x="386" y="578"/>
+      <point x="342" y="596"/>
+      <point x="282" y="596" type="curve" smooth="yes"/>
+      <point x="135" y="596"/>
+      <point x="42" y="476"/>
+      <point x="42" y="321" type="curve" smooth="yes"/>
+      <point x="42" y="126"/>
+      <point x="170" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/kerning.plist
@@ -45714,7 +45714,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -45828,7 +45828,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -45884,7 +45884,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -45939,7 +45939,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>200</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -45986,7 +45986,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -46021,7 +46021,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>110</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -46049,8 +46049,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46085,7 +46083,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46152,7 +46150,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46212,7 +46210,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>130</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46263,7 +46261,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>170</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46321,7 +46319,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46364,7 +46362,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46502,8 +46500,6 @@
       <integer>-10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46589,7 +46585,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46689,8 +46685,6 @@
       <integer>60</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -46723,7 +46717,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -46803,7 +46797,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46845,8 +46839,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla-malayalam_L</key>
       <integer>-30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46964,8 +46956,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -47079,7 +47069,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47128,7 +47118,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>200</integer>
+      <integer>190</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47178,17 +47168,17 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>70</integer>
-      <key>public.kern2.MAL_braceright.loclMALM_R</key>
       <integer>50</integer>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>40</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
       <integer>40</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
@@ -47198,23 +47188,25 @@
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
       <integer>40</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
-      <integer>-30</integer>
+      <integer>-20</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>70</integer>
+      <key>public.kern2.MAL_tt_tta-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
-      <integer>130</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
-      <integer>90</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_uMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>74</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>220</integer>
+      <integer>210</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
       <integer>170</integer>
     </dict>
@@ -47241,7 +47233,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47290,7 +47282,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>160</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47366,7 +47358,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47577,7 +47569,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47603,8 +47595,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47633,7 +47623,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47687,7 +47677,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -47719,8 +47709,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -47837,7 +47825,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_p_pa-malayalam_L</key>
@@ -47949,7 +47937,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47994,7 +47982,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48090,7 +48078,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48230,7 +48218,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48283,7 +48271,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48350,7 +48338,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48403,7 +48391,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>290</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>240</integer>
+      <integer>220</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -48490,7 +48478,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>130</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48639,7 +48627,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48747,7 +48735,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_ng_ka-malayalam_L</key>
@@ -48799,6 +48787,26 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-40</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>110</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>100</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+      <key>public.kern2.MAL_quoteright.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.ODI_a-oriya-L</key>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/c_cha-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/c_cha-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="c_cha-malayalam" format="2">
   <advance width="884"/>
   <anchor x="485" y="-349" name="bottom"/>
-  <anchor x="787" y="0" name="bottomright"/>
   <anchor x="430" y="580" name="top"/>
   <anchor x="768" y="580" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/d_da-malayalam.glif
@@ -1,26 +1,23 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
-  <advance width="665"/>
-  <guideline x="1248" y="-225" angle="0"/>
-  <guideline x="619" y="162" angle="90"/>
-  <guideline x="1442" y="185" angle="90"/>
-  <anchor x="377" y="-209" name="bottom"/>
+  <advance width="655"/>
+  <anchor x="377" y="-263" name="bottom"/>
   <anchor x="363" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="437" y="-225" type="curve" smooth="yes"/>
-      <point x="564" y="-225"/>
-      <point x="629" y="-176"/>
-      <point x="629" y="-88" type="curve" smooth="yes"/>
-      <point x="629" y="-27"/>
-      <point x="591" y="12"/>
-      <point x="520" y="25" type="curve"/>
-      <point x="520" y="31" type="line"/>
-      <point x="569" y="49"/>
-      <point x="619" y="85"/>
+      <point x="400" y="-279" type="curve" smooth="yes"/>
+      <point x="535" y="-279"/>
+      <point x="619" y="-218"/>
+      <point x="619" y="-118" type="curve" smooth="yes"/>
+      <point x="619" y="-47"/>
+      <point x="587" y="1"/>
+      <point x="519" y="23" type="curve"/>
+      <point x="519" y="29" type="line"/>
+      <point x="583" y="52"/>
+      <point x="619" y="101"/>
       <point x="619" y="162" type="curve" smooth="yes"/>
-      <point x="619" y="231"/>
-      <point x="574" y="276"/>
+      <point x="619" y="229"/>
+      <point x="576" y="276"/>
       <point x="499" y="292" type="curve"/>
       <point x="499" y="298" type="line"/>
       <point x="560" y="316"/>
@@ -42,7 +39,7 @@
       <point x="124" y="426"/>
       <point x="214" y="518"/>
       <point x="361" y="518" type="curve" smooth="yes"/>
-      <point x="465" y="518"/>
+      <point x="466" y="518"/>
       <point x="516" y="480"/>
       <point x="516" y="416" type="curve" smooth="yes"/>
       <point x="516" y="361"/>
@@ -51,27 +48,27 @@
       <point x="360" y="329" type="line"/>
       <point x="360" y="255" type="line"/>
       <point x="402" y="255" type="line" smooth="yes"/>
-      <point x="488" y="255"/>
-      <point x="537" y="220"/>
+      <point x="489" y="255"/>
+      <point x="537" y="219"/>
       <point x="537" y="155" type="curve" smooth="yes"/>
-      <point x="537" y="94"/>
-      <point x="483" y="62"/>
+      <point x="537" y="98"/>
+      <point x="489" y="62"/>
       <point x="413" y="62" type="curve" smooth="yes"/>
-      <point x="360" y="62" type="line"/>
-      <point x="360" y="-12" type="line"/>
-      <point x="423" y="-12" type="line" smooth="yes"/>
-      <point x="509" y="-12"/>
-      <point x="547" y="-35"/>
-      <point x="547" y="-77" type="curve" smooth="yes"/>
-      <point x="547" y="-126"/>
-      <point x="507" y="-147"/>
-      <point x="440" y="-147" type="curve" smooth="yes"/>
-      <point x="391" y="-147"/>
-      <point x="357" y="-140"/>
-      <point x="324" y="-129" type="curve"/>
-      <point x="296" y="-201" type="line"/>
-      <point x="332" y="-216"/>
-      <point x="385" y="-225"/>
+      <point x="340" y="62" type="line"/>
+      <point x="340" y="-12" type="line"/>
+      <point x="413" y="-12" type="line" smooth="yes"/>
+      <point x="497" y="-12"/>
+      <point x="537" y="-47"/>
+      <point x="537" y="-106" type="curve" smooth="yes"/>
+      <point x="537" y="-166"/>
+      <point x="488" y="-201"/>
+      <point x="400" y="-201" type="curve" smooth="yes"/>
+      <point x="342" y="-201"/>
+      <point x="296" y="-190"/>
+      <point x="243" y="-164" type="curve"/>
+      <point x="210" y="-233" type="line"/>
+      <point x="270" y="-264"/>
+      <point x="335" y="-279"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="963"/>
-  <anchor x="657" y="0" name="bottom"/>
+  <advance width="956"/>
+  <anchor x="650" y="0" name="bottom"/>
   <anchor x="475" y="580" name="top"/>
-  <anchor x="847" y="580" name="topright"/>
+  <anchor x="840" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="272" y="-16" type="curve" smooth="yes"/>
+      <point x="282" y="-16" type="curve" smooth="yes"/>
       <point x="411" y="-16"/>
-      <point x="479" y="68"/>
-      <point x="494" y="232" type="curve" smooth="yes"/>
-      <point x="504" y="340" type="line" smooth="yes"/>
-      <point x="514" y="449"/>
-      <point x="569" y="516"/>
-      <point x="681" y="516" type="curve" smooth="yes"/>
-      <point x="782" y="516"/>
-      <point x="824" y="476"/>
-      <point x="824" y="416" type="curve" smooth="yes"/>
-      <point x="824" y="361"/>
-      <point x="780" y="329"/>
-      <point x="710" y="329" type="curve" smooth="yes"/>
-      <point x="668" y="329" type="line"/>
-      <point x="668" y="255" type="line"/>
-      <point x="710" y="255" type="line" smooth="yes"/>
-      <point x="796" y="255"/>
-      <point x="845" y="220"/>
-      <point x="845" y="158" type="curve" smooth="yes"/>
-      <point x="845" y="93"/>
-      <point x="805" y="62"/>
-      <point x="729" y="62" type="curve" smooth="yes"/>
-      <point x="697" y="62"/>
-      <point x="667" y="69"/>
-      <point x="634" y="82" type="curve"/>
-      <point x="602" y="10" type="line"/>
-      <point x="638" y="-7"/>
-      <point x="684" y="-16"/>
-      <point x="731" y="-16" type="curve" smooth="yes"/>
-      <point x="848" y="-16"/>
-      <point x="927" y="47"/>
-      <point x="927" y="153" type="curve" smooth="yes"/>
-      <point x="927" y="224"/>
-      <point x="882" y="276"/>
-      <point x="807" y="292" type="curve"/>
-      <point x="807" y="298" type="line"/>
-      <point x="868" y="316"/>
-      <point x="906" y="362"/>
-      <point x="906" y="427" type="curve" smooth="yes"/>
-      <point x="906" y="523"/>
-      <point x="833" y="596"/>
-      <point x="678" y="596" type="curve" smooth="yes"/>
-      <point x="521" y="596"/>
-      <point x="431" y="507"/>
-      <point x="416" y="347" type="curve" smooth="yes"/>
-      <point x="406" y="240" type="line" smooth="yes"/>
-      <point x="396" y="128"/>
-      <point x="355" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="89"/>
-      <point x="131" y="-16"/>
+      <point x="499" y="77"/>
+      <point x="499" y="214" type="curve" smooth="yes"/>
+      <point x="499" y="255"/>
+      <point x="495" y="297"/>
+      <point x="495" y="338" type="curve" smooth="yes"/>
+      <point x="495" y="457"/>
+      <point x="561" y="516"/>
+      <point x="679" y="516" type="curve" smooth="yes"/>
+      <point x="777" y="516"/>
+      <point x="817" y="479"/>
+      <point x="817" y="424" type="curve" smooth="yes"/>
+      <point x="817" y="365"/>
+      <point x="773" y="329"/>
+      <point x="703" y="329" type="curve" smooth="yes"/>
+      <point x="661" y="329" type="line"/>
+      <point x="661" y="255" type="line"/>
+      <point x="703" y="255" type="line" smooth="yes"/>
+      <point x="789" y="255"/>
+      <point x="838" y="220"/>
+      <point x="838" y="158" type="curve" smooth="yes"/>
+      <point x="838" y="93"/>
+      <point x="798" y="62"/>
+      <point x="722" y="62" type="curve" smooth="yes"/>
+      <point x="690" y="62"/>
+      <point x="660" y="69"/>
+      <point x="627" y="82" type="curve"/>
+      <point x="595" y="10" type="line"/>
+      <point x="631" y="-7"/>
+      <point x="677" y="-16"/>
+      <point x="724" y="-16" type="curve" smooth="yes"/>
+      <point x="841" y="-16"/>
+      <point x="920" y="47"/>
+      <point x="920" y="153" type="curve" smooth="yes"/>
+      <point x="920" y="224"/>
+      <point x="875" y="276"/>
+      <point x="800" y="292" type="curve"/>
+      <point x="800" y="298" type="line"/>
+      <point x="861" y="317"/>
+      <point x="899" y="365"/>
+      <point x="899" y="435" type="curve" smooth="yes"/>
+      <point x="899" y="524"/>
+      <point x="828" y="596"/>
+      <point x="680" y="596" type="curve" smooth="yes"/>
+      <point x="518" y="596"/>
+      <point x="411" y="503"/>
+      <point x="411" y="346" type="curve" smooth="yes"/>
+      <point x="411" y="305"/>
+      <point x="415" y="263"/>
+      <point x="415" y="222" type="curve" smooth="yes"/>
+      <point x="415" y="120"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="90"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/g_ga-malayalam.glif
@@ -6,91 +6,95 @@
   <anchor x="763" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="392" y="-367" type="curve" smooth="yes"/>
-      <point x="500" y="-367"/>
-      <point x="551" y="-308"/>
-      <point x="557" y="-175" type="curve" smooth="yes"/>
-      <point x="558" y="-152" type="line" smooth="yes"/>
-      <point x="562" y="-55"/>
-      <point x="593" y="-27"/>
-      <point x="648" y="-27" type="curve" smooth="yes"/>
-      <point x="709" y="-27"/>
-      <point x="747" y="-75"/>
-      <point x="747" y="-155" type="curve" smooth="yes"/>
-      <point x="747" y="-228"/>
-      <point x="719" y="-280"/>
-      <point x="681" y="-324" type="curve"/>
-      <point x="734" y="-367" type="line"/>
-      <point x="794" y="-304"/>
-      <point x="821" y="-235"/>
-      <point x="821" y="-153" type="curve" smooth="yes"/>
-      <point x="821" y="-23"/>
-      <point x="748" y="43"/>
-      <point x="650" y="43" type="curve" smooth="yes"/>
-      <point x="542" y="43"/>
-      <point x="492" y="-16"/>
-      <point x="486" y="-146" type="curve" smooth="yes"/>
-      <point x="485" y="-168" type="line" smooth="yes"/>
-      <point x="480" y="-270"/>
-      <point x="449" y="-297"/>
-      <point x="395" y="-297" type="curve" smooth="yes"/>
-      <point x="334" y="-297"/>
-      <point x="295" y="-250"/>
-      <point x="295" y="-165" type="curve" smooth="yes"/>
-      <point x="295" y="-90"/>
-      <point x="323" y="-35"/>
-      <point x="373" y="17" type="curve"/>
-      <point x="348" y="-4" type="line"/>
-      <point x="434" y="25"/>
-      <point x="481" y="107"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="563" y="512"/>
-      <point x="647" y="512" type="curve" smooth="yes"/>
-      <point x="734" y="512"/>
-      <point x="784" y="440"/>
-      <point x="784" y="326" type="curve" smooth="yes"/>
-      <point x="784" y="213"/>
-      <point x="748" y="113"/>
-      <point x="656" y="17" type="curve"/>
-      <point x="732" y="-16" type="line"/>
+      <point x="284" y="-12" type="curve" smooth="yes"/>
+      <point x="410" y="-12"/>
+      <point x="499" y="84"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="452"/>
+      <point x="550" y="514"/>
+      <point x="642" y="514" type="curve" smooth="yes"/>
+      <point x="734" y="514"/>
+      <point x="784" y="447"/>
+      <point x="784" y="324" type="curve" smooth="yes"/>
+      <point x="784" y="215"/>
+      <point x="741" y="120"/>
+      <point x="659" y="31" type="curve"/>
+      <point x="733" y="-12" type="line"/>
       <point x="823" y="85"/>
-      <point x="868" y="203"/>
+      <point x="868" y="198"/>
       <point x="868" y="327" type="curve" smooth="yes"/>
-      <point x="868" y="491"/>
+      <point x="868" y="495"/>
       <point x="781" y="596"/>
-      <point x="641" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
+      <point x="638" y="596" type="curve" smooth="yes"/>
+      <point x="503" y="596"/>
+      <point x="411" y="498"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
       <point x="42" y="92"/>
-      <point x="128" y="-13"/>
-      <point x="275" y="-13" type="curve" smooth="yes"/>
-      <point x="283" y="-13"/>
-      <point x="291" y="-13"/>
-      <point x="299" y="-12" type="curve"/>
-      <point x="248" y="27" type="line"/>
-      <point x="284" y="-57" type="line"/>
-      <point x="288" y="6" type="line"/>
-      <point x="240" y="-44"/>
-      <point x="221" y="-105"/>
-      <point x="221" y="-167" type="curve" smooth="yes"/>
-      <point x="221" y="-302"/>
+      <point x="139" y="-12"/>
+    </contour>
+    <contour>
+      <point x="398" y="-367" type="curve" smooth="yes"/>
+      <point x="500" y="-367"/>
+      <point x="559" y="-302"/>
+      <point x="559" y="-195" type="curve" smooth="yes"/>
+      <point x="559" y="-174"/>
+      <point x="557" y="-155"/>
+      <point x="557" y="-134" type="curve" smooth="yes"/>
+      <point x="557" y="-63"/>
+      <point x="588" y="-27"/>
+      <point x="648" y="-27" type="curve" smooth="yes"/>
+      <point x="710" y="-27"/>
+      <point x="747" y="-74"/>
+      <point x="747" y="-155" type="curve" smooth="yes"/>
+      <point x="747" y="-220"/>
+      <point x="725" y="-272"/>
+      <point x="678" y="-319" type="curve"/>
+      <point x="729" y="-367" type="line"/>
+      <point x="792" y="-305"/>
+      <point x="821" y="-238"/>
+      <point x="821" y="-155" type="curve" smooth="yes"/>
+      <point x="821" y="-41"/>
+      <point x="746" y="43"/>
+      <point x="646" y="43" type="curve" smooth="yes"/>
+      <point x="545" y="43"/>
+      <point x="483" y="-22"/>
+      <point x="483" y="-127" type="curve" smooth="yes"/>
+      <point x="483" y="-147"/>
+      <point x="485" y="-169"/>
+      <point x="485" y="-188" type="curve" smooth="yes"/>
+      <point x="485" y="-261"/>
+      <point x="454" y="-297"/>
+      <point x="396" y="-297" type="curve" smooth="yes"/>
+      <point x="334" y="-297"/>
+      <point x="295" y="-252"/>
+      <point x="295" y="-175" type="curve" smooth="yes"/>
+      <point x="295" y="-102"/>
+      <point x="314" y="-48"/>
+      <point x="359" y="6" type="curve"/>
+      <point x="284" y="6" type="line"/>
+      <point x="243" y="-42"/>
+      <point x="221" y="-106"/>
+      <point x="221" y="-175" type="curve" smooth="yes"/>
+      <point x="221" y="-291"/>
       <point x="295" y="-367"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/g_la-malayalam.glif
@@ -32,38 +32,40 @@
       <point x="786" y="-367"/>
       <point x="852" y="-308"/>
       <point x="852" y="-182" type="curve" smooth="yes"/>
-      <point x="852" y="-74"/>
-      <point x="811" y="4"/>
-      <point x="752" y="61" type="curve"/>
-      <point x="757" y="13" type="line"/>
-      <point x="831" y="108"/>
-      <point x="868" y="215"/>
+      <point x="852" y="-84"/>
+      <point x="819" y="-4"/>
+      <point x="753" y="60" type="curve"/>
+      <point x="753" y="10" type="line"/>
+      <point x="830" y="102"/>
+      <point x="868" y="208"/>
       <point x="868" y="327" type="curve" smooth="yes"/>
-      <point x="868" y="491"/>
+      <point x="868" y="495"/>
       <point x="781" y="596"/>
-      <point x="641" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="119"/>
-      <point x="100" y="20"/>
+      <point x="638" y="596" type="curve" smooth="yes"/>
+      <point x="503" y="596"/>
+      <point x="411" y="498"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="121"/>
+      <point x="108" y="29"/>
       <point x="213" y="2" type="curve"/>
       <point x="214" y="-3" type="line"/>
-      <point x="160" y="-47"/>
+      <point x="159" y="-48"/>
       <point x="136" y="-111"/>
       <point x="136" y="-181" type="curve" smooth="yes"/>
       <point x="136" y="-305"/>
@@ -91,25 +93,27 @@
       <point x="606" y="-261"/>
       <point x="584" y="-182" type="curve" smooth="yes"/>
       <point x="572" y="-139" type="line" smooth="yes"/>
-      <point x="546" y="-44"/>
-      <point x="496" y="21"/>
-      <point x="408" y="35" type="curve"/>
-      <point x="408" y="40" type="line"/>
-      <point x="466" y="78"/>
-      <point x="485" y="150"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="563" y="512"/>
-      <point x="647" y="512" type="curve" smooth="yes"/>
-      <point x="734" y="512"/>
-      <point x="784" y="440"/>
-      <point x="784" y="326" type="curve" smooth="yes"/>
-      <point x="784" y="222"/>
-      <point x="744" y="130"/>
-      <point x="666" y="41" type="curve"/>
-      <point x="729" y="-12"/>
-      <point x="778" y="-79"/>
+      <point x="546" y="-45"/>
+      <point x="498" y="19"/>
+      <point x="413" y="33" type="curve"/>
+      <point x="413" y="38" type="line"/>
+      <point x="467" y="77"/>
+      <point x="499" y="142"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="452"/>
+      <point x="550" y="514"/>
+      <point x="642" y="514" type="curve" smooth="yes"/>
+      <point x="734" y="514"/>
+      <point x="784" y="447"/>
+      <point x="784" y="324" type="curve" smooth="yes"/>
+      <point x="784" y="220"/>
+      <point x="745" y="128"/>
+      <point x="665" y="44" type="curve"/>
+      <point x="745" y="-21"/>
+      <point x="778" y="-93"/>
       <point x="778" y="-182" type="curve" smooth="yes"/>
       <point x="778" y="-251"/>
       <point x="751" y="-297"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/g_ma-malayalam.glif
@@ -6,16 +6,18 @@
   <anchor x="1300" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="272" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="478" y="74"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="557" y="512"/>
-      <point x="648" y="512" type="curve" smooth="yes"/>
-      <point x="738" y="512"/>
-      <point x="784" y="440"/>
+      <point x="282" y="-16" type="curve" smooth="yes"/>
+      <point x="411" y="-16"/>
+      <point x="499" y="81"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="454"/>
+      <point x="547" y="514"/>
+      <point x="640" y="514" type="curve" smooth="yes"/>
+      <point x="733" y="514"/>
+      <point x="784" y="446"/>
       <point x="784" y="323" type="curve" smooth="yes"/>
       <point x="784" y="0" type="line"/>
       <point x="1350" y="0" type="line"/>
@@ -27,28 +29,30 @@
       <point x="880" y="555"/>
       <point x="834" y="474" type="curve"/>
       <point x="829" y="474" type="line"/>
-      <point x="792" y="559"/>
-      <point x="726" y="596"/>
-      <point x="639" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="89"/>
-      <point x="131" y="-16"/>
+      <point x="794" y="551"/>
+      <point x="728" y="596"/>
+      <point x="634" y="596" type="curve" smooth="yes"/>
+      <point x="500" y="596"/>
+      <point x="411" y="500"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="90"/>
+      <point x="137" y="-16"/>
     </contour>
     <contour>
       <point x="834" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/g_na-malayalam.glif
@@ -6,16 +6,18 @@
   <anchor x="1187" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="272" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="478" y="74"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="558" y="512"/>
-      <point x="648" y="512" type="curve" smooth="yes"/>
-      <point x="740" y="512"/>
-      <point x="784" y="450"/>
+      <point x="282" y="-16" type="curve" smooth="yes"/>
+      <point x="411" y="-16"/>
+      <point x="499" y="81"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="455"/>
+      <point x="551" y="518"/>
+      <point x="641" y="518" type="curve" smooth="yes"/>
+      <point x="736" y="518"/>
+      <point x="784" y="454"/>
       <point x="784" y="326" type="curve" smooth="yes"/>
       <point x="784" y="0" type="line"/>
       <point x="868" y="0" type="line"/>
@@ -40,28 +42,30 @@
       <point x="865" y="554"/>
       <point x="829" y="485" type="curve"/>
       <point x="824" y="485" type="line"/>
-      <point x="791" y="554"/>
-      <point x="729" y="596"/>
-      <point x="641" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="89"/>
-      <point x="131" y="-16"/>
+      <point x="789" y="552"/>
+      <point x="726" y="596"/>
+      <point x="637" y="596" type="curve" smooth="yes"/>
+      <point x="504" y="596"/>
+      <point x="411" y="498"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="90"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ga-malayalam.glif
@@ -7,46 +7,50 @@
   <anchor x="763" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="272" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="478" y="74"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="563" y="512"/>
-      <point x="647" y="512" type="curve" smooth="yes"/>
-      <point x="734" y="512"/>
-      <point x="784" y="440"/>
-      <point x="784" y="326" type="curve" smooth="yes"/>
-      <point x="784" y="222"/>
-      <point x="744" y="130"/>
-      <point x="666" y="41" type="curve"/>
-      <point x="732" y="-16" type="line"/>
-      <point x="823" y="85"/>
-      <point x="868" y="203"/>
+      <point x="282" y="-16" type="curve" smooth="yes"/>
+      <point x="411" y="-16"/>
+      <point x="499" y="81"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="452"/>
+      <point x="550" y="514"/>
+      <point x="642" y="514" type="curve" smooth="yes"/>
+      <point x="734" y="514"/>
+      <point x="784" y="447"/>
+      <point x="784" y="324" type="curve" smooth="yes"/>
+      <point x="784" y="220"/>
+      <point x="745" y="128"/>
+      <point x="665" y="44" type="curve"/>
+      <point x="730" y="-16" type="line"/>
+      <point x="822" y="82"/>
+      <point x="868" y="197"/>
       <point x="868" y="327" type="curve" smooth="yes"/>
-      <point x="868" y="491"/>
+      <point x="868" y="495"/>
       <point x="781" y="596"/>
-      <point x="641" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="89"/>
-      <point x="131" y="-16"/>
+      <point x="638" y="596" type="curve" smooth="yes"/>
+      <point x="503" y="596"/>
+      <point x="411" y="498"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="90"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ga-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ga-malayalam.half" format="2">
   <advance width="910"/>
+  <anchor x="502" y="0" name="bottom"/>
+  <anchor x="459" y="580" name="top"/>
+  <anchor x="763" y="580" name="topright"/>
   <outline>
     <component base="ga-malayalam"/>
     <component base="halant-malayalam" xOffset="763"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/j_ja-malayalam.glif
@@ -1,224 +1,224 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1602"/>
-  <anchor x="1213" y="0" name="bottom"/>
-  <anchor x="793" y="580" name="top"/>
-  <anchor x="1481" y="580" name="topright"/>
+  <advance width="1668"/>
+  <anchor x="1258" y="0" name="bottom"/>
+  <anchor x="834" y="580" name="top"/>
+  <anchor x="1527" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="326" y="-16" type="curve" smooth="yes"/>
-      <point x="623" y="-16"/>
-      <point x="779" y="95"/>
-      <point x="854" y="317" type="curve"/>
-      <point x="867" y="374" type="line"/>
-      <point x="872" y="374" type="line"/>
-      <point x="890" y="316"/>
-      <point x="931" y="294"/>
-      <point x="982" y="294" type="curve" smooth="yes"/>
-      <point x="1069" y="294"/>
-      <point x="1113" y="348"/>
-      <point x="1113" y="417" type="curve" smooth="yes"/>
-      <point x="1113" y="478"/>
-      <point x="1081" y="524"/>
-      <point x="1000" y="524" type="curve" smooth="yes"/>
-      <point x="978" y="524"/>
-      <point x="957" y="520"/>
-      <point x="946" y="514" type="curve"/>
-      <point x="973" y="488" type="line"/>
-      <point x="947" y="550" type="line"/>
-      <point x="941" y="511" type="line"/>
-      <point x="959" y="526"/>
-      <point x="986" y="535"/>
-      <point x="1026" y="535" type="curve" smooth="yes"/>
-      <point x="1134" y="535"/>
-      <point x="1172" y="454"/>
-      <point x="1172" y="380" type="curve" smooth="yes"/>
-      <point x="1172" y="343" type="line"/>
-      <point x="1256" y="343" type="line"/>
-      <point x="1256" y="376" type="line" smooth="yes"/>
-      <point x="1256" y="467"/>
-      <point x="1309" y="518"/>
-      <point x="1380" y="518" type="curve" smooth="yes"/>
-      <point x="1444" y="518"/>
-      <point x="1478" y="478"/>
-      <point x="1478" y="413" type="curve" smooth="yes"/>
-      <point x="1478" y="349"/>
-      <point x="1440" y="287"/>
-      <point x="1317" y="287" type="curve" smooth="yes"/>
-      <point x="1062" y="287" type="line" smooth="yes"/>
-      <point x="923" y="287"/>
-      <point x="852" y="221"/>
-      <point x="852" y="133" type="curve" smooth="yes"/>
-      <point x="852" y="54"/>
-      <point x="901" y="-16"/>
-      <point x="1009" y="-16" type="curve" smooth="yes"/>
-      <point x="1063" y="-16"/>
-      <point x="1122" y="1"/>
-      <point x="1202" y="54" type="curve" smooth="yes"/>
-      <point x="1256" y="90" type="line" smooth="yes"/>
-      <point x="1345" y="150"/>
-      <point x="1384" y="167"/>
-      <point x="1428" y="167" type="curve" smooth="yes"/>
-      <point x="1473" y="167"/>
-      <point x="1489" y="142"/>
-      <point x="1489" y="106" type="curve" smooth="yes"/>
-      <point x="1489" y="72"/>
-      <point x="1469" y="48"/>
-      <point x="1432" y="48" type="curve" smooth="yes"/>
-      <point x="1396" y="48"/>
-      <point x="1376" y="70"/>
-      <point x="1376" y="110" type="curve" smooth="yes"/>
-      <point x="1376" y="145"/>
-      <point x="1392" y="166"/>
-      <point x="1409" y="185" type="curve"/>
-      <point x="1311" y="152" type="line"/>
-      <point x="1328" y="130" type="line"/>
-      <point x="1323" y="116"/>
-      <point x="1320" y="107"/>
-      <point x="1320" y="90" type="curve" smooth="yes"/>
-      <point x="1320" y="34"/>
-      <point x="1357" y="-16"/>
-      <point x="1434" y="-16" type="curve" smooth="yes"/>
-      <point x="1513" y="-16"/>
-      <point x="1555" y="37"/>
-      <point x="1555" y="105" type="curve" smooth="yes"/>
-      <point x="1555" y="183"/>
-      <point x="1505" y="233"/>
-      <point x="1432" y="233" type="curve" smooth="yes"/>
-      <point x="1372" y="233"/>
-      <point x="1329" y="216"/>
-      <point x="1239" y="161" type="curve" smooth="yes"/>
-      <point x="1172" y="120" type="line" smooth="yes"/>
-      <point x="1095" y="73"/>
-      <point x="1062" y="61"/>
-      <point x="1016" y="61" type="curve" smooth="yes"/>
-      <point x="963" y="61"/>
-      <point x="931" y="88"/>
-      <point x="931" y="133" type="curve" smooth="yes"/>
-      <point x="931" y="183"/>
-      <point x="971" y="215"/>
-      <point x="1065" y="215" type="curve" smooth="yes"/>
-      <point x="1301" y="215" type="line" smooth="yes"/>
-      <point x="1494" y="215"/>
-      <point x="1560" y="312"/>
-      <point x="1560" y="416" type="curve" smooth="yes"/>
-      <point x="1560" y="526"/>
-      <point x="1488" y="596"/>
-      <point x="1381" y="596" type="curve" smooth="yes"/>
-      <point x="1297" y="596"/>
-      <point x="1236" y="549"/>
-      <point x="1218" y="478" type="curve"/>
-      <point x="1213" y="478" type="line"/>
-      <point x="1191" y="549"/>
-      <point x="1118" y="596"/>
-      <point x="1021" y="596" type="curve" smooth="yes"/>
-      <point x="931" y="596"/>
-      <point x="860" y="555"/>
-      <point x="824" y="444" type="curve" smooth="yes"/>
-      <point x="799" y="366" type="line" smooth="yes"/>
-      <point x="723" y="128"/>
-      <point x="569" y="61"/>
-      <point x="326" y="61" type="curve" smooth="yes"/>
-      <point x="182" y="61"/>
-      <point x="126" y="91"/>
-      <point x="126" y="147" type="curve" smooth="yes"/>
-      <point x="126" y="191"/>
-      <point x="157" y="215"/>
-      <point x="257" y="215" type="curve" smooth="yes"/>
-      <point x="498" y="215" type="line" smooth="yes"/>
-      <point x="695" y="215"/>
-      <point x="757" y="312"/>
-      <point x="757" y="424" type="curve" smooth="yes"/>
-      <point x="757" y="530"/>
-      <point x="689" y="596"/>
-      <point x="585" y="596" type="curve" smooth="yes"/>
-      <point x="505" y="596"/>
-      <point x="442" y="549"/>
-      <point x="424" y="478" type="curve"/>
-      <point x="419" y="478" type="line"/>
-      <point x="397" y="549"/>
-      <point x="324" y="596"/>
-      <point x="227" y="596" type="curve" smooth="yes"/>
-      <point x="118" y="596"/>
-      <point x="42" y="532"/>
-      <point x="42" y="432" type="curve" smooth="yes"/>
-      <point x="42" y="353"/>
-      <point x="98" y="294"/>
-      <point x="183" y="294" type="curve" smooth="yes"/>
-      <point x="269" y="294"/>
-      <point x="319" y="348"/>
-      <point x="319" y="417" type="curve" smooth="yes"/>
-      <point x="319" y="478"/>
-      <point x="287" y="524"/>
-      <point x="206" y="524" type="curve" smooth="yes"/>
-      <point x="184" y="524"/>
-      <point x="163" y="520"/>
-      <point x="152" y="514" type="curve"/>
-      <point x="179" y="488" type="line"/>
-      <point x="153" y="550" type="line"/>
-      <point x="147" y="511" type="line"/>
-      <point x="165" y="526"/>
-      <point x="192" y="535"/>
-      <point x="232" y="535" type="curve" smooth="yes"/>
-      <point x="340" y="535"/>
-      <point x="378" y="454"/>
-      <point x="378" y="380" type="curve" smooth="yes"/>
-      <point x="378" y="343" type="line"/>
-      <point x="462" y="343" type="line"/>
-      <point x="462" y="376" type="line" smooth="yes"/>
-      <point x="462" y="467"/>
-      <point x="511" y="518"/>
-      <point x="581" y="518" type="curve" smooth="yes"/>
-      <point x="645" y="518"/>
-      <point x="675" y="478"/>
-      <point x="675" y="413" type="curve" smooth="yes"/>
-      <point x="675" y="349"/>
-      <point x="641" y="287"/>
-      <point x="514" y="287" type="curve" smooth="yes"/>
-      <point x="254" y="287" type="line" smooth="yes"/>
-      <point x="105" y="287"/>
-      <point x="48" y="229"/>
-      <point x="48" y="147" type="curve" smooth="yes"/>
-      <point x="48" y="39"/>
-      <point x="134" y="-16"/>
+      <point x="308" y="-16" type="curve" smooth="yes"/>
+      <point x="604" y="-16"/>
+      <point x="783" y="86"/>
+      <point x="879" y="287" type="curve"/>
+      <point x="892" y="344" type="line"/>
+      <point x="897" y="344" type="line"/>
+      <point x="909" y="302"/>
+      <point x="949" y="273"/>
+      <point x="1012" y="273" type="curve" smooth="yes"/>
+      <point x="1090" y="273"/>
+      <point x="1145" y="324"/>
+      <point x="1145" y="402" type="curve" smooth="yes"/>
+      <point x="1145" y="470"/>
+      <point x="1103" y="515"/>
+      <point x="1032" y="515" type="curve" smooth="yes"/>
+      <point x="1006" y="515"/>
+      <point x="983" y="510"/>
+      <point x="961" y="499" type="curve"/>
+      <point x="946" y="523" type="line"/>
+      <point x="946" y="491" type="line"/>
+      <point x="976" y="520"/>
+      <point x="1018" y="536"/>
+      <point x="1073" y="536" type="curve" smooth="yes"/>
+      <point x="1169" y="536"/>
+      <point x="1212" y="484"/>
+      <point x="1212" y="382" type="curve" smooth="yes"/>
+      <point x="1212" y="324" type="line"/>
+      <point x="1296" y="324" type="line"/>
+      <point x="1296" y="380" type="line" smooth="yes"/>
+      <point x="1296" y="469"/>
+      <point x="1349" y="518"/>
+      <point x="1430" y="518" type="curve" smooth="yes"/>
+      <point x="1503" y="518"/>
+      <point x="1544" y="475"/>
+      <point x="1544" y="403" type="curve" smooth="yes"/>
+      <point x="1544" y="316"/>
+      <point x="1481" y="267"/>
+      <point x="1365" y="267" type="curve" smooth="yes"/>
+      <point x="1040" y="267" type="line" smooth="yes"/>
+      <point x="937" y="267"/>
+      <point x="864" y="212"/>
+      <point x="864" y="122" type="curve" smooth="yes"/>
+      <point x="864" y="41"/>
+      <point x="930" y="-16"/>
+      <point x="1020" y="-16" type="curve" smooth="yes"/>
+      <point x="1070" y="-16"/>
+      <point x="1105" y="-5"/>
+      <point x="1189" y="36" type="curve" smooth="yes"/>
+      <point x="1309" y="95" type="line"/>
+      <point x="1378" y="138" type="line"/>
+      <point x="1410" y="146" type="line"/>
+      <point x="1434" y="168"/>
+      <point x="1457" y="176"/>
+      <point x="1486" y="176" type="curve" smooth="yes"/>
+      <point x="1525" y="176"/>
+      <point x="1548" y="154"/>
+      <point x="1548" y="115" type="curve" smooth="yes"/>
+      <point x="1548" y="78"/>
+      <point x="1523" y="54"/>
+      <point x="1485" y="54" type="curve" smooth="yes"/>
+      <point x="1447" y="54"/>
+      <point x="1421" y="79"/>
+      <point x="1421" y="115" type="curve" smooth="yes"/>
+      <point x="1421" y="143"/>
+      <point x="1435" y="168"/>
+      <point x="1458" y="181" type="curve"/>
+      <point x="1351" y="145" type="line"/>
+      <point x="1370" y="128" type="line"/>
+      <point x="1366" y="116"/>
+      <point x="1365" y="106"/>
+      <point x="1365" y="94" type="curve" smooth="yes"/>
+      <point x="1365" y="32"/>
+      <point x="1416" y="-16"/>
+      <point x="1490" y="-16" type="curve" smooth="yes"/>
+      <point x="1571" y="-16"/>
+      <point x="1622" y="38"/>
+      <point x="1622" y="114" type="curve" smooth="yes"/>
+      <point x="1622" y="185"/>
+      <point x="1571" y="236"/>
+      <point x="1492" y="236" type="curve" smooth="yes"/>
+      <point x="1453" y="236"/>
+      <point x="1408" y="220"/>
+      <point x="1334" y="184" type="curve" smooth="yes"/>
+      <point x="1161" y="99" type="line" smooth="yes"/>
+      <point x="1103" y="71"/>
+      <point x="1066" y="60"/>
+      <point x="1024" y="60" type="curve" smooth="yes"/>
+      <point x="977" y="60"/>
+      <point x="946" y="85"/>
+      <point x="946" y="125" type="curve" smooth="yes"/>
+      <point x="946" y="170"/>
+      <point x="981" y="195"/>
+      <point x="1043" y="195" type="curve" smooth="yes"/>
+      <point x="1355" y="195" type="line" smooth="yes"/>
+      <point x="1520" y="195"/>
+      <point x="1626" y="277"/>
+      <point x="1626" y="405" type="curve" smooth="yes"/>
+      <point x="1626" y="521"/>
+      <point x="1556" y="596"/>
+      <point x="1443" y="596" type="curve" smooth="yes"/>
+      <point x="1354" y="596"/>
+      <point x="1290" y="552"/>
+      <point x="1258" y="478" type="curve"/>
+      <point x="1253" y="478" type="line"/>
+      <point x="1227" y="553"/>
+      <point x="1168" y="596"/>
+      <point x="1073" y="596" type="curve" smooth="yes"/>
+      <point x="966" y="596"/>
+      <point x="888" y="543"/>
+      <point x="856" y="444" type="curve" smooth="yes"/>
+      <point x="831" y="366" type="line" smooth="yes"/>
+      <point x="764" y="156"/>
+      <point x="600" y="61"/>
+      <point x="308" y="61" type="curve" smooth="yes"/>
+      <point x="175" y="61"/>
+      <point x="128" y="84"/>
+      <point x="128" y="132" type="curve" smooth="yes"/>
+      <point x="128" y="173"/>
+      <point x="165" y="195"/>
+      <point x="231" y="195" type="curve" smooth="yes"/>
+      <point x="507" y="195" type="line" smooth="yes"/>
+      <point x="673" y="195"/>
+      <point x="776" y="285"/>
+      <point x="776" y="410" type="curve" smooth="yes"/>
+      <point x="776" y="521"/>
+      <point x="710" y="596"/>
+      <point x="604" y="596" type="curve" smooth="yes"/>
+      <point x="524" y="596"/>
+      <point x="464" y="550"/>
+      <point x="440" y="478" type="curve"/>
+      <point x="435" y="478" type="line"/>
+      <point x="408" y="556"/>
+      <point x="346" y="596"/>
+      <point x="254" y="596" type="curve" smooth="yes"/>
+      <point x="137" y="596"/>
+      <point x="42" y="525"/>
+      <point x="42" y="420" type="curve" smooth="yes"/>
+      <point x="42" y="332"/>
+      <point x="100" y="273"/>
+      <point x="188" y="273" type="curve" smooth="yes"/>
+      <point x="270" y="273"/>
+      <point x="327" y="324"/>
+      <point x="327" y="402" type="curve" smooth="yes"/>
+      <point x="327" y="470"/>
+      <point x="285" y="515"/>
+      <point x="214" y="515" type="curve" smooth="yes"/>
+      <point x="188" y="515"/>
+      <point x="165" y="510"/>
+      <point x="143" y="499" type="curve"/>
+      <point x="128" y="523" type="line"/>
+      <point x="128" y="491" type="line"/>
+      <point x="158" y="520"/>
+      <point x="198" y="536"/>
+      <point x="254" y="536" type="curve" smooth="yes"/>
+      <point x="352" y="536"/>
+      <point x="394" y="483"/>
+      <point x="394" y="382" type="curve" smooth="yes"/>
+      <point x="394" y="324" type="line"/>
+      <point x="478" y="324" type="line"/>
+      <point x="478" y="380" type="line" smooth="yes"/>
+      <point x="478" y="467"/>
+      <point x="521" y="518"/>
+      <point x="596" y="518" type="curve" smooth="yes"/>
+      <point x="658" y="518"/>
+      <point x="694" y="479"/>
+      <point x="694" y="410" type="curve" smooth="yes"/>
+      <point x="694" y="316"/>
+      <point x="629" y="267"/>
+      <point x="503" y="267" type="curve" smooth="yes"/>
+      <point x="228" y="267" type="line" smooth="yes"/>
+      <point x="121" y="267"/>
+      <point x="46" y="214"/>
+      <point x="46" y="129" type="curve" smooth="yes"/>
+      <point x="46" y="36"/>
+      <point x="128" y="-16"/>
     </contour>
     <contour>
-      <point x="184" y="357" type="curve" smooth="yes"/>
-      <point x="137" y="357"/>
-      <point x="118" y="392"/>
-      <point x="118" y="441" type="curve" smooth="yes"/>
-      <point x="118" y="457"/>
-      <point x="120" y="472"/>
-      <point x="126" y="484" type="curve"/>
-      <point x="107" y="484" type="line"/>
-      <point x="83" y="451" type="line"/>
-      <point x="107" y="470"/>
-      <point x="144" y="482"/>
-      <point x="178" y="482" type="curve" smooth="yes"/>
-      <point x="236" y="482"/>
-      <point x="247" y="447"/>
-      <point x="247" y="422" type="curve" smooth="yes"/>
-      <point x="247" y="384"/>
-      <point x="227" y="357"/>
+      <point x="183" y="341" type="curve" smooth="yes"/>
+      <point x="139" y="341"/>
+      <point x="110" y="370"/>
+      <point x="110" y="416" type="curve" smooth="yes"/>
+      <point x="110" y="439"/>
+      <point x="114" y="454"/>
+      <point x="126" y="475" type="curve"/>
+      <point x="98" y="475" type="line"/>
+      <point x="90" y="427" type="line"/>
+      <point x="113" y="453"/>
+      <point x="148" y="467"/>
+      <point x="183" y="467" type="curve" smooth="yes"/>
+      <point x="227" y="467"/>
+      <point x="251" y="442"/>
+      <point x="251" y="404" type="curve" smooth="yes"/>
+      <point x="251" y="366"/>
+      <point x="226" y="341"/>
     </contour>
     <contour>
-      <point x="978" y="357" type="curve" smooth="yes"/>
-      <point x="931" y="357"/>
-      <point x="912" y="392"/>
-      <point x="912" y="441" type="curve" smooth="yes"/>
-      <point x="912" y="457"/>
-      <point x="914" y="472"/>
-      <point x="920" y="484" type="curve"/>
-      <point x="901" y="484" type="line"/>
-      <point x="877" y="451" type="line"/>
-      <point x="901" y="470"/>
-      <point x="938" y="482"/>
-      <point x="972" y="482" type="curve" smooth="yes"/>
-      <point x="1030" y="482"/>
-      <point x="1041" y="447"/>
-      <point x="1041" y="422" type="curve" smooth="yes"/>
-      <point x="1041" y="384"/>
-      <point x="1021" y="357"/>
+      <point x="1001" y="341" type="curve" smooth="yes"/>
+      <point x="957" y="341"/>
+      <point x="928" y="370"/>
+      <point x="928" y="416" type="curve" smooth="yes"/>
+      <point x="928" y="439"/>
+      <point x="932" y="454"/>
+      <point x="944" y="475" type="curve"/>
+      <point x="916" y="475" type="line"/>
+      <point x="908" y="427" type="line"/>
+      <point x="931" y="453"/>
+      <point x="966" y="467"/>
+      <point x="1001" y="467" type="curve" smooth="yes"/>
+      <point x="1045" y="467"/>
+      <point x="1069" y="442"/>
+      <point x="1069" y="404" type="curve" smooth="yes"/>
+      <point x="1069" y="366"/>
+      <point x="1044" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/j_nya-malayalam.glif
@@ -1,185 +1,184 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2195"/>
-  <anchor x="1786" y="0" name="bottom"/>
-  <anchor x="1091" y="580" name="top"/>
-  <anchor x="2059" y="580" name="topright"/>
+  <advance width="2228"/>
+  <anchor x="1819" y="0" name="bottom"/>
+  <anchor x="1114" y="580" name="top"/>
+  <anchor x="2092" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="336" y="-16" type="curve" smooth="yes"/>
-      <point x="560" y="-16"/>
-      <point x="712" y="43"/>
-      <point x="800" y="189" type="curve"/>
-      <point x="806" y="189" type="line"/>
-      <point x="829" y="69"/>
-      <point x="904" y="-16"/>
-      <point x="1019" y="-16" type="curve" smooth="yes"/>
-      <point x="1129" y="-16"/>
-      <point x="1195" y="65"/>
-      <point x="1195" y="175" type="curve" smooth="yes"/>
-      <point x="1195" y="272"/>
-      <point x="1138" y="347"/>
-      <point x="1026" y="347" type="curve" smooth="yes"/>
-      <point x="962" y="347"/>
-      <point x="906" y="314"/>
-      <point x="876" y="264" type="curve"/>
-      <point x="864" y="268" type="line"/>
-      <point x="878" y="138" type="line"/>
-      <point x="893" y="223"/>
-      <point x="947" y="273"/>
-      <point x="1016" y="273" type="curve" smooth="yes"/>
-      <point x="1079" y="273"/>
-      <point x="1113" y="239"/>
-      <point x="1113" y="171" type="curve" smooth="yes"/>
-      <point x="1113" y="101"/>
-      <point x="1074" y="62"/>
-      <point x="1014" y="62" type="curve" smooth="yes"/>
-      <point x="923" y="62"/>
-      <point x="871" y="163"/>
-      <point x="871" y="266" type="curve" smooth="yes"/>
-      <point x="871" y="413"/>
-      <point x="961" y="518"/>
-      <point x="1091" y="518" type="curve" smooth="yes"/>
-      <point x="1206" y="518"/>
-      <point x="1268" y="441"/>
-      <point x="1268" y="318" type="curve" smooth="yes"/>
-      <point x="1268" y="0" type="line"/>
-      <point x="1352" y="0" type="line"/>
-      <point x="1352" y="318" type="line" smooth="yes"/>
-      <point x="1352" y="441"/>
-      <point x="1420" y="518"/>
-      <point x="1545" y="518" type="curve" smooth="yes"/>
-      <point x="1716" y="518"/>
-      <point x="1807" y="397"/>
-      <point x="1807" y="241" type="curve" smooth="yes"/>
-      <point x="1807" y="130"/>
-      <point x="1767" y="64"/>
-      <point x="1693" y="64" type="curve" smooth="yes"/>
-      <point x="1621" y="64"/>
-      <point x="1582" y="124"/>
-      <point x="1582" y="216" type="curve" smooth="yes"/>
-      <point x="1582" y="383"/>
-      <point x="1693" y="518"/>
-      <point x="1855" y="518" type="curve" smooth="yes"/>
-      <point x="1995" y="518"/>
-      <point x="2071" y="435"/>
-      <point x="2071" y="305" type="curve" smooth="yes"/>
-      <point x="2071" y="208"/>
-      <point x="2033" y="120"/>
-      <point x="1965" y="42" type="curve"/>
-      <point x="2034" y="-14" type="line"/>
-      <point x="2108" y="78"/>
-      <point x="2153" y="174"/>
-      <point x="2153" y="296" type="curve" smooth="yes"/>
-      <point x="2153" y="484"/>
-      <point x="2047" y="596"/>
-      <point x="1858" y="596" type="curve" smooth="yes"/>
-      <point x="1651" y="596"/>
-      <point x="1500" y="423"/>
-      <point x="1500" y="217" type="curve" smooth="yes"/>
-      <point x="1500" y="79"/>
-      <point x="1575" y="-14"/>
-      <point x="1697" y="-14" type="curve" smooth="yes"/>
-      <point x="1822" y="-14"/>
-      <point x="1889" y="85"/>
-      <point x="1889" y="235" type="curve" smooth="yes"/>
-      <point x="1889" y="432"/>
-      <point x="1761" y="596"/>
-      <point x="1548" y="596" type="curve" smooth="yes"/>
-      <point x="1436" y="596"/>
-      <point x="1359" y="548"/>
-      <point x="1319" y="470" type="curve"/>
-      <point x="1314" y="470" type="line"/>
-      <point x="1274" y="548"/>
-      <point x="1199" y="596"/>
-      <point x="1090" y="596" type="curve" smooth="yes"/>
-      <point x="933" y="596"/>
-      <point x="843" y="506"/>
-      <point x="793" y="348" type="curve" smooth="yes"/>
-      <point x="721" y="117"/>
-      <point x="579" y="61"/>
-      <point x="336" y="61" type="curve" smooth="yes"/>
-      <point x="182" y="61"/>
-      <point x="126" y="91"/>
-      <point x="126" y="147" type="curve" smooth="yes"/>
-      <point x="126" y="191"/>
-      <point x="157" y="215"/>
-      <point x="257" y="215" type="curve" smooth="yes"/>
-      <point x="498" y="215" type="line" smooth="yes"/>
-      <point x="695" y="215"/>
-      <point x="759" y="312"/>
-      <point x="757" y="424" type="curve" smooth="yes"/>
-      <point x="755" y="530"/>
-      <point x="689" y="596"/>
-      <point x="585" y="596" type="curve" smooth="yes"/>
-      <point x="505" y="596"/>
-      <point x="442" y="549"/>
-      <point x="424" y="478" type="curve"/>
-      <point x="419" y="478" type="line"/>
-      <point x="397" y="549"/>
-      <point x="324" y="596"/>
-      <point x="227" y="596" type="curve" smooth="yes"/>
-      <point x="118" y="596"/>
-      <point x="42" y="532"/>
-      <point x="42" y="432" type="curve" smooth="yes"/>
-      <point x="42" y="353"/>
-      <point x="98" y="294"/>
-      <point x="183" y="294" type="curve" smooth="yes"/>
-      <point x="269" y="294"/>
-      <point x="319" y="348"/>
-      <point x="319" y="417" type="curve" smooth="yes"/>
-      <point x="319" y="478"/>
-      <point x="287" y="524"/>
-      <point x="206" y="524" type="curve" smooth="yes"/>
-      <point x="184" y="524"/>
-      <point x="163" y="520"/>
-      <point x="152" y="514" type="curve"/>
-      <point x="179" y="488" type="line"/>
-      <point x="153" y="550" type="line"/>
-      <point x="147" y="511" type="line"/>
-      <point x="165" y="526"/>
-      <point x="192" y="535"/>
-      <point x="232" y="535" type="curve" smooth="yes"/>
-      <point x="340" y="535"/>
-      <point x="378" y="454"/>
-      <point x="378" y="380" type="curve" smooth="yes"/>
-      <point x="378" y="343" type="line"/>
-      <point x="462" y="343" type="line"/>
-      <point x="462" y="376" type="line" smooth="yes"/>
-      <point x="462" y="467"/>
-      <point x="511" y="518"/>
-      <point x="581" y="518" type="curve" smooth="yes"/>
-      <point x="645" y="518"/>
-      <point x="675" y="478"/>
-      <point x="675" y="413" type="curve" smooth="yes"/>
-      <point x="675" y="349"/>
-      <point x="641" y="287"/>
-      <point x="514" y="287" type="curve" smooth="yes"/>
-      <point x="254" y="287" type="line" smooth="yes"/>
-      <point x="105" y="287"/>
-      <point x="48" y="229"/>
-      <point x="48" y="147" type="curve" smooth="yes"/>
-      <point x="48" y="39"/>
-      <point x="134" y="-16"/>
+      <point x="316" y="-16" type="curve" smooth="yes"/>
+      <point x="570" y="-16"/>
+      <point x="740" y="53"/>
+      <point x="830" y="200" type="curve"/>
+      <point x="836" y="200" type="line"/>
+      <point x="856" y="67"/>
+      <point x="935" y="-16"/>
+      <point x="1052" y="-16" type="curve" smooth="yes"/>
+      <point x="1162" y="-16"/>
+      <point x="1228" y="65"/>
+      <point x="1228" y="175" type="curve" smooth="yes"/>
+      <point x="1228" y="272"/>
+      <point x="1171" y="347"/>
+      <point x="1059" y="347" type="curve" smooth="yes"/>
+      <point x="995" y="347"/>
+      <point x="939" y="314"/>
+      <point x="909" y="264" type="curve"/>
+      <point x="897" y="268" type="line"/>
+      <point x="911" y="138" type="line"/>
+      <point x="926" y="223"/>
+      <point x="982" y="273"/>
+      <point x="1049" y="273" type="curve" smooth="yes"/>
+      <point x="1112" y="273"/>
+      <point x="1146" y="239"/>
+      <point x="1146" y="171" type="curve" smooth="yes"/>
+      <point x="1146" y="101"/>
+      <point x="1107" y="62"/>
+      <point x="1047" y="62" type="curve" smooth="yes"/>
+      <point x="954" y="62"/>
+      <point x="904" y="163"/>
+      <point x="904" y="266" type="curve" smooth="yes"/>
+      <point x="904" y="413"/>
+      <point x="994" y="518"/>
+      <point x="1124" y="518" type="curve" smooth="yes"/>
+      <point x="1239" y="518"/>
+      <point x="1301" y="441"/>
+      <point x="1301" y="318" type="curve" smooth="yes"/>
+      <point x="1301" y="0" type="line"/>
+      <point x="1385" y="0" type="line"/>
+      <point x="1385" y="318" type="line" smooth="yes"/>
+      <point x="1385" y="441"/>
+      <point x="1453" y="518"/>
+      <point x="1578" y="518" type="curve" smooth="yes"/>
+      <point x="1749" y="518"/>
+      <point x="1840" y="397"/>
+      <point x="1840" y="241" type="curve" smooth="yes"/>
+      <point x="1840" y="130"/>
+      <point x="1800" y="64"/>
+      <point x="1726" y="64" type="curve" smooth="yes"/>
+      <point x="1654" y="64"/>
+      <point x="1615" y="124"/>
+      <point x="1615" y="216" type="curve" smooth="yes"/>
+      <point x="1615" y="383"/>
+      <point x="1726" y="518"/>
+      <point x="1888" y="518" type="curve" smooth="yes"/>
+      <point x="2028" y="518"/>
+      <point x="2104" y="435"/>
+      <point x="2104" y="305" type="curve" smooth="yes"/>
+      <point x="2104" y="208"/>
+      <point x="2066" y="120"/>
+      <point x="1998" y="42" type="curve"/>
+      <point x="2067" y="-14" type="line"/>
+      <point x="2141" y="78"/>
+      <point x="2186" y="174"/>
+      <point x="2186" y="296" type="curve" smooth="yes"/>
+      <point x="2186" y="484"/>
+      <point x="2080" y="596"/>
+      <point x="1891" y="596" type="curve" smooth="yes"/>
+      <point x="1684" y="596"/>
+      <point x="1533" y="423"/>
+      <point x="1533" y="217" type="curve" smooth="yes"/>
+      <point x="1533" y="79"/>
+      <point x="1608" y="-14"/>
+      <point x="1730" y="-14" type="curve" smooth="yes"/>
+      <point x="1855" y="-14"/>
+      <point x="1922" y="85"/>
+      <point x="1922" y="235" type="curve" smooth="yes"/>
+      <point x="1922" y="432"/>
+      <point x="1794" y="596"/>
+      <point x="1581" y="596" type="curve" smooth="yes"/>
+      <point x="1469" y="596"/>
+      <point x="1392" y="548"/>
+      <point x="1352" y="470" type="curve"/>
+      <point x="1347" y="470" type="line"/>
+      <point x="1307" y="548"/>
+      <point x="1232" y="596"/>
+      <point x="1123" y="596" type="curve" smooth="yes"/>
+      <point x="977" y="596"/>
+      <point x="878" y="514"/>
+      <point x="826" y="348" type="curve" smooth="yes"/>
+      <point x="761" y="142"/>
+      <point x="616" y="61"/>
+      <point x="316" y="61" type="curve" smooth="yes"/>
+      <point x="177" y="61"/>
+      <point x="128" y="85"/>
+      <point x="128" y="131" type="curve" smooth="yes"/>
+      <point x="128" y="172"/>
+      <point x="165" y="195"/>
+      <point x="231" y="195" type="curve" smooth="yes"/>
+      <point x="507" y="195" type="line" smooth="yes"/>
+      <point x="673" y="195"/>
+      <point x="776" y="285"/>
+      <point x="776" y="410" type="curve" smooth="yes"/>
+      <point x="776" y="521"/>
+      <point x="710" y="596"/>
+      <point x="605" y="596" type="curve" smooth="yes"/>
+      <point x="525" y="596"/>
+      <point x="464" y="550"/>
+      <point x="440" y="478" type="curve"/>
+      <point x="435" y="478" type="line"/>
+      <point x="408" y="556"/>
+      <point x="346" y="596"/>
+      <point x="256" y="596" type="curve" smooth="yes"/>
+      <point x="137" y="596"/>
+      <point x="42" y="525"/>
+      <point x="42" y="420" type="curve" smooth="yes"/>
+      <point x="42" y="332"/>
+      <point x="100" y="273"/>
+      <point x="188" y="273" type="curve" smooth="yes"/>
+      <point x="270" y="273"/>
+      <point x="327" y="324"/>
+      <point x="327" y="402" type="curve" smooth="yes"/>
+      <point x="327" y="470"/>
+      <point x="285" y="515"/>
+      <point x="214" y="515" type="curve" smooth="yes"/>
+      <point x="188" y="515"/>
+      <point x="165" y="510"/>
+      <point x="143" y="499" type="curve"/>
+      <point x="128" y="523" type="line"/>
+      <point x="128" y="491" type="line"/>
+      <point x="159" y="520"/>
+      <point x="197" y="536"/>
+      <point x="256" y="536" type="curve" smooth="yes"/>
+      <point x="351" y="536"/>
+      <point x="394" y="483"/>
+      <point x="394" y="382" type="curve" smooth="yes"/>
+      <point x="394" y="324" type="line"/>
+      <point x="478" y="324" type="line"/>
+      <point x="478" y="380" type="line" smooth="yes"/>
+      <point x="478" y="467"/>
+      <point x="522" y="518"/>
+      <point x="597" y="518" type="curve" smooth="yes"/>
+      <point x="658" y="518"/>
+      <point x="694" y="479"/>
+      <point x="694" y="410" type="curve" smooth="yes"/>
+      <point x="694" y="316"/>
+      <point x="629" y="267"/>
+      <point x="503" y="267" type="curve" smooth="yes"/>
+      <point x="228" y="267" type="line" smooth="yes"/>
+      <point x="121" y="267"/>
+      <point x="46" y="214"/>
+      <point x="46" y="128" type="curve" smooth="yes"/>
+      <point x="46" y="38"/>
+      <point x="131" y="-16"/>
     </contour>
     <contour>
-      <point x="184" y="357" type="curve" smooth="yes"/>
-      <point x="137" y="357"/>
-      <point x="118" y="392"/>
-      <point x="118" y="441" type="curve" smooth="yes"/>
-      <point x="118" y="457"/>
-      <point x="120" y="472"/>
-      <point x="126" y="484" type="curve"/>
-      <point x="107" y="484" type="line"/>
-      <point x="83" y="451" type="line"/>
-      <point x="107" y="470"/>
-      <point x="144" y="482"/>
-      <point x="178" y="482" type="curve" smooth="yes"/>
-      <point x="236" y="482"/>
-      <point x="247" y="447"/>
-      <point x="247" y="422" type="curve" smooth="yes"/>
-      <point x="247" y="384"/>
-      <point x="227" y="357"/>
+      <point x="183" y="341" type="curve" smooth="yes"/>
+      <point x="139" y="341"/>
+      <point x="110" y="370"/>
+      <point x="110" y="416" type="curve" smooth="yes"/>
+      <point x="110" y="439"/>
+      <point x="114" y="454"/>
+      <point x="126" y="475" type="curve"/>
+      <point x="98" y="475" type="line"/>
+      <point x="90" y="427" type="line"/>
+      <point x="113" y="453"/>
+      <point x="148" y="467"/>
+      <point x="183" y="467" type="curve" smooth="yes"/>
+      <point x="227" y="467"/>
+      <point x="251" y="442"/>
+      <point x="251" y="404" type="curve" smooth="yes"/>
+      <point x="251" y="366"/>
+      <point x="226" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ja-malayalam.glif
@@ -1,137 +1,135 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <unicode hex="0D1C"/>
-  <guideline x="48" y="133" angle="91.1496"/>
-  <guideline x="766" y="416" angle="269.0789"/>
-  <anchor x="419" y="0" name="bottom"/>
-  <anchor x="419" y="580" name="top"/>
-  <anchor x="687" y="580" name="topright"/>
+  <anchor x="440" y="0" name="bottom"/>
+  <anchor x="425" y="580" name="top"/>
+  <anchor x="709" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="258" y="-16"/>
-      <point x="307" y="2"/>
-      <point x="396" y="54" type="curve" smooth="yes"/>
-      <point x="459" y="91" type="line"/>
-      <point x="546" y="142" type="line"/>
-      <point x="562" y="148" type="line"/>
-      <point x="594" y="163"/>
-      <point x="612" y="167"/>
-      <point x="634" y="167" type="curve" smooth="yes"/>
-      <point x="675" y="167"/>
-      <point x="695" y="147"/>
-      <point x="695" y="106" type="curve" smooth="yes"/>
-      <point x="695" y="70"/>
-      <point x="673" y="48"/>
-      <point x="638" y="48" type="curve" smooth="yes"/>
-      <point x="602" y="48"/>
-      <point x="582" y="70"/>
-      <point x="582" y="110" type="curve" smooth="yes"/>
-      <point x="582" y="137"/>
-      <point x="591" y="159"/>
-      <point x="615" y="185" type="curve"/>
-      <point x="517" y="152" type="line"/>
-      <point x="534" y="130" type="line"/>
-      <point x="528" y="112"/>
-      <point x="526" y="104"/>
-      <point x="526" y="90" type="curve" smooth="yes"/>
-      <point x="526" y="26"/>
-      <point x="571" y="-16"/>
-      <point x="640" y="-16" type="curve" smooth="yes"/>
-      <point x="714" y="-16"/>
-      <point x="761" y="31"/>
-      <point x="761" y="105" type="curve" smooth="yes"/>
-      <point x="761" y="182"/>
-      <point x="712" y="233"/>
-      <point x="638" y="233" type="curve" smooth="yes"/>
-      <point x="586" y="233"/>
-      <point x="556" y="222"/>
-      <point x="442" y="162" type="curve" smooth="yes"/>
-      <point x="366" y="122" type="line" smooth="yes"/>
-      <point x="268" y="70"/>
-      <point x="244" y="61"/>
-      <point x="202" y="61" type="curve" smooth="yes"/>
-      <point x="155" y="61"/>
-      <point x="127" y="88"/>
-      <point x="127" y="133" type="curve" smooth="yes"/>
-      <point x="127" y="188"/>
-      <point x="170" y="215"/>
-      <point x="257" y="215" type="curve" smooth="yes"/>
-      <point x="507" y="215" type="line" smooth="yes"/>
-      <point x="671" y="215"/>
-      <point x="766" y="289"/>
-      <point x="766" y="416" type="curve" smooth="yes"/>
-      <point x="766" y="525"/>
-      <point x="695" y="596"/>
-      <point x="587" y="596" type="curve" smooth="yes"/>
-      <point x="505" y="596"/>
-      <point x="442" y="551"/>
-      <point x="424" y="478" type="curve"/>
-      <point x="419" y="478" type="line"/>
-      <point x="398" y="550"/>
-      <point x="337" y="596"/>
-      <point x="240" y="596" type="curve" smooth="yes"/>
-      <point x="123" y="596"/>
-      <point x="42" y="526"/>
-      <point x="42" y="432" type="curve" smooth="yes"/>
-      <point x="42" y="351"/>
-      <point x="100" y="294"/>
-      <point x="183" y="294" type="curve" smooth="yes"/>
-      <point x="264" y="294"/>
-      <point x="319" y="340"/>
-      <point x="319" y="409" type="curve" smooth="yes"/>
-      <point x="319" y="477"/>
-      <point x="281" y="515"/>
-      <point x="215" y="515" type="curve" smooth="yes"/>
-      <point x="190" y="515"/>
-      <point x="166" y="510"/>
-      <point x="144" y="500" type="curve"/>
-      <point x="128" y="522" type="line"/>
-      <point x="137" y="498" type="line"/>
-      <point x="161" y="523"/>
-      <point x="197" y="536"/>
-      <point x="240" y="536" type="curve" smooth="yes"/>
-      <point x="333" y="536"/>
-      <point x="378" y="475"/>
-      <point x="378" y="380" type="curve" smooth="yes"/>
-      <point x="378" y="343" type="line"/>
-      <point x="462" y="343" type="line"/>
-      <point x="462" y="376" type="line" smooth="yes"/>
-      <point x="462" y="462"/>
-      <point x="511" y="518"/>
-      <point x="586" y="518" type="curve" smooth="yes"/>
-      <point x="648" y="518"/>
-      <point x="684" y="480"/>
-      <point x="684" y="413" type="curve" smooth="yes"/>
-      <point x="684" y="333"/>
-      <point x="625" y="287"/>
-      <point x="523" y="287" type="curve" smooth="yes"/>
-      <point x="254" y="287" type="line" smooth="yes"/>
-      <point x="126" y="287"/>
-      <point x="48" y="229"/>
-      <point x="48" y="133" type="curve" smooth="yes"/>
-      <point x="48" y="39"/>
-      <point x="104" y="-16"/>
+      <point x="202" y="-16" type="curve" smooth="yes"/>
+      <point x="252" y="-16"/>
+      <point x="287" y="-5"/>
+      <point x="371" y="36" type="curve" smooth="yes"/>
+      <point x="491" y="95" type="line"/>
+      <point x="560" y="138" type="line"/>
+      <point x="592" y="146" type="line"/>
+      <point x="616" y="168"/>
+      <point x="639" y="176"/>
+      <point x="668" y="176" type="curve" smooth="yes"/>
+      <point x="707" y="176"/>
+      <point x="730" y="154"/>
+      <point x="730" y="115" type="curve" smooth="yes"/>
+      <point x="730" y="78"/>
+      <point x="705" y="54"/>
+      <point x="667" y="54" type="curve" smooth="yes"/>
+      <point x="629" y="54"/>
+      <point x="603" y="79"/>
+      <point x="603" y="115" type="curve" smooth="yes"/>
+      <point x="603" y="143"/>
+      <point x="617" y="168"/>
+      <point x="640" y="181" type="curve"/>
+      <point x="533" y="145" type="line"/>
+      <point x="552" y="128" type="line"/>
+      <point x="548" y="116"/>
+      <point x="547" y="106"/>
+      <point x="547" y="94" type="curve" smooth="yes"/>
+      <point x="547" y="32"/>
+      <point x="598" y="-16"/>
+      <point x="672" y="-16" type="curve" smooth="yes"/>
+      <point x="753" y="-16"/>
+      <point x="804" y="38"/>
+      <point x="804" y="114" type="curve" smooth="yes"/>
+      <point x="804" y="185"/>
+      <point x="753" y="236"/>
+      <point x="674" y="236" type="curve" smooth="yes"/>
+      <point x="635" y="236"/>
+      <point x="590" y="220"/>
+      <point x="516" y="184" type="curve" smooth="yes"/>
+      <point x="343" y="99" type="line" smooth="yes"/>
+      <point x="285" y="71"/>
+      <point x="248" y="60"/>
+      <point x="206" y="60" type="curve" smooth="yes"/>
+      <point x="159" y="60"/>
+      <point x="128" y="85"/>
+      <point x="128" y="125" type="curve" smooth="yes"/>
+      <point x="128" y="170"/>
+      <point x="163" y="195"/>
+      <point x="225" y="195" type="curve" smooth="yes"/>
+      <point x="537" y="195" type="line" smooth="yes"/>
+      <point x="702" y="195"/>
+      <point x="808" y="277"/>
+      <point x="808" y="405" type="curve" smooth="yes"/>
+      <point x="808" y="521"/>
+      <point x="738" y="596"/>
+      <point x="625" y="596" type="curve" smooth="yes"/>
+      <point x="536" y="596"/>
+      <point x="472" y="552"/>
+      <point x="440" y="478" type="curve"/>
+      <point x="435" y="478" type="line"/>
+      <point x="409" y="553"/>
+      <point x="350" y="596"/>
+      <point x="255" y="596" type="curve" smooth="yes"/>
+      <point x="137" y="596"/>
+      <point x="42" y="525"/>
+      <point x="42" y="420" type="curve" smooth="yes"/>
+      <point x="42" y="332"/>
+      <point x="101" y="273"/>
+      <point x="190" y="273" type="curve" smooth="yes"/>
+      <point x="271" y="273"/>
+      <point x="327" y="324"/>
+      <point x="327" y="401" type="curve" smooth="yes"/>
+      <point x="327" y="470"/>
+      <point x="285" y="515"/>
+      <point x="214" y="515" type="curve" smooth="yes"/>
+      <point x="188" y="515"/>
+      <point x="165" y="510"/>
+      <point x="143" y="499" type="curve"/>
+      <point x="128" y="523" type="line"/>
+      <point x="128" y="491" type="line"/>
+      <point x="158" y="520"/>
+      <point x="198" y="536"/>
+      <point x="255" y="536" type="curve" smooth="yes"/>
+      <point x="351" y="536"/>
+      <point x="394" y="484"/>
+      <point x="394" y="382" type="curve" smooth="yes"/>
+      <point x="394" y="324" type="line"/>
+      <point x="478" y="324" type="line"/>
+      <point x="478" y="380" type="line" smooth="yes"/>
+      <point x="478" y="469"/>
+      <point x="531" y="518"/>
+      <point x="612" y="518" type="curve" smooth="yes"/>
+      <point x="685" y="518"/>
+      <point x="726" y="475"/>
+      <point x="726" y="403" type="curve" smooth="yes"/>
+      <point x="726" y="316"/>
+      <point x="663" y="267"/>
+      <point x="547" y="267" type="curve" smooth="yes"/>
+      <point x="222" y="267" type="line" smooth="yes"/>
+      <point x="119" y="267"/>
+      <point x="46" y="212"/>
+      <point x="46" y="122" type="curve" smooth="yes"/>
+      <point x="46" y="41"/>
+      <point x="112" y="-16"/>
     </contour>
     <contour>
-      <point x="184" y="357" type="curve" smooth="yes"/>
-      <point x="141" y="357"/>
-      <point x="118" y="384"/>
-      <point x="118" y="433" type="curve" smooth="yes"/>
-      <point x="118" y="449"/>
-      <point x="120" y="460"/>
+      <point x="185" y="341" type="curve" smooth="yes"/>
+      <point x="139" y="341"/>
+      <point x="110" y="370"/>
+      <point x="110" y="416" type="curve" smooth="yes"/>
+      <point x="110" y="439"/>
+      <point x="114" y="454"/>
       <point x="126" y="475" type="curve"/>
-      <point x="107" y="475" type="line"/>
+      <point x="98" y="475" type="line"/>
       <point x="90" y="427" type="line"/>
-      <point x="117" y="454"/>
-      <point x="151" y="467"/>
-      <point x="189" y="467" type="curve" smooth="yes"/>
-      <point x="225" y="467"/>
-      <point x="247" y="447"/>
-      <point x="247" y="413" type="curve" smooth="yes"/>
-      <point x="247" y="378"/>
-      <point x="224" y="357"/>
+      <point x="113" y="453"/>
+      <point x="148" y="467"/>
+      <point x="183" y="467" type="curve" smooth="yes"/>
+      <point x="228" y="467"/>
+      <point x="251" y="442"/>
+      <point x="251" y="403" type="curve" smooth="yes"/>
+      <point x="251" y="366"/>
+      <point x="227" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
+  <anchor x="440" y="0" name="bottom"/>
+  <anchor x="425" y="580" name="top"/>
+  <anchor x="709" y="580" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="687"/>
+    <component base="halant-malayalam" xOffset="709"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="808"/>
-  <guideline x="48" y="133" angle="91.1496"/>
-  <guideline x="766" y="416" angle="269.0789"/>
+  <advance width="850"/>
+  <anchor x="440" y="0" name="bottom"/>
+  <anchor x="425" y="580" name="top"/>
+  <anchor x="709" y="580" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="419"/>
+    <component base="lVocalicMatra-malayalam" xOffset="440"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="808"/>
-  <guideline x="48" y="133" angle="91.1496"/>
-  <guideline x="766" y="416" angle="269.0789"/>
+  <advance width="850"/>
+  <anchor x="440" y="0" name="bottom"/>
+  <anchor x="425" y="580" name="top"/>
+  <anchor x="709" y="580" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="419"/>
+    <component base="llVocalicMatra-malayalam" xOffset="440"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
@@ -2,96 +2,95 @@
 <glyph name="kChillu-malayalam" format="2">
   <advance width="1040"/>
   <unicode hex="0D7F"/>
-  <guideline x="1011"/>
   <anchor x="644" y="0" name="bottom"/>
   <anchor x="367" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="397" y="22"/>
+      <point x="457" y="-16"/>
       <point x="532" y="-16" type="curve" smooth="yes"/>
       <point x="600" y="-16"/>
-      <point x="651" y="25"/>
-      <point x="679" y="85" type="curve"/>
-      <point x="686" y="85" type="line"/>
-      <point x="709" y="28"/>
-      <point x="763" y="-16"/>
-      <point x="848" y="-16" type="curve" smooth="yes"/>
-      <point x="941" y="-16"/>
-      <point x="1011" y="44"/>
-      <point x="1011" y="150" type="curve" smooth="yes"/>
-      <point x="1011" y="252"/>
-      <point x="937" y="324"/>
-      <point x="803" y="324" type="curve" smooth="yes"/>
-      <point x="766" y="324" type="line"/>
-      <point x="732" y="250" type="line"/>
-      <point x="807" y="250" type="line" smooth="yes"/>
-      <point x="896" y="250"/>
-      <point x="926" y="207"/>
-      <point x="926" y="154" type="curve" smooth="yes"/>
-      <point x="926" y="99"/>
-      <point x="899" y="62"/>
-      <point x="840" y="62" type="curve" smooth="yes"/>
-      <point x="780" y="62"/>
-      <point x="738" y="107"/>
-      <point x="738" y="180" type="curve" smooth="yes"/>
-      <point x="738" y="256"/>
-      <point x="781" y="328"/>
+      <point x="653" y="22"/>
+      <point x="683" y="85" type="curve"/>
+      <point x="690" y="85" type="line"/>
+      <point x="715" y="21"/>
+      <point x="772" y="-16"/>
+      <point x="846" y="-16" type="curve" smooth="yes"/>
+      <point x="946" y="-16"/>
+      <point x="1011" y="52"/>
+      <point x="1011" y="156" type="curve" smooth="yes"/>
+      <point x="1011" y="272"/>
+      <point x="931" y="344"/>
+      <point x="803" y="344" type="curve" smooth="yes"/>
+      <point x="766" y="344" type="line"/>
+      <point x="732" y="270" type="line"/>
+      <point x="807" y="270" type="line" smooth="yes"/>
+      <point x="885" y="270"/>
+      <point x="926" y="232"/>
+      <point x="926" y="160" type="curve" smooth="yes"/>
+      <point x="926" y="100"/>
+      <point x="892" y="62"/>
+      <point x="839" y="62" type="curve" smooth="yes"/>
+      <point x="777" y="62"/>
+      <point x="738" y="103"/>
+      <point x="738" y="170" type="curve" smooth="yes"/>
+      <point x="738" y="248"/>
+      <point x="762" y="305"/>
       <point x="845" y="426" type="curve" smooth="yes"/>
-      <point x="898" y="508"/>
-      <point x="924" y="554"/>
+      <point x="906" y="515"/>
+      <point x="924" y="561"/>
       <point x="924" y="632" type="curve" smooth="yes"/>
-      <point x="924" y="718"/>
-      <point x="873" y="789"/>
+      <point x="924" y="728"/>
+      <point x="863" y="789"/>
       <point x="768" y="789" type="curve" smooth="yes"/>
-      <point x="710" y="789"/>
-      <point x="661" y="774"/>
+      <point x="708" y="789"/>
+      <point x="660" y="773"/>
       <point x="609" y="737" type="curve"/>
       <point x="647" y="670" type="line"/>
-      <point x="682" y="695"/>
-      <point x="719" y="710"/>
+      <point x="685" y="697"/>
+      <point x="722" y="710"/>
       <point x="762" y="710" type="curve" smooth="yes"/>
-      <point x="821" y="710"/>
-      <point x="841" y="676"/>
+      <point x="814" y="710"/>
+      <point x="841" y="683"/>
       <point x="841" y="632" type="curve" smooth="yes"/>
-      <point x="841" y="583"/>
-      <point x="820" y="536"/>
+      <point x="841" y="586"/>
+      <point x="823" y="542"/>
       <point x="771" y="455" type="curve" smooth="yes"/>
-      <point x="753" y="425"/>
-      <point x="738" y="400"/>
+      <point x="746" y="413"/>
+      <point x="736" y="393"/>
       <point x="728" y="368" type="curve"/>
       <point x="722" y="368" type="line"/>
-      <point x="711" y="499"/>
-      <point x="648" y="596"/>
+      <point x="710" y="511"/>
+      <point x="639" y="596"/>
       <point x="531" y="596" type="curve" smooth="yes"/>
-      <point x="394" y="596"/>
-      <point x="317" y="479"/>
+      <point x="398" y="596"/>
+      <point x="317" y="485"/>
       <point x="317" y="302" type="curve" smooth="yes"/>
-      <point x="317" y="279"/>
-      <point x="320" y="239"/>
-      <point x="320" y="215" type="curve" smooth="yes"/>
-      <point x="320" y="121"/>
-      <point x="276" y="62"/>
-      <point x="205" y="62" type="curve" smooth="yes"/>
-      <point x="144" y="62"/>
-      <point x="110" y="95"/>
-      <point x="110" y="153" type="curve" smooth="yes"/>
-      <point x="110" y="211"/>
-      <point x="147" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="698" y="250" type="line"/>
-      <point x="705" y="324" type="line"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="317" y="276"/>
+      <point x="322" y="236"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="698" y="270" type="line"/>
+      <point x="705" y="344" type="line"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/k_ka-malayalam.glif
@@ -1,102 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ka-malayalam" format="2">
   <advance width="1437"/>
-  <guideline x="1394"/>
   <anchor x="1027" y="0" name="bottom"/>
   <anchor x="810" y="580" name="top"/>
   <anchor x="1309" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="940" y="250" type="line" smooth="yes"/>
-      <point x="1038" y="250"/>
-      <point x="1063" y="201"/>
-      <point x="1063" y="140" type="curve" smooth="yes"/>
-      <point x="1063" y="86"/>
-      <point x="1038" y="62"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="942" y="270" type="line" smooth="yes"/>
+      <point x="1030" y="270"/>
+      <point x="1073" y="233"/>
+      <point x="1073" y="156" type="curve" smooth="yes"/>
+      <point x="1073" y="94"/>
+      <point x="1047" y="62"/>
       <point x="998" y="62" type="curve" smooth="yes"/>
-      <point x="924" y="62"/>
-      <point x="899" y="146"/>
-      <point x="899" y="241" type="curve" smooth="yes"/>
-      <point x="899" y="405"/>
-      <point x="967" y="517"/>
+      <point x="933" y="62"/>
+      <point x="899" y="120"/>
+      <point x="899" y="231" type="curve" smooth="yes"/>
+      <point x="899" y="416"/>
+      <point x="975" y="517"/>
       <point x="1116" y="517" type="curve" smooth="yes"/>
-      <point x="1248" y="517"/>
-      <point x="1313" y="416"/>
+      <point x="1240" y="517"/>
+      <point x="1313" y="428"/>
       <point x="1313" y="278" type="curve" smooth="yes"/>
-      <point x="1313" y="186"/>
-      <point x="1280" y="106"/>
+      <point x="1313" y="192"/>
+      <point x="1284" y="111"/>
       <point x="1225" y="34" type="curve"/>
       <point x="1291" y="-16" type="line"/>
-      <point x="1362" y="68"/>
-      <point x="1395" y="174"/>
+      <point x="1358" y="63"/>
+      <point x="1395" y="167"/>
       <point x="1395" y="277" type="curve" smooth="yes"/>
-      <point x="1395" y="470"/>
-      <point x="1292" y="596"/>
+      <point x="1395" y="475"/>
+      <point x="1290" y="596"/>
       <point x="1118" y="596" type="curve" smooth="yes"/>
-      <point x="928" y="596"/>
-      <point x="817" y="449"/>
-      <point x="817" y="238" type="curve" smooth="yes"/>
-      <point x="817" y="116"/>
-      <point x="866" y="-16"/>
-      <point x="1001" y="-16" type="curve" smooth="yes"/>
-      <point x="1099" y="-16"/>
-      <point x="1145" y="53"/>
-      <point x="1145" y="140" type="curve" smooth="yes"/>
-      <point x="1145" y="234"/>
-      <point x="1098" y="324"/>
-      <point x="936" y="324" type="curve" smooth="yes"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="932" y="596"/>
+      <point x="817" y="455"/>
+      <point x="817" y="228" type="curve" smooth="yes"/>
+      <point x="817" y="78"/>
+      <point x="887" y="-16"/>
+      <point x="999" y="-16" type="curve" smooth="yes"/>
+      <point x="1095" y="-16"/>
+      <point x="1155" y="50"/>
+      <point x="1155" y="156" type="curve" smooth="yes"/>
+      <point x="1155" y="278"/>
+      <point x="1079" y="344"/>
+      <point x="940" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/k_la-malayalam.glif
@@ -54,29 +54,29 @@
       <point x="744" y="153"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="805" y="250" type="line" smooth="yes"/>
-      <point x="883" y="250"/>
-      <point x="924" y="215"/>
-      <point x="924" y="153" type="curve" smooth="yes"/>
-      <point x="924" y="95"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="799" y="270" type="line" smooth="yes"/>
+      <point x="881" y="270"/>
+      <point x="924" y="233"/>
+      <point x="924" y="164" type="curve" smooth="yes"/>
+      <point x="924" y="99"/>
       <point x="891" y="62"/>
       <point x="835" y="62" type="curve" smooth="yes"/>
       <point x="818" y="62"/>
@@ -87,23 +87,23 @@
       <point x="809" y="-16"/>
       <point x="838" y="-16" type="curve" smooth="yes"/>
       <point x="937" y="-16"/>
-      <point x="1006" y="51"/>
-      <point x="1006" y="151" type="curve" smooth="yes"/>
-      <point x="1006" y="257"/>
-      <point x="927" y="324"/>
-      <point x="799" y="324" type="curve" smooth="yes"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="375" y="68"/>
+      <point x="1006" y="55"/>
+      <point x="1006" y="162" type="curve" smooth="yes"/>
+      <point x="1006" y="274"/>
+      <point x="930" y="344"/>
+      <point x="797" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="375" y="69"/>
       <point x="392" y="48"/>
       <point x="413" y="31" type="curve"/>
       <point x="413" y="23" type="line"/>
@@ -131,19 +131,19 @@
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
@@ -1,48 +1,47 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam" format="2">
   <advance width="1702"/>
-  <guideline x="1626"/>
   <anchor x="1259" y="0" name="bottom"/>
   <anchor x="876" y="580" name="top"/>
   <anchor x="1581" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="156" type="curve" smooth="yes"/>
-      <point x="111" y="217"/>
-      <point x="148" y="256"/>
-      <point x="235" y="256" type="curve" smooth="yes"/>
-      <point x="814" y="256" type="line" smooth="yes"/>
-      <point x="895" y="256"/>
-      <point x="924" y="221"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="799" y="270" type="line" smooth="yes"/>
+      <point x="881" y="270"/>
+      <point x="924" y="236"/>
       <point x="924" y="172" type="curve" smooth="yes"/>
-      <point x="924" y="129"/>
-      <point x="901" y="95"/>
+      <point x="924" y="134"/>
+      <point x="906" y="100"/>
       <point x="862" y="56" type="curve"/>
       <point x="881" y="0" type="line"/>
       <point x="1625" y="0" type="line"/>
@@ -51,26 +50,26 @@
       <point x="1500" y="402"/>
       <point x="1392" y="312"/>
       <point x="1254" y="312" type="curve" smooth="yes"/>
-      <point x="1157" y="312"/>
-      <point x="1102" y="363"/>
+      <point x="1161" y="312"/>
+      <point x="1102" y="360"/>
       <point x="1102" y="436" type="curve" smooth="yes"/>
       <point x="1102" y="486"/>
       <point x="1131" y="518"/>
       <point x="1178" y="518" type="curve" smooth="yes"/>
-      <point x="1226" y="518"/>
-      <point x="1252" y="482"/>
+      <point x="1225" y="518"/>
+      <point x="1252" y="484"/>
       <point x="1252" y="425" type="curve" smooth="yes"/>
       <point x="1252" y="61" type="line"/>
       <point x="1334" y="61" type="line"/>
       <point x="1334" y="431" type="line" smooth="yes"/>
-      <point x="1334" y="529"/>
-      <point x="1279" y="596"/>
+      <point x="1334" y="532"/>
+      <point x="1276" y="596"/>
       <point x="1183" y="596" type="curve" smooth="yes"/>
-      <point x="1084" y="596"/>
-      <point x="1020" y="526"/>
+      <point x="1087" y="596"/>
+      <point x="1020" y="529"/>
       <point x="1020" y="435" type="curve" smooth="yes"/>
-      <point x="1020" y="320"/>
-      <point x="1113" y="236"/>
+      <point x="1020" y="317"/>
+      <point x="1116" y="236"/>
       <point x="1256" y="236" type="curve" smooth="yes"/>
       <point x="1366" y="236"/>
       <point x="1464" y="289"/>
@@ -80,34 +79,34 @@
       <point x="1581" y="74" type="line"/>
       <point x="967" y="74" type="line"/>
       <point x="965" y="79" type="line"/>
-      <point x="996" y="114"/>
-      <point x="1006" y="152"/>
+      <point x="991" y="108"/>
+      <point x="1006" y="145"/>
       <point x="1006" y="180" type="curve" smooth="yes"/>
-      <point x="1006" y="267"/>
-      <point x="949" y="330"/>
-      <point x="810" y="330" type="curve" smooth="yes"/>
-      <point x="237" y="330" type="line" smooth="yes"/>
-      <point x="99" y="330"/>
-      <point x="29" y="260"/>
-      <point x="29" y="151" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="1006" y="281"/>
+      <point x="930" y="344"/>
+      <point x="797" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam.half" format="2">
   <advance width="1702"/>
+  <anchor x="1259" y="0" name="bottom"/>
+  <anchor x="876" y="580" name="top"/>
+  <anchor x="1581" y="580" name="topright"/>
   <outline>
     <component base="k_ssa-malayalam"/>
     <component base="halant-malayalam" xOffset="1581"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/k_ta-malayalam.glif
@@ -58,60 +58,60 @@
       <point x="896" y="73"/>
     </contour>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="882" y="250" type="line"/>
-      <point x="882" y="324" type="line"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="898" y="270" type="line"/>
+      <point x="898" y="344" type="line"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/k_tta-malayalam.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_tta-malayalam" format="2">
   <advance width="1035"/>
-  <guideline x="1006" y="158" angle="90"/>
   <anchor x="840" y="-351" name="bottom"/>
   <anchor x="532" y="580" name="top"/>
   <anchor x="879" y="540" name="topright"/>
@@ -29,54 +28,54 @@
       <point x="964" y="22"/>
       <point x="945" y="27" type="curve"/>
       <point x="945" y="35" type="line"/>
-      <point x="984" y="59"/>
-      <point x="1006" y="104"/>
-      <point x="1006" y="158" type="curve" smooth="yes"/>
-      <point x="1006" y="265"/>
-      <point x="927" y="324"/>
-      <point x="799" y="324" type="curve" smooth="yes"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="984" y="62"/>
+      <point x="1006" y="111"/>
+      <point x="1006" y="169" type="curve" smooth="yes"/>
+      <point x="1006" y="278"/>
+      <point x="928" y="344"/>
+      <point x="799" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="805" y="250" type="line" smooth="yes"/>
-      <point x="883" y="250"/>
-      <point x="924" y="215"/>
-      <point x="924" y="153" type="curve" smooth="yes"/>
-      <point x="924" y="95"/>
-      <point x="894" y="62"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="799" y="270" type="line" smooth="yes"/>
+      <point x="881" y="270"/>
+      <point x="924" y="233"/>
+      <point x="924" y="165" type="curve" smooth="yes"/>
+      <point x="924" y="98"/>
+      <point x="892" y="62"/>
       <point x="835" y="62" type="curve" smooth="yes"/>
       <point x="818" y="62"/>
       <point x="799" y="64"/>
@@ -105,19 +104,19 @@
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ka-malayalam.glif
@@ -7,78 +7,78 @@
   <anchor x="879" y="540" name="topright"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="805" y="250" type="line" smooth="yes"/>
-      <point x="883" y="250"/>
-      <point x="924" y="215"/>
-      <point x="924" y="153" type="curve" smooth="yes"/>
-      <point x="924" y="95"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="799" y="270" type="line" smooth="yes"/>
+      <point x="881" y="270"/>
+      <point x="924" y="233"/>
+      <point x="924" y="164" type="curve" smooth="yes"/>
+      <point x="924" y="99"/>
       <point x="891" y="62"/>
       <point x="835" y="62" type="curve" smooth="yes"/>
-      <point x="818" y="62"/>
-      <point x="799" y="64"/>
+      <point x="815" y="62"/>
+      <point x="797" y="65"/>
       <point x="783" y="70" type="curve"/>
       <point x="762" y="-5" type="line"/>
-      <point x="785" y="-12"/>
-      <point x="809" y="-16"/>
+      <point x="787" y="-13"/>
+      <point x="811" y="-16"/>
       <point x="838" y="-16" type="curve" smooth="yes"/>
-      <point x="937" y="-16"/>
-      <point x="1006" y="51"/>
-      <point x="1006" y="151" type="curve" smooth="yes"/>
-      <point x="1006" y="257"/>
-      <point x="927" y="324"/>
-      <point x="799" y="324" type="curve" smooth="yes"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="938" y="-16"/>
+      <point x="1006" y="56"/>
+      <point x="1006" y="162" type="curve" smooth="yes"/>
+      <point x="1006" y="274"/>
+      <point x="930" y="344"/>
+      <point x="797" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/m_la-malayalam.glif
@@ -6,51 +6,7 @@
   <anchor x="567" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="120" y="-367" type="curve" smooth="yes"/>
-      <point x="202" y="-367"/>
-      <point x="250" y="-317"/>
-      <point x="250" y="-238" type="curve" smooth="yes"/>
-      <point x="250" y="-160"/>
-      <point x="206" y="-118"/>
-      <point x="136" y="-118" type="curve" smooth="yes"/>
-      <point x="81" y="-118"/>
-      <point x="21" y="-151"/>
-      <point x="21" y="-236" type="curve"/>
-      <point x="49" y="-169" type="line"/>
-      <point x="-10" y="-166" type="line"/>
-      <point x="31" y="-195" type="line"/>
-      <point x="31" y="-89"/>
-      <point x="81" y="-27"/>
-      <point x="177" y="-27" type="curve" smooth="yes"/>
-      <point x="273" y="-27"/>
-      <point x="310" y="-89"/>
-      <point x="329" y="-164" type="curve" smooth="yes"/>
-      <point x="339" y="-203" type="line" smooth="yes"/>
-      <point x="367" y="-311"/>
-      <point x="420" y="-367"/>
-      <point x="519" y="-367" type="curve" smooth="yes"/>
-      <point x="613" y="-367"/>
-      <point x="679" y="-308"/>
-      <point x="679" y="-182" type="curve" smooth="yes"/>
-      <point x="679" y="-85"/>
-      <point x="646" y="-12"/>
-      <point x="596" y="43" type="curve"/>
-      <point x="537" y="3" type="line"/>
-      <point x="577" y="-44"/>
-      <point x="605" y="-101"/>
-      <point x="605" y="-182" type="curve" smooth="yes"/>
-      <point x="605" y="-251"/>
-      <point x="578" y="-297"/>
-      <point x="518" y="-297" type="curve" smooth="yes"/>
-      <point x="463" y="-297"/>
-      <point x="433" y="-261"/>
-      <point x="411" y="-182" type="curve" smooth="yes"/>
-      <point x="399" y="-139" type="line" smooth="yes"/>
-      <point x="384" y="-84"/>
-      <point x="363" y="-33"/>
-      <point x="322" y="-5" type="curve"/>
-      <point x="323" y="0" type="line"/>
-      <point x="583" y="0" type="line"/>
+      <point x="51" y="0" type="line"/>
       <point x="617" y="0" type="line"/>
       <point x="617" y="324" type="line" smooth="yes"/>
       <point x="617" y="481"/>
@@ -59,29 +15,72 @@
       <point x="157" y="596"/>
       <point x="51" y="480"/>
       <point x="51" y="323" type="curve" smooth="yes"/>
-      <point x="51" y="0" type="line"/>
-      <point x="97" y="30" type="line"/>
-      <point x="13" y="-1"/>
-      <point x="-37" y="-79"/>
-      <point x="-37" y="-181" type="curve" smooth="yes"/>
-      <point x="-37" y="-305"/>
-      <point x="35" y="-367"/>
     </contour>
     <contour>
-      <point x="117" y="-302" type="curve" smooth="yes"/>
-      <point x="59" y="-302"/>
-      <point x="32" y="-253"/>
-      <point x="32" y="-197" type="curve"/>
-      <point x="12" y="-205" type="line"/>
-      <point x="33" y="-262" type="line"/>
-      <point x="33" y="-218"/>
-      <point x="65" y="-178"/>
-      <point x="119" y="-178" type="curve" smooth="yes"/>
-      <point x="160" y="-178"/>
-      <point x="180" y="-203"/>
-      <point x="180" y="-238" type="curve" smooth="yes"/>
-      <point x="180" y="-276"/>
-      <point x="159" y="-302"/>
+      <point x="185" y="-367" type="curve" smooth="yes"/>
+      <point x="264" y="-367"/>
+      <point x="312" y="-317"/>
+      <point x="312" y="-235" type="curve" smooth="yes"/>
+      <point x="312" y="-157"/>
+      <point x="271" y="-109"/>
+      <point x="206" y="-109" type="curve" smooth="yes"/>
+      <point x="140" y="-109"/>
+      <point x="93" y="-162"/>
+      <point x="93" y="-236" type="curve"/>
+      <point x="117" y="-169" type="line"/>
+      <point x="58" y="-169" type="line"/>
+      <point x="95" y="-195" type="line"/>
+      <point x="95" y="-87"/>
+      <point x="148" y="-23"/>
+      <point x="233" y="-23" type="curve" smooth="yes"/>
+      <point x="304" y="-23"/>
+      <point x="343" y="-66"/>
+      <point x="357" y="-152" type="curve" smooth="yes"/>
+      <point x="369" y="-225" type="line" smooth="yes"/>
+      <point x="385" y="-320"/>
+      <point x="430" y="-367"/>
+      <point x="506" y="-367" type="curve" smooth="yes"/>
+      <point x="593" y="-367"/>
+      <point x="643" y="-306"/>
+      <point x="643" y="-199" type="curve" smooth="yes"/>
+      <point x="643" y="-105"/>
+      <point x="613" y="-23"/>
+      <point x="553" y="49" type="curve"/>
+      <point x="498" y="6" type="line"/>
+      <point x="547" y="-52"/>
+      <point x="569" y="-116"/>
+      <point x="569" y="-197" type="curve" smooth="yes"/>
+      <point x="569" y="-263"/>
+      <point x="548" y="-297"/>
+      <point x="508" y="-297" type="curve" smooth="yes"/>
+      <point x="470" y="-297"/>
+      <point x="450" y="-268"/>
+      <point x="438" y="-198" type="curve" smooth="yes"/>
+      <point x="426" y="-125" type="line" smooth="yes"/>
+      <point x="409" y="-23"/>
+      <point x="345" y="37"/>
+      <point x="235" y="37" type="curve" smooth="yes"/>
+      <point x="110" y="37"/>
+      <point x="31" y="-51"/>
+      <point x="31" y="-183" type="curve" smooth="yes"/>
+      <point x="31" y="-293"/>
+      <point x="93" y="-367"/>
+    </contour>
+    <contour>
+      <point x="181" y="-303" type="curve" smooth="yes"/>
+      <point x="126" y="-303"/>
+      <point x="100" y="-254"/>
+      <point x="100" y="-197" type="curve"/>
+      <point x="80" y="-205" type="line"/>
+      <point x="101" y="-262" type="line"/>
+      <point x="101" y="-212"/>
+      <point x="132" y="-167"/>
+      <point x="183" y="-167" type="curve" smooth="yes"/>
+      <point x="220" y="-167"/>
+      <point x="242" y="-192"/>
+      <point x="242" y="-235" type="curve" smooth="yes"/>
+      <point x="242" y="-278"/>
+      <point x="219" y="-303"/>
     </contour>
     <contour>
       <point x="101" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
@@ -6,98 +6,98 @@
   <anchor x="860" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="203" y="-16" type="curve" smooth="yes"/>
-      <point x="281" y="-16"/>
-      <point x="337" y="27"/>
-      <point x="362" y="92" type="curve"/>
-      <point x="367" y="92" type="line"/>
-      <point x="402" y="23"/>
-      <point x="461" y="-16"/>
+      <point x="211" y="-16" type="curve" smooth="yes"/>
+      <point x="280" y="-16"/>
+      <point x="336" y="25"/>
+      <point x="362" y="93" type="curve"/>
+      <point x="367" y="93" type="line"/>
+      <point x="404" y="21"/>
+      <point x="463" y="-16"/>
       <point x="540" y="-16" type="curve" smooth="yes"/>
-      <point x="676" y="-16"/>
-      <point x="749" y="106"/>
+      <point x="669" y="-16"/>
+      <point x="749" y="96"/>
       <point x="749" y="278" type="curve" smooth="yes"/>
       <point x="749" y="302" type="line" smooth="yes"/>
-      <point x="749" y="473"/>
-      <point x="680" y="596"/>
+      <point x="749" y="487"/>
+      <point x="670" y="596"/>
       <point x="537" y="596" type="curve" smooth="yes"/>
-      <point x="456" y="596"/>
-      <point x="398" y="554"/>
+      <point x="459" y="596"/>
+      <point x="399" y="557"/>
       <point x="367" y="484" type="curve"/>
       <point x="362" y="484" type="line"/>
-      <point x="340" y="549"/>
-      <point x="289" y="596"/>
-      <point x="205" y="596" type="curve" smooth="yes"/>
-      <point x="98" y="596"/>
-      <point x="41" y="527"/>
-      <point x="41" y="441" type="curve" smooth="yes"/>
-      <point x="41" y="376"/>
-      <point x="76" y="318"/>
-      <point x="134" y="292" type="curve"/>
-      <point x="134" y="287" type="line"/>
-      <point x="73" y="265"/>
-      <point x="34" y="214"/>
-      <point x="34" y="145" type="curve" smooth="yes"/>
-      <point x="34" y="46"/>
-      <point x="99" y="-16"/>
+      <point x="337" y="556"/>
+      <point x="281" y="596"/>
+      <point x="203" y="596" type="curve" smooth="yes"/>
+      <point x="107" y="596"/>
+      <point x="41" y="535"/>
+      <point x="41" y="446" type="curve" smooth="yes"/>
+      <point x="41" y="388"/>
+      <point x="78" y="335"/>
+      <point x="134" y="313" type="curve"/>
+      <point x="134" y="308" type="line"/>
+      <point x="71" y="283"/>
+      <point x="34" y="226"/>
+      <point x="34" y="154" type="curve" smooth="yes"/>
+      <point x="34" y="54"/>
+      <point x="106" y="-16"/>
     </contour>
     <contour>
       <point x="843" y="-16" type="curve" smooth="yes"/>
-      <point x="942" y="-16"/>
-      <point x="1011" y="51"/>
-      <point x="1011" y="151" type="curve" smooth="yes"/>
-      <point x="1011" y="257"/>
-      <point x="944" y="324"/>
-      <point x="804" y="324" type="curve" smooth="yes"/>
-      <point x="255" y="324" type="line" smooth="yes"/>
-      <point x="164" y="324"/>
-      <point x="123" y="373"/>
-      <point x="123" y="433" type="curve" smooth="yes"/>
-      <point x="123" y="482"/>
-      <point x="155" y="518"/>
-      <point x="215" y="518" type="curve" smooth="yes"/>
-      <point x="294" y="518"/>
-      <point x="326" y="459"/>
+      <point x="943" y="-16"/>
+      <point x="1011" y="56"/>
+      <point x="1011" y="162" type="curve" smooth="yes"/>
+      <point x="1011" y="276"/>
+      <point x="933" y="344"/>
+      <point x="802" y="344" type="curve" smooth="yes"/>
+      <point x="251" y="344" type="line" smooth="yes"/>
+      <point x="172" y="344"/>
+      <point x="123" y="379"/>
+      <point x="123" y="437" type="curve" smooth="yes"/>
+      <point x="123" y="486"/>
+      <point x="158" y="518"/>
+      <point x="213" y="518" type="curve" smooth="yes"/>
+      <point x="289" y="518"/>
+      <point x="326" y="467"/>
       <point x="326" y="363" type="curve" smooth="yes"/>
-      <point x="326" y="215" type="line" smooth="yes"/>
-      <point x="326" y="121"/>
-      <point x="284" y="62"/>
-      <point x="211" y="62" type="curve" smooth="yes"/>
-      <point x="150" y="62"/>
-      <point x="116" y="97"/>
-      <point x="116" y="153" type="curve" smooth="yes"/>
-      <point x="116" y="211"/>
-      <point x="153" y="250"/>
-      <point x="240" y="250" type="curve" smooth="yes"/>
-      <point x="810" y="250" type="line" smooth="yes"/>
-      <point x="892" y="250"/>
-      <point x="929" y="215"/>
-      <point x="929" y="153" type="curve" smooth="yes"/>
-      <point x="929" y="95"/>
+      <point x="326" y="203" type="line" smooth="yes"/>
+      <point x="326" y="113"/>
+      <point x="286" y="62"/>
+      <point x="216" y="62" type="curve" smooth="yes"/>
+      <point x="154" y="62"/>
+      <point x="116" y="99"/>
+      <point x="116" y="158" type="curve" smooth="yes"/>
+      <point x="116" y="231"/>
+      <point x="159" y="270"/>
+      <point x="240" y="270" type="curve" smooth="yes"/>
+      <point x="804" y="270" type="line" smooth="yes"/>
+      <point x="886" y="270"/>
+      <point x="929" y="233"/>
+      <point x="929" y="164" type="curve" smooth="yes"/>
+      <point x="929" y="99"/>
       <point x="896" y="62"/>
       <point x="840" y="62" type="curve" smooth="yes"/>
-      <point x="823" y="62"/>
-      <point x="804" y="64"/>
+      <point x="822" y="62"/>
+      <point x="804" y="65"/>
       <point x="788" y="70" type="curve"/>
       <point x="767" y="-5" type="line"/>
-      <point x="790" y="-12"/>
-      <point x="814" y="-16"/>
+      <point x="790" y="-13"/>
+      <point x="813" y="-16"/>
     </contour>
     <contour>
       <point x="538" y="62" type="curve" smooth="yes"/>
-      <point x="446" y="62"/>
-      <point x="405" y="146"/>
+      <point x="451" y="62"/>
+      <point x="405" y="138"/>
       <point x="405" y="280" type="curve" smooth="yes"/>
       <point x="405" y="300" type="line" smooth="yes"/>
-      <point x="405" y="427"/>
-      <point x="446" y="518"/>
+      <point x="405" y="439"/>
+      <point x="453" y="518"/>
       <point x="537" y="518" type="curve" smooth="yes"/>
-      <point x="629" y="518"/>
-      <point x="665" y="426"/>
+      <point x="620" y="518"/>
+      <point x="665" y="441"/>
       <point x="665" y="300" type="curve" smooth="yes"/>
       <point x="665" y="280" type="line" smooth="yes"/>
-      <point x="665" y="146"/>
-      <point x="626" y="62"/>
+      <point x="665" y="137"/>
+      <point x="621" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1518"/>
-  <anchor x="1129" y="0" name="bottom"/>
-  <anchor x="790" y="580" name="top"/>
-  <anchor x="1397" y="580" name="topright"/>
+  <advance width="1560"/>
+  <anchor x="1150" y="0" name="bottom"/>
+  <anchor x="780" y="580" name="top"/>
+  <anchor x="1419" y="580" name="topright"/>
   <outline>
     <contour>
       <point x="271" y="-16" type="curve" smooth="yes"/>
@@ -45,117 +45,117 @@
       <point x="811" y="529"/>
       <point x="816" y="529"/>
       <point x="833" y="527" type="curve"/>
-      <point x="789" y="570" type="line"/>
-      <point x="797" y="523" type="line"/>
-      <point x="766" y="496"/>
-      <point x="752" y="462"/>
-      <point x="752" y="427" type="curve" smooth="yes"/>
-      <point x="752" y="361"/>
-      <point x="807" y="309"/>
-      <point x="889" y="309" type="curve" smooth="yes"/>
-      <point x="982" y="309"/>
-      <point x="1029" y="362"/>
-      <point x="1029" y="435" type="curve" smooth="yes"/>
-      <point x="1029" y="462"/>
-      <point x="1015" y="503"/>
-      <point x="971" y="532" type="curve"/>
-      <point x="982" y="576" type="line"/>
-      <point x="888" y="538" type="line"/>
-      <point x="902" y="540"/>
-      <point x="915" y="540"/>
-      <point x="927" y="540" type="curve" smooth="yes"/>
-      <point x="1058" y="540"/>
-      <point x="1092" y="451"/>
-      <point x="1092" y="380" type="curve" smooth="yes"/>
-      <point x="1092" y="343" type="line"/>
-      <point x="1176" y="343" type="line"/>
-      <point x="1176" y="376" type="line" smooth="yes"/>
-      <point x="1176" y="467"/>
-      <point x="1229" y="518"/>
-      <point x="1298" y="518" type="curve" smooth="yes"/>
-      <point x="1360" y="518"/>
-      <point x="1394" y="478"/>
-      <point x="1394" y="413" type="curve" smooth="yes"/>
-      <point x="1394" y="349"/>
-      <point x="1356" y="283"/>
-      <point x="1233" y="283" type="curve" smooth="yes"/>
-      <point x="964" y="283" type="line" smooth="yes"/>
-      <point x="825" y="283"/>
-      <point x="758" y="221"/>
-      <point x="758" y="133" type="curve" smooth="yes"/>
-      <point x="758" y="54"/>
-      <point x="799" y="-16"/>
-      <point x="911" y="-16" type="curve" smooth="yes"/>
-      <point x="971" y="-16"/>
-      <point x="1021" y="4"/>
-      <point x="1106" y="54" type="curve" smooth="yes"/>
-      <point x="1169" y="91" type="line"/>
-      <point x="1256" y="142" type="line"/>
-      <point x="1272" y="148" type="line"/>
-      <point x="1304" y="163"/>
-      <point x="1322" y="167"/>
-      <point x="1344" y="167" type="curve" smooth="yes"/>
-      <point x="1385" y="167"/>
-      <point x="1405" y="147"/>
-      <point x="1405" y="106" type="curve" smooth="yes"/>
-      <point x="1405" y="70"/>
-      <point x="1383" y="48"/>
-      <point x="1348" y="48" type="curve" smooth="yes"/>
-      <point x="1312" y="48"/>
-      <point x="1292" y="70"/>
-      <point x="1292" y="110" type="curve" smooth="yes"/>
-      <point x="1292" y="137"/>
-      <point x="1301" y="159"/>
-      <point x="1325" y="185" type="curve"/>
-      <point x="1227" y="152" type="line"/>
-      <point x="1244" y="130" type="line"/>
-      <point x="1238" y="112"/>
-      <point x="1236" y="104"/>
-      <point x="1236" y="90" type="curve" smooth="yes"/>
-      <point x="1236" y="26"/>
-      <point x="1281" y="-16"/>
-      <point x="1350" y="-16" type="curve" smooth="yes"/>
-      <point x="1424" y="-16"/>
-      <point x="1471" y="31"/>
-      <point x="1471" y="105" type="curve" smooth="yes"/>
-      <point x="1471" y="182"/>
-      <point x="1422" y="233"/>
-      <point x="1348" y="233" type="curve" smooth="yes"/>
-      <point x="1296" y="233"/>
-      <point x="1266" y="222"/>
-      <point x="1152" y="162" type="curve" smooth="yes"/>
-      <point x="1076" y="122" type="line" smooth="yes"/>
-      <point x="993" y="78"/>
-      <point x="960" y="61"/>
-      <point x="912" y="61" type="curve" smooth="yes"/>
-      <point x="865" y="61"/>
-      <point x="837" y="88"/>
-      <point x="837" y="133" type="curve" smooth="yes"/>
-      <point x="837" y="183"/>
-      <point x="873" y="211"/>
-      <point x="967" y="211" type="curve" smooth="yes"/>
-      <point x="1217" y="211" type="line" smooth="yes"/>
-      <point x="1410" y="211"/>
-      <point x="1476" y="312"/>
-      <point x="1476" y="416" type="curve" smooth="yes"/>
-      <point x="1476" y="526"/>
-      <point x="1404" y="596"/>
-      <point x="1299" y="596" type="curve" smooth="yes"/>
-      <point x="1217" y="596"/>
-      <point x="1156" y="549"/>
-      <point x="1138" y="478" type="curve"/>
-      <point x="1133" y="478" type="line"/>
-      <point x="1111" y="549"/>
-      <point x="1038" y="596"/>
-      <point x="945" y="596" type="curve" smooth="yes"/>
-      <point x="911" y="596"/>
-      <point x="884" y="589"/>
-      <point x="863" y="578" type="curve"/>
-      <point x="895" y="578" type="line"/>
+      <point x="798" y="546" type="line"/>
+      <point x="803" y="524" type="line"/>
+      <point x="768" y="497"/>
+      <point x="748" y="460"/>
+      <point x="748" y="417" type="curve" smooth="yes"/>
+      <point x="748" y="339"/>
+      <point x="804" y="287"/>
+      <point x="890" y="287" type="curve" smooth="yes"/>
+      <point x="975" y="287"/>
+      <point x="1032" y="340"/>
+      <point x="1032" y="417" type="curve" smooth="yes"/>
+      <point x="1032" y="463"/>
+      <point x="1010" y="503"/>
+      <point x="973" y="530" type="curve"/>
+      <point x="984" y="560" type="line"/>
+      <point x="933" y="534" type="line"/>
+      <point x="940" y="535"/>
+      <point x="952" y="536"/>
+      <point x="964" y="536" type="curve" smooth="yes"/>
+      <point x="1061" y="536"/>
+      <point x="1104" y="484"/>
+      <point x="1104" y="382" type="curve" smooth="yes"/>
+      <point x="1104" y="324" type="line"/>
+      <point x="1188" y="324" type="line"/>
+      <point x="1188" y="380" type="line" smooth="yes"/>
+      <point x="1188" y="469"/>
+      <point x="1241" y="518"/>
+      <point x="1322" y="518" type="curve" smooth="yes"/>
+      <point x="1395" y="518"/>
+      <point x="1436" y="475"/>
+      <point x="1436" y="403" type="curve" smooth="yes"/>
+      <point x="1436" y="316"/>
+      <point x="1373" y="267"/>
+      <point x="1257" y="267" type="curve" smooth="yes"/>
+      <point x="932" y="267" type="line" smooth="yes"/>
+      <point x="829" y="267"/>
+      <point x="756" y="212"/>
+      <point x="756" y="122" type="curve" smooth="yes"/>
+      <point x="756" y="41"/>
+      <point x="822" y="-16"/>
+      <point x="912" y="-16" type="curve" smooth="yes"/>
+      <point x="962" y="-16"/>
+      <point x="997" y="-5"/>
+      <point x="1081" y="36" type="curve" smooth="yes"/>
+      <point x="1201" y="95" type="line"/>
+      <point x="1270" y="138" type="line"/>
+      <point x="1302" y="146" type="line"/>
+      <point x="1326" y="168"/>
+      <point x="1349" y="176"/>
+      <point x="1378" y="176" type="curve" smooth="yes"/>
+      <point x="1417" y="176"/>
+      <point x="1440" y="154"/>
+      <point x="1440" y="115" type="curve" smooth="yes"/>
+      <point x="1440" y="78"/>
+      <point x="1415" y="54"/>
+      <point x="1377" y="54" type="curve" smooth="yes"/>
+      <point x="1339" y="54"/>
+      <point x="1313" y="79"/>
+      <point x="1313" y="115" type="curve" smooth="yes"/>
+      <point x="1313" y="143"/>
+      <point x="1327" y="168"/>
+      <point x="1350" y="181" type="curve"/>
+      <point x="1243" y="145" type="line"/>
+      <point x="1262" y="128" type="line"/>
+      <point x="1258" y="116"/>
+      <point x="1257" y="106"/>
+      <point x="1257" y="94" type="curve" smooth="yes"/>
+      <point x="1257" y="32"/>
+      <point x="1308" y="-16"/>
+      <point x="1382" y="-16" type="curve" smooth="yes"/>
+      <point x="1463" y="-16"/>
+      <point x="1514" y="38"/>
+      <point x="1514" y="114" type="curve" smooth="yes"/>
+      <point x="1514" y="185"/>
+      <point x="1463" y="236"/>
+      <point x="1384" y="236" type="curve" smooth="yes"/>
+      <point x="1345" y="236"/>
+      <point x="1300" y="220"/>
+      <point x="1226" y="184" type="curve" smooth="yes"/>
+      <point x="1053" y="99" type="line" smooth="yes"/>
+      <point x="995" y="71"/>
+      <point x="958" y="60"/>
+      <point x="916" y="60" type="curve" smooth="yes"/>
+      <point x="869" y="60"/>
+      <point x="838" y="85"/>
+      <point x="838" y="125" type="curve" smooth="yes"/>
+      <point x="838" y="170"/>
+      <point x="873" y="195"/>
+      <point x="935" y="195" type="curve" smooth="yes"/>
+      <point x="1247" y="195" type="line" smooth="yes"/>
+      <point x="1412" y="195"/>
+      <point x="1518" y="277"/>
+      <point x="1518" y="405" type="curve" smooth="yes"/>
+      <point x="1518" y="521"/>
+      <point x="1448" y="596"/>
+      <point x="1335" y="596" type="curve" smooth="yes"/>
+      <point x="1246" y="596"/>
+      <point x="1182" y="552"/>
+      <point x="1150" y="478" type="curve"/>
+      <point x="1145" y="478" type="line"/>
+      <point x="1119" y="553"/>
+      <point x="1060" y="596"/>
+      <point x="965" y="596" type="curve" smooth="yes"/>
+      <point x="935" y="596"/>
+      <point x="891" y="589"/>
+      <point x="861" y="576" type="curve"/>
+      <point x="895" y="576" type="line"/>
       <point x="867" y="589"/>
-      <point x="831" y="596"/>
-      <point x="790" y="596" type="curve" smooth="yes"/>
-      <point x="685" y="596"/>
+      <point x="830" y="596"/>
+      <point x="791" y="596" type="curve" smooth="yes"/>
+      <point x="686" y="596"/>
       <point x="611" y="548"/>
       <point x="571" y="470" type="curve"/>
       <point x="566" y="470" type="line"/>
@@ -169,19 +169,19 @@
       <point x="133" y="-16"/>
     </contour>
     <contour>
-      <point x="890" y="379" type="curve" smooth="yes"/>
-      <point x="853" y="379"/>
-      <point x="824" y="399"/>
-      <point x="824" y="442" type="curve" smooth="yes"/>
+      <point x="890" y="357" type="curve" smooth="yes"/>
+      <point x="850" y="357"/>
+      <point x="824" y="386"/>
+      <point x="824" y="426" type="curve" smooth="yes"/>
       <point x="824" y="478"/>
-      <point x="850" y="526"/>
-      <point x="920" y="532" type="curve"/>
-      <point x="837" y="528" type="line"/>
-      <point x="915" y="527"/>
-      <point x="953" y="487"/>
-      <point x="953" y="440" type="curve" smooth="yes"/>
-      <point x="953" y="401"/>
-      <point x="931" y="379"/>
+      <point x="860" y="517"/>
+      <point x="923" y="534" type="curve"/>
+      <point x="858" y="534" type="line"/>
+      <point x="921" y="517"/>
+      <point x="956" y="479"/>
+      <point x="956" y="426" type="curve" smooth="yes"/>
+      <point x="956" y="386"/>
+      <point x="930" y="357"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/t_la-malayalam.glif
@@ -56,22 +56,6 @@
       <point x="294" y="-367"/>
     </contour>
     <contour>
-      <point x="376" y="-302" type="curve" smooth="yes"/>
-      <point x="318" y="-302"/>
-      <point x="291" y="-253"/>
-      <point x="291" y="-197" type="curve"/>
-      <point x="271" y="-205" type="line"/>
-      <point x="292" y="-262" type="line"/>
-      <point x="292" y="-218"/>
-      <point x="324" y="-178"/>
-      <point x="378" y="-178" type="curve" smooth="yes"/>
-      <point x="419" y="-178"/>
-      <point x="439" y="-203"/>
-      <point x="439" y="-238" type="curve" smooth="yes"/>
-      <point x="439" y="-276"/>
-      <point x="418" y="-302"/>
-    </contour>
-    <contour>
       <point x="164" y="-16" type="curve"/>
       <point x="224" y="35" type="line"/>
       <point x="158" y="108"/>
@@ -94,6 +78,22 @@
       <point x="81" y="72"/>
     </contour>
     <contour>
+      <point x="376" y="-302" type="curve" smooth="yes"/>
+      <point x="318" y="-302"/>
+      <point x="291" y="-253"/>
+      <point x="291" y="-197" type="curve"/>
+      <point x="271" y="-205" type="line"/>
+      <point x="292" y="-262" type="line"/>
+      <point x="292" y="-218"/>
+      <point x="324" y="-178"/>
+      <point x="378" y="-178" type="curve" smooth="yes"/>
+      <point x="419" y="-178"/>
+      <point x="439" y="-203"/>
+      <point x="439" y="-238" type="curve" smooth="yes"/>
+      <point x="439" y="-276"/>
+      <point x="418" y="-302"/>
+    </contour>
+    <contour>
       <point x="777" y="-297" type="curve" smooth="yes"/>
       <point x="722" y="-297"/>
       <point x="692" y="-261"/>
@@ -106,11 +106,11 @@
       <point x="652" y="43"/>
       <point x="687" y="129"/>
       <point x="687" y="241" type="curve" smooth="yes"/>
-      <point x="687" y="358"/>
-      <point x="631" y="472"/>
-      <point x="538" y="538" type="curve"/>
-      <point x="463" y="495" type="line"/>
-      <point x="556" y="450"/>
+      <point x="687" y="357"/>
+      <point x="632" y="470"/>
+      <point x="540" y="536" type="curve"/>
+      <point x="465" y="494" type="line"/>
+      <point x="557" y="449"/>
       <point x="601" y="348"/>
       <point x="601" y="241" type="curve" smooth="yes"/>
       <point x="601" y="129"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="572"/>
-  <anchor x="308" y="-209" name="bottom"/>
+  <anchor x="308" y="-235" name="bottom"/>
   <anchor x="283" y="580" name="top"/>
   <anchor x="434" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="288" y="-225" type="curve" smooth="yes"/>
-      <point x="449" y="-225"/>
-      <point x="538" y="-171"/>
-      <point x="538" y="-69" type="curve" smooth="yes"/>
-      <point x="538" y="-9"/>
-      <point x="500" y="29"/>
-      <point x="429" y="42" type="curve"/>
-      <point x="429" y="48" type="line"/>
-      <point x="478" y="66"/>
-      <point x="528" y="102"/>
-      <point x="528" y="190" type="curve" smooth="yes"/>
-      <point x="528" y="284"/>
-      <point x="469" y="340"/>
+      <point x="288" y="-251" type="curve" smooth="yes"/>
+      <point x="449" y="-251"/>
+      <point x="538" y="-190"/>
+      <point x="538" y="-86" type="curve" smooth="yes"/>
+      <point x="538" y="-17"/>
+      <point x="501" y="30"/>
+      <point x="431" y="47" type="curve"/>
+      <point x="431" y="53" type="line"/>
+      <point x="493" y="76"/>
+      <point x="528" y="123"/>
+      <point x="528" y="189" type="curve" smooth="yes"/>
+      <point x="528" y="289"/>
+      <point x="462" y="341"/>
       <point x="327" y="347" type="curve" smooth="yes"/>
       <point x="220" y="352" type="line" smooth="yes"/>
-      <point x="148" y="355"/>
-      <point x="110" y="385"/>
-      <point x="110" y="434" type="curve" smooth="yes"/>
-      <point x="110" y="490"/>
-      <point x="167" y="515"/>
-      <point x="271" y="515" type="curve" smooth="yes"/>
-      <point x="342" y="515"/>
-      <point x="402" y="502"/>
-      <point x="466" y="476" type="curve"/>
+      <point x="149" y="355"/>
+      <point x="110" y="383"/>
+      <point x="110" y="432" type="curve" smooth="yes"/>
+      <point x="110" y="488"/>
+      <point x="163" y="516"/>
+      <point x="271" y="516" type="curve" smooth="yes"/>
+      <point x="340" y="516"/>
+      <point x="400" y="504"/>
+      <point x="466" y="477" type="curve"/>
       <point x="498" y="550" type="line"/>
-      <point x="428" y="582"/>
-      <point x="357" y="596"/>
+      <point x="430" y="582"/>
+      <point x="359" y="596"/>
       <point x="271" y="596" type="curve" smooth="yes"/>
-      <point x="118" y="596"/>
-      <point x="25" y="534"/>
+      <point x="116" y="596"/>
+      <point x="25" y="532"/>
       <point x="25" y="423" type="curve" smooth="yes"/>
-      <point x="25" y="330"/>
-      <point x="94" y="272"/>
-      <point x="210" y="265" type="curve" smooth="yes"/>
+      <point x="25" y="328"/>
+      <point x="94" y="269"/>
+      <point x="210" y="264" type="curve" smooth="yes"/>
       <point x="317" y="259" type="line" smooth="yes"/>
-      <point x="405" y="254"/>
-      <point x="446" y="224"/>
-      <point x="446" y="176" type="curve" smooth="yes"/>
-      <point x="446" y="112"/>
-      <point x="392" y="80"/>
-      <point x="282" y="80" type="curve" smooth="yes"/>
-      <point x="69" y="80" type="line"/>
-      <point x="69" y="6" type="line"/>
-      <point x="292" y="6" type="line" smooth="yes"/>
-      <point x="418" y="6"/>
-      <point x="456" y="-17"/>
-      <point x="456" y="-68" type="curve" smooth="yes"/>
-      <point x="456" y="-126"/>
-      <point x="396" y="-147"/>
-      <point x="288" y="-147" type="curve" smooth="yes"/>
-      <point x="195" y="-147"/>
-      <point x="119" y="-125"/>
-      <point x="69" y="-98" type="curve"/>
-      <point x="35" y="-166" type="line"/>
-      <point x="86" y="-198"/>
-      <point x="179" y="-225"/>
+      <point x="400" y="255"/>
+      <point x="443" y="226"/>
+      <point x="443" y="175" type="curve" smooth="yes"/>
+      <point x="443" y="118"/>
+      <point x="389" y="86"/>
+      <point x="293" y="86" type="curve" smooth="yes"/>
+      <point x="69" y="86" type="line"/>
+      <point x="69" y="12" type="line"/>
+      <point x="314" y="12" type="line" smooth="yes"/>
+      <point x="410" y="12"/>
+      <point x="453" y="-16"/>
+      <point x="453" y="-78" type="curve" smooth="yes"/>
+      <point x="453" y="-140"/>
+      <point x="399" y="-171"/>
+      <point x="288" y="-171" type="curve" smooth="yes"/>
+      <point x="210" y="-171"/>
+      <point x="135" y="-147"/>
+      <point x="79" y="-104" type="curve"/>
+      <point x="33" y="-169" type="line"/>
+      <point x="101" y="-222"/>
+      <point x="192" y="-251"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/tta-malayalam.glif
@@ -8,45 +8,45 @@
   <outline>
     <contour>
       <point x="305" y="-16" type="curve" smooth="yes"/>
-      <point x="451" y="-16"/>
-      <point x="540" y="54"/>
-      <point x="540" y="165" type="curve" smooth="yes"/>
-      <point x="540" y="263"/>
-      <point x="471" y="328"/>
+      <point x="452" y="-16"/>
+      <point x="540" y="50"/>
+      <point x="540" y="162" type="curve" smooth="yes"/>
+      <point x="540" y="267"/>
+      <point x="469" y="328"/>
       <point x="339" y="334" type="curve" smooth="yes"/>
       <point x="232" y="339" type="line" smooth="yes"/>
       <point x="160" y="342"/>
       <point x="122" y="371"/>
-      <point x="122" y="421" type="curve" smooth="yes"/>
-      <point x="122" y="483"/>
-      <point x="179" y="515"/>
-      <point x="283" y="515" type="curve" smooth="yes"/>
-      <point x="354" y="515"/>
-      <point x="414" y="502"/>
-      <point x="478" y="476" type="curve"/>
+      <point x="122" y="422" type="curve" smooth="yes"/>
+      <point x="122" y="484"/>
+      <point x="179" y="516"/>
+      <point x="291" y="516" type="curve" smooth="yes"/>
+      <point x="357" y="516"/>
+      <point x="415" y="504"/>
+      <point x="478" y="477" type="curve"/>
       <point x="510" y="550" type="line"/>
-      <point x="440" y="582"/>
-      <point x="369" y="596"/>
-      <point x="283" y="596" type="curve" smooth="yes"/>
-      <point x="130" y="596"/>
-      <point x="37" y="527"/>
-      <point x="37" y="414" type="curve" smooth="yes"/>
-      <point x="37" y="320"/>
-      <point x="106" y="257"/>
-      <point x="222" y="250" type="curve" smooth="yes"/>
+      <point x="443" y="582"/>
+      <point x="375" y="596"/>
+      <point x="291" y="596" type="curve" smooth="yes"/>
+      <point x="133" y="596"/>
+      <point x="37" y="529"/>
+      <point x="37" y="416" type="curve" smooth="yes"/>
+      <point x="37" y="318"/>
+      <point x="110" y="254"/>
+      <point x="222" y="249" type="curve" smooth="yes"/>
       <point x="329" y="244" type="line" smooth="yes"/>
-      <point x="417" y="239"/>
-      <point x="457" y="210"/>
-      <point x="457" y="158" type="curve" smooth="yes"/>
-      <point x="457" y="98"/>
-      <point x="403" y="65"/>
-      <point x="305" y="65" type="curve" smooth="yes"/>
-      <point x="223" y="65"/>
-      <point x="146" y="89"/>
-      <point x="71" y="135" type="curve"/>
-      <point x="25" y="59" type="line"/>
-      <point x="110" y="9"/>
-      <point x="201" y="-16"/>
+      <point x="415" y="240"/>
+      <point x="455" y="211"/>
+      <point x="455" y="156" type="curve" smooth="yes"/>
+      <point x="455" y="97"/>
+      <point x="402" y="64"/>
+      <point x="305" y="64" type="curve" smooth="yes"/>
+      <point x="215" y="64"/>
+      <point x="140" y="86"/>
+      <point x="67" y="133" type="curve"/>
+      <point x="25" y="65" type="line"/>
+      <point x="112" y="9"/>
+      <point x="198" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
@@ -36,33 +36,39 @@
     </contour>
     <contour>
       <point x="126" y="-185" type="curve" smooth="yes"/>
-      <point x="74" y="-185"/>
-      <point x="38" y="-151"/>
-      <point x="38" y="-100" type="curve" smooth="yes"/>
-      <point x="38" y="-49"/>
-      <point x="73" y="-15"/>
-      <point x="126" y="-15" type="curve" smooth="yes"/>
-      <point x="178" y="-15"/>
-      <point x="214" y="-49"/>
-      <point x="214" y="-100" type="curve" smooth="yes"/>
-      <point x="214" y="-151"/>
-      <point x="178" y="-185"/>
+      <point x="70" y="-185"/>
+      <point x="34" y="-151"/>
+      <point x="34" y="-103" type="curve" smooth="yes"/>
+      <point x="34" y="-85"/>
+      <point x="37" y="-72"/>
+      <point x="42" y="-60" type="curve"/>
+      <point x="46" y="-60" type="line"/>
+      <point x="55" y="-103"/>
+      <point x="84" y="-127"/>
+      <point x="126" y="-127" type="curve" smooth="yes"/>
+      <point x="168" y="-127"/>
+      <point x="197" y="-103"/>
+      <point x="206" y="-60" type="curve"/>
+      <point x="210" y="-60" type="line"/>
+      <point x="215" y="-72"/>
+      <point x="218" y="-85"/>
+      <point x="218" y="-103" type="curve" smooth="yes"/>
+      <point x="218" y="-151"/>
+      <point x="182" y="-185"/>
     </contour>
     <contour>
-      <point x="125" y="-119" type="curve" smooth="yes"/>
-      <point x="171" y="-119"/>
-      <point x="208" y="-106"/>
-      <point x="239" y="-78" type="curve"/>
-      <point x="216" y="-38" type="line"/>
-      <point x="192" y="-60"/>
-      <point x="164" y="-70"/>
-      <point x="125" y="-70" type="curve" smooth="yes"/>
-      <point x="86" y="-70"/>
-      <point x="57" y="-60"/>
-      <point x="34" y="-38" type="curve"/>
-      <point x="11" y="-78" type="line"/>
-      <point x="42" y="-106"/>
-      <point x="79" y="-119"/>
+      <point x="126" y="-63" type="curve" smooth="yes"/>
+      <point x="86" y="-63"/>
+      <point x="63" y="-48"/>
+      <point x="63" y="-29" type="curve" smooth="yes"/>
+      <point x="63" y="-12"/>
+      <point x="86" y="0"/>
+      <point x="126" y="0" type="curve" smooth="yes"/>
+      <point x="166" y="0"/>
+      <point x="189" y="-12"/>
+      <point x="189" y="-29" type="curve" smooth="yes"/>
+      <point x="189" y="-48"/>
+      <point x="166" y="-63"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/v_va-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/v_va-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="v_va-malayalam" format="2">
   <advance width="1029"/>
   <anchor x="699" y="-281" name="bottom"/>
-  <anchor x="932" y="0" name="bottomright"/>
   <anchor x="548" y="580" name="top"/>
   <anchor x="912" y="580" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/y_ya-malayalam.glif
@@ -1,97 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="984"/>
-  <anchor x="622" y="-281" name="bottom"/>
-  <anchor x="855" y="0" name="bottomright"/>
+  <anchor x="622" y="-268" name="bottom"/>
   <anchor x="505" y="580" name="top"/>
   <anchor x="811" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="305" y="-291" type="line"/>
-      <point x="875" y="-291" type="line"/>
+      <point x="305" y="-278" type="line"/>
+      <point x="875" y="-278" type="line"/>
       <point x="875" y="121" type="line"/>
-      <point x="863" y="66" type="line"/>
-      <point x="915" y="122"/>
-      <point x="942" y="204"/>
-      <point x="942" y="300" type="curve" smooth="yes"/>
-      <point x="942" y="399"/>
-      <point x="904" y="510"/>
-      <point x="831" y="596" type="curve"/>
-      <point x="763" y="548" type="line"/>
-      <point x="817" y="480"/>
-      <point x="860" y="398"/>
-      <point x="860" y="302" type="curve" smooth="yes"/>
-      <point x="860" y="161"/>
-      <point x="796" y="62"/>
-      <point x="655" y="62" type="curve" smooth="yes"/>
-      <point x="486" y="62"/>
-      <point x="405" y="195"/>
-      <point x="405" y="362" type="curve" smooth="yes"/>
-      <point x="405" y="459"/>
-      <point x="442" y="518"/>
-      <point x="506" y="518" type="curve" smooth="yes"/>
-      <point x="567" y="518"/>
-      <point x="604" y="459"/>
-      <point x="604" y="362" type="curve" smooth="yes"/>
-      <point x="604" y="244"/>
-      <point x="565" y="154"/>
-      <point x="494" y="104" type="curve"/>
+      <point x="857" y="71" type="line"/>
+      <point x="912" y="126"/>
+      <point x="942" y="206"/>
+      <point x="942" y="303" type="curve" smooth="yes"/>
+      <point x="942" y="405"/>
+      <point x="900" y="514"/>
+      <point x="828" y="596" type="curve"/>
+      <point x="765" y="547" type="line"/>
+      <point x="830" y="473"/>
+      <point x="862" y="390"/>
+      <point x="862" y="299" type="curve" smooth="yes"/>
+      <point x="862" y="151"/>
+      <point x="778" y="62"/>
+      <point x="648" y="62" type="curve" smooth="yes"/>
+      <point x="462" y="62"/>
+      <point x="373" y="190"/>
+      <point x="373" y="338" type="curve" smooth="yes"/>
+      <point x="373" y="453"/>
+      <point x="426" y="518"/>
+      <point x="508" y="518" type="curve" smooth="yes"/>
+      <point x="585" y="518"/>
+      <point x="628" y="453"/>
+      <point x="628" y="346" type="curve" smooth="yes"/>
+      <point x="628" y="233"/>
+      <point x="577" y="146"/>
+      <point x="492" y="95" type="curve"/>
       <point x="547" y="50" type="line"/>
-      <point x="638" y="121"/>
-      <point x="686" y="240"/>
-      <point x="686" y="367" type="curve" smooth="yes"/>
-      <point x="686" y="500"/>
-      <point x="621" y="596"/>
-      <point x="504" y="596" type="curve" smooth="yes"/>
-      <point x="385" y="596"/>
-      <point x="323" y="497"/>
-      <point x="323" y="370" type="curve" smooth="yes"/>
-      <point x="323" y="181"/>
-      <point x="444" y="-13"/>
-      <point x="663" y="-13" type="curve" smooth="yes"/>
-      <point x="680" y="-13"/>
-      <point x="698" y="-12"/>
-      <point x="717" y="-9" type="curve"/>
-      <point x="652" y="29" type="line"/>
-      <point x="652" y="-18" type="line"/>
-      <point x="565" y="-70" type="line"/>
-      <point x="305" y="-235" type="line"/>
+      <point x="649" y="110"/>
+      <point x="710" y="224"/>
+      <point x="710" y="352" type="curve" smooth="yes"/>
+      <point x="710" y="500"/>
+      <point x="632" y="596"/>
+      <point x="508" y="596" type="curve" smooth="yes"/>
+      <point x="374" y="596"/>
+      <point x="291" y="479"/>
+      <point x="291" y="334" type="curve" smooth="yes"/>
+      <point x="291" y="143"/>
+      <point x="448" y="-12"/>
+      <point x="650" y="-12" type="curve" smooth="yes"/>
+      <point x="674" y="-12"/>
+      <point x="697" y="-10"/>
+      <point x="719" y="-5" type="curve"/>
+      <point x="629" y="33" type="line"/>
+      <point x="629" y="-14" type="line"/>
+      <point x="551" y="-58" type="line"/>
+      <point x="305" y="-222" type="line"/>
     </contour>
     <contour>
-      <point x="401" y="-258" type="line"/>
-      <point x="807" y="13" type="line"/>
-      <point x="793" y="13" type="line"/>
-      <point x="793" y="-244" type="line"/>
-      <point x="831" y="-226" type="line"/>
-      <point x="401" y="-226" type="line"/>
+      <point x="401" y="-243" type="line"/>
+      <point x="807" y="26" type="line"/>
+      <point x="793" y="26" type="line"/>
+      <point x="793" y="-231" type="line"/>
+      <point x="831" y="-213" type="line"/>
+      <point x="401" y="-213" type="line"/>
     </contour>
     <contour>
-      <point x="348" y="-16" type="curve" smooth="yes"/>
-      <point x="418" y="-16"/>
-      <point x="474" y="2"/>
-      <point x="522" y="32" type="curve"/>
-      <point x="460" y="84" type="line"/>
-      <point x="431" y="71"/>
+      <point x="349" y="-16" type="curve" smooth="yes"/>
+      <point x="414" y="-16"/>
+      <point x="467" y="0"/>
+      <point x="519" y="35" type="curve"/>
+      <point x="461" y="83" type="line"/>
+      <point x="430" y="69"/>
       <point x="396" y="62"/>
-      <point x="352" y="62" type="curve" smooth="yes"/>
-      <point x="215" y="62"/>
-      <point x="124" y="167"/>
-      <point x="124" y="323" type="curve" smooth="yes"/>
-      <point x="124" y="430"/>
+      <point x="353" y="62" type="curve" smooth="yes"/>
+      <point x="212" y="62"/>
+      <point x="122" y="167"/>
+      <point x="122" y="323" type="curve" smooth="yes"/>
+      <point x="122" y="430"/>
       <point x="176" y="518"/>
-      <point x="274" y="518" type="curve" smooth="yes"/>
-      <point x="320" y="518"/>
-      <point x="349" y="502"/>
-      <point x="371" y="478" type="curve"/>
-      <point x="413" y="532" type="line"/>
-      <point x="378" y="575"/>
-      <point x="334" y="596"/>
-      <point x="271" y="596" type="curve" smooth="yes"/>
-      <point x="131" y="596"/>
-      <point x="42" y="478"/>
-      <point x="42" y="323" type="curve" smooth="yes"/>
-      <point x="42" y="125"/>
-      <point x="168" y="-16"/>
+      <point x="278" y="518" type="curve" smooth="yes"/>
+      <point x="319" y="518"/>
+      <point x="350" y="506"/>
+      <point x="375" y="479" type="curve"/>
+      <point x="427" y="537" type="line"/>
+      <point x="386" y="578"/>
+      <point x="342" y="596"/>
+      <point x="282" y="596" type="curve" smooth="yes"/>
+      <point x="135" y="596"/>
+      <point x="42" y="476"/>
+      <point x="42" y="321" type="curve" smooth="yes"/>
+      <point x="42" y="126"/>
+      <point x="170" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ya-malayalam.glif
@@ -8,72 +8,72 @@
   <anchor x="811" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="658" y="-16" type="curve" smooth="yes"/>
-      <point x="843" y="-16"/>
-      <point x="942" y="117"/>
-      <point x="942" y="300" type="curve" smooth="yes"/>
-      <point x="942" y="399"/>
-      <point x="904" y="510"/>
-      <point x="831" y="596" type="curve"/>
-      <point x="763" y="548" type="line"/>
-      <point x="817" y="480"/>
-      <point x="860" y="398"/>
-      <point x="860" y="302" type="curve" smooth="yes"/>
-      <point x="860" y="161"/>
-      <point x="796" y="62"/>
-      <point x="655" y="62" type="curve" smooth="yes"/>
-      <point x="486" y="62"/>
-      <point x="405" y="195"/>
-      <point x="405" y="362" type="curve" smooth="yes"/>
-      <point x="405" y="459"/>
-      <point x="442" y="518"/>
-      <point x="506" y="518" type="curve" smooth="yes"/>
-      <point x="567" y="518"/>
-      <point x="604" y="459"/>
-      <point x="604" y="362" type="curve" smooth="yes"/>
-      <point x="604" y="244"/>
-      <point x="565" y="154"/>
-      <point x="494" y="104" type="curve"/>
+      <point x="650" y="-16" type="curve" smooth="yes"/>
+      <point x="824" y="-16"/>
+      <point x="942" y="108"/>
+      <point x="942" y="303" type="curve" smooth="yes"/>
+      <point x="942" y="405"/>
+      <point x="900" y="514"/>
+      <point x="828" y="596" type="curve"/>
+      <point x="765" y="547" type="line"/>
+      <point x="830" y="473"/>
+      <point x="862" y="390"/>
+      <point x="862" y="299" type="curve" smooth="yes"/>
+      <point x="862" y="151"/>
+      <point x="778" y="62"/>
+      <point x="648" y="62" type="curve" smooth="yes"/>
+      <point x="462" y="62"/>
+      <point x="373" y="190"/>
+      <point x="373" y="338" type="curve" smooth="yes"/>
+      <point x="373" y="453"/>
+      <point x="426" y="518"/>
+      <point x="508" y="518" type="curve" smooth="yes"/>
+      <point x="585" y="518"/>
+      <point x="628" y="453"/>
+      <point x="628" y="346" type="curve" smooth="yes"/>
+      <point x="628" y="233"/>
+      <point x="577" y="146"/>
+      <point x="492" y="95" type="curve"/>
       <point x="547" y="50" type="line"/>
-      <point x="638" y="121"/>
-      <point x="686" y="240"/>
-      <point x="686" y="367" type="curve" smooth="yes"/>
-      <point x="686" y="500"/>
-      <point x="621" y="596"/>
-      <point x="504" y="596" type="curve" smooth="yes"/>
-      <point x="385" y="596"/>
-      <point x="323" y="497"/>
-      <point x="323" y="370" type="curve" smooth="yes"/>
-      <point x="323" y="179"/>
-      <point x="446" y="-16"/>
+      <point x="649" y="110"/>
+      <point x="710" y="224"/>
+      <point x="710" y="352" type="curve" smooth="yes"/>
+      <point x="710" y="500"/>
+      <point x="632" y="596"/>
+      <point x="508" y="596" type="curve" smooth="yes"/>
+      <point x="374" y="596"/>
+      <point x="291" y="479"/>
+      <point x="291" y="334" type="curve" smooth="yes"/>
+      <point x="291" y="141"/>
+      <point x="448" y="-16"/>
     </contour>
     <contour>
-      <point x="348" y="-16" type="curve" smooth="yes"/>
-      <point x="418" y="-16"/>
-      <point x="474" y="2"/>
-      <point x="522" y="32" type="curve"/>
-      <point x="460" y="84" type="line"/>
-      <point x="431" y="71"/>
+      <point x="349" y="-16" type="curve" smooth="yes"/>
+      <point x="414" y="-16"/>
+      <point x="467" y="0"/>
+      <point x="519" y="35" type="curve"/>
+      <point x="461" y="83" type="line"/>
+      <point x="430" y="69"/>
       <point x="396" y="62"/>
-      <point x="352" y="62" type="curve" smooth="yes"/>
-      <point x="215" y="62"/>
-      <point x="124" y="167"/>
-      <point x="124" y="323" type="curve" smooth="yes"/>
-      <point x="124" y="430"/>
+      <point x="353" y="62" type="curve" smooth="yes"/>
+      <point x="212" y="62"/>
+      <point x="122" y="167"/>
+      <point x="122" y="323" type="curve" smooth="yes"/>
+      <point x="122" y="430"/>
       <point x="176" y="518"/>
-      <point x="274" y="518" type="curve" smooth="yes"/>
-      <point x="320" y="518"/>
-      <point x="349" y="502"/>
-      <point x="371" y="478" type="curve"/>
-      <point x="413" y="532" type="line"/>
-      <point x="378" y="575"/>
-      <point x="334" y="596"/>
-      <point x="271" y="596" type="curve" smooth="yes"/>
-      <point x="131" y="596"/>
-      <point x="42" y="478"/>
-      <point x="42" y="323" type="curve" smooth="yes"/>
-      <point x="42" y="125"/>
-      <point x="168" y="-16"/>
+      <point x="278" y="518" type="curve" smooth="yes"/>
+      <point x="319" y="518"/>
+      <point x="350" y="506"/>
+      <point x="375" y="479" type="curve"/>
+      <point x="427" y="537" type="line"/>
+      <point x="386" y="578"/>
+      <point x="342" y="596"/>
+      <point x="282" y="596" type="curve" smooth="yes"/>
+      <point x="135" y="596"/>
+      <point x="42" y="476"/>
+      <point x="42" y="321" type="curve" smooth="yes"/>
+      <point x="42" y="126"/>
+      <point x="170" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/kerning.plist
@@ -45714,7 +45714,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -45828,7 +45828,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -45884,7 +45884,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -45939,7 +45939,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>200</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -45986,7 +45986,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -46021,7 +46021,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>110</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -46049,8 +46049,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46085,7 +46083,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46152,7 +46150,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46212,7 +46210,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>130</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46263,7 +46261,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>170</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46321,7 +46319,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46364,7 +46362,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46502,8 +46500,6 @@
       <integer>-10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46589,7 +46585,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46689,8 +46685,6 @@
       <integer>60</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -46723,7 +46717,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -46803,7 +46797,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46845,8 +46839,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla-malayalam_L</key>
       <integer>-30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46964,8 +46956,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -47079,7 +47069,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47128,7 +47118,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>200</integer>
+      <integer>190</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47178,17 +47168,17 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>70</integer>
-      <key>public.kern2.MAL_braceright.loclMALM_R</key>
       <integer>50</integer>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>40</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
       <integer>40</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
@@ -47198,23 +47188,25 @@
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
       <integer>40</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
-      <integer>-30</integer>
+      <integer>-20</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>70</integer>
+      <key>public.kern2.MAL_tt_tta-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
-      <integer>130</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
-      <integer>90</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_uMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>74</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>220</integer>
+      <integer>210</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
       <integer>170</integer>
     </dict>
@@ -47241,7 +47233,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47290,7 +47282,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>160</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47366,7 +47358,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47577,7 +47569,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47603,8 +47595,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47633,7 +47623,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47687,7 +47677,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -47719,8 +47709,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -47837,7 +47825,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_p_pa-malayalam_L</key>
@@ -47949,7 +47937,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47994,7 +47982,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48090,7 +48078,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48230,7 +48218,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48283,7 +48271,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48350,7 +48338,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48403,7 +48391,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>290</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>240</integer>
+      <integer>220</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -48490,7 +48478,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>130</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48639,7 +48627,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48747,7 +48735,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_ng_ka-malayalam_L</key>
@@ -48799,6 +48787,26 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-40</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>110</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>100</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+      <key>public.kern2.MAL_quoteright.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.ODI_a-oriya-L</key>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/c_cha-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/c_cha-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="c_cha-malayalam" format="2">
   <advance width="884"/>
   <anchor x="485" y="-349" name="bottom"/>
-  <anchor x="787" y="0" name="bottomright"/>
   <anchor x="430" y="580" name="top"/>
   <anchor x="768" y="580" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/d_da-malayalam.glif
@@ -1,26 +1,23 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
-  <advance width="665"/>
-  <guideline x="1248" y="-225" angle="0"/>
-  <guideline x="619" y="162" angle="90"/>
-  <guideline x="1442" y="185" angle="90"/>
-  <anchor x="377" y="-209" name="bottom"/>
+  <advance width="655"/>
+  <anchor x="377" y="-263" name="bottom"/>
   <anchor x="363" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="437" y="-225" type="curve" smooth="yes"/>
-      <point x="564" y="-225"/>
-      <point x="629" y="-176"/>
-      <point x="629" y="-88" type="curve" smooth="yes"/>
-      <point x="629" y="-27"/>
-      <point x="591" y="12"/>
-      <point x="520" y="25" type="curve"/>
-      <point x="520" y="31" type="line"/>
-      <point x="569" y="49"/>
-      <point x="619" y="85"/>
+      <point x="400" y="-279" type="curve" smooth="yes"/>
+      <point x="535" y="-279"/>
+      <point x="619" y="-218"/>
+      <point x="619" y="-118" type="curve" smooth="yes"/>
+      <point x="619" y="-47"/>
+      <point x="587" y="1"/>
+      <point x="519" y="23" type="curve"/>
+      <point x="519" y="29" type="line"/>
+      <point x="583" y="52"/>
+      <point x="619" y="101"/>
       <point x="619" y="162" type="curve" smooth="yes"/>
-      <point x="619" y="231"/>
-      <point x="574" y="276"/>
+      <point x="619" y="229"/>
+      <point x="576" y="276"/>
       <point x="499" y="292" type="curve"/>
       <point x="499" y="298" type="line"/>
       <point x="560" y="316"/>
@@ -42,7 +39,7 @@
       <point x="124" y="426"/>
       <point x="214" y="518"/>
       <point x="361" y="518" type="curve" smooth="yes"/>
-      <point x="465" y="518"/>
+      <point x="466" y="518"/>
       <point x="516" y="480"/>
       <point x="516" y="416" type="curve" smooth="yes"/>
       <point x="516" y="361"/>
@@ -51,27 +48,27 @@
       <point x="360" y="329" type="line"/>
       <point x="360" y="255" type="line"/>
       <point x="402" y="255" type="line" smooth="yes"/>
-      <point x="488" y="255"/>
-      <point x="537" y="220"/>
+      <point x="489" y="255"/>
+      <point x="537" y="219"/>
       <point x="537" y="155" type="curve" smooth="yes"/>
-      <point x="537" y="94"/>
-      <point x="483" y="62"/>
+      <point x="537" y="98"/>
+      <point x="489" y="62"/>
       <point x="413" y="62" type="curve" smooth="yes"/>
-      <point x="360" y="62" type="line"/>
-      <point x="360" y="-12" type="line"/>
-      <point x="423" y="-12" type="line" smooth="yes"/>
-      <point x="509" y="-12"/>
-      <point x="547" y="-35"/>
-      <point x="547" y="-77" type="curve" smooth="yes"/>
-      <point x="547" y="-126"/>
-      <point x="507" y="-147"/>
-      <point x="440" y="-147" type="curve" smooth="yes"/>
-      <point x="391" y="-147"/>
-      <point x="357" y="-140"/>
-      <point x="324" y="-129" type="curve"/>
-      <point x="296" y="-201" type="line"/>
-      <point x="332" y="-216"/>
-      <point x="385" y="-225"/>
+      <point x="340" y="62" type="line"/>
+      <point x="340" y="-12" type="line"/>
+      <point x="413" y="-12" type="line" smooth="yes"/>
+      <point x="497" y="-12"/>
+      <point x="537" y="-47"/>
+      <point x="537" y="-106" type="curve" smooth="yes"/>
+      <point x="537" y="-166"/>
+      <point x="488" y="-201"/>
+      <point x="400" y="-201" type="curve" smooth="yes"/>
+      <point x="342" y="-201"/>
+      <point x="296" y="-190"/>
+      <point x="243" y="-164" type="curve"/>
+      <point x="210" y="-233" type="line"/>
+      <point x="270" y="-264"/>
+      <point x="335" y="-279"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="963"/>
-  <anchor x="657" y="0" name="bottom"/>
+  <advance width="956"/>
+  <anchor x="650" y="0" name="bottom"/>
   <anchor x="475" y="580" name="top"/>
-  <anchor x="847" y="580" name="topright"/>
+  <anchor x="840" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="272" y="-16" type="curve" smooth="yes"/>
+      <point x="282" y="-16" type="curve" smooth="yes"/>
       <point x="411" y="-16"/>
-      <point x="479" y="68"/>
-      <point x="494" y="232" type="curve" smooth="yes"/>
-      <point x="504" y="340" type="line" smooth="yes"/>
-      <point x="514" y="449"/>
-      <point x="569" y="516"/>
-      <point x="681" y="516" type="curve" smooth="yes"/>
-      <point x="782" y="516"/>
-      <point x="824" y="476"/>
-      <point x="824" y="416" type="curve" smooth="yes"/>
-      <point x="824" y="361"/>
-      <point x="780" y="329"/>
-      <point x="710" y="329" type="curve" smooth="yes"/>
-      <point x="668" y="329" type="line"/>
-      <point x="668" y="255" type="line"/>
-      <point x="710" y="255" type="line" smooth="yes"/>
-      <point x="796" y="255"/>
-      <point x="845" y="220"/>
-      <point x="845" y="158" type="curve" smooth="yes"/>
-      <point x="845" y="93"/>
-      <point x="805" y="62"/>
-      <point x="729" y="62" type="curve" smooth="yes"/>
-      <point x="697" y="62"/>
-      <point x="667" y="69"/>
-      <point x="634" y="82" type="curve"/>
-      <point x="602" y="10" type="line"/>
-      <point x="638" y="-7"/>
-      <point x="684" y="-16"/>
-      <point x="731" y="-16" type="curve" smooth="yes"/>
-      <point x="848" y="-16"/>
-      <point x="927" y="47"/>
-      <point x="927" y="153" type="curve" smooth="yes"/>
-      <point x="927" y="224"/>
-      <point x="882" y="276"/>
-      <point x="807" y="292" type="curve"/>
-      <point x="807" y="298" type="line"/>
-      <point x="868" y="316"/>
-      <point x="906" y="362"/>
-      <point x="906" y="427" type="curve" smooth="yes"/>
-      <point x="906" y="523"/>
-      <point x="833" y="596"/>
-      <point x="678" y="596" type="curve" smooth="yes"/>
-      <point x="521" y="596"/>
-      <point x="431" y="507"/>
-      <point x="416" y="347" type="curve" smooth="yes"/>
-      <point x="406" y="240" type="line" smooth="yes"/>
-      <point x="396" y="128"/>
-      <point x="355" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="89"/>
-      <point x="131" y="-16"/>
+      <point x="499" y="77"/>
+      <point x="499" y="214" type="curve" smooth="yes"/>
+      <point x="499" y="255"/>
+      <point x="495" y="297"/>
+      <point x="495" y="338" type="curve" smooth="yes"/>
+      <point x="495" y="457"/>
+      <point x="561" y="516"/>
+      <point x="679" y="516" type="curve" smooth="yes"/>
+      <point x="777" y="516"/>
+      <point x="817" y="479"/>
+      <point x="817" y="424" type="curve" smooth="yes"/>
+      <point x="817" y="365"/>
+      <point x="773" y="329"/>
+      <point x="703" y="329" type="curve" smooth="yes"/>
+      <point x="661" y="329" type="line"/>
+      <point x="661" y="255" type="line"/>
+      <point x="703" y="255" type="line" smooth="yes"/>
+      <point x="789" y="255"/>
+      <point x="838" y="220"/>
+      <point x="838" y="158" type="curve" smooth="yes"/>
+      <point x="838" y="93"/>
+      <point x="798" y="62"/>
+      <point x="722" y="62" type="curve" smooth="yes"/>
+      <point x="690" y="62"/>
+      <point x="660" y="69"/>
+      <point x="627" y="82" type="curve"/>
+      <point x="595" y="10" type="line"/>
+      <point x="631" y="-7"/>
+      <point x="677" y="-16"/>
+      <point x="724" y="-16" type="curve" smooth="yes"/>
+      <point x="841" y="-16"/>
+      <point x="920" y="47"/>
+      <point x="920" y="153" type="curve" smooth="yes"/>
+      <point x="920" y="224"/>
+      <point x="875" y="276"/>
+      <point x="800" y="292" type="curve"/>
+      <point x="800" y="298" type="line"/>
+      <point x="861" y="317"/>
+      <point x="899" y="365"/>
+      <point x="899" y="435" type="curve" smooth="yes"/>
+      <point x="899" y="524"/>
+      <point x="828" y="596"/>
+      <point x="680" y="596" type="curve" smooth="yes"/>
+      <point x="518" y="596"/>
+      <point x="411" y="503"/>
+      <point x="411" y="346" type="curve" smooth="yes"/>
+      <point x="411" y="305"/>
+      <point x="415" y="263"/>
+      <point x="415" y="222" type="curve" smooth="yes"/>
+      <point x="415" y="120"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="90"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/g_ga-malayalam.glif
@@ -6,91 +6,95 @@
   <anchor x="763" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="392" y="-367" type="curve" smooth="yes"/>
-      <point x="500" y="-367"/>
-      <point x="551" y="-308"/>
-      <point x="557" y="-175" type="curve" smooth="yes"/>
-      <point x="558" y="-152" type="line" smooth="yes"/>
-      <point x="562" y="-55"/>
-      <point x="593" y="-27"/>
-      <point x="648" y="-27" type="curve" smooth="yes"/>
-      <point x="709" y="-27"/>
-      <point x="747" y="-75"/>
-      <point x="747" y="-155" type="curve" smooth="yes"/>
-      <point x="747" y="-228"/>
-      <point x="719" y="-280"/>
-      <point x="681" y="-324" type="curve"/>
-      <point x="734" y="-367" type="line"/>
-      <point x="794" y="-304"/>
-      <point x="821" y="-235"/>
-      <point x="821" y="-153" type="curve" smooth="yes"/>
-      <point x="821" y="-23"/>
-      <point x="748" y="43"/>
-      <point x="650" y="43" type="curve" smooth="yes"/>
-      <point x="542" y="43"/>
-      <point x="492" y="-16"/>
-      <point x="486" y="-146" type="curve" smooth="yes"/>
-      <point x="485" y="-168" type="line" smooth="yes"/>
-      <point x="480" y="-270"/>
-      <point x="449" y="-297"/>
-      <point x="395" y="-297" type="curve" smooth="yes"/>
-      <point x="334" y="-297"/>
-      <point x="295" y="-250"/>
-      <point x="295" y="-165" type="curve" smooth="yes"/>
-      <point x="295" y="-90"/>
-      <point x="323" y="-35"/>
-      <point x="373" y="17" type="curve"/>
-      <point x="348" y="-4" type="line"/>
-      <point x="434" y="25"/>
-      <point x="481" y="107"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="563" y="512"/>
-      <point x="647" y="512" type="curve" smooth="yes"/>
-      <point x="734" y="512"/>
-      <point x="784" y="440"/>
-      <point x="784" y="326" type="curve" smooth="yes"/>
-      <point x="784" y="213"/>
-      <point x="748" y="113"/>
-      <point x="656" y="17" type="curve"/>
-      <point x="732" y="-16" type="line"/>
+      <point x="284" y="-12" type="curve" smooth="yes"/>
+      <point x="410" y="-12"/>
+      <point x="499" y="84"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="452"/>
+      <point x="550" y="514"/>
+      <point x="642" y="514" type="curve" smooth="yes"/>
+      <point x="734" y="514"/>
+      <point x="784" y="447"/>
+      <point x="784" y="324" type="curve" smooth="yes"/>
+      <point x="784" y="215"/>
+      <point x="741" y="120"/>
+      <point x="659" y="31" type="curve"/>
+      <point x="733" y="-12" type="line"/>
       <point x="823" y="85"/>
-      <point x="868" y="203"/>
+      <point x="868" y="198"/>
       <point x="868" y="327" type="curve" smooth="yes"/>
-      <point x="868" y="491"/>
+      <point x="868" y="495"/>
       <point x="781" y="596"/>
-      <point x="641" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
+      <point x="638" y="596" type="curve" smooth="yes"/>
+      <point x="503" y="596"/>
+      <point x="411" y="498"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
       <point x="42" y="92"/>
-      <point x="128" y="-13"/>
-      <point x="275" y="-13" type="curve" smooth="yes"/>
-      <point x="283" y="-13"/>
-      <point x="291" y="-13"/>
-      <point x="299" y="-12" type="curve"/>
-      <point x="248" y="27" type="line"/>
-      <point x="284" y="-57" type="line"/>
-      <point x="288" y="6" type="line"/>
-      <point x="240" y="-44"/>
-      <point x="221" y="-105"/>
-      <point x="221" y="-167" type="curve" smooth="yes"/>
-      <point x="221" y="-302"/>
+      <point x="139" y="-12"/>
+    </contour>
+    <contour>
+      <point x="398" y="-367" type="curve" smooth="yes"/>
+      <point x="500" y="-367"/>
+      <point x="559" y="-302"/>
+      <point x="559" y="-195" type="curve" smooth="yes"/>
+      <point x="559" y="-174"/>
+      <point x="557" y="-155"/>
+      <point x="557" y="-134" type="curve" smooth="yes"/>
+      <point x="557" y="-63"/>
+      <point x="588" y="-27"/>
+      <point x="648" y="-27" type="curve" smooth="yes"/>
+      <point x="710" y="-27"/>
+      <point x="747" y="-74"/>
+      <point x="747" y="-155" type="curve" smooth="yes"/>
+      <point x="747" y="-220"/>
+      <point x="725" y="-272"/>
+      <point x="678" y="-319" type="curve"/>
+      <point x="729" y="-367" type="line"/>
+      <point x="792" y="-305"/>
+      <point x="821" y="-238"/>
+      <point x="821" y="-155" type="curve" smooth="yes"/>
+      <point x="821" y="-41"/>
+      <point x="746" y="43"/>
+      <point x="646" y="43" type="curve" smooth="yes"/>
+      <point x="545" y="43"/>
+      <point x="483" y="-22"/>
+      <point x="483" y="-127" type="curve" smooth="yes"/>
+      <point x="483" y="-147"/>
+      <point x="485" y="-169"/>
+      <point x="485" y="-188" type="curve" smooth="yes"/>
+      <point x="485" y="-261"/>
+      <point x="454" y="-297"/>
+      <point x="396" y="-297" type="curve" smooth="yes"/>
+      <point x="334" y="-297"/>
+      <point x="295" y="-252"/>
+      <point x="295" y="-175" type="curve" smooth="yes"/>
+      <point x="295" y="-102"/>
+      <point x="314" y="-48"/>
+      <point x="359" y="6" type="curve"/>
+      <point x="284" y="6" type="line"/>
+      <point x="243" y="-42"/>
+      <point x="221" y="-106"/>
+      <point x="221" y="-175" type="curve" smooth="yes"/>
+      <point x="221" y="-291"/>
       <point x="295" y="-367"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/g_la-malayalam.glif
@@ -32,38 +32,40 @@
       <point x="786" y="-367"/>
       <point x="852" y="-308"/>
       <point x="852" y="-182" type="curve" smooth="yes"/>
-      <point x="852" y="-74"/>
-      <point x="811" y="4"/>
-      <point x="752" y="61" type="curve"/>
-      <point x="757" y="13" type="line"/>
-      <point x="831" y="108"/>
-      <point x="868" y="215"/>
+      <point x="852" y="-84"/>
+      <point x="819" y="-4"/>
+      <point x="753" y="60" type="curve"/>
+      <point x="753" y="10" type="line"/>
+      <point x="830" y="102"/>
+      <point x="868" y="208"/>
       <point x="868" y="327" type="curve" smooth="yes"/>
-      <point x="868" y="491"/>
+      <point x="868" y="495"/>
       <point x="781" y="596"/>
-      <point x="641" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="119"/>
-      <point x="100" y="20"/>
+      <point x="638" y="596" type="curve" smooth="yes"/>
+      <point x="503" y="596"/>
+      <point x="411" y="498"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="121"/>
+      <point x="108" y="29"/>
       <point x="213" y="2" type="curve"/>
       <point x="214" y="-3" type="line"/>
-      <point x="160" y="-47"/>
+      <point x="159" y="-48"/>
       <point x="136" y="-111"/>
       <point x="136" y="-181" type="curve" smooth="yes"/>
       <point x="136" y="-305"/>
@@ -91,25 +93,27 @@
       <point x="606" y="-261"/>
       <point x="584" y="-182" type="curve" smooth="yes"/>
       <point x="572" y="-139" type="line" smooth="yes"/>
-      <point x="546" y="-44"/>
-      <point x="496" y="21"/>
-      <point x="408" y="35" type="curve"/>
-      <point x="408" y="40" type="line"/>
-      <point x="466" y="78"/>
-      <point x="485" y="150"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="563" y="512"/>
-      <point x="647" y="512" type="curve" smooth="yes"/>
-      <point x="734" y="512"/>
-      <point x="784" y="440"/>
-      <point x="784" y="326" type="curve" smooth="yes"/>
-      <point x="784" y="222"/>
-      <point x="744" y="130"/>
-      <point x="666" y="41" type="curve"/>
-      <point x="729" y="-12"/>
-      <point x="778" y="-79"/>
+      <point x="546" y="-45"/>
+      <point x="498" y="19"/>
+      <point x="413" y="33" type="curve"/>
+      <point x="413" y="38" type="line"/>
+      <point x="467" y="77"/>
+      <point x="499" y="142"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="452"/>
+      <point x="550" y="514"/>
+      <point x="642" y="514" type="curve" smooth="yes"/>
+      <point x="734" y="514"/>
+      <point x="784" y="447"/>
+      <point x="784" y="324" type="curve" smooth="yes"/>
+      <point x="784" y="220"/>
+      <point x="745" y="128"/>
+      <point x="665" y="44" type="curve"/>
+      <point x="745" y="-21"/>
+      <point x="778" y="-93"/>
       <point x="778" y="-182" type="curve" smooth="yes"/>
       <point x="778" y="-251"/>
       <point x="751" y="-297"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/g_ma-malayalam.glif
@@ -6,16 +6,18 @@
   <anchor x="1300" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="272" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="478" y="74"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="557" y="512"/>
-      <point x="648" y="512" type="curve" smooth="yes"/>
-      <point x="738" y="512"/>
-      <point x="784" y="440"/>
+      <point x="282" y="-16" type="curve" smooth="yes"/>
+      <point x="411" y="-16"/>
+      <point x="499" y="81"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="454"/>
+      <point x="547" y="514"/>
+      <point x="640" y="514" type="curve" smooth="yes"/>
+      <point x="733" y="514"/>
+      <point x="784" y="446"/>
       <point x="784" y="323" type="curve" smooth="yes"/>
       <point x="784" y="0" type="line"/>
       <point x="1350" y="0" type="line"/>
@@ -27,28 +29,30 @@
       <point x="880" y="555"/>
       <point x="834" y="474" type="curve"/>
       <point x="829" y="474" type="line"/>
-      <point x="792" y="559"/>
-      <point x="726" y="596"/>
-      <point x="639" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="89"/>
-      <point x="131" y="-16"/>
+      <point x="794" y="551"/>
+      <point x="728" y="596"/>
+      <point x="634" y="596" type="curve" smooth="yes"/>
+      <point x="500" y="596"/>
+      <point x="411" y="500"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="90"/>
+      <point x="137" y="-16"/>
     </contour>
     <contour>
       <point x="834" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/g_na-malayalam.glif
@@ -6,16 +6,18 @@
   <anchor x="1187" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="272" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="478" y="74"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="558" y="512"/>
-      <point x="648" y="512" type="curve" smooth="yes"/>
-      <point x="740" y="512"/>
-      <point x="784" y="450"/>
+      <point x="282" y="-16" type="curve" smooth="yes"/>
+      <point x="411" y="-16"/>
+      <point x="499" y="81"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="455"/>
+      <point x="551" y="518"/>
+      <point x="641" y="518" type="curve" smooth="yes"/>
+      <point x="736" y="518"/>
+      <point x="784" y="454"/>
       <point x="784" y="326" type="curve" smooth="yes"/>
       <point x="784" y="0" type="line"/>
       <point x="868" y="0" type="line"/>
@@ -40,28 +42,30 @@
       <point x="865" y="554"/>
       <point x="829" y="485" type="curve"/>
       <point x="824" y="485" type="line"/>
-      <point x="791" y="554"/>
-      <point x="729" y="596"/>
-      <point x="641" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="89"/>
-      <point x="131" y="-16"/>
+      <point x="789" y="552"/>
+      <point x="726" y="596"/>
+      <point x="637" y="596" type="curve" smooth="yes"/>
+      <point x="504" y="596"/>
+      <point x="411" y="498"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="90"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ga-malayalam.glif
@@ -7,46 +7,50 @@
   <anchor x="763" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="272" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="478" y="74"/>
-      <point x="493" y="233" type="curve" smooth="yes"/>
-      <point x="503" y="338" type="line" smooth="yes"/>
-      <point x="513" y="444"/>
-      <point x="563" y="512"/>
-      <point x="647" y="512" type="curve" smooth="yes"/>
-      <point x="734" y="512"/>
-      <point x="784" y="440"/>
-      <point x="784" y="326" type="curve" smooth="yes"/>
-      <point x="784" y="222"/>
-      <point x="744" y="130"/>
-      <point x="666" y="41" type="curve"/>
-      <point x="732" y="-16" type="line"/>
-      <point x="823" y="85"/>
-      <point x="868" y="203"/>
+      <point x="282" y="-16" type="curve" smooth="yes"/>
+      <point x="411" y="-16"/>
+      <point x="499" y="81"/>
+      <point x="499" y="224" type="curve" smooth="yes"/>
+      <point x="499" y="265"/>
+      <point x="495" y="307"/>
+      <point x="495" y="348" type="curve" smooth="yes"/>
+      <point x="495" y="452"/>
+      <point x="550" y="514"/>
+      <point x="642" y="514" type="curve" smooth="yes"/>
+      <point x="734" y="514"/>
+      <point x="784" y="447"/>
+      <point x="784" y="324" type="curve" smooth="yes"/>
+      <point x="784" y="220"/>
+      <point x="745" y="128"/>
+      <point x="665" y="44" type="curve"/>
+      <point x="730" y="-16" type="line"/>
+      <point x="822" y="82"/>
+      <point x="868" y="197"/>
       <point x="868" y="327" type="curve" smooth="yes"/>
-      <point x="868" y="491"/>
+      <point x="868" y="495"/>
       <point x="781" y="596"/>
-      <point x="641" y="596" type="curve" smooth="yes"/>
-      <point x="509" y="596"/>
-      <point x="431" y="513"/>
-      <point x="415" y="345" type="curve" smooth="yes"/>
-      <point x="405" y="241" type="line" smooth="yes"/>
-      <point x="394" y="124"/>
-      <point x="348" y="68"/>
-      <point x="267" y="68" type="curve" smooth="yes"/>
-      <point x="179" y="68"/>
-      <point x="126" y="137"/>
-      <point x="126" y="253" type="curve" smooth="yes"/>
-      <point x="126" y="355"/>
-      <point x="163" y="449"/>
-      <point x="249" y="541" type="curve"/>
-      <point x="191" y="596" type="line"/>
-      <point x="87" y="496"/>
-      <point x="42" y="376"/>
-      <point x="42" y="253" type="curve" smooth="yes"/>
-      <point x="42" y="89"/>
-      <point x="131" y="-16"/>
+      <point x="638" y="596" type="curve" smooth="yes"/>
+      <point x="503" y="596"/>
+      <point x="411" y="498"/>
+      <point x="411" y="356" type="curve" smooth="yes"/>
+      <point x="411" y="315"/>
+      <point x="415" y="273"/>
+      <point x="415" y="232" type="curve" smooth="yes"/>
+      <point x="415" y="123"/>
+      <point x="368" y="66"/>
+      <point x="278" y="66" type="curve" smooth="yes"/>
+      <point x="182" y="66"/>
+      <point x="126" y="136"/>
+      <point x="126" y="254" type="curve" smooth="yes"/>
+      <point x="126" y="362"/>
+      <point x="166" y="450"/>
+      <point x="255" y="536" type="curve"/>
+      <point x="196" y="596" type="line"/>
+      <point x="95" y="501"/>
+      <point x="42" y="383"/>
+      <point x="42" y="252" type="curve" smooth="yes"/>
+      <point x="42" y="90"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ga-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ga-malayalam.half" format="2">
   <advance width="910"/>
+  <anchor x="502" y="0" name="bottom"/>
+  <anchor x="459" y="580" name="top"/>
+  <anchor x="763" y="580" name="topright"/>
   <outline>
     <component base="ga-malayalam"/>
     <component base="halant-malayalam" xOffset="763"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/j_ja-malayalam.glif
@@ -1,224 +1,224 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1602"/>
-  <anchor x="1213" y="0" name="bottom"/>
-  <anchor x="793" y="580" name="top"/>
-  <anchor x="1481" y="580" name="topright"/>
+  <advance width="1668"/>
+  <anchor x="1258" y="0" name="bottom"/>
+  <anchor x="834" y="580" name="top"/>
+  <anchor x="1527" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="326" y="-16" type="curve" smooth="yes"/>
-      <point x="623" y="-16"/>
-      <point x="779" y="95"/>
-      <point x="854" y="317" type="curve"/>
-      <point x="867" y="374" type="line"/>
-      <point x="872" y="374" type="line"/>
-      <point x="890" y="316"/>
-      <point x="931" y="294"/>
-      <point x="982" y="294" type="curve" smooth="yes"/>
-      <point x="1069" y="294"/>
-      <point x="1113" y="348"/>
-      <point x="1113" y="417" type="curve" smooth="yes"/>
-      <point x="1113" y="478"/>
-      <point x="1081" y="524"/>
-      <point x="1000" y="524" type="curve" smooth="yes"/>
-      <point x="978" y="524"/>
-      <point x="957" y="520"/>
-      <point x="946" y="514" type="curve"/>
-      <point x="973" y="488" type="line"/>
-      <point x="947" y="550" type="line"/>
-      <point x="941" y="511" type="line"/>
-      <point x="959" y="526"/>
-      <point x="986" y="535"/>
-      <point x="1026" y="535" type="curve" smooth="yes"/>
-      <point x="1134" y="535"/>
-      <point x="1172" y="454"/>
-      <point x="1172" y="380" type="curve" smooth="yes"/>
-      <point x="1172" y="343" type="line"/>
-      <point x="1256" y="343" type="line"/>
-      <point x="1256" y="376" type="line" smooth="yes"/>
-      <point x="1256" y="467"/>
-      <point x="1309" y="518"/>
-      <point x="1380" y="518" type="curve" smooth="yes"/>
-      <point x="1444" y="518"/>
-      <point x="1478" y="478"/>
-      <point x="1478" y="413" type="curve" smooth="yes"/>
-      <point x="1478" y="349"/>
-      <point x="1440" y="287"/>
-      <point x="1317" y="287" type="curve" smooth="yes"/>
-      <point x="1062" y="287" type="line" smooth="yes"/>
-      <point x="923" y="287"/>
-      <point x="852" y="221"/>
-      <point x="852" y="133" type="curve" smooth="yes"/>
-      <point x="852" y="54"/>
-      <point x="901" y="-16"/>
-      <point x="1009" y="-16" type="curve" smooth="yes"/>
-      <point x="1063" y="-16"/>
-      <point x="1122" y="1"/>
-      <point x="1202" y="54" type="curve" smooth="yes"/>
-      <point x="1256" y="90" type="line" smooth="yes"/>
-      <point x="1345" y="150"/>
-      <point x="1384" y="167"/>
-      <point x="1428" y="167" type="curve" smooth="yes"/>
-      <point x="1473" y="167"/>
-      <point x="1489" y="142"/>
-      <point x="1489" y="106" type="curve" smooth="yes"/>
-      <point x="1489" y="72"/>
-      <point x="1469" y="48"/>
-      <point x="1432" y="48" type="curve" smooth="yes"/>
-      <point x="1396" y="48"/>
-      <point x="1376" y="70"/>
-      <point x="1376" y="110" type="curve" smooth="yes"/>
-      <point x="1376" y="145"/>
-      <point x="1392" y="166"/>
-      <point x="1409" y="185" type="curve"/>
-      <point x="1311" y="152" type="line"/>
-      <point x="1328" y="130" type="line"/>
-      <point x="1323" y="116"/>
-      <point x="1320" y="107"/>
-      <point x="1320" y="90" type="curve" smooth="yes"/>
-      <point x="1320" y="34"/>
-      <point x="1357" y="-16"/>
-      <point x="1434" y="-16" type="curve" smooth="yes"/>
-      <point x="1513" y="-16"/>
-      <point x="1555" y="37"/>
-      <point x="1555" y="105" type="curve" smooth="yes"/>
-      <point x="1555" y="183"/>
-      <point x="1505" y="233"/>
-      <point x="1432" y="233" type="curve" smooth="yes"/>
-      <point x="1372" y="233"/>
-      <point x="1329" y="216"/>
-      <point x="1239" y="161" type="curve" smooth="yes"/>
-      <point x="1172" y="120" type="line" smooth="yes"/>
-      <point x="1095" y="73"/>
-      <point x="1062" y="61"/>
-      <point x="1016" y="61" type="curve" smooth="yes"/>
-      <point x="963" y="61"/>
-      <point x="931" y="88"/>
-      <point x="931" y="133" type="curve" smooth="yes"/>
-      <point x="931" y="183"/>
-      <point x="971" y="215"/>
-      <point x="1065" y="215" type="curve" smooth="yes"/>
-      <point x="1301" y="215" type="line" smooth="yes"/>
-      <point x="1494" y="215"/>
-      <point x="1560" y="312"/>
-      <point x="1560" y="416" type="curve" smooth="yes"/>
-      <point x="1560" y="526"/>
-      <point x="1488" y="596"/>
-      <point x="1381" y="596" type="curve" smooth="yes"/>
-      <point x="1297" y="596"/>
-      <point x="1236" y="549"/>
-      <point x="1218" y="478" type="curve"/>
-      <point x="1213" y="478" type="line"/>
-      <point x="1191" y="549"/>
-      <point x="1118" y="596"/>
-      <point x="1021" y="596" type="curve" smooth="yes"/>
-      <point x="931" y="596"/>
-      <point x="860" y="555"/>
-      <point x="824" y="444" type="curve" smooth="yes"/>
-      <point x="799" y="366" type="line" smooth="yes"/>
-      <point x="723" y="128"/>
-      <point x="569" y="61"/>
-      <point x="326" y="61" type="curve" smooth="yes"/>
-      <point x="182" y="61"/>
-      <point x="126" y="91"/>
-      <point x="126" y="147" type="curve" smooth="yes"/>
-      <point x="126" y="191"/>
-      <point x="157" y="215"/>
-      <point x="257" y="215" type="curve" smooth="yes"/>
-      <point x="498" y="215" type="line" smooth="yes"/>
-      <point x="695" y="215"/>
-      <point x="757" y="312"/>
-      <point x="757" y="424" type="curve" smooth="yes"/>
-      <point x="757" y="530"/>
-      <point x="689" y="596"/>
-      <point x="585" y="596" type="curve" smooth="yes"/>
-      <point x="505" y="596"/>
-      <point x="442" y="549"/>
-      <point x="424" y="478" type="curve"/>
-      <point x="419" y="478" type="line"/>
-      <point x="397" y="549"/>
-      <point x="324" y="596"/>
-      <point x="227" y="596" type="curve" smooth="yes"/>
-      <point x="118" y="596"/>
-      <point x="42" y="532"/>
-      <point x="42" y="432" type="curve" smooth="yes"/>
-      <point x="42" y="353"/>
-      <point x="98" y="294"/>
-      <point x="183" y="294" type="curve" smooth="yes"/>
-      <point x="269" y="294"/>
-      <point x="319" y="348"/>
-      <point x="319" y="417" type="curve" smooth="yes"/>
-      <point x="319" y="478"/>
-      <point x="287" y="524"/>
-      <point x="206" y="524" type="curve" smooth="yes"/>
-      <point x="184" y="524"/>
-      <point x="163" y="520"/>
-      <point x="152" y="514" type="curve"/>
-      <point x="179" y="488" type="line"/>
-      <point x="153" y="550" type="line"/>
-      <point x="147" y="511" type="line"/>
-      <point x="165" y="526"/>
-      <point x="192" y="535"/>
-      <point x="232" y="535" type="curve" smooth="yes"/>
-      <point x="340" y="535"/>
-      <point x="378" y="454"/>
-      <point x="378" y="380" type="curve" smooth="yes"/>
-      <point x="378" y="343" type="line"/>
-      <point x="462" y="343" type="line"/>
-      <point x="462" y="376" type="line" smooth="yes"/>
-      <point x="462" y="467"/>
-      <point x="511" y="518"/>
-      <point x="581" y="518" type="curve" smooth="yes"/>
-      <point x="645" y="518"/>
-      <point x="675" y="478"/>
-      <point x="675" y="413" type="curve" smooth="yes"/>
-      <point x="675" y="349"/>
-      <point x="641" y="287"/>
-      <point x="514" y="287" type="curve" smooth="yes"/>
-      <point x="254" y="287" type="line" smooth="yes"/>
-      <point x="105" y="287"/>
-      <point x="48" y="229"/>
-      <point x="48" y="147" type="curve" smooth="yes"/>
-      <point x="48" y="39"/>
-      <point x="134" y="-16"/>
+      <point x="308" y="-16" type="curve" smooth="yes"/>
+      <point x="604" y="-16"/>
+      <point x="783" y="86"/>
+      <point x="879" y="287" type="curve"/>
+      <point x="892" y="344" type="line"/>
+      <point x="897" y="344" type="line"/>
+      <point x="909" y="302"/>
+      <point x="949" y="273"/>
+      <point x="1012" y="273" type="curve" smooth="yes"/>
+      <point x="1090" y="273"/>
+      <point x="1145" y="324"/>
+      <point x="1145" y="402" type="curve" smooth="yes"/>
+      <point x="1145" y="470"/>
+      <point x="1103" y="515"/>
+      <point x="1032" y="515" type="curve" smooth="yes"/>
+      <point x="1006" y="515"/>
+      <point x="983" y="510"/>
+      <point x="961" y="499" type="curve"/>
+      <point x="946" y="523" type="line"/>
+      <point x="946" y="491" type="line"/>
+      <point x="976" y="520"/>
+      <point x="1018" y="536"/>
+      <point x="1073" y="536" type="curve" smooth="yes"/>
+      <point x="1169" y="536"/>
+      <point x="1212" y="484"/>
+      <point x="1212" y="382" type="curve" smooth="yes"/>
+      <point x="1212" y="324" type="line"/>
+      <point x="1296" y="324" type="line"/>
+      <point x="1296" y="380" type="line" smooth="yes"/>
+      <point x="1296" y="469"/>
+      <point x="1349" y="518"/>
+      <point x="1430" y="518" type="curve" smooth="yes"/>
+      <point x="1503" y="518"/>
+      <point x="1544" y="475"/>
+      <point x="1544" y="403" type="curve" smooth="yes"/>
+      <point x="1544" y="316"/>
+      <point x="1481" y="267"/>
+      <point x="1365" y="267" type="curve" smooth="yes"/>
+      <point x="1040" y="267" type="line" smooth="yes"/>
+      <point x="937" y="267"/>
+      <point x="864" y="212"/>
+      <point x="864" y="122" type="curve" smooth="yes"/>
+      <point x="864" y="41"/>
+      <point x="930" y="-16"/>
+      <point x="1020" y="-16" type="curve" smooth="yes"/>
+      <point x="1070" y="-16"/>
+      <point x="1105" y="-5"/>
+      <point x="1189" y="36" type="curve" smooth="yes"/>
+      <point x="1309" y="95" type="line"/>
+      <point x="1378" y="138" type="line"/>
+      <point x="1410" y="146" type="line"/>
+      <point x="1434" y="168"/>
+      <point x="1457" y="176"/>
+      <point x="1486" y="176" type="curve" smooth="yes"/>
+      <point x="1525" y="176"/>
+      <point x="1548" y="154"/>
+      <point x="1548" y="115" type="curve" smooth="yes"/>
+      <point x="1548" y="78"/>
+      <point x="1523" y="54"/>
+      <point x="1485" y="54" type="curve" smooth="yes"/>
+      <point x="1447" y="54"/>
+      <point x="1421" y="79"/>
+      <point x="1421" y="115" type="curve" smooth="yes"/>
+      <point x="1421" y="143"/>
+      <point x="1435" y="168"/>
+      <point x="1458" y="181" type="curve"/>
+      <point x="1351" y="145" type="line"/>
+      <point x="1370" y="128" type="line"/>
+      <point x="1366" y="116"/>
+      <point x="1365" y="106"/>
+      <point x="1365" y="94" type="curve" smooth="yes"/>
+      <point x="1365" y="32"/>
+      <point x="1416" y="-16"/>
+      <point x="1490" y="-16" type="curve" smooth="yes"/>
+      <point x="1571" y="-16"/>
+      <point x="1622" y="38"/>
+      <point x="1622" y="114" type="curve" smooth="yes"/>
+      <point x="1622" y="185"/>
+      <point x="1571" y="236"/>
+      <point x="1492" y="236" type="curve" smooth="yes"/>
+      <point x="1453" y="236"/>
+      <point x="1408" y="220"/>
+      <point x="1334" y="184" type="curve" smooth="yes"/>
+      <point x="1161" y="99" type="line" smooth="yes"/>
+      <point x="1103" y="71"/>
+      <point x="1066" y="60"/>
+      <point x="1024" y="60" type="curve" smooth="yes"/>
+      <point x="977" y="60"/>
+      <point x="946" y="85"/>
+      <point x="946" y="125" type="curve" smooth="yes"/>
+      <point x="946" y="170"/>
+      <point x="981" y="195"/>
+      <point x="1043" y="195" type="curve" smooth="yes"/>
+      <point x="1355" y="195" type="line" smooth="yes"/>
+      <point x="1520" y="195"/>
+      <point x="1626" y="277"/>
+      <point x="1626" y="405" type="curve" smooth="yes"/>
+      <point x="1626" y="521"/>
+      <point x="1556" y="596"/>
+      <point x="1443" y="596" type="curve" smooth="yes"/>
+      <point x="1354" y="596"/>
+      <point x="1290" y="552"/>
+      <point x="1258" y="478" type="curve"/>
+      <point x="1253" y="478" type="line"/>
+      <point x="1227" y="553"/>
+      <point x="1168" y="596"/>
+      <point x="1073" y="596" type="curve" smooth="yes"/>
+      <point x="966" y="596"/>
+      <point x="888" y="543"/>
+      <point x="856" y="444" type="curve" smooth="yes"/>
+      <point x="831" y="366" type="line" smooth="yes"/>
+      <point x="764" y="156"/>
+      <point x="600" y="61"/>
+      <point x="308" y="61" type="curve" smooth="yes"/>
+      <point x="175" y="61"/>
+      <point x="128" y="84"/>
+      <point x="128" y="132" type="curve" smooth="yes"/>
+      <point x="128" y="173"/>
+      <point x="165" y="195"/>
+      <point x="231" y="195" type="curve" smooth="yes"/>
+      <point x="507" y="195" type="line" smooth="yes"/>
+      <point x="673" y="195"/>
+      <point x="776" y="285"/>
+      <point x="776" y="410" type="curve" smooth="yes"/>
+      <point x="776" y="521"/>
+      <point x="710" y="596"/>
+      <point x="604" y="596" type="curve" smooth="yes"/>
+      <point x="524" y="596"/>
+      <point x="464" y="550"/>
+      <point x="440" y="478" type="curve"/>
+      <point x="435" y="478" type="line"/>
+      <point x="408" y="556"/>
+      <point x="346" y="596"/>
+      <point x="254" y="596" type="curve" smooth="yes"/>
+      <point x="137" y="596"/>
+      <point x="42" y="525"/>
+      <point x="42" y="420" type="curve" smooth="yes"/>
+      <point x="42" y="332"/>
+      <point x="100" y="273"/>
+      <point x="188" y="273" type="curve" smooth="yes"/>
+      <point x="270" y="273"/>
+      <point x="327" y="324"/>
+      <point x="327" y="402" type="curve" smooth="yes"/>
+      <point x="327" y="470"/>
+      <point x="285" y="515"/>
+      <point x="214" y="515" type="curve" smooth="yes"/>
+      <point x="188" y="515"/>
+      <point x="165" y="510"/>
+      <point x="143" y="499" type="curve"/>
+      <point x="128" y="523" type="line"/>
+      <point x="128" y="491" type="line"/>
+      <point x="158" y="520"/>
+      <point x="198" y="536"/>
+      <point x="254" y="536" type="curve" smooth="yes"/>
+      <point x="352" y="536"/>
+      <point x="394" y="483"/>
+      <point x="394" y="382" type="curve" smooth="yes"/>
+      <point x="394" y="324" type="line"/>
+      <point x="478" y="324" type="line"/>
+      <point x="478" y="380" type="line" smooth="yes"/>
+      <point x="478" y="467"/>
+      <point x="521" y="518"/>
+      <point x="596" y="518" type="curve" smooth="yes"/>
+      <point x="658" y="518"/>
+      <point x="694" y="479"/>
+      <point x="694" y="410" type="curve" smooth="yes"/>
+      <point x="694" y="316"/>
+      <point x="629" y="267"/>
+      <point x="503" y="267" type="curve" smooth="yes"/>
+      <point x="228" y="267" type="line" smooth="yes"/>
+      <point x="121" y="267"/>
+      <point x="46" y="214"/>
+      <point x="46" y="129" type="curve" smooth="yes"/>
+      <point x="46" y="36"/>
+      <point x="128" y="-16"/>
     </contour>
     <contour>
-      <point x="184" y="357" type="curve" smooth="yes"/>
-      <point x="137" y="357"/>
-      <point x="118" y="392"/>
-      <point x="118" y="441" type="curve" smooth="yes"/>
-      <point x="118" y="457"/>
-      <point x="120" y="472"/>
-      <point x="126" y="484" type="curve"/>
-      <point x="107" y="484" type="line"/>
-      <point x="83" y="451" type="line"/>
-      <point x="107" y="470"/>
-      <point x="144" y="482"/>
-      <point x="178" y="482" type="curve" smooth="yes"/>
-      <point x="236" y="482"/>
-      <point x="247" y="447"/>
-      <point x="247" y="422" type="curve" smooth="yes"/>
-      <point x="247" y="384"/>
-      <point x="227" y="357"/>
+      <point x="183" y="341" type="curve" smooth="yes"/>
+      <point x="139" y="341"/>
+      <point x="110" y="370"/>
+      <point x="110" y="416" type="curve" smooth="yes"/>
+      <point x="110" y="439"/>
+      <point x="114" y="454"/>
+      <point x="126" y="475" type="curve"/>
+      <point x="98" y="475" type="line"/>
+      <point x="90" y="427" type="line"/>
+      <point x="113" y="453"/>
+      <point x="148" y="467"/>
+      <point x="183" y="467" type="curve" smooth="yes"/>
+      <point x="227" y="467"/>
+      <point x="251" y="442"/>
+      <point x="251" y="404" type="curve" smooth="yes"/>
+      <point x="251" y="366"/>
+      <point x="226" y="341"/>
     </contour>
     <contour>
-      <point x="978" y="357" type="curve" smooth="yes"/>
-      <point x="931" y="357"/>
-      <point x="912" y="392"/>
-      <point x="912" y="441" type="curve" smooth="yes"/>
-      <point x="912" y="457"/>
-      <point x="914" y="472"/>
-      <point x="920" y="484" type="curve"/>
-      <point x="901" y="484" type="line"/>
-      <point x="877" y="451" type="line"/>
-      <point x="901" y="470"/>
-      <point x="938" y="482"/>
-      <point x="972" y="482" type="curve" smooth="yes"/>
-      <point x="1030" y="482"/>
-      <point x="1041" y="447"/>
-      <point x="1041" y="422" type="curve" smooth="yes"/>
-      <point x="1041" y="384"/>
-      <point x="1021" y="357"/>
+      <point x="1001" y="341" type="curve" smooth="yes"/>
+      <point x="957" y="341"/>
+      <point x="928" y="370"/>
+      <point x="928" y="416" type="curve" smooth="yes"/>
+      <point x="928" y="439"/>
+      <point x="932" y="454"/>
+      <point x="944" y="475" type="curve"/>
+      <point x="916" y="475" type="line"/>
+      <point x="908" y="427" type="line"/>
+      <point x="931" y="453"/>
+      <point x="966" y="467"/>
+      <point x="1001" y="467" type="curve" smooth="yes"/>
+      <point x="1045" y="467"/>
+      <point x="1069" y="442"/>
+      <point x="1069" y="404" type="curve" smooth="yes"/>
+      <point x="1069" y="366"/>
+      <point x="1044" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/j_nya-malayalam.glif
@@ -1,185 +1,184 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2195"/>
-  <anchor x="1786" y="0" name="bottom"/>
-  <anchor x="1091" y="580" name="top"/>
-  <anchor x="2059" y="580" name="topright"/>
+  <advance width="2228"/>
+  <anchor x="1819" y="0" name="bottom"/>
+  <anchor x="1114" y="580" name="top"/>
+  <anchor x="2092" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="336" y="-16" type="curve" smooth="yes"/>
-      <point x="560" y="-16"/>
-      <point x="712" y="43"/>
-      <point x="800" y="189" type="curve"/>
-      <point x="806" y="189" type="line"/>
-      <point x="829" y="69"/>
-      <point x="904" y="-16"/>
-      <point x="1019" y="-16" type="curve" smooth="yes"/>
-      <point x="1129" y="-16"/>
-      <point x="1195" y="65"/>
-      <point x="1195" y="175" type="curve" smooth="yes"/>
-      <point x="1195" y="272"/>
-      <point x="1138" y="347"/>
-      <point x="1026" y="347" type="curve" smooth="yes"/>
-      <point x="962" y="347"/>
-      <point x="906" y="314"/>
-      <point x="876" y="264" type="curve"/>
-      <point x="864" y="268" type="line"/>
-      <point x="878" y="138" type="line"/>
-      <point x="893" y="223"/>
-      <point x="947" y="273"/>
-      <point x="1016" y="273" type="curve" smooth="yes"/>
-      <point x="1079" y="273"/>
-      <point x="1113" y="239"/>
-      <point x="1113" y="171" type="curve" smooth="yes"/>
-      <point x="1113" y="101"/>
-      <point x="1074" y="62"/>
-      <point x="1014" y="62" type="curve" smooth="yes"/>
-      <point x="923" y="62"/>
-      <point x="871" y="163"/>
-      <point x="871" y="266" type="curve" smooth="yes"/>
-      <point x="871" y="413"/>
-      <point x="961" y="518"/>
-      <point x="1091" y="518" type="curve" smooth="yes"/>
-      <point x="1206" y="518"/>
-      <point x="1268" y="441"/>
-      <point x="1268" y="318" type="curve" smooth="yes"/>
-      <point x="1268" y="0" type="line"/>
-      <point x="1352" y="0" type="line"/>
-      <point x="1352" y="318" type="line" smooth="yes"/>
-      <point x="1352" y="441"/>
-      <point x="1420" y="518"/>
-      <point x="1545" y="518" type="curve" smooth="yes"/>
-      <point x="1716" y="518"/>
-      <point x="1807" y="397"/>
-      <point x="1807" y="241" type="curve" smooth="yes"/>
-      <point x="1807" y="130"/>
-      <point x="1767" y="64"/>
-      <point x="1693" y="64" type="curve" smooth="yes"/>
-      <point x="1621" y="64"/>
-      <point x="1582" y="124"/>
-      <point x="1582" y="216" type="curve" smooth="yes"/>
-      <point x="1582" y="383"/>
-      <point x="1693" y="518"/>
-      <point x="1855" y="518" type="curve" smooth="yes"/>
-      <point x="1995" y="518"/>
-      <point x="2071" y="435"/>
-      <point x="2071" y="305" type="curve" smooth="yes"/>
-      <point x="2071" y="208"/>
-      <point x="2033" y="120"/>
-      <point x="1965" y="42" type="curve"/>
-      <point x="2034" y="-14" type="line"/>
-      <point x="2108" y="78"/>
-      <point x="2153" y="174"/>
-      <point x="2153" y="296" type="curve" smooth="yes"/>
-      <point x="2153" y="484"/>
-      <point x="2047" y="596"/>
-      <point x="1858" y="596" type="curve" smooth="yes"/>
-      <point x="1651" y="596"/>
-      <point x="1500" y="423"/>
-      <point x="1500" y="217" type="curve" smooth="yes"/>
-      <point x="1500" y="79"/>
-      <point x="1575" y="-14"/>
-      <point x="1697" y="-14" type="curve" smooth="yes"/>
-      <point x="1822" y="-14"/>
-      <point x="1889" y="85"/>
-      <point x="1889" y="235" type="curve" smooth="yes"/>
-      <point x="1889" y="432"/>
-      <point x="1761" y="596"/>
-      <point x="1548" y="596" type="curve" smooth="yes"/>
-      <point x="1436" y="596"/>
-      <point x="1359" y="548"/>
-      <point x="1319" y="470" type="curve"/>
-      <point x="1314" y="470" type="line"/>
-      <point x="1274" y="548"/>
-      <point x="1199" y="596"/>
-      <point x="1090" y="596" type="curve" smooth="yes"/>
-      <point x="933" y="596"/>
-      <point x="843" y="506"/>
-      <point x="793" y="348" type="curve" smooth="yes"/>
-      <point x="721" y="117"/>
-      <point x="579" y="61"/>
-      <point x="336" y="61" type="curve" smooth="yes"/>
-      <point x="182" y="61"/>
-      <point x="126" y="91"/>
-      <point x="126" y="147" type="curve" smooth="yes"/>
-      <point x="126" y="191"/>
-      <point x="157" y="215"/>
-      <point x="257" y="215" type="curve" smooth="yes"/>
-      <point x="498" y="215" type="line" smooth="yes"/>
-      <point x="695" y="215"/>
-      <point x="759" y="312"/>
-      <point x="757" y="424" type="curve" smooth="yes"/>
-      <point x="755" y="530"/>
-      <point x="689" y="596"/>
-      <point x="585" y="596" type="curve" smooth="yes"/>
-      <point x="505" y="596"/>
-      <point x="442" y="549"/>
-      <point x="424" y="478" type="curve"/>
-      <point x="419" y="478" type="line"/>
-      <point x="397" y="549"/>
-      <point x="324" y="596"/>
-      <point x="227" y="596" type="curve" smooth="yes"/>
-      <point x="118" y="596"/>
-      <point x="42" y="532"/>
-      <point x="42" y="432" type="curve" smooth="yes"/>
-      <point x="42" y="353"/>
-      <point x="98" y="294"/>
-      <point x="183" y="294" type="curve" smooth="yes"/>
-      <point x="269" y="294"/>
-      <point x="319" y="348"/>
-      <point x="319" y="417" type="curve" smooth="yes"/>
-      <point x="319" y="478"/>
-      <point x="287" y="524"/>
-      <point x="206" y="524" type="curve" smooth="yes"/>
-      <point x="184" y="524"/>
-      <point x="163" y="520"/>
-      <point x="152" y="514" type="curve"/>
-      <point x="179" y="488" type="line"/>
-      <point x="153" y="550" type="line"/>
-      <point x="147" y="511" type="line"/>
-      <point x="165" y="526"/>
-      <point x="192" y="535"/>
-      <point x="232" y="535" type="curve" smooth="yes"/>
-      <point x="340" y="535"/>
-      <point x="378" y="454"/>
-      <point x="378" y="380" type="curve" smooth="yes"/>
-      <point x="378" y="343" type="line"/>
-      <point x="462" y="343" type="line"/>
-      <point x="462" y="376" type="line" smooth="yes"/>
-      <point x="462" y="467"/>
-      <point x="511" y="518"/>
-      <point x="581" y="518" type="curve" smooth="yes"/>
-      <point x="645" y="518"/>
-      <point x="675" y="478"/>
-      <point x="675" y="413" type="curve" smooth="yes"/>
-      <point x="675" y="349"/>
-      <point x="641" y="287"/>
-      <point x="514" y="287" type="curve" smooth="yes"/>
-      <point x="254" y="287" type="line" smooth="yes"/>
-      <point x="105" y="287"/>
-      <point x="48" y="229"/>
-      <point x="48" y="147" type="curve" smooth="yes"/>
-      <point x="48" y="39"/>
-      <point x="134" y="-16"/>
+      <point x="316" y="-16" type="curve" smooth="yes"/>
+      <point x="570" y="-16"/>
+      <point x="740" y="53"/>
+      <point x="830" y="200" type="curve"/>
+      <point x="836" y="200" type="line"/>
+      <point x="856" y="67"/>
+      <point x="935" y="-16"/>
+      <point x="1052" y="-16" type="curve" smooth="yes"/>
+      <point x="1162" y="-16"/>
+      <point x="1228" y="65"/>
+      <point x="1228" y="175" type="curve" smooth="yes"/>
+      <point x="1228" y="272"/>
+      <point x="1171" y="347"/>
+      <point x="1059" y="347" type="curve" smooth="yes"/>
+      <point x="995" y="347"/>
+      <point x="939" y="314"/>
+      <point x="909" y="264" type="curve"/>
+      <point x="897" y="268" type="line"/>
+      <point x="911" y="138" type="line"/>
+      <point x="926" y="223"/>
+      <point x="982" y="273"/>
+      <point x="1049" y="273" type="curve" smooth="yes"/>
+      <point x="1112" y="273"/>
+      <point x="1146" y="239"/>
+      <point x="1146" y="171" type="curve" smooth="yes"/>
+      <point x="1146" y="101"/>
+      <point x="1107" y="62"/>
+      <point x="1047" y="62" type="curve" smooth="yes"/>
+      <point x="954" y="62"/>
+      <point x="904" y="163"/>
+      <point x="904" y="266" type="curve" smooth="yes"/>
+      <point x="904" y="413"/>
+      <point x="994" y="518"/>
+      <point x="1124" y="518" type="curve" smooth="yes"/>
+      <point x="1239" y="518"/>
+      <point x="1301" y="441"/>
+      <point x="1301" y="318" type="curve" smooth="yes"/>
+      <point x="1301" y="0" type="line"/>
+      <point x="1385" y="0" type="line"/>
+      <point x="1385" y="318" type="line" smooth="yes"/>
+      <point x="1385" y="441"/>
+      <point x="1453" y="518"/>
+      <point x="1578" y="518" type="curve" smooth="yes"/>
+      <point x="1749" y="518"/>
+      <point x="1840" y="397"/>
+      <point x="1840" y="241" type="curve" smooth="yes"/>
+      <point x="1840" y="130"/>
+      <point x="1800" y="64"/>
+      <point x="1726" y="64" type="curve" smooth="yes"/>
+      <point x="1654" y="64"/>
+      <point x="1615" y="124"/>
+      <point x="1615" y="216" type="curve" smooth="yes"/>
+      <point x="1615" y="383"/>
+      <point x="1726" y="518"/>
+      <point x="1888" y="518" type="curve" smooth="yes"/>
+      <point x="2028" y="518"/>
+      <point x="2104" y="435"/>
+      <point x="2104" y="305" type="curve" smooth="yes"/>
+      <point x="2104" y="208"/>
+      <point x="2066" y="120"/>
+      <point x="1998" y="42" type="curve"/>
+      <point x="2067" y="-14" type="line"/>
+      <point x="2141" y="78"/>
+      <point x="2186" y="174"/>
+      <point x="2186" y="296" type="curve" smooth="yes"/>
+      <point x="2186" y="484"/>
+      <point x="2080" y="596"/>
+      <point x="1891" y="596" type="curve" smooth="yes"/>
+      <point x="1684" y="596"/>
+      <point x="1533" y="423"/>
+      <point x="1533" y="217" type="curve" smooth="yes"/>
+      <point x="1533" y="79"/>
+      <point x="1608" y="-14"/>
+      <point x="1730" y="-14" type="curve" smooth="yes"/>
+      <point x="1855" y="-14"/>
+      <point x="1922" y="85"/>
+      <point x="1922" y="235" type="curve" smooth="yes"/>
+      <point x="1922" y="432"/>
+      <point x="1794" y="596"/>
+      <point x="1581" y="596" type="curve" smooth="yes"/>
+      <point x="1469" y="596"/>
+      <point x="1392" y="548"/>
+      <point x="1352" y="470" type="curve"/>
+      <point x="1347" y="470" type="line"/>
+      <point x="1307" y="548"/>
+      <point x="1232" y="596"/>
+      <point x="1123" y="596" type="curve" smooth="yes"/>
+      <point x="977" y="596"/>
+      <point x="878" y="514"/>
+      <point x="826" y="348" type="curve" smooth="yes"/>
+      <point x="761" y="142"/>
+      <point x="616" y="61"/>
+      <point x="316" y="61" type="curve" smooth="yes"/>
+      <point x="177" y="61"/>
+      <point x="128" y="85"/>
+      <point x="128" y="131" type="curve" smooth="yes"/>
+      <point x="128" y="172"/>
+      <point x="165" y="195"/>
+      <point x="231" y="195" type="curve" smooth="yes"/>
+      <point x="507" y="195" type="line" smooth="yes"/>
+      <point x="673" y="195"/>
+      <point x="776" y="285"/>
+      <point x="776" y="410" type="curve" smooth="yes"/>
+      <point x="776" y="521"/>
+      <point x="710" y="596"/>
+      <point x="605" y="596" type="curve" smooth="yes"/>
+      <point x="525" y="596"/>
+      <point x="464" y="550"/>
+      <point x="440" y="478" type="curve"/>
+      <point x="435" y="478" type="line"/>
+      <point x="408" y="556"/>
+      <point x="346" y="596"/>
+      <point x="256" y="596" type="curve" smooth="yes"/>
+      <point x="137" y="596"/>
+      <point x="42" y="525"/>
+      <point x="42" y="420" type="curve" smooth="yes"/>
+      <point x="42" y="332"/>
+      <point x="100" y="273"/>
+      <point x="188" y="273" type="curve" smooth="yes"/>
+      <point x="270" y="273"/>
+      <point x="327" y="324"/>
+      <point x="327" y="402" type="curve" smooth="yes"/>
+      <point x="327" y="470"/>
+      <point x="285" y="515"/>
+      <point x="214" y="515" type="curve" smooth="yes"/>
+      <point x="188" y="515"/>
+      <point x="165" y="510"/>
+      <point x="143" y="499" type="curve"/>
+      <point x="128" y="523" type="line"/>
+      <point x="128" y="491" type="line"/>
+      <point x="159" y="520"/>
+      <point x="197" y="536"/>
+      <point x="256" y="536" type="curve" smooth="yes"/>
+      <point x="351" y="536"/>
+      <point x="394" y="483"/>
+      <point x="394" y="382" type="curve" smooth="yes"/>
+      <point x="394" y="324" type="line"/>
+      <point x="478" y="324" type="line"/>
+      <point x="478" y="380" type="line" smooth="yes"/>
+      <point x="478" y="467"/>
+      <point x="522" y="518"/>
+      <point x="597" y="518" type="curve" smooth="yes"/>
+      <point x="658" y="518"/>
+      <point x="694" y="479"/>
+      <point x="694" y="410" type="curve" smooth="yes"/>
+      <point x="694" y="316"/>
+      <point x="629" y="267"/>
+      <point x="503" y="267" type="curve" smooth="yes"/>
+      <point x="228" y="267" type="line" smooth="yes"/>
+      <point x="121" y="267"/>
+      <point x="46" y="214"/>
+      <point x="46" y="128" type="curve" smooth="yes"/>
+      <point x="46" y="38"/>
+      <point x="131" y="-16"/>
     </contour>
     <contour>
-      <point x="184" y="357" type="curve" smooth="yes"/>
-      <point x="137" y="357"/>
-      <point x="118" y="392"/>
-      <point x="118" y="441" type="curve" smooth="yes"/>
-      <point x="118" y="457"/>
-      <point x="120" y="472"/>
-      <point x="126" y="484" type="curve"/>
-      <point x="107" y="484" type="line"/>
-      <point x="83" y="451" type="line"/>
-      <point x="107" y="470"/>
-      <point x="144" y="482"/>
-      <point x="178" y="482" type="curve" smooth="yes"/>
-      <point x="236" y="482"/>
-      <point x="247" y="447"/>
-      <point x="247" y="422" type="curve" smooth="yes"/>
-      <point x="247" y="384"/>
-      <point x="227" y="357"/>
+      <point x="183" y="341" type="curve" smooth="yes"/>
+      <point x="139" y="341"/>
+      <point x="110" y="370"/>
+      <point x="110" y="416" type="curve" smooth="yes"/>
+      <point x="110" y="439"/>
+      <point x="114" y="454"/>
+      <point x="126" y="475" type="curve"/>
+      <point x="98" y="475" type="line"/>
+      <point x="90" y="427" type="line"/>
+      <point x="113" y="453"/>
+      <point x="148" y="467"/>
+      <point x="183" y="467" type="curve" smooth="yes"/>
+      <point x="227" y="467"/>
+      <point x="251" y="442"/>
+      <point x="251" y="404" type="curve" smooth="yes"/>
+      <point x="251" y="366"/>
+      <point x="226" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ja-malayalam.glif
@@ -1,137 +1,135 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <unicode hex="0D1C"/>
-  <guideline x="48" y="133" angle="91.1496"/>
-  <guideline x="766" y="416" angle="269.0789"/>
-  <anchor x="419" y="0" name="bottom"/>
-  <anchor x="419" y="580" name="top"/>
-  <anchor x="687" y="580" name="topright"/>
+  <anchor x="440" y="0" name="bottom"/>
+  <anchor x="425" y="580" name="top"/>
+  <anchor x="709" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="258" y="-16"/>
-      <point x="307" y="2"/>
-      <point x="396" y="54" type="curve" smooth="yes"/>
-      <point x="459" y="91" type="line"/>
-      <point x="546" y="142" type="line"/>
-      <point x="562" y="148" type="line"/>
-      <point x="594" y="163"/>
-      <point x="612" y="167"/>
-      <point x="634" y="167" type="curve" smooth="yes"/>
-      <point x="675" y="167"/>
-      <point x="695" y="147"/>
-      <point x="695" y="106" type="curve" smooth="yes"/>
-      <point x="695" y="70"/>
-      <point x="673" y="48"/>
-      <point x="638" y="48" type="curve" smooth="yes"/>
-      <point x="602" y="48"/>
-      <point x="582" y="70"/>
-      <point x="582" y="110" type="curve" smooth="yes"/>
-      <point x="582" y="137"/>
-      <point x="591" y="159"/>
-      <point x="615" y="185" type="curve"/>
-      <point x="517" y="152" type="line"/>
-      <point x="534" y="130" type="line"/>
-      <point x="528" y="112"/>
-      <point x="526" y="104"/>
-      <point x="526" y="90" type="curve" smooth="yes"/>
-      <point x="526" y="26"/>
-      <point x="571" y="-16"/>
-      <point x="640" y="-16" type="curve" smooth="yes"/>
-      <point x="714" y="-16"/>
-      <point x="761" y="31"/>
-      <point x="761" y="105" type="curve" smooth="yes"/>
-      <point x="761" y="182"/>
-      <point x="712" y="233"/>
-      <point x="638" y="233" type="curve" smooth="yes"/>
-      <point x="586" y="233"/>
-      <point x="556" y="222"/>
-      <point x="442" y="162" type="curve" smooth="yes"/>
-      <point x="366" y="122" type="line" smooth="yes"/>
-      <point x="268" y="70"/>
-      <point x="244" y="61"/>
-      <point x="202" y="61" type="curve" smooth="yes"/>
-      <point x="155" y="61"/>
-      <point x="127" y="88"/>
-      <point x="127" y="133" type="curve" smooth="yes"/>
-      <point x="127" y="188"/>
-      <point x="170" y="215"/>
-      <point x="257" y="215" type="curve" smooth="yes"/>
-      <point x="507" y="215" type="line" smooth="yes"/>
-      <point x="671" y="215"/>
-      <point x="766" y="289"/>
-      <point x="766" y="416" type="curve" smooth="yes"/>
-      <point x="766" y="525"/>
-      <point x="695" y="596"/>
-      <point x="587" y="596" type="curve" smooth="yes"/>
-      <point x="505" y="596"/>
-      <point x="442" y="551"/>
-      <point x="424" y="478" type="curve"/>
-      <point x="419" y="478" type="line"/>
-      <point x="398" y="550"/>
-      <point x="337" y="596"/>
-      <point x="240" y="596" type="curve" smooth="yes"/>
-      <point x="123" y="596"/>
-      <point x="42" y="526"/>
-      <point x="42" y="432" type="curve" smooth="yes"/>
-      <point x="42" y="351"/>
-      <point x="100" y="294"/>
-      <point x="183" y="294" type="curve" smooth="yes"/>
-      <point x="264" y="294"/>
-      <point x="319" y="340"/>
-      <point x="319" y="409" type="curve" smooth="yes"/>
-      <point x="319" y="477"/>
-      <point x="281" y="515"/>
-      <point x="215" y="515" type="curve" smooth="yes"/>
-      <point x="190" y="515"/>
-      <point x="166" y="510"/>
-      <point x="144" y="500" type="curve"/>
-      <point x="128" y="522" type="line"/>
-      <point x="137" y="498" type="line"/>
-      <point x="161" y="523"/>
-      <point x="197" y="536"/>
-      <point x="240" y="536" type="curve" smooth="yes"/>
-      <point x="333" y="536"/>
-      <point x="378" y="475"/>
-      <point x="378" y="380" type="curve" smooth="yes"/>
-      <point x="378" y="343" type="line"/>
-      <point x="462" y="343" type="line"/>
-      <point x="462" y="376" type="line" smooth="yes"/>
-      <point x="462" y="462"/>
-      <point x="511" y="518"/>
-      <point x="586" y="518" type="curve" smooth="yes"/>
-      <point x="648" y="518"/>
-      <point x="684" y="480"/>
-      <point x="684" y="413" type="curve" smooth="yes"/>
-      <point x="684" y="333"/>
-      <point x="625" y="287"/>
-      <point x="523" y="287" type="curve" smooth="yes"/>
-      <point x="254" y="287" type="line" smooth="yes"/>
-      <point x="126" y="287"/>
-      <point x="48" y="229"/>
-      <point x="48" y="133" type="curve" smooth="yes"/>
-      <point x="48" y="39"/>
-      <point x="104" y="-16"/>
+      <point x="202" y="-16" type="curve" smooth="yes"/>
+      <point x="252" y="-16"/>
+      <point x="287" y="-5"/>
+      <point x="371" y="36" type="curve" smooth="yes"/>
+      <point x="491" y="95" type="line"/>
+      <point x="560" y="138" type="line"/>
+      <point x="592" y="146" type="line"/>
+      <point x="616" y="168"/>
+      <point x="639" y="176"/>
+      <point x="668" y="176" type="curve" smooth="yes"/>
+      <point x="707" y="176"/>
+      <point x="730" y="154"/>
+      <point x="730" y="115" type="curve" smooth="yes"/>
+      <point x="730" y="78"/>
+      <point x="705" y="54"/>
+      <point x="667" y="54" type="curve" smooth="yes"/>
+      <point x="629" y="54"/>
+      <point x="603" y="79"/>
+      <point x="603" y="115" type="curve" smooth="yes"/>
+      <point x="603" y="143"/>
+      <point x="617" y="168"/>
+      <point x="640" y="181" type="curve"/>
+      <point x="533" y="145" type="line"/>
+      <point x="552" y="128" type="line"/>
+      <point x="548" y="116"/>
+      <point x="547" y="106"/>
+      <point x="547" y="94" type="curve" smooth="yes"/>
+      <point x="547" y="32"/>
+      <point x="598" y="-16"/>
+      <point x="672" y="-16" type="curve" smooth="yes"/>
+      <point x="753" y="-16"/>
+      <point x="804" y="38"/>
+      <point x="804" y="114" type="curve" smooth="yes"/>
+      <point x="804" y="185"/>
+      <point x="753" y="236"/>
+      <point x="674" y="236" type="curve" smooth="yes"/>
+      <point x="635" y="236"/>
+      <point x="590" y="220"/>
+      <point x="516" y="184" type="curve" smooth="yes"/>
+      <point x="343" y="99" type="line" smooth="yes"/>
+      <point x="285" y="71"/>
+      <point x="248" y="60"/>
+      <point x="206" y="60" type="curve" smooth="yes"/>
+      <point x="159" y="60"/>
+      <point x="128" y="85"/>
+      <point x="128" y="125" type="curve" smooth="yes"/>
+      <point x="128" y="170"/>
+      <point x="163" y="195"/>
+      <point x="225" y="195" type="curve" smooth="yes"/>
+      <point x="537" y="195" type="line" smooth="yes"/>
+      <point x="702" y="195"/>
+      <point x="808" y="277"/>
+      <point x="808" y="405" type="curve" smooth="yes"/>
+      <point x="808" y="521"/>
+      <point x="738" y="596"/>
+      <point x="625" y="596" type="curve" smooth="yes"/>
+      <point x="536" y="596"/>
+      <point x="472" y="552"/>
+      <point x="440" y="478" type="curve"/>
+      <point x="435" y="478" type="line"/>
+      <point x="409" y="553"/>
+      <point x="350" y="596"/>
+      <point x="255" y="596" type="curve" smooth="yes"/>
+      <point x="137" y="596"/>
+      <point x="42" y="525"/>
+      <point x="42" y="420" type="curve" smooth="yes"/>
+      <point x="42" y="332"/>
+      <point x="101" y="273"/>
+      <point x="190" y="273" type="curve" smooth="yes"/>
+      <point x="271" y="273"/>
+      <point x="327" y="324"/>
+      <point x="327" y="401" type="curve" smooth="yes"/>
+      <point x="327" y="470"/>
+      <point x="285" y="515"/>
+      <point x="214" y="515" type="curve" smooth="yes"/>
+      <point x="188" y="515"/>
+      <point x="165" y="510"/>
+      <point x="143" y="499" type="curve"/>
+      <point x="128" y="523" type="line"/>
+      <point x="128" y="491" type="line"/>
+      <point x="158" y="520"/>
+      <point x="198" y="536"/>
+      <point x="255" y="536" type="curve" smooth="yes"/>
+      <point x="351" y="536"/>
+      <point x="394" y="484"/>
+      <point x="394" y="382" type="curve" smooth="yes"/>
+      <point x="394" y="324" type="line"/>
+      <point x="478" y="324" type="line"/>
+      <point x="478" y="380" type="line" smooth="yes"/>
+      <point x="478" y="469"/>
+      <point x="531" y="518"/>
+      <point x="612" y="518" type="curve" smooth="yes"/>
+      <point x="685" y="518"/>
+      <point x="726" y="475"/>
+      <point x="726" y="403" type="curve" smooth="yes"/>
+      <point x="726" y="316"/>
+      <point x="663" y="267"/>
+      <point x="547" y="267" type="curve" smooth="yes"/>
+      <point x="222" y="267" type="line" smooth="yes"/>
+      <point x="119" y="267"/>
+      <point x="46" y="212"/>
+      <point x="46" y="122" type="curve" smooth="yes"/>
+      <point x="46" y="41"/>
+      <point x="112" y="-16"/>
     </contour>
     <contour>
-      <point x="184" y="357" type="curve" smooth="yes"/>
-      <point x="141" y="357"/>
-      <point x="118" y="384"/>
-      <point x="118" y="433" type="curve" smooth="yes"/>
-      <point x="118" y="449"/>
-      <point x="120" y="460"/>
+      <point x="185" y="341" type="curve" smooth="yes"/>
+      <point x="139" y="341"/>
+      <point x="110" y="370"/>
+      <point x="110" y="416" type="curve" smooth="yes"/>
+      <point x="110" y="439"/>
+      <point x="114" y="454"/>
       <point x="126" y="475" type="curve"/>
-      <point x="107" y="475" type="line"/>
+      <point x="98" y="475" type="line"/>
       <point x="90" y="427" type="line"/>
-      <point x="117" y="454"/>
-      <point x="151" y="467"/>
-      <point x="189" y="467" type="curve" smooth="yes"/>
-      <point x="225" y="467"/>
-      <point x="247" y="447"/>
-      <point x="247" y="413" type="curve" smooth="yes"/>
-      <point x="247" y="378"/>
-      <point x="224" y="357"/>
+      <point x="113" y="453"/>
+      <point x="148" y="467"/>
+      <point x="183" y="467" type="curve" smooth="yes"/>
+      <point x="228" y="467"/>
+      <point x="251" y="442"/>
+      <point x="251" y="403" type="curve" smooth="yes"/>
+      <point x="251" y="366"/>
+      <point x="227" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
+  <anchor x="440" y="0" name="bottom"/>
+  <anchor x="425" y="580" name="top"/>
+  <anchor x="709" y="580" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="687"/>
+    <component base="halant-malayalam" xOffset="709"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="808"/>
-  <guideline x="48" y="133" angle="91.1496"/>
-  <guideline x="766" y="416" angle="269.0789"/>
+  <advance width="850"/>
+  <anchor x="440" y="0" name="bottom"/>
+  <anchor x="425" y="580" name="top"/>
+  <anchor x="709" y="580" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="419"/>
+    <component base="lVocalicMatra-malayalam" xOffset="440"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="808"/>
-  <guideline x="48" y="133" angle="91.1496"/>
-  <guideline x="766" y="416" angle="269.0789"/>
+  <advance width="850"/>
+  <anchor x="440" y="0" name="bottom"/>
+  <anchor x="425" y="580" name="top"/>
+  <anchor x="709" y="580" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="419"/>
+    <component base="llVocalicMatra-malayalam" xOffset="440"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/kC_hillu-malayalam.glif
@@ -2,96 +2,95 @@
 <glyph name="kChillu-malayalam" format="2">
   <advance width="1040"/>
   <unicode hex="0D7F"/>
-  <guideline x="1011"/>
   <anchor x="644" y="0" name="bottom"/>
   <anchor x="367" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="397" y="22"/>
+      <point x="457" y="-16"/>
       <point x="532" y="-16" type="curve" smooth="yes"/>
       <point x="600" y="-16"/>
-      <point x="651" y="25"/>
-      <point x="679" y="85" type="curve"/>
-      <point x="686" y="85" type="line"/>
-      <point x="709" y="28"/>
-      <point x="763" y="-16"/>
-      <point x="848" y="-16" type="curve" smooth="yes"/>
-      <point x="941" y="-16"/>
-      <point x="1011" y="44"/>
-      <point x="1011" y="150" type="curve" smooth="yes"/>
-      <point x="1011" y="252"/>
-      <point x="937" y="324"/>
-      <point x="803" y="324" type="curve" smooth="yes"/>
-      <point x="766" y="324" type="line"/>
-      <point x="732" y="250" type="line"/>
-      <point x="807" y="250" type="line" smooth="yes"/>
-      <point x="896" y="250"/>
-      <point x="926" y="207"/>
-      <point x="926" y="154" type="curve" smooth="yes"/>
-      <point x="926" y="99"/>
-      <point x="899" y="62"/>
-      <point x="840" y="62" type="curve" smooth="yes"/>
-      <point x="780" y="62"/>
-      <point x="738" y="107"/>
-      <point x="738" y="180" type="curve" smooth="yes"/>
-      <point x="738" y="256"/>
-      <point x="781" y="328"/>
+      <point x="653" y="22"/>
+      <point x="683" y="85" type="curve"/>
+      <point x="690" y="85" type="line"/>
+      <point x="715" y="21"/>
+      <point x="772" y="-16"/>
+      <point x="846" y="-16" type="curve" smooth="yes"/>
+      <point x="946" y="-16"/>
+      <point x="1011" y="52"/>
+      <point x="1011" y="156" type="curve" smooth="yes"/>
+      <point x="1011" y="272"/>
+      <point x="931" y="344"/>
+      <point x="803" y="344" type="curve" smooth="yes"/>
+      <point x="766" y="344" type="line"/>
+      <point x="732" y="270" type="line"/>
+      <point x="807" y="270" type="line" smooth="yes"/>
+      <point x="885" y="270"/>
+      <point x="926" y="232"/>
+      <point x="926" y="160" type="curve" smooth="yes"/>
+      <point x="926" y="100"/>
+      <point x="892" y="62"/>
+      <point x="839" y="62" type="curve" smooth="yes"/>
+      <point x="777" y="62"/>
+      <point x="738" y="103"/>
+      <point x="738" y="170" type="curve" smooth="yes"/>
+      <point x="738" y="248"/>
+      <point x="762" y="305"/>
       <point x="845" y="426" type="curve" smooth="yes"/>
-      <point x="898" y="508"/>
-      <point x="924" y="554"/>
+      <point x="906" y="515"/>
+      <point x="924" y="561"/>
       <point x="924" y="632" type="curve" smooth="yes"/>
-      <point x="924" y="718"/>
-      <point x="873" y="789"/>
+      <point x="924" y="728"/>
+      <point x="863" y="789"/>
       <point x="768" y="789" type="curve" smooth="yes"/>
-      <point x="710" y="789"/>
-      <point x="661" y="774"/>
+      <point x="708" y="789"/>
+      <point x="660" y="773"/>
       <point x="609" y="737" type="curve"/>
       <point x="647" y="670" type="line"/>
-      <point x="682" y="695"/>
-      <point x="719" y="710"/>
+      <point x="685" y="697"/>
+      <point x="722" y="710"/>
       <point x="762" y="710" type="curve" smooth="yes"/>
-      <point x="821" y="710"/>
-      <point x="841" y="676"/>
+      <point x="814" y="710"/>
+      <point x="841" y="683"/>
       <point x="841" y="632" type="curve" smooth="yes"/>
-      <point x="841" y="583"/>
-      <point x="820" y="536"/>
+      <point x="841" y="586"/>
+      <point x="823" y="542"/>
       <point x="771" y="455" type="curve" smooth="yes"/>
-      <point x="753" y="425"/>
-      <point x="738" y="400"/>
+      <point x="746" y="413"/>
+      <point x="736" y="393"/>
       <point x="728" y="368" type="curve"/>
       <point x="722" y="368" type="line"/>
-      <point x="711" y="499"/>
-      <point x="648" y="596"/>
+      <point x="710" y="511"/>
+      <point x="639" y="596"/>
       <point x="531" y="596" type="curve" smooth="yes"/>
-      <point x="394" y="596"/>
-      <point x="317" y="479"/>
+      <point x="398" y="596"/>
+      <point x="317" y="485"/>
       <point x="317" y="302" type="curve" smooth="yes"/>
-      <point x="317" y="279"/>
-      <point x="320" y="239"/>
-      <point x="320" y="215" type="curve" smooth="yes"/>
-      <point x="320" y="121"/>
-      <point x="276" y="62"/>
-      <point x="205" y="62" type="curve" smooth="yes"/>
-      <point x="144" y="62"/>
-      <point x="110" y="95"/>
-      <point x="110" y="153" type="curve" smooth="yes"/>
-      <point x="110" y="211"/>
-      <point x="147" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="698" y="250" type="line"/>
-      <point x="705" y="324" type="line"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="317" y="276"/>
+      <point x="322" y="236"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="698" y="270" type="line"/>
+      <point x="705" y="344" type="line"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/k_ka-malayalam.glif
@@ -1,102 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ka-malayalam" format="2">
   <advance width="1437"/>
-  <guideline x="1394"/>
   <anchor x="1027" y="0" name="bottom"/>
   <anchor x="810" y="580" name="top"/>
   <anchor x="1309" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="940" y="250" type="line" smooth="yes"/>
-      <point x="1038" y="250"/>
-      <point x="1063" y="201"/>
-      <point x="1063" y="140" type="curve" smooth="yes"/>
-      <point x="1063" y="86"/>
-      <point x="1038" y="62"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="942" y="270" type="line" smooth="yes"/>
+      <point x="1030" y="270"/>
+      <point x="1073" y="233"/>
+      <point x="1073" y="156" type="curve" smooth="yes"/>
+      <point x="1073" y="94"/>
+      <point x="1047" y="62"/>
       <point x="998" y="62" type="curve" smooth="yes"/>
-      <point x="924" y="62"/>
-      <point x="899" y="146"/>
-      <point x="899" y="241" type="curve" smooth="yes"/>
-      <point x="899" y="405"/>
-      <point x="967" y="517"/>
+      <point x="933" y="62"/>
+      <point x="899" y="120"/>
+      <point x="899" y="231" type="curve" smooth="yes"/>
+      <point x="899" y="416"/>
+      <point x="975" y="517"/>
       <point x="1116" y="517" type="curve" smooth="yes"/>
-      <point x="1248" y="517"/>
-      <point x="1313" y="416"/>
+      <point x="1240" y="517"/>
+      <point x="1313" y="428"/>
       <point x="1313" y="278" type="curve" smooth="yes"/>
-      <point x="1313" y="186"/>
-      <point x="1280" y="106"/>
+      <point x="1313" y="192"/>
+      <point x="1284" y="111"/>
       <point x="1225" y="34" type="curve"/>
       <point x="1291" y="-16" type="line"/>
-      <point x="1362" y="68"/>
-      <point x="1395" y="174"/>
+      <point x="1358" y="63"/>
+      <point x="1395" y="167"/>
       <point x="1395" y="277" type="curve" smooth="yes"/>
-      <point x="1395" y="470"/>
-      <point x="1292" y="596"/>
+      <point x="1395" y="475"/>
+      <point x="1290" y="596"/>
       <point x="1118" y="596" type="curve" smooth="yes"/>
-      <point x="928" y="596"/>
-      <point x="817" y="449"/>
-      <point x="817" y="238" type="curve" smooth="yes"/>
-      <point x="817" y="116"/>
-      <point x="866" y="-16"/>
-      <point x="1001" y="-16" type="curve" smooth="yes"/>
-      <point x="1099" y="-16"/>
-      <point x="1145" y="53"/>
-      <point x="1145" y="140" type="curve" smooth="yes"/>
-      <point x="1145" y="234"/>
-      <point x="1098" y="324"/>
-      <point x="936" y="324" type="curve" smooth="yes"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="932" y="596"/>
+      <point x="817" y="455"/>
+      <point x="817" y="228" type="curve" smooth="yes"/>
+      <point x="817" y="78"/>
+      <point x="887" y="-16"/>
+      <point x="999" y="-16" type="curve" smooth="yes"/>
+      <point x="1095" y="-16"/>
+      <point x="1155" y="50"/>
+      <point x="1155" y="156" type="curve" smooth="yes"/>
+      <point x="1155" y="278"/>
+      <point x="1079" y="344"/>
+      <point x="940" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/k_la-malayalam.glif
@@ -54,29 +54,29 @@
       <point x="744" y="153"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="805" y="250" type="line" smooth="yes"/>
-      <point x="883" y="250"/>
-      <point x="924" y="215"/>
-      <point x="924" y="153" type="curve" smooth="yes"/>
-      <point x="924" y="95"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="799" y="270" type="line" smooth="yes"/>
+      <point x="881" y="270"/>
+      <point x="924" y="233"/>
+      <point x="924" y="164" type="curve" smooth="yes"/>
+      <point x="924" y="99"/>
       <point x="891" y="62"/>
       <point x="835" y="62" type="curve" smooth="yes"/>
       <point x="818" y="62"/>
@@ -87,23 +87,23 @@
       <point x="809" y="-16"/>
       <point x="838" y="-16" type="curve" smooth="yes"/>
       <point x="937" y="-16"/>
-      <point x="1006" y="51"/>
-      <point x="1006" y="151" type="curve" smooth="yes"/>
-      <point x="1006" y="257"/>
-      <point x="927" y="324"/>
-      <point x="799" y="324" type="curve" smooth="yes"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="375" y="68"/>
+      <point x="1006" y="55"/>
+      <point x="1006" y="162" type="curve" smooth="yes"/>
+      <point x="1006" y="274"/>
+      <point x="930" y="344"/>
+      <point x="797" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="375" y="69"/>
       <point x="392" y="48"/>
       <point x="413" y="31" type="curve"/>
       <point x="413" y="23" type="line"/>
@@ -131,19 +131,19 @@
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.glif
@@ -1,48 +1,47 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam" format="2">
   <advance width="1702"/>
-  <guideline x="1626"/>
   <anchor x="1259" y="0" name="bottom"/>
   <anchor x="876" y="580" name="top"/>
   <anchor x="1581" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="156" type="curve" smooth="yes"/>
-      <point x="111" y="217"/>
-      <point x="148" y="256"/>
-      <point x="235" y="256" type="curve" smooth="yes"/>
-      <point x="814" y="256" type="line" smooth="yes"/>
-      <point x="895" y="256"/>
-      <point x="924" y="221"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="799" y="270" type="line" smooth="yes"/>
+      <point x="881" y="270"/>
+      <point x="924" y="236"/>
       <point x="924" y="172" type="curve" smooth="yes"/>
-      <point x="924" y="129"/>
-      <point x="901" y="95"/>
+      <point x="924" y="134"/>
+      <point x="906" y="100"/>
       <point x="862" y="56" type="curve"/>
       <point x="881" y="0" type="line"/>
       <point x="1625" y="0" type="line"/>
@@ -51,26 +50,26 @@
       <point x="1500" y="402"/>
       <point x="1392" y="312"/>
       <point x="1254" y="312" type="curve" smooth="yes"/>
-      <point x="1157" y="312"/>
-      <point x="1102" y="363"/>
+      <point x="1161" y="312"/>
+      <point x="1102" y="360"/>
       <point x="1102" y="436" type="curve" smooth="yes"/>
       <point x="1102" y="486"/>
       <point x="1131" y="518"/>
       <point x="1178" y="518" type="curve" smooth="yes"/>
-      <point x="1226" y="518"/>
-      <point x="1252" y="482"/>
+      <point x="1225" y="518"/>
+      <point x="1252" y="484"/>
       <point x="1252" y="425" type="curve" smooth="yes"/>
       <point x="1252" y="61" type="line"/>
       <point x="1334" y="61" type="line"/>
       <point x="1334" y="431" type="line" smooth="yes"/>
-      <point x="1334" y="529"/>
-      <point x="1279" y="596"/>
+      <point x="1334" y="532"/>
+      <point x="1276" y="596"/>
       <point x="1183" y="596" type="curve" smooth="yes"/>
-      <point x="1084" y="596"/>
-      <point x="1020" y="526"/>
+      <point x="1087" y="596"/>
+      <point x="1020" y="529"/>
       <point x="1020" y="435" type="curve" smooth="yes"/>
-      <point x="1020" y="320"/>
-      <point x="1113" y="236"/>
+      <point x="1020" y="317"/>
+      <point x="1116" y="236"/>
       <point x="1256" y="236" type="curve" smooth="yes"/>
       <point x="1366" y="236"/>
       <point x="1464" y="289"/>
@@ -80,34 +79,34 @@
       <point x="1581" y="74" type="line"/>
       <point x="967" y="74" type="line"/>
       <point x="965" y="79" type="line"/>
-      <point x="996" y="114"/>
-      <point x="1006" y="152"/>
+      <point x="991" y="108"/>
+      <point x="1006" y="145"/>
       <point x="1006" y="180" type="curve" smooth="yes"/>
-      <point x="1006" y="267"/>
-      <point x="949" y="330"/>
-      <point x="810" y="330" type="curve" smooth="yes"/>
-      <point x="237" y="330" type="line" smooth="yes"/>
-      <point x="99" y="330"/>
-      <point x="29" y="260"/>
-      <point x="29" y="151" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="1006" y="281"/>
+      <point x="930" y="344"/>
+      <point x="797" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam.half" format="2">
   <advance width="1702"/>
+  <anchor x="1259" y="0" name="bottom"/>
+  <anchor x="876" y="580" name="top"/>
+  <anchor x="1581" y="580" name="topright"/>
   <outline>
     <component base="k_ssa-malayalam"/>
     <component base="halant-malayalam" xOffset="1581"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/k_ta-malayalam.glif
@@ -58,60 +58,60 @@
       <point x="896" y="73"/>
     </contour>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="882" y="250" type="line"/>
-      <point x="882" y="324" type="line"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="898" y="270" type="line"/>
+      <point x="898" y="344" type="line"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/k_tta-malayalam.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_tta-malayalam" format="2">
   <advance width="1035"/>
-  <guideline x="1006" y="158" angle="90"/>
   <anchor x="840" y="-351" name="bottom"/>
   <anchor x="532" y="580" name="top"/>
   <anchor x="879" y="540" name="topright"/>
@@ -29,54 +28,54 @@
       <point x="964" y="22"/>
       <point x="945" y="27" type="curve"/>
       <point x="945" y="35" type="line"/>
-      <point x="984" y="59"/>
-      <point x="1006" y="104"/>
-      <point x="1006" y="158" type="curve" smooth="yes"/>
-      <point x="1006" y="265"/>
-      <point x="927" y="324"/>
-      <point x="799" y="324" type="curve" smooth="yes"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="984" y="62"/>
+      <point x="1006" y="111"/>
+      <point x="1006" y="169" type="curve" smooth="yes"/>
+      <point x="1006" y="278"/>
+      <point x="928" y="344"/>
+      <point x="799" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="805" y="250" type="line" smooth="yes"/>
-      <point x="883" y="250"/>
-      <point x="924" y="215"/>
-      <point x="924" y="153" type="curve" smooth="yes"/>
-      <point x="924" y="95"/>
-      <point x="894" y="62"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="799" y="270" type="line" smooth="yes"/>
+      <point x="881" y="270"/>
+      <point x="924" y="233"/>
+      <point x="924" y="165" type="curve" smooth="yes"/>
+      <point x="924" y="98"/>
+      <point x="892" y="62"/>
       <point x="835" y="62" type="curve" smooth="yes"/>
       <point x="818" y="62"/>
       <point x="799" y="64"/>
@@ -105,19 +104,19 @@
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ka-malayalam.glif
@@ -7,78 +7,78 @@
   <anchor x="879" y="540" name="topright"/>
   <outline>
     <contour>
-      <point x="201" y="-16" type="curve" smooth="yes"/>
-      <point x="276" y="-16"/>
-      <point x="330" y="29"/>
-      <point x="357" y="92" type="curve"/>
-      <point x="362" y="92" type="line"/>
-      <point x="397" y="23"/>
-      <point x="456" y="-16"/>
+      <point x="203" y="-16" type="curve" smooth="yes"/>
+      <point x="273" y="-16"/>
+      <point x="330" y="25"/>
+      <point x="357" y="93" type="curve"/>
+      <point x="362" y="93" type="line"/>
+      <point x="398" y="22"/>
+      <point x="458" y="-16"/>
       <point x="535" y="-16" type="curve" smooth="yes"/>
-      <point x="671" y="-16"/>
-      <point x="744" y="106"/>
+      <point x="664" y="-16"/>
+      <point x="744" y="96"/>
       <point x="744" y="278" type="curve" smooth="yes"/>
       <point x="744" y="302" type="line" smooth="yes"/>
-      <point x="744" y="473"/>
-      <point x="675" y="596"/>
+      <point x="744" y="487"/>
+      <point x="665" y="596"/>
       <point x="532" y="596" type="curve" smooth="yes"/>
-      <point x="395" y="596"/>
-      <point x="318" y="479"/>
+      <point x="399" y="596"/>
+      <point x="318" y="485"/>
       <point x="318" y="302" type="curve" smooth="yes"/>
-      <point x="318" y="279"/>
-      <point x="321" y="239"/>
-      <point x="321" y="215" type="curve" smooth="yes"/>
-      <point x="321" y="121"/>
-      <point x="277" y="62"/>
-      <point x="206" y="62" type="curve" smooth="yes"/>
-      <point x="145" y="62"/>
-      <point x="111" y="95"/>
-      <point x="111" y="153" type="curve" smooth="yes"/>
-      <point x="111" y="211"/>
-      <point x="148" y="250"/>
-      <point x="235" y="250" type="curve" smooth="yes"/>
-      <point x="805" y="250" type="line" smooth="yes"/>
-      <point x="883" y="250"/>
-      <point x="924" y="215"/>
-      <point x="924" y="153" type="curve" smooth="yes"/>
-      <point x="924" y="95"/>
+      <point x="318" y="276"/>
+      <point x="322" y="230"/>
+      <point x="322" y="203" type="curve" smooth="yes"/>
+      <point x="322" y="112"/>
+      <point x="281" y="62"/>
+      <point x="208" y="62" type="curve" smooth="yes"/>
+      <point x="147" y="62"/>
+      <point x="111" y="101"/>
+      <point x="111" y="160" type="curve" smooth="yes"/>
+      <point x="111" y="231"/>
+      <point x="159" y="270"/>
+      <point x="243" y="270" type="curve" smooth="yes"/>
+      <point x="799" y="270" type="line" smooth="yes"/>
+      <point x="881" y="270"/>
+      <point x="924" y="233"/>
+      <point x="924" y="164" type="curve" smooth="yes"/>
+      <point x="924" y="99"/>
       <point x="891" y="62"/>
       <point x="835" y="62" type="curve" smooth="yes"/>
-      <point x="818" y="62"/>
-      <point x="799" y="64"/>
+      <point x="815" y="62"/>
+      <point x="797" y="65"/>
       <point x="783" y="70" type="curve"/>
       <point x="762" y="-5" type="line"/>
-      <point x="785" y="-12"/>
-      <point x="809" y="-16"/>
+      <point x="787" y="-13"/>
+      <point x="811" y="-16"/>
       <point x="838" y="-16" type="curve" smooth="yes"/>
-      <point x="937" y="-16"/>
-      <point x="1006" y="51"/>
-      <point x="1006" y="151" type="curve" smooth="yes"/>
-      <point x="1006" y="257"/>
-      <point x="927" y="324"/>
-      <point x="799" y="324" type="curve" smooth="yes"/>
-      <point x="237" y="324" type="line" smooth="yes"/>
-      <point x="99" y="324"/>
-      <point x="29" y="254"/>
-      <point x="29" y="149" type="curve" smooth="yes"/>
-      <point x="29" y="50"/>
-      <point x="94" y="-16"/>
+      <point x="938" y="-16"/>
+      <point x="1006" y="56"/>
+      <point x="1006" y="162" type="curve" smooth="yes"/>
+      <point x="1006" y="274"/>
+      <point x="930" y="344"/>
+      <point x="797" y="344" type="curve" smooth="yes"/>
+      <point x="245" y="344" type="line" smooth="yes"/>
+      <point x="111" y="344"/>
+      <point x="29" y="276"/>
+      <point x="29" y="156" type="curve" smooth="yes"/>
+      <point x="29" y="56"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="533" y="62" type="curve" smooth="yes"/>
-      <point x="441" y="62"/>
-      <point x="400" y="146"/>
+      <point x="446" y="62"/>
+      <point x="400" y="138"/>
       <point x="400" y="280" type="curve" smooth="yes"/>
       <point x="400" y="300" type="line" smooth="yes"/>
-      <point x="400" y="427"/>
-      <point x="441" y="518"/>
+      <point x="400" y="439"/>
+      <point x="448" y="518"/>
       <point x="532" y="518" type="curve" smooth="yes"/>
-      <point x="624" y="518"/>
-      <point x="660" y="426"/>
+      <point x="615" y="518"/>
+      <point x="660" y="441"/>
       <point x="660" y="300" type="curve" smooth="yes"/>
       <point x="660" y="280" type="line" smooth="yes"/>
-      <point x="660" y="146"/>
-      <point x="621" y="62"/>
+      <point x="660" y="137"/>
+      <point x="616" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/m_la-malayalam.glif
@@ -6,51 +6,7 @@
   <anchor x="567" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="120" y="-367" type="curve" smooth="yes"/>
-      <point x="202" y="-367"/>
-      <point x="250" y="-317"/>
-      <point x="250" y="-238" type="curve" smooth="yes"/>
-      <point x="250" y="-160"/>
-      <point x="206" y="-118"/>
-      <point x="136" y="-118" type="curve" smooth="yes"/>
-      <point x="81" y="-118"/>
-      <point x="21" y="-151"/>
-      <point x="21" y="-236" type="curve"/>
-      <point x="49" y="-169" type="line"/>
-      <point x="-10" y="-166" type="line"/>
-      <point x="31" y="-195" type="line"/>
-      <point x="31" y="-89"/>
-      <point x="81" y="-27"/>
-      <point x="177" y="-27" type="curve" smooth="yes"/>
-      <point x="273" y="-27"/>
-      <point x="310" y="-89"/>
-      <point x="329" y="-164" type="curve" smooth="yes"/>
-      <point x="339" y="-203" type="line" smooth="yes"/>
-      <point x="367" y="-311"/>
-      <point x="420" y="-367"/>
-      <point x="519" y="-367" type="curve" smooth="yes"/>
-      <point x="613" y="-367"/>
-      <point x="679" y="-308"/>
-      <point x="679" y="-182" type="curve" smooth="yes"/>
-      <point x="679" y="-85"/>
-      <point x="646" y="-12"/>
-      <point x="596" y="43" type="curve"/>
-      <point x="537" y="3" type="line"/>
-      <point x="577" y="-44"/>
-      <point x="605" y="-101"/>
-      <point x="605" y="-182" type="curve" smooth="yes"/>
-      <point x="605" y="-251"/>
-      <point x="578" y="-297"/>
-      <point x="518" y="-297" type="curve" smooth="yes"/>
-      <point x="463" y="-297"/>
-      <point x="433" y="-261"/>
-      <point x="411" y="-182" type="curve" smooth="yes"/>
-      <point x="399" y="-139" type="line" smooth="yes"/>
-      <point x="384" y="-84"/>
-      <point x="363" y="-33"/>
-      <point x="322" y="-5" type="curve"/>
-      <point x="323" y="0" type="line"/>
-      <point x="583" y="0" type="line"/>
+      <point x="51" y="0" type="line"/>
       <point x="617" y="0" type="line"/>
       <point x="617" y="324" type="line" smooth="yes"/>
       <point x="617" y="481"/>
@@ -59,29 +15,72 @@
       <point x="157" y="596"/>
       <point x="51" y="480"/>
       <point x="51" y="323" type="curve" smooth="yes"/>
-      <point x="51" y="0" type="line"/>
-      <point x="97" y="30" type="line"/>
-      <point x="13" y="-1"/>
-      <point x="-37" y="-79"/>
-      <point x="-37" y="-181" type="curve" smooth="yes"/>
-      <point x="-37" y="-305"/>
-      <point x="35" y="-367"/>
     </contour>
     <contour>
-      <point x="117" y="-302" type="curve" smooth="yes"/>
-      <point x="59" y="-302"/>
-      <point x="32" y="-253"/>
-      <point x="32" y="-197" type="curve"/>
-      <point x="12" y="-205" type="line"/>
-      <point x="33" y="-262" type="line"/>
-      <point x="33" y="-218"/>
-      <point x="65" y="-178"/>
-      <point x="119" y="-178" type="curve" smooth="yes"/>
-      <point x="160" y="-178"/>
-      <point x="180" y="-203"/>
-      <point x="180" y="-238" type="curve" smooth="yes"/>
-      <point x="180" y="-276"/>
-      <point x="159" y="-302"/>
+      <point x="185" y="-367" type="curve" smooth="yes"/>
+      <point x="264" y="-367"/>
+      <point x="312" y="-317"/>
+      <point x="312" y="-235" type="curve" smooth="yes"/>
+      <point x="312" y="-157"/>
+      <point x="271" y="-109"/>
+      <point x="206" y="-109" type="curve" smooth="yes"/>
+      <point x="140" y="-109"/>
+      <point x="93" y="-162"/>
+      <point x="93" y="-236" type="curve"/>
+      <point x="117" y="-169" type="line"/>
+      <point x="58" y="-169" type="line"/>
+      <point x="95" y="-195" type="line"/>
+      <point x="95" y="-87"/>
+      <point x="148" y="-23"/>
+      <point x="233" y="-23" type="curve" smooth="yes"/>
+      <point x="304" y="-23"/>
+      <point x="343" y="-66"/>
+      <point x="357" y="-152" type="curve" smooth="yes"/>
+      <point x="369" y="-225" type="line" smooth="yes"/>
+      <point x="385" y="-320"/>
+      <point x="430" y="-367"/>
+      <point x="506" y="-367" type="curve" smooth="yes"/>
+      <point x="593" y="-367"/>
+      <point x="643" y="-306"/>
+      <point x="643" y="-199" type="curve" smooth="yes"/>
+      <point x="643" y="-105"/>
+      <point x="613" y="-23"/>
+      <point x="553" y="49" type="curve"/>
+      <point x="498" y="6" type="line"/>
+      <point x="547" y="-52"/>
+      <point x="569" y="-116"/>
+      <point x="569" y="-197" type="curve" smooth="yes"/>
+      <point x="569" y="-263"/>
+      <point x="548" y="-297"/>
+      <point x="508" y="-297" type="curve" smooth="yes"/>
+      <point x="470" y="-297"/>
+      <point x="450" y="-268"/>
+      <point x="438" y="-198" type="curve" smooth="yes"/>
+      <point x="426" y="-125" type="line" smooth="yes"/>
+      <point x="409" y="-23"/>
+      <point x="345" y="37"/>
+      <point x="235" y="37" type="curve" smooth="yes"/>
+      <point x="110" y="37"/>
+      <point x="31" y="-51"/>
+      <point x="31" y="-183" type="curve" smooth="yes"/>
+      <point x="31" y="-293"/>
+      <point x="93" y="-367"/>
+    </contour>
+    <contour>
+      <point x="181" y="-303" type="curve" smooth="yes"/>
+      <point x="126" y="-303"/>
+      <point x="100" y="-254"/>
+      <point x="100" y="-197" type="curve"/>
+      <point x="80" y="-205" type="line"/>
+      <point x="101" y="-262" type="line"/>
+      <point x="101" y="-212"/>
+      <point x="132" y="-167"/>
+      <point x="183" y="-167" type="curve" smooth="yes"/>
+      <point x="220" y="-167"/>
+      <point x="242" y="-192"/>
+      <point x="242" y="-235" type="curve" smooth="yes"/>
+      <point x="242" y="-278"/>
+      <point x="219" y="-303"/>
     </contour>
     <contour>
       <point x="101" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ng_ka-malayalam.glif
@@ -6,98 +6,98 @@
   <anchor x="860" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="203" y="-16" type="curve" smooth="yes"/>
-      <point x="281" y="-16"/>
-      <point x="337" y="27"/>
-      <point x="362" y="92" type="curve"/>
-      <point x="367" y="92" type="line"/>
-      <point x="402" y="23"/>
-      <point x="461" y="-16"/>
+      <point x="211" y="-16" type="curve" smooth="yes"/>
+      <point x="280" y="-16"/>
+      <point x="336" y="25"/>
+      <point x="362" y="93" type="curve"/>
+      <point x="367" y="93" type="line"/>
+      <point x="404" y="21"/>
+      <point x="463" y="-16"/>
       <point x="540" y="-16" type="curve" smooth="yes"/>
-      <point x="676" y="-16"/>
-      <point x="749" y="106"/>
+      <point x="669" y="-16"/>
+      <point x="749" y="96"/>
       <point x="749" y="278" type="curve" smooth="yes"/>
       <point x="749" y="302" type="line" smooth="yes"/>
-      <point x="749" y="473"/>
-      <point x="680" y="596"/>
+      <point x="749" y="487"/>
+      <point x="670" y="596"/>
       <point x="537" y="596" type="curve" smooth="yes"/>
-      <point x="456" y="596"/>
-      <point x="398" y="554"/>
+      <point x="459" y="596"/>
+      <point x="399" y="557"/>
       <point x="367" y="484" type="curve"/>
       <point x="362" y="484" type="line"/>
-      <point x="340" y="549"/>
-      <point x="289" y="596"/>
-      <point x="205" y="596" type="curve" smooth="yes"/>
-      <point x="98" y="596"/>
-      <point x="41" y="527"/>
-      <point x="41" y="441" type="curve" smooth="yes"/>
-      <point x="41" y="376"/>
-      <point x="76" y="318"/>
-      <point x="134" y="292" type="curve"/>
-      <point x="134" y="287" type="line"/>
-      <point x="73" y="265"/>
-      <point x="34" y="214"/>
-      <point x="34" y="145" type="curve" smooth="yes"/>
-      <point x="34" y="46"/>
-      <point x="99" y="-16"/>
+      <point x="337" y="556"/>
+      <point x="281" y="596"/>
+      <point x="203" y="596" type="curve" smooth="yes"/>
+      <point x="107" y="596"/>
+      <point x="41" y="535"/>
+      <point x="41" y="446" type="curve" smooth="yes"/>
+      <point x="41" y="388"/>
+      <point x="78" y="335"/>
+      <point x="134" y="313" type="curve"/>
+      <point x="134" y="308" type="line"/>
+      <point x="71" y="283"/>
+      <point x="34" y="226"/>
+      <point x="34" y="154" type="curve" smooth="yes"/>
+      <point x="34" y="54"/>
+      <point x="106" y="-16"/>
     </contour>
     <contour>
       <point x="843" y="-16" type="curve" smooth="yes"/>
-      <point x="942" y="-16"/>
-      <point x="1011" y="51"/>
-      <point x="1011" y="151" type="curve" smooth="yes"/>
-      <point x="1011" y="257"/>
-      <point x="944" y="324"/>
-      <point x="804" y="324" type="curve" smooth="yes"/>
-      <point x="255" y="324" type="line" smooth="yes"/>
-      <point x="164" y="324"/>
-      <point x="123" y="373"/>
-      <point x="123" y="433" type="curve" smooth="yes"/>
-      <point x="123" y="482"/>
-      <point x="155" y="518"/>
-      <point x="215" y="518" type="curve" smooth="yes"/>
-      <point x="294" y="518"/>
-      <point x="326" y="459"/>
+      <point x="943" y="-16"/>
+      <point x="1011" y="56"/>
+      <point x="1011" y="162" type="curve" smooth="yes"/>
+      <point x="1011" y="276"/>
+      <point x="933" y="344"/>
+      <point x="802" y="344" type="curve" smooth="yes"/>
+      <point x="251" y="344" type="line" smooth="yes"/>
+      <point x="172" y="344"/>
+      <point x="123" y="379"/>
+      <point x="123" y="437" type="curve" smooth="yes"/>
+      <point x="123" y="486"/>
+      <point x="158" y="518"/>
+      <point x="213" y="518" type="curve" smooth="yes"/>
+      <point x="289" y="518"/>
+      <point x="326" y="467"/>
       <point x="326" y="363" type="curve" smooth="yes"/>
-      <point x="326" y="215" type="line" smooth="yes"/>
-      <point x="326" y="121"/>
-      <point x="284" y="62"/>
-      <point x="211" y="62" type="curve" smooth="yes"/>
-      <point x="150" y="62"/>
-      <point x="116" y="97"/>
-      <point x="116" y="153" type="curve" smooth="yes"/>
-      <point x="116" y="211"/>
-      <point x="153" y="250"/>
-      <point x="240" y="250" type="curve" smooth="yes"/>
-      <point x="810" y="250" type="line" smooth="yes"/>
-      <point x="892" y="250"/>
-      <point x="929" y="215"/>
-      <point x="929" y="153" type="curve" smooth="yes"/>
-      <point x="929" y="95"/>
+      <point x="326" y="203" type="line" smooth="yes"/>
+      <point x="326" y="113"/>
+      <point x="286" y="62"/>
+      <point x="216" y="62" type="curve" smooth="yes"/>
+      <point x="154" y="62"/>
+      <point x="116" y="99"/>
+      <point x="116" y="158" type="curve" smooth="yes"/>
+      <point x="116" y="231"/>
+      <point x="159" y="270"/>
+      <point x="240" y="270" type="curve" smooth="yes"/>
+      <point x="804" y="270" type="line" smooth="yes"/>
+      <point x="886" y="270"/>
+      <point x="929" y="233"/>
+      <point x="929" y="164" type="curve" smooth="yes"/>
+      <point x="929" y="99"/>
       <point x="896" y="62"/>
       <point x="840" y="62" type="curve" smooth="yes"/>
-      <point x="823" y="62"/>
-      <point x="804" y="64"/>
+      <point x="822" y="62"/>
+      <point x="804" y="65"/>
       <point x="788" y="70" type="curve"/>
       <point x="767" y="-5" type="line"/>
-      <point x="790" y="-12"/>
-      <point x="814" y="-16"/>
+      <point x="790" y="-13"/>
+      <point x="813" y="-16"/>
     </contour>
     <contour>
       <point x="538" y="62" type="curve" smooth="yes"/>
-      <point x="446" y="62"/>
-      <point x="405" y="146"/>
+      <point x="451" y="62"/>
+      <point x="405" y="138"/>
       <point x="405" y="280" type="curve" smooth="yes"/>
       <point x="405" y="300" type="line" smooth="yes"/>
-      <point x="405" y="427"/>
-      <point x="446" y="518"/>
+      <point x="405" y="439"/>
+      <point x="453" y="518"/>
       <point x="537" y="518" type="curve" smooth="yes"/>
-      <point x="629" y="518"/>
-      <point x="665" y="426"/>
+      <point x="620" y="518"/>
+      <point x="665" y="441"/>
       <point x="665" y="300" type="curve" smooth="yes"/>
       <point x="665" y="280" type="line" smooth="yes"/>
-      <point x="665" y="146"/>
-      <point x="626" y="62"/>
+      <point x="665" y="137"/>
+      <point x="621" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1518"/>
-  <anchor x="1129" y="0" name="bottom"/>
-  <anchor x="790" y="580" name="top"/>
-  <anchor x="1397" y="580" name="topright"/>
+  <advance width="1560"/>
+  <anchor x="1150" y="0" name="bottom"/>
+  <anchor x="780" y="580" name="top"/>
+  <anchor x="1419" y="580" name="topright"/>
   <outline>
     <contour>
       <point x="271" y="-16" type="curve" smooth="yes"/>
@@ -45,117 +45,117 @@
       <point x="811" y="529"/>
       <point x="816" y="529"/>
       <point x="833" y="527" type="curve"/>
-      <point x="789" y="570" type="line"/>
-      <point x="797" y="523" type="line"/>
-      <point x="766" y="496"/>
-      <point x="752" y="462"/>
-      <point x="752" y="427" type="curve" smooth="yes"/>
-      <point x="752" y="361"/>
-      <point x="807" y="309"/>
-      <point x="889" y="309" type="curve" smooth="yes"/>
-      <point x="982" y="309"/>
-      <point x="1029" y="362"/>
-      <point x="1029" y="435" type="curve" smooth="yes"/>
-      <point x="1029" y="462"/>
-      <point x="1015" y="503"/>
-      <point x="971" y="532" type="curve"/>
-      <point x="982" y="576" type="line"/>
-      <point x="888" y="538" type="line"/>
-      <point x="902" y="540"/>
-      <point x="915" y="540"/>
-      <point x="927" y="540" type="curve" smooth="yes"/>
-      <point x="1058" y="540"/>
-      <point x="1092" y="451"/>
-      <point x="1092" y="380" type="curve" smooth="yes"/>
-      <point x="1092" y="343" type="line"/>
-      <point x="1176" y="343" type="line"/>
-      <point x="1176" y="376" type="line" smooth="yes"/>
-      <point x="1176" y="467"/>
-      <point x="1229" y="518"/>
-      <point x="1298" y="518" type="curve" smooth="yes"/>
-      <point x="1360" y="518"/>
-      <point x="1394" y="478"/>
-      <point x="1394" y="413" type="curve" smooth="yes"/>
-      <point x="1394" y="349"/>
-      <point x="1356" y="283"/>
-      <point x="1233" y="283" type="curve" smooth="yes"/>
-      <point x="964" y="283" type="line" smooth="yes"/>
-      <point x="825" y="283"/>
-      <point x="758" y="221"/>
-      <point x="758" y="133" type="curve" smooth="yes"/>
-      <point x="758" y="54"/>
-      <point x="799" y="-16"/>
-      <point x="911" y="-16" type="curve" smooth="yes"/>
-      <point x="971" y="-16"/>
-      <point x="1021" y="4"/>
-      <point x="1106" y="54" type="curve" smooth="yes"/>
-      <point x="1169" y="91" type="line"/>
-      <point x="1256" y="142" type="line"/>
-      <point x="1272" y="148" type="line"/>
-      <point x="1304" y="163"/>
-      <point x="1322" y="167"/>
-      <point x="1344" y="167" type="curve" smooth="yes"/>
-      <point x="1385" y="167"/>
-      <point x="1405" y="147"/>
-      <point x="1405" y="106" type="curve" smooth="yes"/>
-      <point x="1405" y="70"/>
-      <point x="1383" y="48"/>
-      <point x="1348" y="48" type="curve" smooth="yes"/>
-      <point x="1312" y="48"/>
-      <point x="1292" y="70"/>
-      <point x="1292" y="110" type="curve" smooth="yes"/>
-      <point x="1292" y="137"/>
-      <point x="1301" y="159"/>
-      <point x="1325" y="185" type="curve"/>
-      <point x="1227" y="152" type="line"/>
-      <point x="1244" y="130" type="line"/>
-      <point x="1238" y="112"/>
-      <point x="1236" y="104"/>
-      <point x="1236" y="90" type="curve" smooth="yes"/>
-      <point x="1236" y="26"/>
-      <point x="1281" y="-16"/>
-      <point x="1350" y="-16" type="curve" smooth="yes"/>
-      <point x="1424" y="-16"/>
-      <point x="1471" y="31"/>
-      <point x="1471" y="105" type="curve" smooth="yes"/>
-      <point x="1471" y="182"/>
-      <point x="1422" y="233"/>
-      <point x="1348" y="233" type="curve" smooth="yes"/>
-      <point x="1296" y="233"/>
-      <point x="1266" y="222"/>
-      <point x="1152" y="162" type="curve" smooth="yes"/>
-      <point x="1076" y="122" type="line" smooth="yes"/>
-      <point x="993" y="78"/>
-      <point x="960" y="61"/>
-      <point x="912" y="61" type="curve" smooth="yes"/>
-      <point x="865" y="61"/>
-      <point x="837" y="88"/>
-      <point x="837" y="133" type="curve" smooth="yes"/>
-      <point x="837" y="183"/>
-      <point x="873" y="211"/>
-      <point x="967" y="211" type="curve" smooth="yes"/>
-      <point x="1217" y="211" type="line" smooth="yes"/>
-      <point x="1410" y="211"/>
-      <point x="1476" y="312"/>
-      <point x="1476" y="416" type="curve" smooth="yes"/>
-      <point x="1476" y="526"/>
-      <point x="1404" y="596"/>
-      <point x="1299" y="596" type="curve" smooth="yes"/>
-      <point x="1217" y="596"/>
-      <point x="1156" y="549"/>
-      <point x="1138" y="478" type="curve"/>
-      <point x="1133" y="478" type="line"/>
-      <point x="1111" y="549"/>
-      <point x="1038" y="596"/>
-      <point x="945" y="596" type="curve" smooth="yes"/>
-      <point x="911" y="596"/>
-      <point x="884" y="589"/>
-      <point x="863" y="578" type="curve"/>
-      <point x="895" y="578" type="line"/>
+      <point x="798" y="546" type="line"/>
+      <point x="803" y="524" type="line"/>
+      <point x="768" y="497"/>
+      <point x="748" y="460"/>
+      <point x="748" y="417" type="curve" smooth="yes"/>
+      <point x="748" y="339"/>
+      <point x="804" y="287"/>
+      <point x="890" y="287" type="curve" smooth="yes"/>
+      <point x="975" y="287"/>
+      <point x="1032" y="340"/>
+      <point x="1032" y="417" type="curve" smooth="yes"/>
+      <point x="1032" y="463"/>
+      <point x="1010" y="503"/>
+      <point x="973" y="530" type="curve"/>
+      <point x="984" y="560" type="line"/>
+      <point x="933" y="534" type="line"/>
+      <point x="940" y="535"/>
+      <point x="952" y="536"/>
+      <point x="964" y="536" type="curve" smooth="yes"/>
+      <point x="1061" y="536"/>
+      <point x="1104" y="484"/>
+      <point x="1104" y="382" type="curve" smooth="yes"/>
+      <point x="1104" y="324" type="line"/>
+      <point x="1188" y="324" type="line"/>
+      <point x="1188" y="380" type="line" smooth="yes"/>
+      <point x="1188" y="469"/>
+      <point x="1241" y="518"/>
+      <point x="1322" y="518" type="curve" smooth="yes"/>
+      <point x="1395" y="518"/>
+      <point x="1436" y="475"/>
+      <point x="1436" y="403" type="curve" smooth="yes"/>
+      <point x="1436" y="316"/>
+      <point x="1373" y="267"/>
+      <point x="1257" y="267" type="curve" smooth="yes"/>
+      <point x="932" y="267" type="line" smooth="yes"/>
+      <point x="829" y="267"/>
+      <point x="756" y="212"/>
+      <point x="756" y="122" type="curve" smooth="yes"/>
+      <point x="756" y="41"/>
+      <point x="822" y="-16"/>
+      <point x="912" y="-16" type="curve" smooth="yes"/>
+      <point x="962" y="-16"/>
+      <point x="997" y="-5"/>
+      <point x="1081" y="36" type="curve" smooth="yes"/>
+      <point x="1201" y="95" type="line"/>
+      <point x="1270" y="138" type="line"/>
+      <point x="1302" y="146" type="line"/>
+      <point x="1326" y="168"/>
+      <point x="1349" y="176"/>
+      <point x="1378" y="176" type="curve" smooth="yes"/>
+      <point x="1417" y="176"/>
+      <point x="1440" y="154"/>
+      <point x="1440" y="115" type="curve" smooth="yes"/>
+      <point x="1440" y="78"/>
+      <point x="1415" y="54"/>
+      <point x="1377" y="54" type="curve" smooth="yes"/>
+      <point x="1339" y="54"/>
+      <point x="1313" y="79"/>
+      <point x="1313" y="115" type="curve" smooth="yes"/>
+      <point x="1313" y="143"/>
+      <point x="1327" y="168"/>
+      <point x="1350" y="181" type="curve"/>
+      <point x="1243" y="145" type="line"/>
+      <point x="1262" y="128" type="line"/>
+      <point x="1258" y="116"/>
+      <point x="1257" y="106"/>
+      <point x="1257" y="94" type="curve" smooth="yes"/>
+      <point x="1257" y="32"/>
+      <point x="1308" y="-16"/>
+      <point x="1382" y="-16" type="curve" smooth="yes"/>
+      <point x="1463" y="-16"/>
+      <point x="1514" y="38"/>
+      <point x="1514" y="114" type="curve" smooth="yes"/>
+      <point x="1514" y="185"/>
+      <point x="1463" y="236"/>
+      <point x="1384" y="236" type="curve" smooth="yes"/>
+      <point x="1345" y="236"/>
+      <point x="1300" y="220"/>
+      <point x="1226" y="184" type="curve" smooth="yes"/>
+      <point x="1053" y="99" type="line" smooth="yes"/>
+      <point x="995" y="71"/>
+      <point x="958" y="60"/>
+      <point x="916" y="60" type="curve" smooth="yes"/>
+      <point x="869" y="60"/>
+      <point x="838" y="85"/>
+      <point x="838" y="125" type="curve" smooth="yes"/>
+      <point x="838" y="170"/>
+      <point x="873" y="195"/>
+      <point x="935" y="195" type="curve" smooth="yes"/>
+      <point x="1247" y="195" type="line" smooth="yes"/>
+      <point x="1412" y="195"/>
+      <point x="1518" y="277"/>
+      <point x="1518" y="405" type="curve" smooth="yes"/>
+      <point x="1518" y="521"/>
+      <point x="1448" y="596"/>
+      <point x="1335" y="596" type="curve" smooth="yes"/>
+      <point x="1246" y="596"/>
+      <point x="1182" y="552"/>
+      <point x="1150" y="478" type="curve"/>
+      <point x="1145" y="478" type="line"/>
+      <point x="1119" y="553"/>
+      <point x="1060" y="596"/>
+      <point x="965" y="596" type="curve" smooth="yes"/>
+      <point x="935" y="596"/>
+      <point x="891" y="589"/>
+      <point x="861" y="576" type="curve"/>
+      <point x="895" y="576" type="line"/>
       <point x="867" y="589"/>
-      <point x="831" y="596"/>
-      <point x="790" y="596" type="curve" smooth="yes"/>
-      <point x="685" y="596"/>
+      <point x="830" y="596"/>
+      <point x="791" y="596" type="curve" smooth="yes"/>
+      <point x="686" y="596"/>
       <point x="611" y="548"/>
       <point x="571" y="470" type="curve"/>
       <point x="566" y="470" type="line"/>
@@ -169,19 +169,19 @@
       <point x="133" y="-16"/>
     </contour>
     <contour>
-      <point x="890" y="379" type="curve" smooth="yes"/>
-      <point x="853" y="379"/>
-      <point x="824" y="399"/>
-      <point x="824" y="442" type="curve" smooth="yes"/>
+      <point x="890" y="357" type="curve" smooth="yes"/>
+      <point x="850" y="357"/>
+      <point x="824" y="386"/>
+      <point x="824" y="426" type="curve" smooth="yes"/>
       <point x="824" y="478"/>
-      <point x="850" y="526"/>
-      <point x="920" y="532" type="curve"/>
-      <point x="837" y="528" type="line"/>
-      <point x="915" y="527"/>
-      <point x="953" y="487"/>
-      <point x="953" y="440" type="curve" smooth="yes"/>
-      <point x="953" y="401"/>
-      <point x="931" y="379"/>
+      <point x="860" y="517"/>
+      <point x="923" y="534" type="curve"/>
+      <point x="858" y="534" type="line"/>
+      <point x="921" y="517"/>
+      <point x="956" y="479"/>
+      <point x="956" y="426" type="curve" smooth="yes"/>
+      <point x="956" y="386"/>
+      <point x="930" y="357"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/t_la-malayalam.glif
@@ -56,22 +56,6 @@
       <point x="294" y="-367"/>
     </contour>
     <contour>
-      <point x="376" y="-302" type="curve" smooth="yes"/>
-      <point x="318" y="-302"/>
-      <point x="291" y="-253"/>
-      <point x="291" y="-197" type="curve"/>
-      <point x="271" y="-205" type="line"/>
-      <point x="292" y="-262" type="line"/>
-      <point x="292" y="-218"/>
-      <point x="324" y="-178"/>
-      <point x="378" y="-178" type="curve" smooth="yes"/>
-      <point x="419" y="-178"/>
-      <point x="439" y="-203"/>
-      <point x="439" y="-238" type="curve" smooth="yes"/>
-      <point x="439" y="-276"/>
-      <point x="418" y="-302"/>
-    </contour>
-    <contour>
       <point x="164" y="-16" type="curve"/>
       <point x="224" y="35" type="line"/>
       <point x="158" y="108"/>
@@ -94,6 +78,22 @@
       <point x="81" y="72"/>
     </contour>
     <contour>
+      <point x="376" y="-302" type="curve" smooth="yes"/>
+      <point x="318" y="-302"/>
+      <point x="291" y="-253"/>
+      <point x="291" y="-197" type="curve"/>
+      <point x="271" y="-205" type="line"/>
+      <point x="292" y="-262" type="line"/>
+      <point x="292" y="-218"/>
+      <point x="324" y="-178"/>
+      <point x="378" y="-178" type="curve" smooth="yes"/>
+      <point x="419" y="-178"/>
+      <point x="439" y="-203"/>
+      <point x="439" y="-238" type="curve" smooth="yes"/>
+      <point x="439" y="-276"/>
+      <point x="418" y="-302"/>
+    </contour>
+    <contour>
       <point x="777" y="-297" type="curve" smooth="yes"/>
       <point x="722" y="-297"/>
       <point x="692" y="-261"/>
@@ -106,11 +106,11 @@
       <point x="652" y="43"/>
       <point x="687" y="129"/>
       <point x="687" y="241" type="curve" smooth="yes"/>
-      <point x="687" y="358"/>
-      <point x="631" y="472"/>
-      <point x="538" y="538" type="curve"/>
-      <point x="463" y="495" type="line"/>
-      <point x="556" y="450"/>
+      <point x="687" y="357"/>
+      <point x="632" y="470"/>
+      <point x="540" y="536" type="curve"/>
+      <point x="465" y="494" type="line"/>
+      <point x="557" y="449"/>
       <point x="601" y="348"/>
       <point x="601" y="241" type="curve" smooth="yes"/>
       <point x="601" y="129"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="572"/>
-  <anchor x="308" y="-209" name="bottom"/>
+  <anchor x="308" y="-235" name="bottom"/>
   <anchor x="283" y="580" name="top"/>
   <anchor x="434" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="288" y="-225" type="curve" smooth="yes"/>
-      <point x="449" y="-225"/>
-      <point x="538" y="-171"/>
-      <point x="538" y="-69" type="curve" smooth="yes"/>
-      <point x="538" y="-9"/>
-      <point x="500" y="29"/>
-      <point x="429" y="42" type="curve"/>
-      <point x="429" y="48" type="line"/>
-      <point x="478" y="66"/>
-      <point x="528" y="102"/>
-      <point x="528" y="190" type="curve" smooth="yes"/>
-      <point x="528" y="284"/>
-      <point x="469" y="340"/>
+      <point x="288" y="-251" type="curve" smooth="yes"/>
+      <point x="449" y="-251"/>
+      <point x="538" y="-190"/>
+      <point x="538" y="-86" type="curve" smooth="yes"/>
+      <point x="538" y="-17"/>
+      <point x="501" y="30"/>
+      <point x="431" y="47" type="curve"/>
+      <point x="431" y="53" type="line"/>
+      <point x="493" y="76"/>
+      <point x="528" y="123"/>
+      <point x="528" y="189" type="curve" smooth="yes"/>
+      <point x="528" y="289"/>
+      <point x="462" y="341"/>
       <point x="327" y="347" type="curve" smooth="yes"/>
       <point x="220" y="352" type="line" smooth="yes"/>
-      <point x="148" y="355"/>
-      <point x="110" y="385"/>
-      <point x="110" y="434" type="curve" smooth="yes"/>
-      <point x="110" y="490"/>
-      <point x="167" y="515"/>
-      <point x="271" y="515" type="curve" smooth="yes"/>
-      <point x="342" y="515"/>
-      <point x="402" y="502"/>
-      <point x="466" y="476" type="curve"/>
+      <point x="149" y="355"/>
+      <point x="110" y="383"/>
+      <point x="110" y="432" type="curve" smooth="yes"/>
+      <point x="110" y="488"/>
+      <point x="163" y="516"/>
+      <point x="271" y="516" type="curve" smooth="yes"/>
+      <point x="340" y="516"/>
+      <point x="400" y="504"/>
+      <point x="466" y="477" type="curve"/>
       <point x="498" y="550" type="line"/>
-      <point x="428" y="582"/>
-      <point x="357" y="596"/>
+      <point x="430" y="582"/>
+      <point x="359" y="596"/>
       <point x="271" y="596" type="curve" smooth="yes"/>
-      <point x="118" y="596"/>
-      <point x="25" y="534"/>
+      <point x="116" y="596"/>
+      <point x="25" y="532"/>
       <point x="25" y="423" type="curve" smooth="yes"/>
-      <point x="25" y="330"/>
-      <point x="94" y="272"/>
-      <point x="210" y="265" type="curve" smooth="yes"/>
+      <point x="25" y="328"/>
+      <point x="94" y="269"/>
+      <point x="210" y="264" type="curve" smooth="yes"/>
       <point x="317" y="259" type="line" smooth="yes"/>
-      <point x="405" y="254"/>
-      <point x="446" y="224"/>
-      <point x="446" y="176" type="curve" smooth="yes"/>
-      <point x="446" y="112"/>
-      <point x="392" y="80"/>
-      <point x="282" y="80" type="curve" smooth="yes"/>
-      <point x="69" y="80" type="line"/>
-      <point x="69" y="6" type="line"/>
-      <point x="292" y="6" type="line" smooth="yes"/>
-      <point x="418" y="6"/>
-      <point x="456" y="-17"/>
-      <point x="456" y="-68" type="curve" smooth="yes"/>
-      <point x="456" y="-126"/>
-      <point x="396" y="-147"/>
-      <point x="288" y="-147" type="curve" smooth="yes"/>
-      <point x="195" y="-147"/>
-      <point x="119" y="-125"/>
-      <point x="69" y="-98" type="curve"/>
-      <point x="35" y="-166" type="line"/>
-      <point x="86" y="-198"/>
-      <point x="179" y="-225"/>
+      <point x="400" y="255"/>
+      <point x="443" y="226"/>
+      <point x="443" y="175" type="curve" smooth="yes"/>
+      <point x="443" y="118"/>
+      <point x="389" y="86"/>
+      <point x="293" y="86" type="curve" smooth="yes"/>
+      <point x="69" y="86" type="line"/>
+      <point x="69" y="12" type="line"/>
+      <point x="314" y="12" type="line" smooth="yes"/>
+      <point x="410" y="12"/>
+      <point x="453" y="-16"/>
+      <point x="453" y="-78" type="curve" smooth="yes"/>
+      <point x="453" y="-140"/>
+      <point x="399" y="-171"/>
+      <point x="288" y="-171" type="curve" smooth="yes"/>
+      <point x="210" y="-171"/>
+      <point x="135" y="-147"/>
+      <point x="79" y="-104" type="curve"/>
+      <point x="33" y="-169" type="line"/>
+      <point x="101" y="-222"/>
+      <point x="192" y="-251"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/tta-malayalam.glif
@@ -8,45 +8,45 @@
   <outline>
     <contour>
       <point x="305" y="-16" type="curve" smooth="yes"/>
-      <point x="451" y="-16"/>
-      <point x="540" y="54"/>
-      <point x="540" y="165" type="curve" smooth="yes"/>
-      <point x="540" y="263"/>
-      <point x="471" y="328"/>
+      <point x="452" y="-16"/>
+      <point x="540" y="50"/>
+      <point x="540" y="162" type="curve" smooth="yes"/>
+      <point x="540" y="267"/>
+      <point x="469" y="328"/>
       <point x="339" y="334" type="curve" smooth="yes"/>
       <point x="232" y="339" type="line" smooth="yes"/>
       <point x="160" y="342"/>
       <point x="122" y="371"/>
-      <point x="122" y="421" type="curve" smooth="yes"/>
-      <point x="122" y="483"/>
-      <point x="179" y="515"/>
-      <point x="283" y="515" type="curve" smooth="yes"/>
-      <point x="354" y="515"/>
-      <point x="414" y="502"/>
-      <point x="478" y="476" type="curve"/>
+      <point x="122" y="422" type="curve" smooth="yes"/>
+      <point x="122" y="484"/>
+      <point x="179" y="516"/>
+      <point x="291" y="516" type="curve" smooth="yes"/>
+      <point x="357" y="516"/>
+      <point x="415" y="504"/>
+      <point x="478" y="477" type="curve"/>
       <point x="510" y="550" type="line"/>
-      <point x="440" y="582"/>
-      <point x="369" y="596"/>
-      <point x="283" y="596" type="curve" smooth="yes"/>
-      <point x="130" y="596"/>
-      <point x="37" y="527"/>
-      <point x="37" y="414" type="curve" smooth="yes"/>
-      <point x="37" y="320"/>
-      <point x="106" y="257"/>
-      <point x="222" y="250" type="curve" smooth="yes"/>
+      <point x="443" y="582"/>
+      <point x="375" y="596"/>
+      <point x="291" y="596" type="curve" smooth="yes"/>
+      <point x="133" y="596"/>
+      <point x="37" y="529"/>
+      <point x="37" y="416" type="curve" smooth="yes"/>
+      <point x="37" y="318"/>
+      <point x="110" y="254"/>
+      <point x="222" y="249" type="curve" smooth="yes"/>
       <point x="329" y="244" type="line" smooth="yes"/>
-      <point x="417" y="239"/>
-      <point x="457" y="210"/>
-      <point x="457" y="158" type="curve" smooth="yes"/>
-      <point x="457" y="98"/>
-      <point x="403" y="65"/>
-      <point x="305" y="65" type="curve" smooth="yes"/>
-      <point x="223" y="65"/>
-      <point x="146" y="89"/>
-      <point x="71" y="135" type="curve"/>
-      <point x="25" y="59" type="line"/>
-      <point x="110" y="9"/>
-      <point x="201" y="-16"/>
+      <point x="415" y="240"/>
+      <point x="455" y="211"/>
+      <point x="455" y="156" type="curve" smooth="yes"/>
+      <point x="455" y="97"/>
+      <point x="402" y="64"/>
+      <point x="305" y="64" type="curve" smooth="yes"/>
+      <point x="215" y="64"/>
+      <point x="140" y="86"/>
+      <point x="67" y="133" type="curve"/>
+      <point x="25" y="65" type="line"/>
+      <point x="112" y="9"/>
+      <point x="198" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/uuM_atra-malayalam.glif
@@ -36,33 +36,39 @@
     </contour>
     <contour>
       <point x="126" y="-185" type="curve" smooth="yes"/>
-      <point x="74" y="-185"/>
-      <point x="38" y="-151"/>
-      <point x="38" y="-100" type="curve" smooth="yes"/>
-      <point x="38" y="-49"/>
-      <point x="73" y="-15"/>
-      <point x="126" y="-15" type="curve" smooth="yes"/>
-      <point x="178" y="-15"/>
-      <point x="214" y="-49"/>
-      <point x="214" y="-100" type="curve" smooth="yes"/>
-      <point x="214" y="-151"/>
-      <point x="178" y="-185"/>
+      <point x="70" y="-185"/>
+      <point x="34" y="-151"/>
+      <point x="34" y="-103" type="curve" smooth="yes"/>
+      <point x="34" y="-85"/>
+      <point x="37" y="-72"/>
+      <point x="42" y="-60" type="curve"/>
+      <point x="46" y="-60" type="line"/>
+      <point x="55" y="-103"/>
+      <point x="84" y="-127"/>
+      <point x="126" y="-127" type="curve" smooth="yes"/>
+      <point x="168" y="-127"/>
+      <point x="197" y="-103"/>
+      <point x="206" y="-60" type="curve"/>
+      <point x="210" y="-60" type="line"/>
+      <point x="215" y="-72"/>
+      <point x="218" y="-85"/>
+      <point x="218" y="-103" type="curve" smooth="yes"/>
+      <point x="218" y="-151"/>
+      <point x="182" y="-185"/>
     </contour>
     <contour>
-      <point x="125" y="-119" type="curve" smooth="yes"/>
-      <point x="171" y="-119"/>
-      <point x="208" y="-106"/>
-      <point x="239" y="-78" type="curve"/>
-      <point x="216" y="-38" type="line"/>
-      <point x="192" y="-60"/>
-      <point x="164" y="-70"/>
-      <point x="125" y="-70" type="curve" smooth="yes"/>
-      <point x="86" y="-70"/>
-      <point x="57" y="-60"/>
-      <point x="34" y="-38" type="curve"/>
-      <point x="11" y="-78" type="line"/>
-      <point x="42" y="-106"/>
-      <point x="79" y="-119"/>
+      <point x="126" y="-63" type="curve" smooth="yes"/>
+      <point x="86" y="-63"/>
+      <point x="63" y="-48"/>
+      <point x="63" y="-29" type="curve" smooth="yes"/>
+      <point x="63" y="-12"/>
+      <point x="86" y="0"/>
+      <point x="126" y="0" type="curve" smooth="yes"/>
+      <point x="166" y="0"/>
+      <point x="189" y="-12"/>
+      <point x="189" y="-29" type="curve" smooth="yes"/>
+      <point x="189" y="-48"/>
+      <point x="166" y="-63"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/v_va-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/v_va-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="v_va-malayalam" format="2">
   <advance width="1029"/>
   <anchor x="699" y="-281" name="bottom"/>
-  <anchor x="932" y="0" name="bottomright"/>
   <anchor x="548" y="580" name="top"/>
   <anchor x="912" y="580" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/y_ya-malayalam.glif
@@ -1,97 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="984"/>
-  <anchor x="622" y="-281" name="bottom"/>
-  <anchor x="855" y="0" name="bottomright"/>
+  <anchor x="622" y="-268" name="bottom"/>
   <anchor x="505" y="580" name="top"/>
   <anchor x="811" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="305" y="-291" type="line"/>
-      <point x="875" y="-291" type="line"/>
+      <point x="305" y="-278" type="line"/>
+      <point x="875" y="-278" type="line"/>
       <point x="875" y="121" type="line"/>
-      <point x="863" y="66" type="line"/>
-      <point x="915" y="122"/>
-      <point x="942" y="204"/>
-      <point x="942" y="300" type="curve" smooth="yes"/>
-      <point x="942" y="399"/>
-      <point x="904" y="510"/>
-      <point x="831" y="596" type="curve"/>
-      <point x="763" y="548" type="line"/>
-      <point x="817" y="480"/>
-      <point x="860" y="398"/>
-      <point x="860" y="302" type="curve" smooth="yes"/>
-      <point x="860" y="161"/>
-      <point x="796" y="62"/>
-      <point x="655" y="62" type="curve" smooth="yes"/>
-      <point x="486" y="62"/>
-      <point x="405" y="195"/>
-      <point x="405" y="362" type="curve" smooth="yes"/>
-      <point x="405" y="459"/>
-      <point x="442" y="518"/>
-      <point x="506" y="518" type="curve" smooth="yes"/>
-      <point x="567" y="518"/>
-      <point x="604" y="459"/>
-      <point x="604" y="362" type="curve" smooth="yes"/>
-      <point x="604" y="244"/>
-      <point x="565" y="154"/>
-      <point x="494" y="104" type="curve"/>
+      <point x="857" y="71" type="line"/>
+      <point x="912" y="126"/>
+      <point x="942" y="206"/>
+      <point x="942" y="303" type="curve" smooth="yes"/>
+      <point x="942" y="405"/>
+      <point x="900" y="514"/>
+      <point x="828" y="596" type="curve"/>
+      <point x="765" y="547" type="line"/>
+      <point x="830" y="473"/>
+      <point x="862" y="390"/>
+      <point x="862" y="299" type="curve" smooth="yes"/>
+      <point x="862" y="151"/>
+      <point x="778" y="62"/>
+      <point x="648" y="62" type="curve" smooth="yes"/>
+      <point x="462" y="62"/>
+      <point x="373" y="190"/>
+      <point x="373" y="338" type="curve" smooth="yes"/>
+      <point x="373" y="453"/>
+      <point x="426" y="518"/>
+      <point x="508" y="518" type="curve" smooth="yes"/>
+      <point x="585" y="518"/>
+      <point x="628" y="453"/>
+      <point x="628" y="346" type="curve" smooth="yes"/>
+      <point x="628" y="233"/>
+      <point x="577" y="146"/>
+      <point x="492" y="95" type="curve"/>
       <point x="547" y="50" type="line"/>
-      <point x="638" y="121"/>
-      <point x="686" y="240"/>
-      <point x="686" y="367" type="curve" smooth="yes"/>
-      <point x="686" y="500"/>
-      <point x="621" y="596"/>
-      <point x="504" y="596" type="curve" smooth="yes"/>
-      <point x="385" y="596"/>
-      <point x="323" y="497"/>
-      <point x="323" y="370" type="curve" smooth="yes"/>
-      <point x="323" y="181"/>
-      <point x="444" y="-13"/>
-      <point x="663" y="-13" type="curve" smooth="yes"/>
-      <point x="680" y="-13"/>
-      <point x="698" y="-12"/>
-      <point x="717" y="-9" type="curve"/>
-      <point x="652" y="29" type="line"/>
-      <point x="652" y="-18" type="line"/>
-      <point x="565" y="-70" type="line"/>
-      <point x="305" y="-235" type="line"/>
+      <point x="649" y="110"/>
+      <point x="710" y="224"/>
+      <point x="710" y="352" type="curve" smooth="yes"/>
+      <point x="710" y="500"/>
+      <point x="632" y="596"/>
+      <point x="508" y="596" type="curve" smooth="yes"/>
+      <point x="374" y="596"/>
+      <point x="291" y="479"/>
+      <point x="291" y="334" type="curve" smooth="yes"/>
+      <point x="291" y="143"/>
+      <point x="448" y="-12"/>
+      <point x="650" y="-12" type="curve" smooth="yes"/>
+      <point x="674" y="-12"/>
+      <point x="697" y="-10"/>
+      <point x="719" y="-5" type="curve"/>
+      <point x="629" y="33" type="line"/>
+      <point x="629" y="-14" type="line"/>
+      <point x="551" y="-58" type="line"/>
+      <point x="305" y="-222" type="line"/>
     </contour>
     <contour>
-      <point x="401" y="-258" type="line"/>
-      <point x="807" y="13" type="line"/>
-      <point x="793" y="13" type="line"/>
-      <point x="793" y="-244" type="line"/>
-      <point x="831" y="-226" type="line"/>
-      <point x="401" y="-226" type="line"/>
+      <point x="401" y="-243" type="line"/>
+      <point x="807" y="26" type="line"/>
+      <point x="793" y="26" type="line"/>
+      <point x="793" y="-231" type="line"/>
+      <point x="831" y="-213" type="line"/>
+      <point x="401" y="-213" type="line"/>
     </contour>
     <contour>
-      <point x="348" y="-16" type="curve" smooth="yes"/>
-      <point x="418" y="-16"/>
-      <point x="474" y="2"/>
-      <point x="522" y="32" type="curve"/>
-      <point x="460" y="84" type="line"/>
-      <point x="431" y="71"/>
+      <point x="349" y="-16" type="curve" smooth="yes"/>
+      <point x="414" y="-16"/>
+      <point x="467" y="0"/>
+      <point x="519" y="35" type="curve"/>
+      <point x="461" y="83" type="line"/>
+      <point x="430" y="69"/>
       <point x="396" y="62"/>
-      <point x="352" y="62" type="curve" smooth="yes"/>
-      <point x="215" y="62"/>
-      <point x="124" y="167"/>
-      <point x="124" y="323" type="curve" smooth="yes"/>
-      <point x="124" y="430"/>
+      <point x="353" y="62" type="curve" smooth="yes"/>
+      <point x="212" y="62"/>
+      <point x="122" y="167"/>
+      <point x="122" y="323" type="curve" smooth="yes"/>
+      <point x="122" y="430"/>
       <point x="176" y="518"/>
-      <point x="274" y="518" type="curve" smooth="yes"/>
-      <point x="320" y="518"/>
-      <point x="349" y="502"/>
-      <point x="371" y="478" type="curve"/>
-      <point x="413" y="532" type="line"/>
-      <point x="378" y="575"/>
-      <point x="334" y="596"/>
-      <point x="271" y="596" type="curve" smooth="yes"/>
-      <point x="131" y="596"/>
-      <point x="42" y="478"/>
-      <point x="42" y="323" type="curve" smooth="yes"/>
-      <point x="42" y="125"/>
-      <point x="168" y="-16"/>
+      <point x="278" y="518" type="curve" smooth="yes"/>
+      <point x="319" y="518"/>
+      <point x="350" y="506"/>
+      <point x="375" y="479" type="curve"/>
+      <point x="427" y="537" type="line"/>
+      <point x="386" y="578"/>
+      <point x="342" y="596"/>
+      <point x="282" y="596" type="curve" smooth="yes"/>
+      <point x="135" y="596"/>
+      <point x="42" y="476"/>
+      <point x="42" y="321" type="curve" smooth="yes"/>
+      <point x="42" y="126"/>
+      <point x="170" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ya-malayalam.glif
@@ -8,72 +8,72 @@
   <anchor x="811" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="658" y="-16" type="curve" smooth="yes"/>
-      <point x="843" y="-16"/>
-      <point x="942" y="117"/>
-      <point x="942" y="300" type="curve" smooth="yes"/>
-      <point x="942" y="399"/>
-      <point x="904" y="510"/>
-      <point x="831" y="596" type="curve"/>
-      <point x="763" y="548" type="line"/>
-      <point x="817" y="480"/>
-      <point x="860" y="398"/>
-      <point x="860" y="302" type="curve" smooth="yes"/>
-      <point x="860" y="161"/>
-      <point x="796" y="62"/>
-      <point x="655" y="62" type="curve" smooth="yes"/>
-      <point x="486" y="62"/>
-      <point x="405" y="195"/>
-      <point x="405" y="362" type="curve" smooth="yes"/>
-      <point x="405" y="459"/>
-      <point x="442" y="518"/>
-      <point x="506" y="518" type="curve" smooth="yes"/>
-      <point x="567" y="518"/>
-      <point x="604" y="459"/>
-      <point x="604" y="362" type="curve" smooth="yes"/>
-      <point x="604" y="244"/>
-      <point x="565" y="154"/>
-      <point x="494" y="104" type="curve"/>
+      <point x="650" y="-16" type="curve" smooth="yes"/>
+      <point x="824" y="-16"/>
+      <point x="942" y="108"/>
+      <point x="942" y="303" type="curve" smooth="yes"/>
+      <point x="942" y="405"/>
+      <point x="900" y="514"/>
+      <point x="828" y="596" type="curve"/>
+      <point x="765" y="547" type="line"/>
+      <point x="830" y="473"/>
+      <point x="862" y="390"/>
+      <point x="862" y="299" type="curve" smooth="yes"/>
+      <point x="862" y="151"/>
+      <point x="778" y="62"/>
+      <point x="648" y="62" type="curve" smooth="yes"/>
+      <point x="462" y="62"/>
+      <point x="373" y="190"/>
+      <point x="373" y="338" type="curve" smooth="yes"/>
+      <point x="373" y="453"/>
+      <point x="426" y="518"/>
+      <point x="508" y="518" type="curve" smooth="yes"/>
+      <point x="585" y="518"/>
+      <point x="628" y="453"/>
+      <point x="628" y="346" type="curve" smooth="yes"/>
+      <point x="628" y="233"/>
+      <point x="577" y="146"/>
+      <point x="492" y="95" type="curve"/>
       <point x="547" y="50" type="line"/>
-      <point x="638" y="121"/>
-      <point x="686" y="240"/>
-      <point x="686" y="367" type="curve" smooth="yes"/>
-      <point x="686" y="500"/>
-      <point x="621" y="596"/>
-      <point x="504" y="596" type="curve" smooth="yes"/>
-      <point x="385" y="596"/>
-      <point x="323" y="497"/>
-      <point x="323" y="370" type="curve" smooth="yes"/>
-      <point x="323" y="179"/>
-      <point x="446" y="-16"/>
+      <point x="649" y="110"/>
+      <point x="710" y="224"/>
+      <point x="710" y="352" type="curve" smooth="yes"/>
+      <point x="710" y="500"/>
+      <point x="632" y="596"/>
+      <point x="508" y="596" type="curve" smooth="yes"/>
+      <point x="374" y="596"/>
+      <point x="291" y="479"/>
+      <point x="291" y="334" type="curve" smooth="yes"/>
+      <point x="291" y="141"/>
+      <point x="448" y="-16"/>
     </contour>
     <contour>
-      <point x="348" y="-16" type="curve" smooth="yes"/>
-      <point x="418" y="-16"/>
-      <point x="474" y="2"/>
-      <point x="522" y="32" type="curve"/>
-      <point x="460" y="84" type="line"/>
-      <point x="431" y="71"/>
+      <point x="349" y="-16" type="curve" smooth="yes"/>
+      <point x="414" y="-16"/>
+      <point x="467" y="0"/>
+      <point x="519" y="35" type="curve"/>
+      <point x="461" y="83" type="line"/>
+      <point x="430" y="69"/>
       <point x="396" y="62"/>
-      <point x="352" y="62" type="curve" smooth="yes"/>
-      <point x="215" y="62"/>
-      <point x="124" y="167"/>
-      <point x="124" y="323" type="curve" smooth="yes"/>
-      <point x="124" y="430"/>
+      <point x="353" y="62" type="curve" smooth="yes"/>
+      <point x="212" y="62"/>
+      <point x="122" y="167"/>
+      <point x="122" y="323" type="curve" smooth="yes"/>
+      <point x="122" y="430"/>
       <point x="176" y="518"/>
-      <point x="274" y="518" type="curve" smooth="yes"/>
-      <point x="320" y="518"/>
-      <point x="349" y="502"/>
-      <point x="371" y="478" type="curve"/>
-      <point x="413" y="532" type="line"/>
-      <point x="378" y="575"/>
-      <point x="334" y="596"/>
-      <point x="271" y="596" type="curve" smooth="yes"/>
-      <point x="131" y="596"/>
-      <point x="42" y="478"/>
-      <point x="42" y="323" type="curve" smooth="yes"/>
-      <point x="42" y="125"/>
-      <point x="168" y="-16"/>
+      <point x="278" y="518" type="curve" smooth="yes"/>
+      <point x="319" y="518"/>
+      <point x="350" y="506"/>
+      <point x="375" y="479" type="curve"/>
+      <point x="427" y="537" type="line"/>
+      <point x="386" y="578"/>
+      <point x="342" y="596"/>
+      <point x="282" y="596" type="curve" smooth="yes"/>
+      <point x="135" y="596"/>
+      <point x="42" y="476"/>
+      <point x="42" y="321" type="curve" smooth="yes"/>
+      <point x="42" y="126"/>
+      <point x="170" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/kerning.plist
@@ -45714,7 +45714,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -45828,7 +45828,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -45884,7 +45884,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -45939,7 +45939,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>200</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -45986,7 +45986,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -46021,7 +46021,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>110</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -46049,8 +46049,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46085,7 +46083,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46152,7 +46150,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46212,7 +46210,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>130</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46263,7 +46261,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>170</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46321,7 +46319,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46364,7 +46362,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -46502,8 +46500,6 @@
       <integer>-10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46589,7 +46585,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -46689,8 +46685,6 @@
       <integer>60</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -46723,7 +46717,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -46803,7 +46797,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46845,8 +46839,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla-malayalam_L</key>
       <integer>-30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -46964,8 +46956,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -47079,7 +47069,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47128,7 +47118,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>200</integer>
+      <integer>190</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47178,17 +47168,17 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>70</integer>
-      <key>public.kern2.MAL_braceright.loclMALM_R</key>
       <integer>50</integer>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>40</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
       <integer>40</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
@@ -47198,23 +47188,25 @@
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
       <integer>40</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
-      <integer>-30</integer>
+      <integer>-20</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>70</integer>
+      <key>public.kern2.MAL_tt_tta-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
-      <integer>130</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
-      <integer>90</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_uMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>74</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>220</integer>
+      <integer>210</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
       <integer>170</integer>
     </dict>
@@ -47241,7 +47233,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47290,7 +47282,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>160</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47366,7 +47358,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47577,7 +47569,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47603,8 +47595,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47633,7 +47623,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47687,7 +47677,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -47719,8 +47709,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -47837,7 +47825,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_p_pa-malayalam_L</key>
@@ -47949,7 +47937,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47994,7 +47982,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48090,7 +48078,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48230,7 +48218,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48283,7 +48271,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48350,7 +48338,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48403,7 +48391,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>290</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>240</integer>
+      <integer>220</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -48490,7 +48478,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>130</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48639,7 +48627,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48747,7 +48735,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_ng_ka-malayalam_L</key>
@@ -48799,6 +48787,26 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-40</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>110</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>100</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+      <key>public.kern2.MAL_quoteright.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.ODI_a-oriya-L</key>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/c_cha-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/c_cha-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="c_cha-malayalam" format="2">
   <advance width="925"/>
   <anchor x="499" y="-346" name="bottom"/>
-  <anchor x="830" y="0" name="bottomright"/>
   <anchor x="438" y="597" name="top"/>
   <anchor x="795" y="597" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/d_da-malayalam.glif
@@ -1,16 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
   <advance width="704"/>
-  <anchor x="413" y="-213" name="bottom"/>
+  <anchor x="408" y="-249" name="bottom"/>
   <anchor x="380" y="597" name="top"/>
   <outline>
     <contour>
-      <point x="453" y="-229" type="curve" smooth="yes"/>
-      <point x="592" y="-229"/>
-      <point x="671" y="-173"/>
-      <point x="671" y="-76" type="curve" smooth="yes"/>
-      <point x="671" y="-5"/>
-      <point x="626" y="37"/>
+      <point x="423" y="-263" type="curve" smooth="yes"/>
+      <point x="579" y="-263"/>
+      <point x="671" y="-199"/>
+      <point x="671" y="-92" type="curve" smooth="yes"/>
+      <point x="671" y="-19"/>
+      <point x="624" y="35"/>
       <point x="547" y="51" type="curve"/>
       <point x="547" y="58" type="line"/>
       <point x="617" y="73"/>
@@ -54,21 +54,21 @@
       <point x="540" y="127"/>
       <point x="498" y="101"/>
       <point x="427" y="101" type="curve" smooth="yes"/>
-      <point x="370" y="101" type="line"/>
-      <point x="370" y="-4" type="line"/>
-      <point x="451" y="-4" type="line" smooth="yes"/>
-      <point x="519" y="-4"/>
-      <point x="550" y="-21"/>
-      <point x="550" y="-57" type="curve" smooth="yes"/>
-      <point x="550" y="-97"/>
-      <point x="516" y="-116"/>
-      <point x="449" y="-116" type="curve" smooth="yes"/>
-      <point x="399" y="-116"/>
-      <point x="367" y="-109"/>
-      <point x="333" y="-97" type="curve"/>
-      <point x="293" y="-200" type="line"/>
-      <point x="332" y="-217"/>
-      <point x="389" y="-229"/>
+      <point x="350" y="101" type="line"/>
+      <point x="350" y="-4" type="line"/>
+      <point x="449" y="-4" type="line" smooth="yes"/>
+      <point x="515" y="-4"/>
+      <point x="550" y="-30"/>
+      <point x="550" y="-75" type="curve" smooth="yes"/>
+      <point x="550" y="-125"/>
+      <point x="502" y="-152"/>
+      <point x="419" y="-152" type="curve" smooth="yes"/>
+      <point x="362" y="-152"/>
+      <point x="315" y="-141"/>
+      <point x="265" y="-116" type="curve"/>
+      <point x="218" y="-215" type="line"/>
+      <point x="283" y="-248"/>
+      <point x="349" y="-263"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="1002"/>
-  <anchor x="681" y="0" name="bottom"/>
+  <advance width="994"/>
+  <anchor x="673" y="0" name="bottom"/>
   <anchor x="497" y="597" name="top"/>
-  <anchor x="861" y="597" name="topright"/>
+  <anchor x="853" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="293" y="-16" type="curve" smooth="yes"/>
-      <point x="436" y="-16"/>
-      <point x="514" y="71"/>
-      <point x="530" y="235" type="curve" smooth="yes"/>
-      <point x="541" y="339" type="line" smooth="yes"/>
-      <point x="551" y="442"/>
-      <point x="602" y="502"/>
-      <point x="705" y="502" type="curve" smooth="yes"/>
-      <point x="782" y="502"/>
-      <point x="827" y="473"/>
-      <point x="827" y="419" type="curve" smooth="yes"/>
-      <point x="827" y="373"/>
-      <point x="789" y="347"/>
-      <point x="729" y="347" type="curve" smooth="yes"/>
-      <point x="678" y="347" type="line"/>
-      <point x="678" y="242" type="line"/>
-      <point x="729" y="242" type="line" smooth="yes"/>
-      <point x="801" y="242"/>
-      <point x="848" y="221"/>
-      <point x="848" y="167" type="curve" smooth="yes"/>
-      <point x="848" y="119"/>
-      <point x="813" y="97"/>
-      <point x="753" y="97" type="curve" smooth="yes"/>
-      <point x="719" y="97"/>
-      <point x="690" y="104"/>
-      <point x="658" y="117" type="curve"/>
-      <point x="609" y="13" type="line"/>
-      <point x="648" y="-6"/>
-      <point x="700" y="-16"/>
-      <point x="757" y="-16" type="curve" smooth="yes"/>
-      <point x="885" y="-16"/>
-      <point x="969" y="51"/>
-      <point x="969" y="154" type="curve" smooth="yes"/>
-      <point x="969" y="230"/>
-      <point x="923" y="281"/>
-      <point x="834" y="297" type="curve"/>
-      <point x="834" y="305" type="line"/>
-      <point x="905" y="321"/>
-      <point x="948" y="367"/>
-      <point x="948" y="438" type="curve" smooth="yes"/>
-      <point x="948" y="541"/>
-      <point x="865" y="613"/>
-      <point x="701" y="613" type="curve" smooth="yes"/>
-      <point x="526" y="613"/>
-      <point x="435" y="518"/>
-      <point x="417" y="350" type="curve" smooth="yes"/>
-      <point x="407" y="254" type="line" smooth="yes"/>
-      <point x="397" y="150"/>
-      <point x="358" y="97"/>
-      <point x="284" y="97" type="curve" smooth="yes"/>
-      <point x="204" y="97"/>
-      <point x="156" y="158"/>
-      <point x="156" y="265" type="curve" smooth="yes"/>
-      <point x="156" y="367"/>
-      <point x="199" y="456"/>
-      <point x="273" y="548" type="curve"/>
-      <point x="186" y="613" type="line"/>
-      <point x="85" y="505"/>
-      <point x="39" y="388"/>
-      <point x="39" y="265" type="curve" smooth="yes"/>
-      <point x="39" y="98"/>
-      <point x="141" y="-16"/>
+      <point x="298" y="-16" type="curve" smooth="yes"/>
+      <point x="445" y="-16"/>
+      <point x="539" y="78"/>
+      <point x="539" y="224" type="curve" smooth="yes"/>
+      <point x="539" y="263"/>
+      <point x="533" y="300"/>
+      <point x="533" y="339" type="curve" smooth="yes"/>
+      <point x="533" y="444"/>
+      <point x="595" y="502"/>
+      <point x="704" y="502" type="curve" smooth="yes"/>
+      <point x="777" y="502"/>
+      <point x="819" y="475"/>
+      <point x="819" y="424" type="curve" smooth="yes"/>
+      <point x="819" y="375"/>
+      <point x="784" y="347"/>
+      <point x="725" y="347" type="curve" smooth="yes"/>
+      <point x="670" y="347" type="line"/>
+      <point x="670" y="242" type="line"/>
+      <point x="721" y="242" type="line" smooth="yes"/>
+      <point x="793" y="242"/>
+      <point x="840" y="221"/>
+      <point x="840" y="167" type="curve" smooth="yes"/>
+      <point x="840" y="119"/>
+      <point x="805" y="97"/>
+      <point x="745" y="97" type="curve" smooth="yes"/>
+      <point x="711" y="97"/>
+      <point x="682" y="104"/>
+      <point x="650" y="117" type="curve"/>
+      <point x="601" y="13" type="line"/>
+      <point x="640" y="-6"/>
+      <point x="692" y="-16"/>
+      <point x="749" y="-16" type="curve" smooth="yes"/>
+      <point x="877" y="-16"/>
+      <point x="961" y="51"/>
+      <point x="961" y="154" type="curve" smooth="yes"/>
+      <point x="961" y="230"/>
+      <point x="915" y="281"/>
+      <point x="826" y="297" type="curve"/>
+      <point x="826" y="305" type="line"/>
+      <point x="897" y="322"/>
+      <point x="940" y="373"/>
+      <point x="940" y="447" type="curve" smooth="yes"/>
+      <point x="940" y="545"/>
+      <point x="862" y="613"/>
+      <point x="706" y="613" type="curve" smooth="yes"/>
+      <point x="530" y="613"/>
+      <point x="411" y="519"/>
+      <point x="411" y="352" type="curve" smooth="yes"/>
+      <point x="411" y="313"/>
+      <point x="417" y="276"/>
+      <point x="417" y="237" type="curve" smooth="yes"/>
+      <point x="417" y="145"/>
+      <point x="375" y="98"/>
+      <point x="293" y="98" type="curve" smooth="yes"/>
+      <point x="207" y="98"/>
+      <point x="161" y="154"/>
+      <point x="161" y="259" type="curve" smooth="yes"/>
+      <point x="161" y="361"/>
+      <point x="204" y="449"/>
+      <point x="282" y="535" type="curve"/>
+      <point x="191" y="613" type="line"/>
+      <point x="87" y="504"/>
+      <point x="39" y="382"/>
+      <point x="39" y="255" type="curve" smooth="yes"/>
+      <point x="39" y="94"/>
+      <point x="143" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/g_ga-malayalam.glif
@@ -1,97 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ga-malayalam" format="2">
-  <advance width="949"/>
+  <advance width="950"/>
   <anchor x="559" y="-352" name="bottom"/>
   <anchor x="482" y="597" name="top"/>
   <anchor x="776" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="404" y="-368" type="curve" smooth="yes"/>
-      <point x="515" y="-368"/>
-      <point x="577" y="-310"/>
-      <point x="584" y="-187" type="curve" smooth="yes"/>
-      <point x="587" y="-145" type="line" smooth="yes"/>
-      <point x="592" y="-70"/>
-      <point x="617" y="-37"/>
-      <point x="673" y="-37" type="curve" smooth="yes"/>
-      <point x="731" y="-37"/>
-      <point x="765" y="-78"/>
-      <point x="765" y="-147" type="curve" smooth="yes"/>
-      <point x="765" y="-216"/>
-      <point x="734" y="-272"/>
-      <point x="699" y="-312" type="curve"/>
-      <point x="773" y="-368" type="line"/>
-      <point x="830" y="-307"/>
-      <point x="863" y="-232"/>
-      <point x="863" y="-147" type="curve" smooth="yes"/>
-      <point x="863" y="-22"/>
-      <point x="792" y="53"/>
-      <point x="669" y="53" type="curve" smooth="yes"/>
-      <point x="559" y="53"/>
-      <point x="501" y="-5"/>
-      <point x="493" y="-135" type="curve" smooth="yes"/>
-      <point x="490" y="-171" type="line" smooth="yes"/>
-      <point x="486" y="-247"/>
-      <point x="456" y="-278"/>
-      <point x="407" y="-278" type="curve" smooth="yes"/>
-      <point x="351" y="-278"/>
-      <point x="316" y="-236"/>
-      <point x="316" y="-161" type="curve" smooth="yes"/>
-      <point x="316" y="-97"/>
-      <point x="338" y="-42"/>
-      <point x="382" y="6" type="curve"/>
-      <point x="359" y="-8" type="line"/>
-      <point x="460" y="17"/>
-      <point x="518" y="101"/>
-      <point x="530" y="235" type="curve" smooth="yes"/>
-      <point x="540" y="339" type="line" smooth="yes"/>
-      <point x="550" y="440"/>
-      <point x="594" y="500"/>
-      <point x="671" y="500" type="curve" smooth="yes"/>
-      <point x="749" y="500"/>
-      <point x="788" y="439"/>
-      <point x="788" y="333" type="curve" smooth="yes"/>
-      <point x="788" y="219"/>
-      <point x="752" y="116"/>
-      <point x="661" y="22" type="curve"/>
-      <point x="776" y="-16" type="line"/>
-      <point x="866" y="88"/>
-      <point x="910" y="200"/>
-      <point x="910" y="333" type="curve" smooth="yes"/>
-      <point x="910" y="501"/>
-      <point x="816" y="613"/>
-      <point x="664" y="613" type="curve" smooth="yes"/>
-      <point x="516" y="613"/>
-      <point x="434" y="523"/>
-      <point x="417" y="352" type="curve" smooth="yes"/>
-      <point x="407" y="254" type="line" smooth="yes"/>
-      <point x="397" y="149"/>
-      <point x="360" y="97"/>
-      <point x="286" y="97" type="curve" smooth="yes"/>
-      <point x="207" y="97"/>
-      <point x="161" y="157"/>
-      <point x="161" y="265" type="curve" smooth="yes"/>
-      <point x="161" y="367"/>
-      <point x="203" y="454"/>
-      <point x="280" y="540" type="curve"/>
-      <point x="186" y="613" type="line"/>
-      <point x="85" y="507"/>
-      <point x="39" y="388"/>
-      <point x="39" y="265" type="curve" smooth="yes"/>
-      <point x="39" y="99"/>
-      <point x="135" y="-14"/>
-      <point x="301" y="-14" type="curve" smooth="yes"/>
-      <point x="315" y="-14"/>
-      <point x="329" y="-14"/>
-      <point x="343" y="-12" type="curve"/>
-      <point x="241" y="45" type="line"/>
-      <point x="284" y="-76" type="line"/>
-      <point x="289" y="10" type="line"/>
-      <point x="244" y="-35"/>
-      <point x="218" y="-97"/>
-      <point x="218" y="-164" type="curve" smooth="yes"/>
-      <point x="218" y="-293"/>
-      <point x="292" y="-368"/>
+      <point x="298" y="-10" type="curve" smooth="yes"/>
+      <point x="445" y="-10"/>
+      <point x="539" y="85"/>
+      <point x="539" y="231" type="curve" smooth="yes"/>
+      <point x="539" y="272"/>
+      <point x="533" y="312"/>
+      <point x="533" y="353" type="curve" smooth="yes"/>
+      <point x="533" y="447"/>
+      <point x="582" y="499"/>
+      <point x="661" y="499" type="curve" smooth="yes"/>
+      <point x="746" y="499"/>
+      <point x="789" y="443"/>
+      <point x="789" y="333" type="curve" smooth="yes"/>
+      <point x="789" y="223"/>
+      <point x="748" y="125"/>
+      <point x="666" y="39" type="curve"/>
+      <point x="772" y="-10" type="line"/>
+      <point x="866" y="91"/>
+      <point x="911" y="202"/>
+      <point x="911" y="337" type="curve" smooth="yes"/>
+      <point x="911" y="504"/>
+      <point x="810" y="613"/>
+      <point x="656" y="613" type="curve" smooth="yes"/>
+      <point x="514" y="613"/>
+      <point x="411" y="524"/>
+      <point x="411" y="366" type="curve" smooth="yes"/>
+      <point x="411" y="325"/>
+      <point x="417" y="285"/>
+      <point x="417" y="244" type="curve" smooth="yes"/>
+      <point x="417" y="147"/>
+      <point x="375" y="98"/>
+      <point x="293" y="98" type="curve" smooth="yes"/>
+      <point x="207" y="98"/>
+      <point x="161" y="154"/>
+      <point x="161" y="259" type="curve" smooth="yes"/>
+      <point x="161" y="361"/>
+      <point x="204" y="449"/>
+      <point x="282" y="535" type="curve"/>
+      <point x="191" y="613" type="line"/>
+      <point x="87" y="504"/>
+      <point x="39" y="382"/>
+      <point x="39" y="255" type="curve" smooth="yes"/>
+      <point x="39" y="97"/>
+      <point x="143" y="-10"/>
+    </contour>
+    <contour>
+      <point x="413" y="-368" type="curve" smooth="yes"/>
+      <point x="522" y="-368"/>
+      <point x="591" y="-300"/>
+      <point x="591" y="-190" type="curve" smooth="yes"/>
+      <point x="591" y="-171"/>
+      <point x="589" y="-153"/>
+      <point x="589" y="-134" type="curve" smooth="yes"/>
+      <point x="589" y="-71"/>
+      <point x="619" y="-37"/>
+      <point x="675" y="-37" type="curve" smooth="yes"/>
+      <point x="735" y="-37"/>
+      <point x="764" y="-76"/>
+      <point x="764" y="-146" type="curve" smooth="yes"/>
+      <point x="764" y="-203"/>
+      <point x="741" y="-259"/>
+      <point x="699" y="-305" type="curve"/>
+      <point x="774" y="-368" type="line"/>
+      <point x="834" y="-305"/>
+      <point x="863" y="-228"/>
+      <point x="863" y="-146" type="curve" smooth="yes"/>
+      <point x="863" y="-29"/>
+      <point x="784" y="53"/>
+      <point x="673" y="53" type="curve" smooth="yes"/>
+      <point x="560" y="53"/>
+      <point x="489" y="-16"/>
+      <point x="489" y="-124" type="curve" smooth="yes"/>
+      <point x="489" y="-143"/>
+      <point x="491" y="-161"/>
+      <point x="491" y="-180" type="curve" smooth="yes"/>
+      <point x="491" y="-243"/>
+      <point x="463" y="-277"/>
+      <point x="411" y="-277" type="curve" smooth="yes"/>
+      <point x="352" y="-277"/>
+      <point x="317" y="-231"/>
+      <point x="317" y="-156" type="curve" smooth="yes"/>
+      <point x="317" y="-93"/>
+      <point x="338" y="-35"/>
+      <point x="381" y="14" type="curve"/>
+      <point x="289" y="14" type="line"/>
+      <point x="245" y="-31"/>
+      <point x="218" y="-91"/>
+      <point x="218" y="-156" type="curve" smooth="yes"/>
+      <point x="218" y="-287"/>
+      <point x="293" y="-368"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/g_la-malayalam.glif
@@ -1,118 +1,122 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_la-malayalam" format="2">
-  <advance width="949"/>
+  <advance width="950"/>
   <anchor x="542" y="-352" name="bottom"/>
   <anchor x="482" y="597" name="top"/>
   <anchor x="776" y="597" name="topright"/>
   <outline>
     <contour>
       <point x="302" y="-368" type="curve" smooth="yes"/>
-      <point x="397" y="-368"/>
-      <point x="444" y="-312"/>
-      <point x="444" y="-233" type="curve" smooth="yes"/>
-      <point x="444" y="-151"/>
-      <point x="396" y="-112"/>
+      <point x="391" y="-368"/>
+      <point x="443" y="-318"/>
+      <point x="443" y="-233" type="curve" smooth="yes"/>
+      <point x="443" y="-151"/>
+      <point x="395" y="-112"/>
       <point x="327" y="-112" type="curve" smooth="yes"/>
-      <point x="270" y="-112"/>
-      <point x="218" y="-141"/>
-      <point x="214" y="-222" type="curve"/>
-      <point x="249" y="-157" type="line"/>
-      <point x="198" y="-156" type="line"/>
+      <point x="271" y="-112"/>
+      <point x="217" y="-141"/>
+      <point x="213" y="-222" type="curve"/>
+      <point x="249" y="-158" type="line"/>
+      <point x="197" y="-154" type="line"/>
       <point x="224" y="-175" type="line"/>
       <point x="224" y="-101"/>
       <point x="266" y="-35"/>
-      <point x="363" y="-35" type="curve" smooth="yes"/>
-      <point x="454" y="-35"/>
-      <point x="488" y="-84"/>
-      <point x="509" y="-159" type="curve" smooth="yes"/>
-      <point x="519" y="-197" type="line" smooth="yes"/>
-      <point x="549" y="-309"/>
-      <point x="602" y="-368"/>
-      <point x="711" y="-368" type="curve" smooth="yes"/>
-      <point x="823" y="-368"/>
-      <point x="893" y="-303"/>
+      <point x="362" y="-35" type="curve" smooth="yes"/>
+      <point x="442" y="-35"/>
+      <point x="485" y="-72"/>
+      <point x="508" y="-159" type="curve" smooth="yes"/>
+      <point x="518" y="-197" type="line" smooth="yes"/>
+      <point x="550" y="-316"/>
+      <point x="608" y="-368"/>
+      <point x="710" y="-368" type="curve" smooth="yes"/>
+      <point x="829" y="-368"/>
+      <point x="893" y="-296"/>
       <point x="893" y="-164" type="curve" smooth="yes"/>
-      <point x="893" y="-62"/>
-      <point x="850" y="24"/>
-      <point x="786" y="83" type="curve"/>
-      <point x="785" y="-6" type="line"/>
-      <point x="868" y="96"/>
-      <point x="910" y="205"/>
-      <point x="910" y="333" type="curve" smooth="yes"/>
-      <point x="910" y="501"/>
-      <point x="816" y="613"/>
-      <point x="664" y="613" type="curve" smooth="yes"/>
-      <point x="516" y="613"/>
-      <point x="434" y="523"/>
-      <point x="417" y="352" type="curve" smooth="yes"/>
-      <point x="407" y="254" type="line" smooth="yes"/>
-      <point x="397" y="149"/>
-      <point x="360" y="97"/>
-      <point x="286" y="97" type="curve" smooth="yes"/>
-      <point x="207" y="97"/>
-      <point x="161" y="157"/>
-      <point x="161" y="265" type="curve" smooth="yes"/>
-      <point x="161" y="367"/>
-      <point x="203" y="454"/>
-      <point x="280" y="540" type="curve"/>
-      <point x="186" y="613" type="line"/>
-      <point x="85" y="507"/>
-      <point x="39" y="388"/>
-      <point x="39" y="265" type="curve" smooth="yes"/>
-      <point x="39" y="134"/>
-      <point x="97" y="36"/>
-      <point x="214" y="10" type="curve"/>
-      <point x="215" y="2" type="line"/>
-      <point x="160" y="-40"/>
-      <point x="133" y="-106"/>
-      <point x="133" y="-176" type="curve" smooth="yes"/>
-      <point x="133" y="-304"/>
-      <point x="205" y="-368"/>
+      <point x="893" y="-68"/>
+      <point x="855" y="19"/>
+      <point x="787" y="82" type="curve"/>
+      <point x="787" y="6" type="line"/>
+      <point x="871" y="104"/>
+      <point x="911" y="210"/>
+      <point x="911" y="337" type="curve" smooth="yes"/>
+      <point x="911" y="504"/>
+      <point x="810" y="613"/>
+      <point x="656" y="613" type="curve" smooth="yes"/>
+      <point x="514" y="613"/>
+      <point x="411" y="524"/>
+      <point x="411" y="366" type="curve" smooth="yes"/>
+      <point x="411" y="325"/>
+      <point x="417" y="285"/>
+      <point x="417" y="244" type="curve" smooth="yes"/>
+      <point x="417" y="147"/>
+      <point x="375" y="98"/>
+      <point x="293" y="98" type="curve" smooth="yes"/>
+      <point x="207" y="98"/>
+      <point x="161" y="154"/>
+      <point x="161" y="259" type="curve" smooth="yes"/>
+      <point x="161" y="361"/>
+      <point x="204" y="449"/>
+      <point x="282" y="535" type="curve"/>
+      <point x="191" y="613" type="line"/>
+      <point x="87" y="504"/>
+      <point x="39" y="382"/>
+      <point x="39" y="255" type="curve" smooth="yes"/>
+      <point x="39" y="133"/>
+      <point x="99" y="48"/>
+      <point x="212" y="9" type="curve"/>
+      <point x="213" y="1" type="line"/>
+      <point x="161" y="-39"/>
+      <point x="132" y="-103"/>
+      <point x="132" y="-176" type="curve" smooth="yes"/>
+      <point x="132" y="-295"/>
+      <point x="197" y="-368"/>
     </contour>
     <contour>
-      <point x="300" y="-288" type="curve" smooth="yes"/>
-      <point x="252" y="-288"/>
-      <point x="230" y="-246"/>
+      <point x="299" y="-288" type="curve" smooth="yes"/>
+      <point x="251" y="-288"/>
+      <point x="229" y="-246"/>
       <point x="229" y="-209" type="curve"/>
-      <point x="213" y="-214" type="line"/>
-      <point x="228" y="-253" type="line"/>
-      <point x="233" y="-210"/>
-      <point x="262" y="-185"/>
-      <point x="302" y="-185" type="curve" smooth="yes"/>
+      <point x="212" y="-214" type="line"/>
+      <point x="227" y="-253" type="line"/>
+      <point x="232" y="-210"/>
+      <point x="261" y="-185"/>
+      <point x="301" y="-185" type="curve" smooth="yes"/>
       <point x="338" y="-185"/>
-      <point x="356" y="-204"/>
-      <point x="356" y="-235" type="curve" smooth="yes"/>
-      <point x="356" y="-268"/>
-      <point x="336" y="-288"/>
+      <point x="355" y="-204"/>
+      <point x="355" y="-235" type="curve" smooth="yes"/>
+      <point x="355" y="-268"/>
+      <point x="335" y="-288"/>
     </contour>
     <contour>
-      <point x="712" y="-278" type="curve" smooth="yes"/>
-      <point x="661" y="-278"/>
-      <point x="634" y="-243"/>
-      <point x="614" y="-172" type="curve" smooth="yes"/>
+      <point x="711" y="-278" type="curve" smooth="yes"/>
+      <point x="662" y="-278"/>
+      <point x="633" y="-246"/>
+      <point x="613" y="-172" type="curve" smooth="yes"/>
       <point x="603" y="-134" type="line" smooth="yes"/>
-      <point x="579" y="-48"/>
-      <point x="540" y="20"/>
-      <point x="443" y="42" type="curve"/>
-      <point x="442" y="49" type="line"/>
-      <point x="501" y="87"/>
-      <point x="522" y="154"/>
-      <point x="530" y="235" type="curve" smooth="yes"/>
-      <point x="540" y="339" type="line" smooth="yes"/>
-      <point x="550" y="440"/>
-      <point x="594" y="500"/>
-      <point x="671" y="500" type="curve" smooth="yes"/>
-      <point x="749" y="500"/>
-      <point x="788" y="439"/>
-      <point x="788" y="333" type="curve" smooth="yes"/>
-      <point x="788" y="232"/>
-      <point x="752" y="145"/>
-      <point x="680" y="61" type="curve"/>
-      <point x="744" y="4"/>
-      <point x="796" y="-65"/>
-      <point x="796" y="-174" type="curve" smooth="yes"/>
-      <point x="796" y="-237"/>
-      <point x="770" y="-278"/>
+      <point x="578" y="-38"/>
+      <point x="527" y="19"/>
+      <point x="446" y="39" type="curve"/>
+      <point x="445" y="46" type="line"/>
+      <point x="509" y="88"/>
+      <point x="539" y="147"/>
+      <point x="539" y="231" type="curve" smooth="yes"/>
+      <point x="539" y="272"/>
+      <point x="533" y="312"/>
+      <point x="533" y="353" type="curve" smooth="yes"/>
+      <point x="533" y="447"/>
+      <point x="582" y="499"/>
+      <point x="661" y="499" type="curve" smooth="yes"/>
+      <point x="746" y="499"/>
+      <point x="789" y="443"/>
+      <point x="789" y="333" type="curve" smooth="yes"/>
+      <point x="789" y="232"/>
+      <point x="752" y="142"/>
+      <point x="677" y="63" type="curve"/>
+      <point x="758" y="-8"/>
+      <point x="795" y="-82"/>
+      <point x="795" y="-174" type="curve" smooth="yes"/>
+      <point x="795" y="-241"/>
+      <point x="765" y="-278"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/g_ma-malayalam.glif
@@ -6,62 +6,66 @@
   <anchor x="1320" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="292" y="-16" type="curve" smooth="yes"/>
-      <point x="434" y="-16"/>
-      <point x="512" y="73"/>
-      <point x="528" y="235" type="curve" smooth="yes"/>
-      <point x="538" y="339" type="line" smooth="yes"/>
-      <point x="548" y="440"/>
-      <point x="586" y="500"/>
-      <point x="667" y="500" type="curve" smooth="yes"/>
-      <point x="750" y="500"/>
-      <point x="787" y="437"/>
+      <point x="298" y="-16" type="curve" smooth="yes"/>
+      <point x="445" y="-16"/>
+      <point x="539" y="81"/>
+      <point x="539" y="231" type="curve" smooth="yes"/>
+      <point x="539" y="272"/>
+      <point x="533" y="312"/>
+      <point x="533" y="353" type="curve" smooth="yes"/>
+      <point x="533" y="447"/>
+      <point x="582" y="499"/>
+      <point x="661" y="499" type="curve" smooth="yes"/>
+      <point x="748" y="499"/>
+      <point x="787" y="436"/>
       <point x="787" y="326" type="curve" smooth="yes"/>
       <point x="787" y="0" type="line"/>
       <point x="1392" y="0" type="line"/>
       <point x="1392" y="327" type="line" smooth="yes"/>
-      <point x="1392" y="498"/>
-      <point x="1302" y="613"/>
+      <point x="1392" y="512"/>
+      <point x="1287" y="613"/>
       <point x="1096" y="613" type="curve" smooth="yes"/>
-      <point x="989" y="613"/>
-      <point x="902" y="576"/>
+      <point x="987" y="613"/>
+      <point x="901" y="574"/>
       <point x="852" y="503" type="curve"/>
       <point x="845" y="503" type="line"/>
-      <point x="804" y="580"/>
-      <point x="736" y="613"/>
-      <point x="653" y="613" type="curve" smooth="yes"/>
-      <point x="512" y="613"/>
-      <point x="432" y="523"/>
-      <point x="414" y="352" type="curve" smooth="yes"/>
-      <point x="404" y="254" type="line" smooth="yes"/>
-      <point x="394" y="149"/>
-      <point x="355" y="97"/>
-      <point x="283" y="97" type="curve" smooth="yes"/>
-      <point x="204" y="97"/>
-      <point x="156" y="158"/>
-      <point x="156" y="265" type="curve" smooth="yes"/>
-      <point x="156" y="367"/>
-      <point x="199" y="456"/>
-      <point x="273" y="548" type="curve"/>
-      <point x="186" y="613" type="line"/>
-      <point x="85" y="505"/>
-      <point x="39" y="388"/>
-      <point x="39" y="265" type="curve" smooth="yes"/>
-      <point x="39" y="91"/>
-      <point x="141" y="-16"/>
+      <point x="805" y="580"/>
+      <point x="738" y="613"/>
+      <point x="656" y="613" type="curve" smooth="yes"/>
+      <point x="514" y="613"/>
+      <point x="411" y="524"/>
+      <point x="411" y="366" type="curve" smooth="yes"/>
+      <point x="411" y="325"/>
+      <point x="417" y="285"/>
+      <point x="417" y="244" type="curve" smooth="yes"/>
+      <point x="417" y="147"/>
+      <point x="375" y="98"/>
+      <point x="293" y="98" type="curve" smooth="yes"/>
+      <point x="207" y="98"/>
+      <point x="161" y="154"/>
+      <point x="161" y="259" type="curve" smooth="yes"/>
+      <point x="161" y="361"/>
+      <point x="204" y="449"/>
+      <point x="282" y="535" type="curve"/>
+      <point x="191" y="613" type="line"/>
+      <point x="87" y="504"/>
+      <point x="39" y="382"/>
+      <point x="39" y="255" type="curve" smooth="yes"/>
+      <point x="39" y="94"/>
+      <point x="143" y="-16"/>
     </contour>
     <contour>
       <point x="853" y="48" type="line"/>
       <point x="907" y="48" type="line"/>
       <point x="907" y="311" type="line" smooth="yes"/>
-      <point x="907" y="400"/>
-      <point x="937" y="456"/>
+      <point x="907" y="406"/>
+      <point x="941" y="456"/>
       <point x="1006" y="456" type="curve" smooth="yes"/>
-      <point x="1063" y="456"/>
-      <point x="1083" y="423"/>
+      <point x="1056" y="456"/>
+      <point x="1083" y="430"/>
       <point x="1083" y="380" type="curve" smooth="yes"/>
-      <point x="1083" y="314"/>
-      <point x="1040" y="256"/>
+      <point x="1083" y="323"/>
+      <point x="1054" y="273"/>
       <point x="963" y="171" type="curve" smooth="yes"/>
     </contour>
     <contour>
@@ -70,19 +74,19 @@
       <point x="942" y="104" type="line"/>
       <point x="1006" y="45" type="line"/>
       <point x="1103" y="158" type="line" smooth="yes"/>
-      <point x="1168" y="233"/>
-      <point x="1200" y="298"/>
+      <point x="1169" y="235"/>
+      <point x="1200" y="300"/>
       <point x="1200" y="365" type="curve" smooth="yes"/>
-      <point x="1200" y="462"/>
-      <point x="1135" y="512"/>
+      <point x="1200" y="457"/>
+      <point x="1140" y="512"/>
       <point x="1034" y="516" type="curve"/>
       <point x="1034" y="554" type="line"/>
       <point x="996" y="514" type="line"/>
       <point x="1022" y="523"/>
       <point x="1048" y="527"/>
       <point x="1087" y="527" type="curve" smooth="yes"/>
-      <point x="1218" y="527"/>
-      <point x="1271" y="444"/>
+      <point x="1208" y="527"/>
+      <point x="1271" y="456"/>
       <point x="1271" y="320" type="curve" smooth="yes"/>
     </contour>
   </outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/g_na-malayalam.glif
@@ -6,15 +6,17 @@
   <anchor x="1213" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="292" y="-16" type="curve" smooth="yes"/>
-      <point x="432" y="-16"/>
-      <point x="512" y="73"/>
-      <point x="528" y="235" type="curve" smooth="yes"/>
-      <point x="538" y="339" type="line" smooth="yes"/>
-      <point x="548" y="443"/>
-      <point x="587" y="500"/>
-      <point x="668" y="500" type="curve" smooth="yes"/>
-      <point x="751" y="500"/>
+      <point x="298" y="-16" type="curve" smooth="yes"/>
+      <point x="445" y="-16"/>
+      <point x="539" y="81"/>
+      <point x="539" y="231" type="curve" smooth="yes"/>
+      <point x="539" y="272"/>
+      <point x="533" y="312"/>
+      <point x="533" y="353" type="curve" smooth="yes"/>
+      <point x="533" y="448"/>
+      <point x="584" y="500"/>
+      <point x="662" y="500" type="curve" smooth="yes"/>
+      <point x="749" y="500"/>
       <point x="787" y="440"/>
       <point x="787" y="327" type="curve" smooth="yes"/>
       <point x="787" y="0" type="line"/>
@@ -40,28 +42,30 @@
       <point x="894" y="572"/>
       <point x="855" y="503" type="curve"/>
       <point x="846" y="503" type="line"/>
-      <point x="813" y="570"/>
-      <point x="747" y="613"/>
-      <point x="656" y="613" type="curve" smooth="yes"/>
-      <point x="512" y="613"/>
-      <point x="432" y="523"/>
-      <point x="414" y="352" type="curve" smooth="yes"/>
-      <point x="404" y="254" type="line" smooth="yes"/>
-      <point x="394" y="149"/>
-      <point x="353" y="97"/>
-      <point x="283" y="97" type="curve" smooth="yes"/>
-      <point x="204" y="97"/>
-      <point x="156" y="158"/>
-      <point x="156" y="265" type="curve" smooth="yes"/>
-      <point x="156" y="367"/>
-      <point x="199" y="456"/>
-      <point x="273" y="548" type="curve"/>
-      <point x="186" y="613" type="line"/>
-      <point x="85" y="505"/>
-      <point x="39" y="388"/>
-      <point x="39" y="265" type="curve" smooth="yes"/>
-      <point x="39" y="98"/>
-      <point x="141" y="-16"/>
+      <point x="808" y="572"/>
+      <point x="748" y="613"/>
+      <point x="651" y="613" type="curve" smooth="yes"/>
+      <point x="511" y="613"/>
+      <point x="411" y="524"/>
+      <point x="411" y="366" type="curve" smooth="yes"/>
+      <point x="411" y="325"/>
+      <point x="417" y="285"/>
+      <point x="417" y="244" type="curve" smooth="yes"/>
+      <point x="417" y="147"/>
+      <point x="375" y="98"/>
+      <point x="293" y="98" type="curve" smooth="yes"/>
+      <point x="207" y="98"/>
+      <point x="161" y="154"/>
+      <point x="161" y="259" type="curve" smooth="yes"/>
+      <point x="161" y="361"/>
+      <point x="204" y="449"/>
+      <point x="282" y="535" type="curve"/>
+      <point x="191" y="613" type="line"/>
+      <point x="87" y="504"/>
+      <point x="39" y="382"/>
+      <point x="39" y="255" type="curve" smooth="yes"/>
+      <point x="39" y="94"/>
+      <point x="143" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ga-malayalam.glif
@@ -1,52 +1,56 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ga-malayalam" format="2">
-  <advance width="949"/>
+  <advance width="950"/>
   <unicode hex="0D17"/>
   <anchor x="525" y="0" name="bottom"/>
   <anchor x="482" y="597" name="top"/>
   <anchor x="776" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="291" y="-16" type="curve" smooth="yes"/>
-      <point x="435" y="-16"/>
-      <point x="515" y="73"/>
-      <point x="530" y="235" type="curve" smooth="yes"/>
-      <point x="540" y="339" type="line" smooth="yes"/>
-      <point x="550" y="440"/>
-      <point x="594" y="500"/>
-      <point x="671" y="500" type="curve" smooth="yes"/>
-      <point x="749" y="500"/>
-      <point x="788" y="439"/>
-      <point x="788" y="333" type="curve" smooth="yes"/>
-      <point x="788" y="232"/>
-      <point x="752" y="145"/>
-      <point x="680" y="61" type="curve"/>
-      <point x="776" y="-16" type="line"/>
-      <point x="866" y="88"/>
-      <point x="910" y="200"/>
-      <point x="910" y="333" type="curve" smooth="yes"/>
-      <point x="910" y="501"/>
-      <point x="816" y="613"/>
-      <point x="664" y="613" type="curve" smooth="yes"/>
-      <point x="516" y="613"/>
-      <point x="434" y="523"/>
-      <point x="417" y="352" type="curve" smooth="yes"/>
-      <point x="407" y="254" type="line" smooth="yes"/>
-      <point x="397" y="149"/>
-      <point x="360" y="97"/>
-      <point x="286" y="97" type="curve" smooth="yes"/>
-      <point x="207" y="97"/>
-      <point x="161" y="157"/>
-      <point x="161" y="265" type="curve" smooth="yes"/>
-      <point x="161" y="367"/>
-      <point x="203" y="454"/>
-      <point x="280" y="540" type="curve"/>
-      <point x="186" y="613" type="line"/>
-      <point x="85" y="507"/>
-      <point x="39" y="388"/>
-      <point x="39" y="265" type="curve" smooth="yes"/>
-      <point x="39" y="98"/>
-      <point x="136" y="-16"/>
+      <point x="298" y="-16" type="curve" smooth="yes"/>
+      <point x="445" y="-16"/>
+      <point x="539" y="81"/>
+      <point x="539" y="231" type="curve" smooth="yes"/>
+      <point x="539" y="272"/>
+      <point x="533" y="312"/>
+      <point x="533" y="353" type="curve" smooth="yes"/>
+      <point x="533" y="447"/>
+      <point x="582" y="499"/>
+      <point x="661" y="499" type="curve" smooth="yes"/>
+      <point x="746" y="499"/>
+      <point x="789" y="443"/>
+      <point x="789" y="333" type="curve" smooth="yes"/>
+      <point x="789" y="232"/>
+      <point x="752" y="142"/>
+      <point x="677" y="63" type="curve"/>
+      <point x="767" y="-16" type="line"/>
+      <point x="865" y="87"/>
+      <point x="911" y="200"/>
+      <point x="911" y="337" type="curve" smooth="yes"/>
+      <point x="911" y="504"/>
+      <point x="810" y="613"/>
+      <point x="656" y="613" type="curve" smooth="yes"/>
+      <point x="514" y="613"/>
+      <point x="411" y="524"/>
+      <point x="411" y="366" type="curve" smooth="yes"/>
+      <point x="411" y="325"/>
+      <point x="417" y="285"/>
+      <point x="417" y="244" type="curve" smooth="yes"/>
+      <point x="417" y="147"/>
+      <point x="375" y="98"/>
+      <point x="293" y="98" type="curve" smooth="yes"/>
+      <point x="207" y="98"/>
+      <point x="161" y="154"/>
+      <point x="161" y="259" type="curve" smooth="yes"/>
+      <point x="161" y="361"/>
+      <point x="204" y="449"/>
+      <point x="282" y="535" type="curve"/>
+      <point x="191" y="613" type="line"/>
+      <point x="87" y="504"/>
+      <point x="39" y="382"/>
+      <point x="39" y="255" type="curve" smooth="yes"/>
+      <point x="39" y="94"/>
+      <point x="143" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ga-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ga-malayalam.half" format="2">
-  <advance width="949"/>
+  <advance width="950"/>
+  <anchor x="525" y="0" name="bottom"/>
+  <anchor x="482" y="597" name="top"/>
+  <anchor x="776" y="597" name="topright"/>
   <outline>
     <component base="ga-malayalam"/>
     <component base="halant-malayalam" xOffset="776"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/j_ja-malayalam.glif
@@ -1,224 +1,224 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1641"/>
-  <anchor x="1233" y="0" name="bottom"/>
-  <anchor x="822" y="597" name="top"/>
-  <anchor x="1520" y="597" name="topright"/>
+  <advance width="1707"/>
+  <anchor x="1281" y="0" name="bottom"/>
+  <anchor x="854" y="597" name="top"/>
+  <anchor x="1553" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="346" y="-16" type="curve" smooth="yes"/>
-      <point x="672" y="-16"/>
-      <point x="818" y="87"/>
-      <point x="881" y="293" type="curve"/>
-      <point x="895" y="356" type="line"/>
-      <point x="901" y="356" type="line"/>
-      <point x="920" y="323"/>
-      <point x="954" y="309"/>
-      <point x="995" y="309" type="curve" smooth="yes"/>
-      <point x="1083" y="309"/>
-      <point x="1127" y="360"/>
-      <point x="1127" y="424" type="curve" smooth="yes"/>
-      <point x="1127" y="478"/>
-      <point x="1100" y="525"/>
-      <point x="1016" y="525" type="curve" smooth="yes"/>
-      <point x="992" y="525"/>
-      <point x="966" y="520"/>
-      <point x="947" y="511" type="curve"/>
-      <point x="982" y="500" type="line"/>
-      <point x="961" y="553" type="line"/>
-      <point x="957" y="520" type="line"/>
-      <point x="977" y="529"/>
-      <point x="1002" y="536"/>
-      <point x="1040" y="536" type="curve" smooth="yes"/>
-      <point x="1151" y="536"/>
-      <point x="1184" y="471"/>
-      <point x="1184" y="396" type="curve" smooth="yes"/>
-      <point x="1184" y="352" type="line"/>
-      <point x="1301" y="352" type="line"/>
-      <point x="1301" y="388" type="line" smooth="yes"/>
-      <point x="1301" y="465"/>
-      <point x="1340" y="510"/>
-      <point x="1402" y="510" type="curve" smooth="yes"/>
-      <point x="1460" y="510"/>
-      <point x="1485" y="472"/>
-      <point x="1485" y="416" type="curve" smooth="yes"/>
-      <point x="1485" y="343"/>
-      <point x="1446" y="302"/>
-      <point x="1343" y="302" type="curve" smooth="yes"/>
-      <point x="1095" y="302" type="line" smooth="yes"/>
-      <point x="947" y="302"/>
-      <point x="871" y="239"/>
-      <point x="871" y="134" type="curve" smooth="yes"/>
-      <point x="871" y="59"/>
-      <point x="920" y="-16"/>
-      <point x="1041" y="-16" type="curve" smooth="yes"/>
-      <point x="1115" y="-16"/>
-      <point x="1175" y="6"/>
-      <point x="1241" y="54" type="curve" smooth="yes"/>
-      <point x="1320" y="113" type="line" smooth="yes"/>
-      <point x="1374" y="151"/>
-      <point x="1420" y="174"/>
-      <point x="1460" y="174" type="curve" smooth="yes"/>
-      <point x="1499" y="174"/>
-      <point x="1511" y="151"/>
-      <point x="1511" y="122" type="curve" smooth="yes"/>
-      <point x="1511" y="96"/>
-      <point x="1498" y="73"/>
-      <point x="1463" y="73" type="curve" smooth="yes"/>
-      <point x="1431" y="73"/>
-      <point x="1415" y="96"/>
-      <point x="1415" y="124" type="curve" smooth="yes"/>
-      <point x="1415" y="145"/>
-      <point x="1423" y="162"/>
-      <point x="1435" y="180" type="curve"/>
-      <point x="1333" y="150" type="line"/>
-      <point x="1351" y="125" type="line"/>
-      <point x="1345" y="113"/>
-      <point x="1342" y="101"/>
-      <point x="1342" y="87" type="curve" smooth="yes"/>
-      <point x="1342" y="31"/>
-      <point x="1379" y="-16"/>
-      <point x="1465" y="-16" type="curve" smooth="yes"/>
-      <point x="1554" y="-16"/>
-      <point x="1600" y="42"/>
-      <point x="1600" y="114" type="curve" smooth="yes"/>
-      <point x="1600" y="198"/>
-      <point x="1542" y="255"/>
-      <point x="1459" y="255" type="curve" smooth="yes"/>
-      <point x="1405" y="255"/>
-      <point x="1354" y="242"/>
-      <point x="1276" y="190" type="curve" smooth="yes"/>
-      <point x="1209" y="144" type="line" smooth="yes"/>
-      <point x="1143" y="99"/>
-      <point x="1103" y="87"/>
-      <point x="1057" y="87" type="curve" smooth="yes"/>
-      <point x="1009" y="87"/>
-      <point x="981" y="105"/>
-      <point x="981" y="144" type="curve" smooth="yes"/>
-      <point x="981" y="181"/>
-      <point x="1008" y="204"/>
-      <point x="1077" y="204" type="curve" smooth="yes"/>
-      <point x="1365" y="204" type="line" smooth="yes"/>
-      <point x="1546" y="204"/>
-      <point x="1602" y="306"/>
-      <point x="1602" y="413" type="curve" smooth="yes"/>
-      <point x="1602" y="527"/>
-      <point x="1542" y="613"/>
-      <point x="1416" y="613" type="curve" smooth="yes"/>
-      <point x="1336" y="613"/>
-      <point x="1272" y="573"/>
-      <point x="1249" y="502" type="curve"/>
-      <point x="1242" y="502" type="line"/>
-      <point x="1211" y="573"/>
-      <point x="1142" y="613"/>
-      <point x="1046" y="613" type="curve" smooth="yes"/>
-      <point x="921" y="613"/>
-      <point x="854" y="556"/>
-      <point x="821" y="426" type="curve" smooth="yes"/>
-      <point x="803" y="354" type="line" smooth="yes"/>
-      <point x="752" y="161"/>
-      <point x="623" y="87"/>
-      <point x="341" y="87" type="curve" smooth="yes"/>
-      <point x="204" y="87"/>
-      <point x="161" y="111"/>
-      <point x="161" y="154" type="curve" smooth="yes"/>
-      <point x="161" y="185"/>
-      <point x="184" y="204"/>
-      <point x="249" y="204" type="curve" smooth="yes"/>
-      <point x="488" y="204" type="line" smooth="yes"/>
-      <point x="694" y="204"/>
-      <point x="775" y="287"/>
-      <point x="775" y="427" type="curve" smooth="yes"/>
-      <point x="775" y="532"/>
-      <point x="722" y="613"/>
-      <point x="604" y="613" type="curve" smooth="yes"/>
-      <point x="527" y="613"/>
-      <point x="468" y="573"/>
-      <point x="445" y="502" type="curve"/>
-      <point x="438" y="502" type="line"/>
-      <point x="407" y="573"/>
-      <point x="338" y="613"/>
-      <point x="243" y="613" type="curve" smooth="yes"/>
-      <point x="111" y="613"/>
-      <point x="39" y="539"/>
-      <point x="39" y="445" type="curve" smooth="yes"/>
-      <point x="39" y="368"/>
-      <point x="90" y="309"/>
-      <point x="186" y="309" type="curve" smooth="yes"/>
-      <point x="277" y="309"/>
-      <point x="328" y="362"/>
-      <point x="328" y="426" type="curve" smooth="yes"/>
-      <point x="328" y="480"/>
-      <point x="301" y="525"/>
-      <point x="216" y="525" type="curve" smooth="yes"/>
-      <point x="193" y="525"/>
-      <point x="166" y="520"/>
-      <point x="148" y="511" type="curve"/>
-      <point x="183" y="500" type="line"/>
-      <point x="162" y="553" type="line"/>
-      <point x="155" y="519" type="line"/>
-      <point x="175" y="529"/>
-      <point x="203" y="536"/>
-      <point x="244" y="536" type="curve" smooth="yes"/>
-      <point x="347" y="536"/>
-      <point x="379" y="471"/>
-      <point x="379" y="396" type="curve" smooth="yes"/>
-      <point x="379" y="352" type="line"/>
-      <point x="497" y="352" type="line"/>
-      <point x="497" y="388" type="line" smooth="yes"/>
-      <point x="497" y="465"/>
-      <point x="532" y="510"/>
-      <point x="589" y="510" type="curve" smooth="yes"/>
-      <point x="643" y="510"/>
-      <point x="665" y="472"/>
-      <point x="665" y="416" type="curve" smooth="yes"/>
-      <point x="665" y="343"/>
-      <point x="628" y="302"/>
-      <point x="513" y="302" type="curve" smooth="yes"/>
-      <point x="251" y="302" type="line" smooth="yes"/>
-      <point x="117" y="302"/>
-      <point x="45" y="245"/>
-      <point x="45" y="155" type="curve" smooth="yes"/>
-      <point x="45" y="49"/>
-      <point x="112" y="-16"/>
+      <point x="338" y="-16" type="curve" smooth="yes"/>
+      <point x="691" y="-16"/>
+      <point x="842" y="86"/>
+      <point x="917" y="293" type="curve"/>
+      <point x="924" y="328" type="line"/>
+      <point x="930" y="328" type="line"/>
+      <point x="945" y="303"/>
+      <point x="976" y="286"/>
+      <point x="1024" y="286" type="curve" smooth="yes"/>
+      <point x="1103" y="286"/>
+      <point x="1156" y="335"/>
+      <point x="1156" y="408" type="curve" smooth="yes"/>
+      <point x="1156" y="473"/>
+      <point x="1114" y="520"/>
+      <point x="1041" y="520" type="curve" smooth="yes"/>
+      <point x="1021" y="520"/>
+      <point x="998" y="517"/>
+      <point x="977" y="509" type="curve"/>
+      <point x="962" y="537" type="line"/>
+      <point x="958" y="505" type="line"/>
+      <point x="987" y="527"/>
+      <point x="1029" y="539"/>
+      <point x="1077" y="539" type="curve" smooth="yes"/>
+      <point x="1169" y="539"/>
+      <point x="1210" y="490"/>
+      <point x="1210" y="396" type="curve" smooth="yes"/>
+      <point x="1210" y="323" type="line"/>
+      <point x="1328" y="323" type="line"/>
+      <point x="1328" y="390" type="line" smooth="yes"/>
+      <point x="1328" y="464"/>
+      <point x="1373" y="509"/>
+      <point x="1446" y="509" type="curve" smooth="yes"/>
+      <point x="1513" y="509"/>
+      <point x="1550" y="471"/>
+      <point x="1550" y="405" type="curve" smooth="yes"/>
+      <point x="1550" y="319"/>
+      <point x="1490" y="278"/>
+      <point x="1373" y="278" type="curve" smooth="yes"/>
+      <point x="1077" y="278" type="line" smooth="yes"/>
+      <point x="969" y="278"/>
+      <point x="899" y="215"/>
+      <point x="899" y="126" type="curve" smooth="yes"/>
+      <point x="899" y="43"/>
+      <point x="962" y="-16"/>
+      <point x="1052" y="-16" type="curve" smooth="yes"/>
+      <point x="1097" y="-16"/>
+      <point x="1128" y="-7"/>
+      <point x="1224" y="38" type="curve" smooth="yes"/>
+      <point x="1358" y="100" type="line"/>
+      <point x="1427" y="155" type="line"/>
+      <point x="1443" y="155" type="line"/>
+      <point x="1474" y="170"/>
+      <point x="1495" y="175"/>
+      <point x="1518" y="175" type="curve" smooth="yes"/>
+      <point x="1556" y="175"/>
+      <point x="1574" y="155"/>
+      <point x="1574" y="124" type="curve" smooth="yes"/>
+      <point x="1574" y="92"/>
+      <point x="1553" y="73"/>
+      <point x="1521" y="73" type="curve" smooth="yes"/>
+      <point x="1488" y="73"/>
+      <point x="1467" y="93"/>
+      <point x="1467" y="123" type="curve" smooth="yes"/>
+      <point x="1467" y="145"/>
+      <point x="1475" y="164"/>
+      <point x="1492" y="181" type="curve"/>
+      <point x="1386" y="153" type="line"/>
+      <point x="1406" y="130" type="line"/>
+      <point x="1398" y="116"/>
+      <point x="1394" y="104"/>
+      <point x="1394" y="90" type="curve" smooth="yes"/>
+      <point x="1394" y="28"/>
+      <point x="1446" y="-16"/>
+      <point x="1523" y="-16" type="curve" smooth="yes"/>
+      <point x="1609" y="-16"/>
+      <point x="1664" y="36"/>
+      <point x="1664" y="116" type="curve" smooth="yes"/>
+      <point x="1664" y="192"/>
+      <point x="1611" y="243"/>
+      <point x="1519" y="243" type="curve" smooth="yes"/>
+      <point x="1465" y="243"/>
+      <point x="1420" y="228"/>
+      <point x="1327" y="185" type="curve" smooth="yes"/>
+      <point x="1186" y="120" type="line" smooth="yes"/>
+      <point x="1126" y="92"/>
+      <point x="1102" y="84"/>
+      <point x="1069" y="84" type="curve" smooth="yes"/>
+      <point x="1031" y="84"/>
+      <point x="1011" y="102"/>
+      <point x="1011" y="132" type="curve" smooth="yes"/>
+      <point x="1011" y="165"/>
+      <point x="1034" y="184"/>
+      <point x="1075" y="184" type="curve" smooth="yes"/>
+      <point x="1371" y="184" type="line" smooth="yes"/>
+      <point x="1541" y="184"/>
+      <point x="1668" y="278"/>
+      <point x="1668" y="414" type="curve" smooth="yes"/>
+      <point x="1668" y="534"/>
+      <point x="1598" y="613"/>
+      <point x="1470" y="613" type="curve" smooth="yes"/>
+      <point x="1381" y="613"/>
+      <point x="1309" y="570"/>
+      <point x="1277" y="498" type="curve"/>
+      <point x="1270" y="498" type="line"/>
+      <point x="1243" y="566"/>
+      <point x="1189" y="613"/>
+      <point x="1080" y="613" type="curve" smooth="yes"/>
+      <point x="964" y="613"/>
+      <point x="890" y="559"/>
+      <point x="857" y="426" type="curve" smooth="yes"/>
+      <point x="839" y="354" type="line" smooth="yes"/>
+      <point x="790" y="160"/>
+      <point x="644" y="87"/>
+      <point x="340" y="87" type="curve" smooth="yes"/>
+      <point x="202" y="87"/>
+      <point x="163" y="106"/>
+      <point x="163" y="141" type="curve" smooth="yes"/>
+      <point x="163" y="168"/>
+      <point x="187" y="184"/>
+      <point x="228" y="184" type="curve" smooth="yes"/>
+      <point x="513" y="184" type="line" smooth="yes"/>
+      <point x="687" y="184"/>
+      <point x="804" y="278"/>
+      <point x="804" y="427" type="curve" smooth="yes"/>
+      <point x="804" y="541"/>
+      <point x="741" y="613"/>
+      <point x="634" y="613" type="curve" smooth="yes"/>
+      <point x="552" y="613"/>
+      <point x="488" y="570"/>
+      <point x="459" y="498" type="curve"/>
+      <point x="452" y="498" type="line"/>
+      <point x="425" y="567"/>
+      <point x="370" y="613"/>
+      <point x="261" y="613" type="curve" smooth="yes"/>
+      <point x="127" y="613"/>
+      <point x="39" y="541"/>
+      <point x="39" y="437" type="curve" smooth="yes"/>
+      <point x="39" y="347"/>
+      <point x="100" y="286"/>
+      <point x="195" y="286" type="curve" smooth="yes"/>
+      <point x="280" y="286"/>
+      <point x="338" y="335"/>
+      <point x="338" y="408" type="curve" smooth="yes"/>
+      <point x="338" y="473"/>
+      <point x="298" y="520"/>
+      <point x="223" y="520" type="curve" smooth="yes"/>
+      <point x="203" y="520"/>
+      <point x="180" y="517"/>
+      <point x="159" y="509" type="curve"/>
+      <point x="144" y="537" type="line"/>
+      <point x="140" y="505" type="line"/>
+      <point x="170" y="527"/>
+      <point x="208" y="539"/>
+      <point x="258" y="539" type="curve" smooth="yes"/>
+      <point x="352" y="539"/>
+      <point x="392" y="489"/>
+      <point x="392" y="396" type="curve" smooth="yes"/>
+      <point x="392" y="323" type="line"/>
+      <point x="510" y="323" type="line"/>
+      <point x="510" y="390" type="line" smooth="yes"/>
+      <point x="510" y="464"/>
+      <point x="549" y="509"/>
+      <point x="612" y="509" type="curve" smooth="yes"/>
+      <point x="668" y="509"/>
+      <point x="696" y="474"/>
+      <point x="696" y="413" type="curve" smooth="yes"/>
+      <point x="696" y="325"/>
+      <point x="633" y="278"/>
+      <point x="513" y="278" type="curve" smooth="yes"/>
+      <point x="224" y="278" type="line" smooth="yes"/>
+      <point x="115" y="278"/>
+      <point x="45" y="220"/>
+      <point x="45" y="137" type="curve" smooth="yes"/>
+      <point x="45" y="42"/>
+      <point x="109" y="-16"/>
     </contour>
     <contour>
-      <point x="191" y="386" type="curve" smooth="yes"/>
-      <point x="153" y="386"/>
-      <point x="135" y="414"/>
-      <point x="135" y="445" type="curve" smooth="yes"/>
-      <point x="135" y="460"/>
-      <point x="138" y="471"/>
-      <point x="148" y="484" type="curve"/>
-      <point x="117" y="484" type="line"/>
-      <point x="108" y="459" type="line"/>
-      <point x="131" y="471"/>
-      <point x="155" y="479"/>
-      <point x="185" y="479" type="curve" smooth="yes"/>
-      <point x="235" y="479"/>
-      <point x="246" y="457"/>
-      <point x="246" y="436" type="curve" smooth="yes"/>
-      <point x="246" y="410"/>
-      <point x="230" y="386"/>
+      <point x="190" y="367" type="curve" smooth="yes"/>
+      <point x="150" y="367"/>
+      <point x="127" y="393"/>
+      <point x="127" y="432" type="curve" smooth="yes"/>
+      <point x="127" y="452"/>
+      <point x="130" y="465"/>
+      <point x="142" y="481" type="curve"/>
+      <point x="115" y="481" type="line"/>
+      <point x="115" y="432" type="line"/>
+      <point x="131" y="456"/>
+      <point x="158" y="470"/>
+      <point x="191" y="470" type="curve" smooth="yes"/>
+      <point x="227" y="470"/>
+      <point x="246" y="449"/>
+      <point x="246" y="419" type="curve" smooth="yes"/>
+      <point x="246" y="388"/>
+      <point x="225" y="367"/>
     </contour>
     <contour>
-      <point x="990" y="387" type="curve" smooth="yes"/>
-      <point x="949" y="387"/>
-      <point x="933" y="414"/>
-      <point x="933" y="446" type="curve" smooth="yes"/>
-      <point x="933" y="461"/>
-      <point x="936" y="472"/>
-      <point x="946" y="485" type="curve"/>
-      <point x="920" y="485" type="line"/>
-      <point x="911" y="460" type="line"/>
-      <point x="934" y="472"/>
-      <point x="958" y="480"/>
-      <point x="984" y="480" type="curve" smooth="yes"/>
-      <point x="1034" y="480"/>
-      <point x="1046" y="457"/>
-      <point x="1046" y="435" type="curve" smooth="yes"/>
-      <point x="1046" y="408"/>
-      <point x="1032" y="387"/>
+      <point x="1008" y="367" type="curve" smooth="yes"/>
+      <point x="968" y="367"/>
+      <point x="945" y="393"/>
+      <point x="945" y="432" type="curve" smooth="yes"/>
+      <point x="945" y="452"/>
+      <point x="948" y="465"/>
+      <point x="960" y="481" type="curve"/>
+      <point x="933" y="481" type="line"/>
+      <point x="933" y="432" type="line"/>
+      <point x="949" y="456"/>
+      <point x="976" y="470"/>
+      <point x="1009" y="470" type="curve" smooth="yes"/>
+      <point x="1045" y="470"/>
+      <point x="1064" y="449"/>
+      <point x="1064" y="419" type="curve" smooth="yes"/>
+      <point x="1064" y="388"/>
+      <point x="1043" y="367"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/j_nya-malayalam.glif
@@ -1,185 +1,184 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2254"/>
-  <anchor x="1830" y="0" name="bottom"/>
+  <advance width="2286"/>
+  <anchor x="1862" y="0" name="bottom"/>
   <anchor x="1126" y="597" name="top"/>
-  <anchor x="2109" y="597" name="topright"/>
+  <anchor x="2140" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="356" y="-16" type="curve" smooth="yes"/>
-      <point x="590" y="-16"/>
-      <point x="741" y="42"/>
-      <point x="827" y="155" type="curve"/>
-      <point x="833" y="155" type="line"/>
-      <point x="866" y="50"/>
-      <point x="939" y="-16"/>
-      <point x="1049" y="-16" type="curve" smooth="yes"/>
-      <point x="1170" y="-16"/>
-      <point x="1243" y="70"/>
-      <point x="1243" y="182" type="curve" smooth="yes"/>
-      <point x="1243" y="290"/>
-      <point x="1182" y="364"/>
-      <point x="1066" y="364" type="curve" smooth="yes"/>
-      <point x="1009" y="364"/>
-      <point x="958" y="338"/>
-      <point x="928" y="297" type="curve"/>
-      <point x="901" y="305" type="line"/>
-      <point x="921" y="145" type="line"/>
-      <point x="936" y="226"/>
-      <point x="991" y="261"/>
-      <point x="1043" y="261" type="curve" smooth="yes"/>
-      <point x="1098" y="261"/>
-      <point x="1125" y="232"/>
-      <point x="1125" y="180" type="curve" smooth="yes"/>
-      <point x="1125" y="126"/>
-      <point x="1094" y="92"/>
-      <point x="1041" y="92" type="curve" smooth="yes"/>
-      <point x="969" y="92"/>
-      <point x="919" y="166"/>
-      <point x="919" y="274" type="curve" smooth="yes"/>
-      <point x="919" y="410"/>
-      <point x="998" y="502"/>
-      <point x="1124" y="502" type="curve" smooth="yes"/>
-      <point x="1241" y="502"/>
-      <point x="1298" y="428"/>
-      <point x="1298" y="315" type="curve" smooth="yes"/>
-      <point x="1298" y="0" type="line"/>
-      <point x="1420" y="0" type="line"/>
-      <point x="1420" y="315" type="line" smooth="yes"/>
-      <point x="1420" y="434"/>
-      <point x="1480" y="502"/>
-      <point x="1590" y="502" type="curve" smooth="yes"/>
-      <point x="1756" y="502"/>
-      <point x="1831" y="385"/>
-      <point x="1831" y="240" type="curve" smooth="yes"/>
-      <point x="1831" y="150"/>
-      <point x="1798" y="97"/>
-      <point x="1737" y="97" type="curve" smooth="yes"/>
-      <point x="1681" y="97"/>
-      <point x="1645" y="142"/>
-      <point x="1645" y="229" type="curve" smooth="yes"/>
-      <point x="1645" y="378"/>
-      <point x="1746" y="502"/>
-      <point x="1899" y="502" type="curve" smooth="yes"/>
-      <point x="2024" y="502"/>
-      <point x="2097" y="427"/>
-      <point x="2097" y="309" type="curve" smooth="yes"/>
-      <point x="2097" y="223"/>
-      <point x="2065" y="140"/>
-      <point x="1999" y="61" type="curve"/>
-      <point x="2096" y="-14" type="line"/>
-      <point x="2172" y="79"/>
-      <point x="2215" y="187"/>
-      <point x="2215" y="301" type="curve" smooth="yes"/>
-      <point x="2215" y="496"/>
-      <point x="2101" y="613"/>
-      <point x="1902" y="613" type="curve" smooth="yes"/>
-      <point x="1693" y="613"/>
-      <point x="1533" y="438"/>
-      <point x="1533" y="226" type="curve" smooth="yes"/>
-      <point x="1533" y="72"/>
-      <point x="1618" y="-14"/>
-      <point x="1741" y="-14" type="curve" smooth="yes"/>
-      <point x="1872" y="-14"/>
-      <point x="1949" y="84"/>
-      <point x="1949" y="238" type="curve" smooth="yes"/>
-      <point x="1949" y="423"/>
-      <point x="1819" y="613"/>
-      <point x="1595" y="613" type="curve" smooth="yes"/>
-      <point x="1486" y="613"/>
-      <point x="1408" y="565"/>
-      <point x="1368" y="486" type="curve"/>
-      <point x="1361" y="486" type="line"/>
-      <point x="1318" y="561"/>
-      <point x="1243" y="613"/>
-      <point x="1125" y="613" type="curve" smooth="yes"/>
-      <point x="950" y="613"/>
-      <point x="859" y="524"/>
-      <point x="814" y="349" type="curve" smooth="yes"/>
-      <point x="763" y="156"/>
-      <point x="638" y="87"/>
-      <point x="364" y="87" type="curve" smooth="yes"/>
-      <point x="204" y="87"/>
-      <point x="161" y="111"/>
-      <point x="161" y="154" type="curve" smooth="yes"/>
-      <point x="161" y="185"/>
-      <point x="184" y="204"/>
-      <point x="249" y="204" type="curve" smooth="yes"/>
-      <point x="488" y="204" type="line" smooth="yes"/>
-      <point x="694" y="204"/>
-      <point x="776" y="287"/>
-      <point x="775" y="427" type="curve" smooth="yes"/>
-      <point x="775" y="532"/>
-      <point x="722" y="613"/>
-      <point x="604" y="613" type="curve" smooth="yes"/>
-      <point x="527" y="613"/>
-      <point x="468" y="573"/>
-      <point x="445" y="502" type="curve"/>
-      <point x="438" y="502" type="line"/>
-      <point x="407" y="573"/>
-      <point x="338" y="613"/>
-      <point x="243" y="613" type="curve" smooth="yes"/>
-      <point x="111" y="613"/>
-      <point x="39" y="539"/>
-      <point x="39" y="445" type="curve" smooth="yes"/>
-      <point x="39" y="368"/>
-      <point x="90" y="309"/>
-      <point x="186" y="309" type="curve" smooth="yes"/>
-      <point x="277" y="309"/>
-      <point x="328" y="362"/>
-      <point x="328" y="426" type="curve" smooth="yes"/>
-      <point x="328" y="480"/>
-      <point x="301" y="525"/>
-      <point x="216" y="525" type="curve" smooth="yes"/>
-      <point x="193" y="525"/>
-      <point x="166" y="520"/>
-      <point x="148" y="511" type="curve"/>
-      <point x="183" y="500" type="line"/>
-      <point x="162" y="553" type="line"/>
-      <point x="155" y="519" type="line"/>
-      <point x="175" y="529"/>
-      <point x="203" y="536"/>
-      <point x="244" y="536" type="curve" smooth="yes"/>
-      <point x="347" y="536"/>
-      <point x="379" y="471"/>
-      <point x="379" y="396" type="curve" smooth="yes"/>
-      <point x="379" y="352" type="line"/>
-      <point x="497" y="352" type="line"/>
-      <point x="497" y="388" type="line" smooth="yes"/>
-      <point x="497" y="465"/>
-      <point x="532" y="510"/>
-      <point x="589" y="510" type="curve" smooth="yes"/>
-      <point x="643" y="510"/>
-      <point x="665" y="472"/>
-      <point x="665" y="416" type="curve" smooth="yes"/>
-      <point x="665" y="343"/>
-      <point x="628" y="302"/>
-      <point x="513" y="302" type="curve" smooth="yes"/>
-      <point x="251" y="302" type="line" smooth="yes"/>
-      <point x="117" y="302"/>
-      <point x="45" y="245"/>
-      <point x="45" y="155" type="curve" smooth="yes"/>
-      <point x="45" y="49"/>
+      <point x="348" y="-16" type="curve" smooth="yes"/>
+      <point x="604" y="-16"/>
+      <point x="766" y="46"/>
+      <point x="863" y="166" type="curve"/>
+      <point x="869" y="166" type="line"/>
+      <point x="898" y="56"/>
+      <point x="973" y="-16"/>
+      <point x="1081" y="-16" type="curve" smooth="yes"/>
+      <point x="1202" y="-16"/>
+      <point x="1275" y="70"/>
+      <point x="1275" y="182" type="curve" smooth="yes"/>
+      <point x="1275" y="290"/>
+      <point x="1214" y="364"/>
+      <point x="1098" y="364" type="curve" smooth="yes"/>
+      <point x="1041" y="364"/>
+      <point x="990" y="338"/>
+      <point x="960" y="297" type="curve"/>
+      <point x="933" y="305" type="line"/>
+      <point x="953" y="145" type="line"/>
+      <point x="968" y="226"/>
+      <point x="1023" y="261"/>
+      <point x="1075" y="261" type="curve" smooth="yes"/>
+      <point x="1130" y="261"/>
+      <point x="1157" y="232"/>
+      <point x="1157" y="180" type="curve" smooth="yes"/>
+      <point x="1157" y="126"/>
+      <point x="1126" y="92"/>
+      <point x="1073" y="92" type="curve" smooth="yes"/>
+      <point x="1001" y="92"/>
+      <point x="951" y="166"/>
+      <point x="951" y="274" type="curve" smooth="yes"/>
+      <point x="951" y="410"/>
+      <point x="1030" y="502"/>
+      <point x="1157" y="502" type="curve" smooth="yes"/>
+      <point x="1273" y="502"/>
+      <point x="1330" y="428"/>
+      <point x="1330" y="315" type="curve" smooth="yes"/>
+      <point x="1330" y="0" type="line"/>
+      <point x="1452" y="0" type="line"/>
+      <point x="1452" y="315" type="line" smooth="yes"/>
+      <point x="1452" y="434"/>
+      <point x="1512" y="502"/>
+      <point x="1622" y="502" type="curve" smooth="yes"/>
+      <point x="1788" y="502"/>
+      <point x="1863" y="385"/>
+      <point x="1863" y="240" type="curve" smooth="yes"/>
+      <point x="1863" y="150"/>
+      <point x="1830" y="97"/>
+      <point x="1769" y="97" type="curve" smooth="yes"/>
+      <point x="1713" y="97"/>
+      <point x="1677" y="142"/>
+      <point x="1677" y="229" type="curve" smooth="yes"/>
+      <point x="1677" y="378"/>
+      <point x="1778" y="502"/>
+      <point x="1931" y="502" type="curve" smooth="yes"/>
+      <point x="2056" y="502"/>
+      <point x="2129" y="427"/>
+      <point x="2129" y="309" type="curve" smooth="yes"/>
+      <point x="2129" y="223"/>
+      <point x="2097" y="140"/>
+      <point x="2031" y="61" type="curve"/>
+      <point x="2128" y="-14" type="line"/>
+      <point x="2204" y="79"/>
+      <point x="2247" y="187"/>
+      <point x="2247" y="301" type="curve" smooth="yes"/>
+      <point x="2247" y="496"/>
+      <point x="2133" y="613"/>
+      <point x="1934" y="613" type="curve" smooth="yes"/>
+      <point x="1725" y="613"/>
+      <point x="1565" y="438"/>
+      <point x="1565" y="226" type="curve" smooth="yes"/>
+      <point x="1565" y="72"/>
+      <point x="1650" y="-14"/>
+      <point x="1773" y="-14" type="curve" smooth="yes"/>
+      <point x="1904" y="-14"/>
+      <point x="1981" y="84"/>
+      <point x="1981" y="238" type="curve" smooth="yes"/>
+      <point x="1981" y="423"/>
+      <point x="1851" y="613"/>
+      <point x="1627" y="613" type="curve" smooth="yes"/>
+      <point x="1518" y="613"/>
+      <point x="1440" y="565"/>
+      <point x="1400" y="486" type="curve"/>
+      <point x="1393" y="486" type="line"/>
+      <point x="1350" y="561"/>
+      <point x="1278" y="613"/>
+      <point x="1158" y="613" type="curve" smooth="yes"/>
+      <point x="997" y="613"/>
+      <point x="893" y="525"/>
+      <point x="846" y="349" type="curve" smooth="yes"/>
+      <point x="794" y="155"/>
+      <point x="652" y="87"/>
+      <point x="350" y="87" type="curve" smooth="yes"/>
+      <point x="208" y="87"/>
+      <point x="163" y="106"/>
+      <point x="163" y="140" type="curve" smooth="yes"/>
+      <point x="163" y="168"/>
+      <point x="186" y="184"/>
+      <point x="228" y="184" type="curve" smooth="yes"/>
+      <point x="515" y="184" type="line" smooth="yes"/>
+      <point x="692" y="184"/>
+      <point x="808" y="277"/>
+      <point x="808" y="425" type="curve" smooth="yes"/>
+      <point x="808" y="538"/>
+      <point x="744" y="613"/>
+      <point x="638" y="613" type="curve" smooth="yes"/>
+      <point x="555" y="613"/>
+      <point x="489" y="570"/>
+      <point x="459" y="498" type="curve"/>
+      <point x="452" y="498" type="line"/>
+      <point x="425" y="567"/>
+      <point x="370" y="613"/>
+      <point x="261" y="613" type="curve" smooth="yes"/>
+      <point x="128" y="613"/>
+      <point x="39" y="541"/>
+      <point x="39" y="437" type="curve" smooth="yes"/>
+      <point x="39" y="347"/>
+      <point x="100" y="286"/>
+      <point x="195" y="286" type="curve" smooth="yes"/>
+      <point x="280" y="286"/>
+      <point x="338" y="335"/>
+      <point x="338" y="408" type="curve" smooth="yes"/>
+      <point x="338" y="473"/>
+      <point x="296" y="520"/>
+      <point x="223" y="520" type="curve" smooth="yes"/>
+      <point x="203" y="520"/>
+      <point x="180" y="517"/>
+      <point x="159" y="509" type="curve"/>
+      <point x="144" y="537" type="line"/>
+      <point x="140" y="505" type="line"/>
+      <point x="170" y="527"/>
+      <point x="207" y="539"/>
+      <point x="261" y="539" type="curve" smooth="yes"/>
+      <point x="350" y="539"/>
+      <point x="392" y="490"/>
+      <point x="392" y="396" type="curve" smooth="yes"/>
+      <point x="392" y="323" type="line"/>
+      <point x="510" y="323" type="line"/>
+      <point x="510" y="390" type="line" smooth="yes"/>
+      <point x="510" y="464"/>
+      <point x="551" y="509"/>
+      <point x="617" y="509" type="curve" smooth="yes"/>
+      <point x="671" y="509"/>
+      <point x="700" y="474"/>
+      <point x="700" y="413" type="curve" smooth="yes"/>
+      <point x="700" y="325"/>
+      <point x="636" y="278"/>
+      <point x="515" y="278" type="curve" smooth="yes"/>
+      <point x="224" y="278" type="line" smooth="yes"/>
+      <point x="114" y="278"/>
+      <point x="45" y="221"/>
+      <point x="45" y="136" type="curve" smooth="yes"/>
+      <point x="45" y="42"/>
       <point x="112" y="-16"/>
     </contour>
     <contour>
-      <point x="191" y="386" type="curve" smooth="yes"/>
-      <point x="153" y="386"/>
-      <point x="135" y="414"/>
-      <point x="135" y="445" type="curve" smooth="yes"/>
-      <point x="135" y="460"/>
-      <point x="138" y="471"/>
-      <point x="148" y="484" type="curve"/>
-      <point x="117" y="484" type="line"/>
-      <point x="108" y="459" type="line"/>
-      <point x="131" y="471"/>
-      <point x="155" y="479"/>
-      <point x="185" y="479" type="curve" smooth="yes"/>
-      <point x="235" y="479"/>
-      <point x="246" y="457"/>
-      <point x="246" y="436" type="curve" smooth="yes"/>
-      <point x="246" y="410"/>
-      <point x="230" y="386"/>
+      <point x="190" y="367" type="curve" smooth="yes"/>
+      <point x="150" y="367"/>
+      <point x="127" y="393"/>
+      <point x="127" y="432" type="curve" smooth="yes"/>
+      <point x="127" y="452"/>
+      <point x="130" y="465"/>
+      <point x="142" y="481" type="curve"/>
+      <point x="115" y="481" type="line"/>
+      <point x="115" y="432" type="line"/>
+      <point x="131" y="456"/>
+      <point x="158" y="470"/>
+      <point x="191" y="470" type="curve" smooth="yes"/>
+      <point x="227" y="470"/>
+      <point x="246" y="449"/>
+      <point x="246" y="419" type="curve" smooth="yes"/>
+      <point x="246" y="388"/>
+      <point x="225" y="367"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ja-malayalam.glif
@@ -1,135 +1,135 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="847"/>
+  <advance width="889"/>
   <unicode hex="0D1C"/>
-  <anchor x="439" y="0" name="bottom"/>
-  <anchor x="444" y="597" name="top"/>
-  <anchor x="726" y="597" name="topright"/>
+  <anchor x="463" y="0" name="bottom"/>
+  <anchor x="445" y="597" name="top"/>
+  <anchor x="735" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="223" y="-16" type="curve" smooth="yes"/>
-      <point x="297" y="-16"/>
-      <point x="358" y="5"/>
-      <point x="440" y="59" type="curve" smooth="yes"/>
-      <point x="509" y="104" type="line"/>
-      <point x="578" y="153" type="line"/>
-      <point x="595" y="155" type="line"/>
-      <point x="623" y="169"/>
-      <point x="644" y="174"/>
-      <point x="663" y="174" type="curve" smooth="yes"/>
-      <point x="697" y="174"/>
-      <point x="715" y="156"/>
-      <point x="715" y="122" type="curve" smooth="yes"/>
-      <point x="715" y="91"/>
-      <point x="697" y="73"/>
-      <point x="668" y="73" type="curve" smooth="yes"/>
-      <point x="638" y="73"/>
-      <point x="619" y="92"/>
-      <point x="619" y="124" type="curve" smooth="yes"/>
-      <point x="619" y="143"/>
-      <point x="624" y="160"/>
-      <point x="639" y="180" type="curve"/>
-      <point x="536" y="151" type="line"/>
-      <point x="556" y="128" type="line"/>
-      <point x="549" y="114"/>
-      <point x="546" y="101"/>
-      <point x="546" y="87" type="curve" smooth="yes"/>
-      <point x="546" y="25"/>
-      <point x="592" y="-16"/>
-      <point x="668" y="-16" type="curve" smooth="yes"/>
-      <point x="751" y="-16"/>
-      <point x="804" y="35"/>
-      <point x="804" y="114" type="curve" smooth="yes"/>
-      <point x="804" y="198"/>
-      <point x="746" y="255"/>
-      <point x="663" y="255" type="curve" smooth="yes"/>
-      <point x="610" y="255"/>
-      <point x="566" y="240"/>
-      <point x="479" y="190" type="curve" smooth="yes"/>
-      <point x="408" y="149" type="line" smooth="yes"/>
-      <point x="327" y="103"/>
-      <point x="281" y="87"/>
-      <point x="231" y="87" type="curve" smooth="yes"/>
-      <point x="188" y="87"/>
-      <point x="162" y="108"/>
-      <point x="162" y="142" type="curve" smooth="yes"/>
-      <point x="162" y="182"/>
-      <point x="194" y="204"/>
-      <point x="256" y="204" type="curve" smooth="yes"/>
-      <point x="570" y="204" type="line" smooth="yes"/>
-      <point x="721" y="204"/>
-      <point x="808" y="280"/>
-      <point x="808" y="413" type="curve" smooth="yes"/>
-      <point x="808" y="538"/>
-      <point x="736" y="613"/>
-      <point x="618" y="613" type="curve" smooth="yes"/>
-      <point x="535" y="613"/>
-      <point x="473" y="571"/>
-      <point x="450" y="502" type="curve"/>
-      <point x="443" y="502" type="line"/>
-      <point x="422" y="571"/>
-      <point x="359" y="613"/>
-      <point x="256" y="613" type="curve" smooth="yes"/>
-      <point x="124" y="613"/>
-      <point x="39" y="546"/>
-      <point x="39" y="448" type="curve" smooth="yes"/>
-      <point x="39" y="365"/>
-      <point x="99" y="309"/>
-      <point x="189" y="309" type="curve" smooth="yes"/>
-      <point x="274" y="309"/>
-      <point x="328" y="352"/>
-      <point x="328" y="421" type="curve" smooth="yes"/>
-      <point x="328" y="483"/>
-      <point x="290" y="520"/>
-      <point x="225" y="520" type="curve" smooth="yes"/>
-      <point x="204" y="520"/>
-      <point x="181" y="517"/>
+      <point x="225" y="-16" type="curve" smooth="yes"/>
+      <point x="275" y="-16"/>
+      <point x="317" y="-3"/>
+      <point x="406" y="38" type="curve" smooth="yes"/>
+      <point x="540" y="100" type="line"/>
+      <point x="609" y="155" type="line"/>
+      <point x="625" y="155" type="line"/>
+      <point x="656" y="170"/>
+      <point x="677" y="175"/>
+      <point x="700" y="175" type="curve" smooth="yes"/>
+      <point x="738" y="175"/>
+      <point x="756" y="155"/>
+      <point x="756" y="124" type="curve" smooth="yes"/>
+      <point x="756" y="92"/>
+      <point x="735" y="73"/>
+      <point x="703" y="73" type="curve" smooth="yes"/>
+      <point x="670" y="73"/>
+      <point x="649" y="93"/>
+      <point x="649" y="123" type="curve" smooth="yes"/>
+      <point x="649" y="145"/>
+      <point x="657" y="164"/>
+      <point x="674" y="181" type="curve"/>
+      <point x="568" y="153" type="line"/>
+      <point x="588" y="130" type="line"/>
+      <point x="580" y="116"/>
+      <point x="576" y="104"/>
+      <point x="576" y="90" type="curve" smooth="yes"/>
+      <point x="576" y="28"/>
+      <point x="628" y="-16"/>
+      <point x="705" y="-16" type="curve" smooth="yes"/>
+      <point x="791" y="-16"/>
+      <point x="846" y="36"/>
+      <point x="846" y="116" type="curve" smooth="yes"/>
+      <point x="846" y="192"/>
+      <point x="793" y="243"/>
+      <point x="701" y="243" type="curve" smooth="yes"/>
+      <point x="647" y="243"/>
+      <point x="602" y="228"/>
+      <point x="509" y="185" type="curve" smooth="yes"/>
+      <point x="368" y="120" type="line" smooth="yes"/>
+      <point x="310" y="93"/>
+      <point x="275" y="84"/>
+      <point x="236" y="84" type="curve" smooth="yes"/>
+      <point x="190" y="84"/>
+      <point x="163" y="102"/>
+      <point x="163" y="134" type="curve" smooth="yes"/>
+      <point x="163" y="166"/>
+      <point x="186" y="184"/>
+      <point x="228" y="184" type="curve" smooth="yes"/>
+      <point x="553" y="184" type="line" smooth="yes"/>
+      <point x="723" y="184"/>
+      <point x="850" y="278"/>
+      <point x="850" y="414" type="curve" smooth="yes"/>
+      <point x="850" y="534"/>
+      <point x="780" y="613"/>
+      <point x="652" y="613" type="curve" smooth="yes"/>
+      <point x="563" y="613"/>
+      <point x="491" y="570"/>
+      <point x="459" y="498" type="curve"/>
+      <point x="452" y="498" type="line"/>
+      <point x="425" y="566"/>
+      <point x="371" y="613"/>
+      <point x="262" y="613" type="curve" smooth="yes"/>
+      <point x="127" y="613"/>
+      <point x="39" y="541"/>
+      <point x="39" y="436" type="curve" smooth="yes"/>
+      <point x="39" y="347"/>
+      <point x="100" y="286"/>
+      <point x="195" y="286" type="curve" smooth="yes"/>
+      <point x="280" y="286"/>
+      <point x="338" y="335"/>
+      <point x="338" y="408" type="curve" smooth="yes"/>
+      <point x="338" y="473"/>
+      <point x="298" y="520"/>
+      <point x="223" y="520" type="curve" smooth="yes"/>
+      <point x="203" y="520"/>
+      <point x="180" y="517"/>
       <point x="159" y="509" type="curve"/>
       <point x="144" y="537" type="line"/>
       <point x="140" y="505" type="line"/>
-      <point x="168" y="528"/>
-      <point x="206" y="539"/>
-      <point x="249" y="539" type="curve" smooth="yes"/>
-      <point x="341" y="539"/>
-      <point x="385" y="489"/>
-      <point x="385" y="396" type="curve" smooth="yes"/>
-      <point x="385" y="352" type="line"/>
-      <point x="503" y="352" type="line"/>
-      <point x="503" y="388" type="line" smooth="yes"/>
-      <point x="503" y="464"/>
-      <point x="542" y="510"/>
-      <point x="606" y="510" type="curve" smooth="yes"/>
-      <point x="661" y="510"/>
-      <point x="691" y="478"/>
-      <point x="691" y="416" type="curve" smooth="yes"/>
-      <point x="691" y="338"/>
-      <point x="645" y="302"/>
-      <point x="548" y="302" type="curve" smooth="yes"/>
-      <point x="251" y="302" type="line" smooth="yes"/>
-      <point x="121" y="302"/>
-      <point x="45" y="243"/>
-      <point x="45" y="142" type="curve" smooth="yes"/>
-      <point x="45" y="44"/>
-      <point x="113" y="-16"/>
+      <point x="171" y="528"/>
+      <point x="208" y="539"/>
+      <point x="259" y="539" type="curve" smooth="yes"/>
+      <point x="351" y="539"/>
+      <point x="392" y="490"/>
+      <point x="392" y="396" type="curve" smooth="yes"/>
+      <point x="392" y="323" type="line"/>
+      <point x="510" y="323" type="line"/>
+      <point x="510" y="390" type="line" smooth="yes"/>
+      <point x="510" y="464"/>
+      <point x="555" y="509"/>
+      <point x="628" y="509" type="curve" smooth="yes"/>
+      <point x="695" y="509"/>
+      <point x="732" y="471"/>
+      <point x="732" y="405" type="curve" smooth="yes"/>
+      <point x="732" y="319"/>
+      <point x="672" y="278"/>
+      <point x="555" y="278" type="curve" smooth="yes"/>
+      <point x="224" y="278" type="line" smooth="yes"/>
+      <point x="114" y="278"/>
+      <point x="45" y="218"/>
+      <point x="45" y="130" type="curve" smooth="yes"/>
+      <point x="45" y="41"/>
+      <point x="117" y="-16"/>
     </contour>
     <contour>
-      <point x="193" y="390" type="curve" smooth="yes"/>
-      <point x="155" y="390"/>
-      <point x="135" y="410"/>
-      <point x="135" y="447" type="curve" smooth="yes"/>
-      <point x="135" y="461"/>
-      <point x="136" y="469"/>
+      <point x="190" y="367" type="curve" smooth="yes"/>
+      <point x="150" y="367"/>
+      <point x="127" y="393"/>
+      <point x="127" y="432" type="curve" smooth="yes"/>
+      <point x="127" y="452"/>
+      <point x="130" y="465"/>
       <point x="142" y="481" type="curve"/>
-      <point x="116" y="481" type="line"/>
-      <point x="110" y="443" type="line"/>
-      <point x="135" y="463"/>
-      <point x="165" y="472"/>
-      <point x="195" y="472" type="curve" smooth="yes"/>
-      <point x="228" y="472"/>
-      <point x="246" y="457"/>
-      <point x="246" y="431" type="curve" smooth="yes"/>
-      <point x="246" y="405"/>
-      <point x="226" y="390"/>
+      <point x="115" y="481" type="line"/>
+      <point x="115" y="432" type="line"/>
+      <point x="131" y="456"/>
+      <point x="158" y="470"/>
+      <point x="191" y="470" type="curve" smooth="yes"/>
+      <point x="227" y="470"/>
+      <point x="246" y="449"/>
+      <point x="246" y="419" type="curve" smooth="yes"/>
+      <point x="246" y="388"/>
+      <point x="225" y="367"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="847"/>
+  <advance width="889"/>
+  <anchor x="463" y="0" name="bottom"/>
+  <anchor x="445" y="597" name="top"/>
+  <anchor x="735" y="597" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="726"/>
+    <component base="halant-malayalam" xOffset="735"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="847"/>
+  <advance width="889"/>
+  <anchor x="463" y="0" name="bottom"/>
+  <anchor x="445" y="597" name="top"/>
+  <anchor x="735" y="597" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="439"/>
+    <component base="lVocalicMatra-malayalam" xOffset="463"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="847"/>
+  <advance width="889"/>
+  <anchor x="463" y="0" name="bottom"/>
+  <anchor x="445" y="597" name="top"/>
+  <anchor x="735" y="597" name="topright"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="439"/>
+    <component base="llVocalicMatra-malayalam" xOffset="463"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
@@ -6,9 +6,9 @@
   <anchor x="360" y="597" name="top"/>
   <outline>
     <contour>
-      <point x="203" y="-16" type="curve" smooth="yes"/>
-      <point x="287" y="-16"/>
-      <point x="340" y="33"/>
+      <point x="206" y="-16" type="curve" smooth="yes"/>
+      <point x="279" y="-16"/>
+      <point x="336" y="24"/>
       <point x="369" y="97" type="curve"/>
       <point x="376" y="97" type="line"/>
       <point x="410" y="23"/>
@@ -18,29 +18,29 @@
       <point x="673" y="17"/>
       <point x="701" y="87" type="curve"/>
       <point x="708" y="87" type="line"/>
-      <point x="736" y="23"/>
-      <point x="787" y="-16"/>
-      <point x="873" y="-16" type="curve" smooth="yes"/>
-      <point x="987" y="-16"/>
-      <point x="1053" y="53"/>
-      <point x="1053" y="163" type="curve" smooth="yes"/>
-      <point x="1053" y="272"/>
-      <point x="973" y="346"/>
-      <point x="843" y="346" type="curve" smooth="yes"/>
-      <point x="793" y="346" type="line"/>
-      <point x="746" y="245" type="line"/>
-      <point x="836" y="245" type="line" smooth="yes"/>
-      <point x="904" y="245"/>
-      <point x="933" y="214"/>
-      <point x="933" y="169" type="curve" smooth="yes"/>
-      <point x="933" y="124"/>
-      <point x="907" y="95"/>
-      <point x="862" y="95" type="curve" smooth="yes"/>
-      <point x="808" y="95"/>
-      <point x="775" y="130"/>
-      <point x="775" y="196" type="curve" smooth="yes"/>
-      <point x="775" y="259"/>
-      <point x="803" y="318"/>
+      <point x="736" y="25"/>
+      <point x="790" y="-16"/>
+      <point x="875" y="-16" type="curve" smooth="yes"/>
+      <point x="985" y="-16"/>
+      <point x="1053" y="60"/>
+      <point x="1053" y="174" type="curve" smooth="yes"/>
+      <point x="1053" y="288"/>
+      <point x="971" y="366"/>
+      <point x="829" y="366" type="curve" smooth="yes"/>
+      <point x="793" y="366" type="line"/>
+      <point x="746" y="265" type="line"/>
+      <point x="822" y="265" type="line" smooth="yes"/>
+      <point x="904" y="265"/>
+      <point x="935" y="229"/>
+      <point x="935" y="176" type="curve" smooth="yes"/>
+      <point x="935" y="127"/>
+      <point x="905" y="95"/>
+      <point x="858" y="95" type="curve" smooth="yes"/>
+      <point x="805" y="95"/>
+      <point x="775" y="129"/>
+      <point x="775" y="184" type="curve" smooth="yes"/>
+      <point x="775" y="253"/>
+      <point x="799" y="315"/>
       <point x="880" y="423" type="curve" smooth="yes"/>
       <point x="940" y="504"/>
       <point x="972" y="566"/>
@@ -59,38 +59,38 @@
       <point x="859" y="683"/>
       <point x="859" y="643" type="curve" smooth="yes"/>
       <point x="859" y="601"/>
-      <point x="837" y="560"/>
+      <point x="838" y="559"/>
       <point x="795" y="496" type="curve" smooth="yes"/>
-      <point x="779" y="471"/>
-      <point x="765" y="450"/>
-      <point x="758" y="429" type="curve"/>
-      <point x="751" y="429" type="line"/>
-      <point x="727" y="536"/>
-      <point x="657" y="613"/>
+      <point x="778" y="471"/>
+      <point x="767" y="450"/>
+      <point x="760" y="427" type="curve"/>
+      <point x="753" y="427" type="line"/>
+      <point x="729" y="535"/>
+      <point x="658" y="613"/>
       <point x="548" y="613" type="curve" smooth="yes"/>
       <point x="409" y="613"/>
       <point x="320" y="491"/>
       <point x="320" y="314" type="curve" smooth="yes"/>
-      <point x="320" y="287"/>
-      <point x="325" y="255"/>
-      <point x="325" y="227" type="curve" smooth="yes"/>
-      <point x="325" y="145"/>
+      <point x="320" y="281"/>
+      <point x="328" y="241"/>
+      <point x="328" y="207" type="curve" smooth="yes"/>
+      <point x="328" y="138"/>
       <point x="290" y="95"/>
-      <point x="226" y="95" type="curve" smooth="yes"/>
-      <point x="173" y="95"/>
-      <point x="143" y="123"/>
-      <point x="143" y="170" type="curve" smooth="yes"/>
-      <point x="143" y="216"/>
-      <point x="175" y="245"/>
-      <point x="240" y="245" type="curve" smooth="yes"/>
-      <point x="728" y="245" type="line"/>
-      <point x="731" y="346" type="line"/>
-      <point x="241" y="346" type="line" smooth="yes"/>
-      <point x="101" y="346"/>
-      <point x="26" y="271"/>
-      <point x="26" y="160" type="curve" smooth="yes"/>
+      <point x="229" y="95" type="curve" smooth="yes"/>
+      <point x="176" y="95"/>
+      <point x="144" y="126"/>
+      <point x="144" y="176" type="curve" smooth="yes"/>
+      <point x="144" y="232"/>
+      <point x="183" y="265"/>
+      <point x="249" y="265" type="curve" smooth="yes"/>
+      <point x="728" y="265" type="line"/>
+      <point x="731" y="366" type="line"/>
+      <point x="250" y="366" type="line" smooth="yes"/>
+      <point x="111" y="366"/>
+      <point x="26" y="291"/>
+      <point x="26" y="169" type="curve" smooth="yes"/>
       <point x="26" y="60"/>
-      <point x="94" y="-16"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="551" y="95" type="curve" smooth="yes"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/k_ka-malayalam.glif
@@ -6,96 +6,96 @@
   <anchor x="1326" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="203" y="-16" type="curve" smooth="yes"/>
-      <point x="287" y="-16"/>
-      <point x="340" y="33"/>
+      <point x="206" y="-16" type="curve" smooth="yes"/>
+      <point x="279" y="-16"/>
+      <point x="336" y="24"/>
       <point x="369" y="97" type="curve"/>
       <point x="376" y="97" type="line"/>
-      <point x="410" y="23"/>
-      <point x="476" y="-16"/>
+      <point x="409" y="25"/>
+      <point x="474" y="-16"/>
       <point x="557" y="-16" type="curve" smooth="yes"/>
-      <point x="697" y="-16"/>
-      <point x="783" y="107"/>
+      <point x="694" y="-16"/>
+      <point x="783" y="103"/>
       <point x="783" y="284" type="curve" smooth="yes"/>
       <point x="783" y="314" type="line" smooth="yes"/>
-      <point x="783" y="489"/>
-      <point x="697" y="613"/>
+      <point x="783" y="495"/>
+      <point x="692" y="613"/>
       <point x="552" y="613" type="curve" smooth="yes"/>
-      <point x="409" y="613"/>
-      <point x="320" y="491"/>
+      <point x="412" y="613"/>
+      <point x="320" y="495"/>
       <point x="320" y="314" type="curve" smooth="yes"/>
-      <point x="320" y="287"/>
-      <point x="326" y="255"/>
-      <point x="326" y="227" type="curve" smooth="yes"/>
-      <point x="326" y="145"/>
+      <point x="320" y="281"/>
+      <point x="328" y="241"/>
+      <point x="328" y="207" type="curve" smooth="yes"/>
+      <point x="328" y="138"/>
       <point x="290" y="95"/>
-      <point x="226" y="95" type="curve" smooth="yes"/>
-      <point x="173" y="95"/>
-      <point x="143" y="123"/>
-      <point x="143" y="170" type="curve" smooth="yes"/>
-      <point x="143" y="216"/>
-      <point x="175" y="245"/>
-      <point x="240" y="245" type="curve" smooth="yes"/>
-      <point x="971" y="245" type="line" smooth="yes"/>
-      <point x="1050" y="245"/>
-      <point x="1078" y="215"/>
-      <point x="1078" y="160" type="curve" smooth="yes"/>
-      <point x="1078" y="113"/>
-      <point x="1058" y="92"/>
-      <point x="1025" y="92" type="curve" smooth="yes"/>
-      <point x="973" y="92"/>
-      <point x="949" y="142"/>
-      <point x="949" y="232" type="curve" smooth="yes"/>
-      <point x="949" y="386"/>
-      <point x="1006" y="501"/>
-      <point x="1145" y="501" type="curve" smooth="yes"/>
-      <point x="1259" y="501"/>
-      <point x="1316" y="409"/>
+      <point x="229" y="95" type="curve" smooth="yes"/>
+      <point x="175" y="95"/>
+      <point x="143" y="126"/>
+      <point x="143" y="176" type="curve" smooth="yes"/>
+      <point x="143" y="232"/>
+      <point x="182" y="265"/>
+      <point x="249" y="265" type="curve" smooth="yes"/>
+      <point x="973" y="265" type="line" smooth="yes"/>
+      <point x="1046" y="265"/>
+      <point x="1080" y="236"/>
+      <point x="1080" y="175" type="curve" smooth="yes"/>
+      <point x="1080" y="123"/>
+      <point x="1057" y="92"/>
+      <point x="1018" y="92" type="curve" smooth="yes"/>
+      <point x="971" y="92"/>
+      <point x="949" y="137"/>
+      <point x="949" y="235" type="curve" smooth="yes"/>
+      <point x="949" y="405"/>
+      <point x="1022" y="501"/>
+      <point x="1149" y="501" type="curve" smooth="yes"/>
+      <point x="1255" y="501"/>
+      <point x="1316" y="419"/>
       <point x="1316" y="285" type="curve" smooth="yes"/>
       <point x="1316" y="198"/>
       <point x="1292" y="126"/>
       <point x="1236" y="47" type="curve"/>
       <point x="1337" y="-16" type="line"/>
-      <point x="1406" y="75"/>
-      <point x="1437" y="180"/>
+      <point x="1402" y="70"/>
+      <point x="1437" y="174"/>
       <point x="1437" y="284" type="curve" smooth="yes"/>
-      <point x="1437" y="482"/>
-      <point x="1337" y="613"/>
-      <point x="1144" y="613" type="curve" smooth="yes"/>
-      <point x="942" y="613"/>
-      <point x="832" y="455"/>
-      <point x="832" y="256" type="curve" smooth="yes"/>
-      <point x="832" y="96"/>
-      <point x="893" y="-16"/>
-      <point x="1030" y="-16" type="curve" smooth="yes"/>
-      <point x="1151" y="-16"/>
-      <point x="1194" y="76"/>
-      <point x="1194" y="159" type="curve" smooth="yes"/>
-      <point x="1194" y="286"/>
-      <point x="1110" y="346"/>
-      <point x="967" y="346" type="curve" smooth="yes"/>
-      <point x="241" y="346" type="line" smooth="yes"/>
-      <point x="101" y="346"/>
-      <point x="26" y="271"/>
-      <point x="26" y="160" type="curve" smooth="yes"/>
+      <point x="1437" y="491"/>
+      <point x="1332" y="613"/>
+      <point x="1148" y="613" type="curve" smooth="yes"/>
+      <point x="961" y="613"/>
+      <point x="834" y="460"/>
+      <point x="834" y="229" type="curve" smooth="yes"/>
+      <point x="834" y="77"/>
+      <point x="905" y="-16"/>
+      <point x="1022" y="-16" type="curve" smooth="yes"/>
+      <point x="1127" y="-16"/>
+      <point x="1196" y="59"/>
+      <point x="1196" y="174" type="curve" smooth="yes"/>
+      <point x="1196" y="298"/>
+      <point x="1116" y="366"/>
+      <point x="971" y="366" type="curve" smooth="yes"/>
+      <point x="250" y="366" type="line" smooth="yes"/>
+      <point x="111" y="366"/>
+      <point x="26" y="291"/>
+      <point x="26" y="169" type="curve" smooth="yes"/>
       <point x="26" y="60"/>
-      <point x="94" y="-16"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="551" y="95" type="curve" smooth="yes"/>
-      <point x="475" y="95"/>
-      <point x="431" y="162"/>
+      <point x="474" y="95"/>
+      <point x="431" y="164"/>
       <point x="431" y="287" type="curve" smooth="yes"/>
       <point x="431" y="312" type="line" smooth="yes"/>
-      <point x="431" y="434"/>
-      <point x="476" y="502"/>
+      <point x="431" y="432"/>
+      <point x="475" y="502"/>
       <point x="551" y="502" type="curve" smooth="yes"/>
       <point x="624" y="502"/>
       <point x="665" y="433"/>
       <point x="665" y="312" type="curve" smooth="yes"/>
       <point x="665" y="287" type="line" smooth="yes"/>
-      <point x="665" y="162"/>
-      <point x="623" y="95"/>
+      <point x="665" y="164"/>
+      <point x="624" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/k_la-malayalam.glif
@@ -16,8 +16,8 @@
       <point x="401" y="-112"/>
       <point x="347" y="-141"/>
       <point x="343" y="-222" type="curve"/>
-      <point x="379" y="-157" type="line"/>
-      <point x="327" y="-156" type="line"/>
+      <point x="379" y="-158" type="line"/>
+      <point x="327" y="-154" type="line"/>
       <point x="354" y="-175" type="line"/>
       <point x="354" y="-101"/>
       <point x="396" y="-35"/>
@@ -43,7 +43,7 @@
       <point x="899" y="-278"/>
       <point x="841" y="-278" type="curve" smooth="yes"/>
       <point x="790" y="-278"/>
-      <point x="763" y="-243"/>
+      <point x="762" y="-243"/>
       <point x="743" y="-172" type="curve" smooth="yes"/>
       <point x="733" y="-134" type="line" smooth="yes"/>
       <point x="717" y="-76"/>
@@ -54,32 +54,32 @@
       <point x="783" y="154"/>
       <point x="783" y="284" type="curve" smooth="yes"/>
       <point x="783" y="314" type="line" smooth="yes"/>
-      <point x="783" y="489"/>
-      <point x="697" y="613"/>
+      <point x="783" y="495"/>
+      <point x="692" y="613"/>
       <point x="552" y="613" type="curve" smooth="yes"/>
-      <point x="409" y="613"/>
-      <point x="320" y="491"/>
+      <point x="412" y="613"/>
+      <point x="320" y="495"/>
       <point x="320" y="314" type="curve" smooth="yes"/>
-      <point x="320" y="287"/>
-      <point x="326" y="255"/>
-      <point x="326" y="227" type="curve" smooth="yes"/>
-      <point x="326" y="145"/>
+      <point x="320" y="281"/>
+      <point x="328" y="241"/>
+      <point x="328" y="207" type="curve" smooth="yes"/>
+      <point x="328" y="138"/>
       <point x="290" y="95"/>
-      <point x="226" y="95" type="curve" smooth="yes"/>
-      <point x="173" y="95"/>
-      <point x="143" y="123"/>
-      <point x="143" y="170" type="curve" smooth="yes"/>
-      <point x="143" y="216"/>
-      <point x="175" y="245"/>
-      <point x="240" y="245" type="curve" smooth="yes"/>
-      <point x="835" y="245" type="line" smooth="yes"/>
-      <point x="901" y="245"/>
-      <point x="931" y="218"/>
-      <point x="931" y="170" type="curve" smooth="yes"/>
-      <point x="931" y="122"/>
+      <point x="229" y="95" type="curve" smooth="yes"/>
+      <point x="175" y="95"/>
+      <point x="143" y="126"/>
+      <point x="143" y="176" type="curve" smooth="yes"/>
+      <point x="143" y="232"/>
+      <point x="182" y="265"/>
+      <point x="249" y="265" type="curve" smooth="yes"/>
+      <point x="831" y="265" type="line" smooth="yes"/>
+      <point x="898" y="265"/>
+      <point x="931" y="236"/>
+      <point x="931" y="178" type="curve" smooth="yes"/>
+      <point x="931" y="125"/>
       <point x="903" y="95"/>
       <point x="857" y="95" type="curve" smooth="yes"/>
-      <point x="838" y="95"/>
+      <point x="837" y="95"/>
       <point x="821" y="97"/>
       <point x="807" y="102" type="curve"/>
       <point x="778" y="-3" type="line"/>
@@ -87,20 +87,20 @@
       <point x="836" y="-16"/>
       <point x="866" y="-16" type="curve" smooth="yes"/>
       <point x="973" y="-16"/>
-      <point x="1048" y="53"/>
-      <point x="1048" y="163" type="curve" smooth="yes"/>
-      <point x="1048" y="279"/>
-      <point x="967" y="346"/>
-      <point x="824" y="346" type="curve" smooth="yes"/>
-      <point x="241" y="346" type="line" smooth="yes"/>
-      <point x="101" y="346"/>
-      <point x="26" y="271"/>
-      <point x="26" y="160" type="curve" smooth="yes"/>
+      <point x="1048" y="56"/>
+      <point x="1048" y="171" type="curve" smooth="yes"/>
+      <point x="1048" y="296"/>
+      <point x="966" y="366"/>
+      <point x="820" y="366" type="curve" smooth="yes"/>
+      <point x="250" y="366" type="line" smooth="yes"/>
+      <point x="111" y="366"/>
+      <point x="26" y="291"/>
+      <point x="26" y="169" type="curve" smooth="yes"/>
       <point x="26" y="60"/>
-      <point x="94" y="-16"/>
-      <point x="203" y="-16" type="curve" smooth="yes"/>
-      <point x="287" y="-16"/>
-      <point x="340" y="33"/>
+      <point x="99" y="-16"/>
+      <point x="206" y="-16" type="curve" smooth="yes"/>
+      <point x="279" y="-16"/>
+      <point x="336" y="24"/>
       <point x="369" y="97" type="curve"/>
       <point x="376" y="97" type="line"/>
       <point x="386" y="76"/>
@@ -131,19 +131,19 @@
     </contour>
     <contour>
       <point x="551" y="95" type="curve" smooth="yes"/>
-      <point x="475" y="95"/>
-      <point x="431" y="162"/>
+      <point x="474" y="95"/>
+      <point x="431" y="164"/>
       <point x="431" y="287" type="curve" smooth="yes"/>
       <point x="431" y="312" type="line" smooth="yes"/>
-      <point x="431" y="434"/>
-      <point x="476" y="502"/>
+      <point x="431" y="432"/>
+      <point x="475" y="502"/>
       <point x="551" y="502" type="curve" smooth="yes"/>
       <point x="624" y="502"/>
       <point x="665" y="433"/>
       <point x="665" y="312" type="curve" smooth="yes"/>
       <point x="665" y="287" type="line" smooth="yes"/>
-      <point x="665" y="162"/>
-      <point x="623" y="95"/>
+      <point x="665" y="164"/>
+      <point x="624" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
@@ -6,42 +6,42 @@
   <anchor x="1611" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="203" y="-16" type="curve" smooth="yes"/>
-      <point x="287" y="-16"/>
-      <point x="340" y="33"/>
+      <point x="206" y="-16" type="curve" smooth="yes"/>
+      <point x="279" y="-16"/>
+      <point x="336" y="24"/>
       <point x="369" y="97" type="curve"/>
       <point x="376" y="97" type="line"/>
-      <point x="410" y="23"/>
-      <point x="476" y="-16"/>
+      <point x="409" y="25"/>
+      <point x="474" y="-16"/>
       <point x="557" y="-16" type="curve" smooth="yes"/>
-      <point x="697" y="-16"/>
-      <point x="783" y="107"/>
+      <point x="694" y="-16"/>
+      <point x="783" y="103"/>
       <point x="783" y="284" type="curve" smooth="yes"/>
       <point x="783" y="314" type="line" smooth="yes"/>
-      <point x="783" y="489"/>
-      <point x="697" y="613"/>
+      <point x="783" y="495"/>
+      <point x="692" y="613"/>
       <point x="552" y="613" type="curve" smooth="yes"/>
-      <point x="409" y="613"/>
-      <point x="320" y="491"/>
+      <point x="412" y="613"/>
+      <point x="320" y="495"/>
       <point x="320" y="314" type="curve" smooth="yes"/>
-      <point x="320" y="287"/>
-      <point x="326" y="255"/>
-      <point x="326" y="227" type="curve" smooth="yes"/>
-      <point x="326" y="145"/>
+      <point x="320" y="281"/>
+      <point x="328" y="241"/>
+      <point x="328" y="207" type="curve" smooth="yes"/>
+      <point x="328" y="138"/>
       <point x="290" y="95"/>
-      <point x="226" y="95" type="curve" smooth="yes"/>
-      <point x="173" y="95"/>
-      <point x="143" y="123"/>
-      <point x="143" y="173" type="curve" smooth="yes"/>
-      <point x="143" y="222"/>
-      <point x="175" y="251"/>
-      <point x="240" y="251" type="curve" smooth="yes"/>
-      <point x="830" y="251" type="line" smooth="yes"/>
-      <point x="892" y="251"/>
-      <point x="918" y="224"/>
-      <point x="918" y="179" type="curve" smooth="yes"/>
-      <point x="918" y="142"/>
-      <point x="902" y="114"/>
+      <point x="229" y="95" type="curve" smooth="yes"/>
+      <point x="175" y="95"/>
+      <point x="143" y="126"/>
+      <point x="143" y="176" type="curve" smooth="yes"/>
+      <point x="143" y="232"/>
+      <point x="182" y="265"/>
+      <point x="249" y="265" type="curve" smooth="yes"/>
+      <point x="831" y="265" type="line" smooth="yes"/>
+      <point x="888" y="265"/>
+      <point x="918" y="237"/>
+      <point x="918" y="184" type="curve" smooth="yes"/>
+      <point x="918" y="145"/>
+      <point x="902" y="112"/>
       <point x="865" y="76" type="curve"/>
       <point x="895" y="0" type="line"/>
       <point x="1667" y="0" type="line"/>
@@ -79,34 +79,34 @@
       <point x="1615" y="105" type="line"/>
       <point x="1012" y="105" type="line"/>
       <point x="1009" y="112" type="line"/>
-      <point x="1029" y="138"/>
-      <point x="1037" y="168"/>
-      <point x="1037" y="194" type="curve" smooth="yes"/>
-      <point x="1037" y="293"/>
-      <point x="968" y="352"/>
-      <point x="828" y="352" type="curve" smooth="yes"/>
-      <point x="241" y="352" type="line" smooth="yes"/>
-      <point x="101" y="352"/>
-      <point x="26" y="277"/>
-      <point x="26" y="163" type="curve" smooth="yes"/>
+      <point x="1028" y="142"/>
+      <point x="1037" y="170"/>
+      <point x="1037" y="203" type="curve" smooth="yes"/>
+      <point x="1037" y="308"/>
+      <point x="959" y="366"/>
+      <point x="820" y="366" type="curve" smooth="yes"/>
+      <point x="250" y="366" type="line" smooth="yes"/>
+      <point x="111" y="366"/>
+      <point x="26" y="291"/>
+      <point x="26" y="169" type="curve" smooth="yes"/>
       <point x="26" y="60"/>
-      <point x="94" y="-16"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="551" y="95" type="curve" smooth="yes"/>
-      <point x="475" y="95"/>
-      <point x="431" y="162"/>
+      <point x="474" y="95"/>
+      <point x="431" y="164"/>
       <point x="431" y="287" type="curve" smooth="yes"/>
       <point x="431" y="312" type="line" smooth="yes"/>
-      <point x="431" y="434"/>
-      <point x="476" y="502"/>
+      <point x="431" y="432"/>
+      <point x="475" y="502"/>
       <point x="551" y="502" type="curve" smooth="yes"/>
       <point x="624" y="502"/>
       <point x="665" y="433"/>
       <point x="665" y="312" type="curve" smooth="yes"/>
       <point x="665" y="287" type="line" smooth="yes"/>
-      <point x="665" y="162"/>
-      <point x="623" y="95"/>
+      <point x="665" y="164"/>
+      <point x="624" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam.half" format="2">
   <advance width="1741"/>
+  <anchor x="1282" y="0" name="bottom"/>
+  <anchor x="894" y="597" name="top"/>
+  <anchor x="1611" y="597" name="topright"/>
   <outline>
     <component base="k_ssa-malayalam"/>
     <component base="halant-malayalam" xOffset="1611"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/k_ta-malayalam.glif
@@ -58,60 +58,60 @@
       <point x="893" y="74"/>
     </contour>
     <contour>
-      <point x="203" y="-16" type="curve" smooth="yes"/>
-      <point x="287" y="-16"/>
-      <point x="340" y="33"/>
+      <point x="206" y="-16" type="curve" smooth="yes"/>
+      <point x="279" y="-16"/>
+      <point x="336" y="24"/>
       <point x="369" y="97" type="curve"/>
       <point x="376" y="97" type="line"/>
-      <point x="410" y="23"/>
-      <point x="476" y="-16"/>
+      <point x="409" y="25"/>
+      <point x="474" y="-16"/>
       <point x="557" y="-16" type="curve" smooth="yes"/>
-      <point x="697" y="-16"/>
-      <point x="783" y="107"/>
+      <point x="694" y="-16"/>
+      <point x="783" y="103"/>
       <point x="783" y="284" type="curve" smooth="yes"/>
       <point x="783" y="314" type="line" smooth="yes"/>
-      <point x="783" y="489"/>
-      <point x="697" y="613"/>
+      <point x="783" y="495"/>
+      <point x="692" y="613"/>
       <point x="552" y="613" type="curve" smooth="yes"/>
-      <point x="409" y="613"/>
-      <point x="320" y="491"/>
+      <point x="412" y="613"/>
+      <point x="320" y="495"/>
       <point x="320" y="314" type="curve" smooth="yes"/>
-      <point x="320" y="287"/>
-      <point x="326" y="255"/>
-      <point x="326" y="227" type="curve" smooth="yes"/>
-      <point x="326" y="145"/>
+      <point x="320" y="281"/>
+      <point x="328" y="241"/>
+      <point x="328" y="207" type="curve" smooth="yes"/>
+      <point x="328" y="138"/>
       <point x="290" y="95"/>
-      <point x="226" y="95" type="curve" smooth="yes"/>
-      <point x="173" y="95"/>
-      <point x="143" y="123"/>
-      <point x="143" y="170" type="curve" smooth="yes"/>
-      <point x="143" y="216"/>
-      <point x="175" y="245"/>
-      <point x="240" y="245" type="curve" smooth="yes"/>
-      <point x="883" y="245" type="line"/>
-      <point x="883" y="346" type="line"/>
-      <point x="241" y="346" type="line" smooth="yes"/>
-      <point x="101" y="346"/>
-      <point x="26" y="271"/>
-      <point x="26" y="160" type="curve" smooth="yes"/>
+      <point x="229" y="95" type="curve" smooth="yes"/>
+      <point x="175" y="95"/>
+      <point x="143" y="126"/>
+      <point x="143" y="176" type="curve" smooth="yes"/>
+      <point x="143" y="232"/>
+      <point x="182" y="265"/>
+      <point x="249" y="265" type="curve" smooth="yes"/>
+      <point x="916" y="265" type="line"/>
+      <point x="916" y="366" type="line"/>
+      <point x="250" y="366" type="line" smooth="yes"/>
+      <point x="111" y="366"/>
+      <point x="26" y="291"/>
+      <point x="26" y="169" type="curve" smooth="yes"/>
       <point x="26" y="60"/>
-      <point x="94" y="-16"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="551" y="95" type="curve" smooth="yes"/>
-      <point x="475" y="95"/>
-      <point x="431" y="162"/>
+      <point x="474" y="95"/>
+      <point x="431" y="164"/>
       <point x="431" y="287" type="curve" smooth="yes"/>
       <point x="431" y="312" type="line" smooth="yes"/>
-      <point x="431" y="434"/>
-      <point x="476" y="502"/>
+      <point x="431" y="432"/>
+      <point x="475" y="502"/>
       <point x="551" y="502" type="curve" smooth="yes"/>
       <point x="624" y="502"/>
       <point x="665" y="433"/>
       <point x="665" y="312" type="curve" smooth="yes"/>
       <point x="665" y="287" type="line" smooth="yes"/>
-      <point x="665" y="162"/>
-      <point x="623" y="95"/>
+      <point x="665" y="164"/>
+      <point x="624" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/k_tta-malayalam.glif
@@ -28,57 +28,57 @@
       <point x="995" y="31"/>
       <point x="976" y="35" type="curve"/>
       <point x="976" y="44" type="line"/>
-      <point x="1022" y="65"/>
-      <point x="1048" y="114"/>
-      <point x="1048" y="179" type="curve" smooth="yes"/>
-      <point x="1048" y="286"/>
-      <point x="967" y="346"/>
-      <point x="824" y="346" type="curve" smooth="yes"/>
-      <point x="241" y="346" type="line" smooth="yes"/>
-      <point x="101" y="346"/>
-      <point x="26" y="271"/>
-      <point x="26" y="160" type="curve" smooth="yes"/>
+      <point x="1020" y="70"/>
+      <point x="1048" y="119"/>
+      <point x="1048" y="185" type="curve" smooth="yes"/>
+      <point x="1048" y="299"/>
+      <point x="971" y="366"/>
+      <point x="829" y="366" type="curve" smooth="yes"/>
+      <point x="250" y="366" type="line" smooth="yes"/>
+      <point x="111" y="366"/>
+      <point x="26" y="291"/>
+      <point x="26" y="169" type="curve" smooth="yes"/>
       <point x="26" y="60"/>
-      <point x="94" y="-16"/>
-      <point x="203" y="-16" type="curve" smooth="yes"/>
-      <point x="287" y="-16"/>
-      <point x="340" y="33"/>
+      <point x="99" y="-16"/>
+      <point x="206" y="-16" type="curve" smooth="yes"/>
+      <point x="279" y="-16"/>
+      <point x="336" y="24"/>
       <point x="369" y="97" type="curve"/>
       <point x="376" y="97" type="line"/>
-      <point x="410" y="23"/>
-      <point x="476" y="-16"/>
+      <point x="409" y="25"/>
+      <point x="474" y="-16"/>
       <point x="557" y="-16" type="curve" smooth="yes"/>
-      <point x="697" y="-16"/>
-      <point x="783" y="107"/>
+      <point x="694" y="-16"/>
+      <point x="783" y="103"/>
       <point x="783" y="284" type="curve" smooth="yes"/>
       <point x="783" y="314" type="line" smooth="yes"/>
-      <point x="783" y="489"/>
-      <point x="697" y="613"/>
+      <point x="783" y="495"/>
+      <point x="692" y="613"/>
       <point x="552" y="613" type="curve" smooth="yes"/>
-      <point x="409" y="613"/>
-      <point x="320" y="491"/>
+      <point x="412" y="613"/>
+      <point x="320" y="495"/>
       <point x="320" y="314" type="curve" smooth="yes"/>
-      <point x="320" y="287"/>
-      <point x="326" y="255"/>
-      <point x="326" y="227" type="curve" smooth="yes"/>
-      <point x="326" y="145"/>
+      <point x="320" y="281"/>
+      <point x="328" y="241"/>
+      <point x="328" y="207" type="curve" smooth="yes"/>
+      <point x="328" y="138"/>
       <point x="290" y="95"/>
-      <point x="226" y="95" type="curve" smooth="yes"/>
-      <point x="173" y="95"/>
-      <point x="143" y="123"/>
-      <point x="143" y="170" type="curve" smooth="yes"/>
-      <point x="143" y="216"/>
-      <point x="175" y="245"/>
-      <point x="240" y="245" type="curve" smooth="yes"/>
-      <point x="835" y="245" type="line" smooth="yes"/>
-      <point x="901" y="245"/>
-      <point x="931" y="218"/>
-      <point x="931" y="170" type="curve" smooth="yes"/>
-      <point x="931" y="122"/>
-      <point x="904" y="95"/>
-      <point x="857" y="95" type="curve" smooth="yes"/>
-      <point x="838" y="95"/>
-      <point x="821" y="97"/>
+      <point x="229" y="95" type="curve" smooth="yes"/>
+      <point x="175" y="95"/>
+      <point x="143" y="126"/>
+      <point x="143" y="176" type="curve" smooth="yes"/>
+      <point x="143" y="232"/>
+      <point x="182" y="265"/>
+      <point x="249" y="265" type="curve" smooth="yes"/>
+      <point x="831" y="265" type="line" smooth="yes"/>
+      <point x="898" y="265"/>
+      <point x="931" y="236"/>
+      <point x="931" y="179" type="curve" smooth="yes"/>
+      <point x="931" y="125"/>
+      <point x="900" y="95"/>
+      <point x="851" y="95" type="curve" smooth="yes"/>
+      <point x="834" y="95"/>
+      <point x="819" y="97"/>
       <point x="807" y="102" type="curve"/>
       <point x="785" y="22" type="line"/>
       <point x="834" y="52" type="line"/>
@@ -104,19 +104,19 @@
     </contour>
     <contour>
       <point x="551" y="95" type="curve" smooth="yes"/>
-      <point x="475" y="95"/>
-      <point x="431" y="162"/>
+      <point x="474" y="95"/>
+      <point x="431" y="164"/>
       <point x="431" y="287" type="curve" smooth="yes"/>
       <point x="431" y="312" type="line" smooth="yes"/>
-      <point x="431" y="434"/>
-      <point x="476" y="502"/>
+      <point x="431" y="432"/>
+      <point x="475" y="502"/>
       <point x="551" y="502" type="curve" smooth="yes"/>
       <point x="624" y="502"/>
       <point x="665" y="433"/>
       <point x="665" y="312" type="curve" smooth="yes"/>
       <point x="665" y="287" type="line" smooth="yes"/>
-      <point x="665" y="162"/>
-      <point x="623" y="95"/>
+      <point x="665" y="164"/>
+      <point x="624" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ka-malayalam.glif
@@ -7,78 +7,78 @@
   <anchor x="914" y="557" name="topright"/>
   <outline>
     <contour>
-      <point x="203" y="-16" type="curve" smooth="yes"/>
-      <point x="287" y="-16"/>
-      <point x="340" y="33"/>
+      <point x="206" y="-16" type="curve" smooth="yes"/>
+      <point x="279" y="-16"/>
+      <point x="336" y="24"/>
       <point x="369" y="97" type="curve"/>
       <point x="376" y="97" type="line"/>
-      <point x="410" y="23"/>
-      <point x="476" y="-16"/>
+      <point x="409" y="25"/>
+      <point x="474" y="-16"/>
       <point x="557" y="-16" type="curve" smooth="yes"/>
-      <point x="697" y="-16"/>
-      <point x="783" y="107"/>
+      <point x="694" y="-16"/>
+      <point x="783" y="103"/>
       <point x="783" y="284" type="curve" smooth="yes"/>
       <point x="783" y="314" type="line" smooth="yes"/>
-      <point x="783" y="489"/>
-      <point x="697" y="613"/>
+      <point x="783" y="495"/>
+      <point x="692" y="613"/>
       <point x="552" y="613" type="curve" smooth="yes"/>
-      <point x="409" y="613"/>
-      <point x="320" y="491"/>
+      <point x="412" y="613"/>
+      <point x="320" y="495"/>
       <point x="320" y="314" type="curve" smooth="yes"/>
-      <point x="320" y="287"/>
-      <point x="326" y="255"/>
-      <point x="326" y="227" type="curve" smooth="yes"/>
-      <point x="326" y="145"/>
+      <point x="320" y="281"/>
+      <point x="328" y="241"/>
+      <point x="328" y="207" type="curve" smooth="yes"/>
+      <point x="328" y="138"/>
       <point x="290" y="95"/>
-      <point x="226" y="95" type="curve" smooth="yes"/>
-      <point x="173" y="95"/>
-      <point x="143" y="123"/>
-      <point x="143" y="170" type="curve" smooth="yes"/>
-      <point x="143" y="216"/>
-      <point x="175" y="245"/>
-      <point x="240" y="245" type="curve" smooth="yes"/>
-      <point x="835" y="245" type="line" smooth="yes"/>
-      <point x="901" y="245"/>
-      <point x="931" y="218"/>
-      <point x="931" y="170" type="curve" smooth="yes"/>
-      <point x="931" y="122"/>
-      <point x="903" y="95"/>
+      <point x="229" y="95" type="curve" smooth="yes"/>
+      <point x="175" y="95"/>
+      <point x="143" y="126"/>
+      <point x="143" y="176" type="curve" smooth="yes"/>
+      <point x="143" y="232"/>
+      <point x="182" y="265"/>
+      <point x="249" y="265" type="curve" smooth="yes"/>
+      <point x="831" y="265" type="line" smooth="yes"/>
+      <point x="898" y="265"/>
+      <point x="931" y="236"/>
+      <point x="931" y="178" type="curve" smooth="yes"/>
+      <point x="931" y="126"/>
+      <point x="904" y="95"/>
       <point x="857" y="95" type="curve" smooth="yes"/>
-      <point x="838" y="95"/>
-      <point x="821" y="97"/>
+      <point x="836" y="95"/>
+      <point x="819" y="97"/>
       <point x="807" y="102" type="curve"/>
       <point x="778" y="-3" type="line"/>
-      <point x="807" y="-12"/>
-      <point x="836" y="-16"/>
+      <point x="805" y="-12"/>
+      <point x="834" y="-16"/>
       <point x="866" y="-16" type="curve" smooth="yes"/>
-      <point x="973" y="-16"/>
-      <point x="1048" y="53"/>
-      <point x="1048" y="163" type="curve" smooth="yes"/>
-      <point x="1048" y="279"/>
-      <point x="967" y="346"/>
-      <point x="824" y="346" type="curve" smooth="yes"/>
-      <point x="241" y="346" type="line" smooth="yes"/>
-      <point x="101" y="346"/>
-      <point x="26" y="271"/>
-      <point x="26" y="160" type="curve" smooth="yes"/>
+      <point x="975" y="-16"/>
+      <point x="1048" y="59"/>
+      <point x="1048" y="171" type="curve" smooth="yes"/>
+      <point x="1048" y="296"/>
+      <point x="966" y="366"/>
+      <point x="820" y="366" type="curve" smooth="yes"/>
+      <point x="250" y="366" type="line" smooth="yes"/>
+      <point x="111" y="366"/>
+      <point x="26" y="291"/>
+      <point x="26" y="169" type="curve" smooth="yes"/>
       <point x="26" y="60"/>
-      <point x="94" y="-16"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
       <point x="551" y="95" type="curve" smooth="yes"/>
-      <point x="475" y="95"/>
-      <point x="431" y="162"/>
+      <point x="474" y="95"/>
+      <point x="431" y="164"/>
       <point x="431" y="287" type="curve" smooth="yes"/>
       <point x="431" y="312" type="line" smooth="yes"/>
-      <point x="431" y="434"/>
-      <point x="476" y="502"/>
+      <point x="431" y="432"/>
+      <point x="475" y="502"/>
       <point x="551" y="502" type="curve" smooth="yes"/>
       <point x="624" y="502"/>
       <point x="665" y="433"/>
       <point x="665" y="312" type="curve" smooth="yes"/>
       <point x="665" y="287" type="line" smooth="yes"/>
-      <point x="665" y="162"/>
-      <point x="623" y="95"/>
+      <point x="665" y="164"/>
+      <point x="624" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/m_la-malayalam.glif
@@ -6,51 +6,7 @@
   <anchor x="587" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="130" y="-368" type="curve" smooth="yes"/>
-      <point x="226" y="-368"/>
-      <point x="272" y="-312"/>
-      <point x="272" y="-233" type="curve" smooth="yes"/>
-      <point x="272" y="-151"/>
-      <point x="224" y="-112"/>
-      <point x="156" y="-112" type="curve" smooth="yes"/>
-      <point x="99" y="-112"/>
-      <point x="46" y="-141"/>
-      <point x="42" y="-222" type="curve"/>
-      <point x="78" y="-157" type="line"/>
-      <point x="26" y="-156" type="line"/>
-      <point x="53" y="-175" type="line"/>
-      <point x="53" y="-101"/>
-      <point x="95" y="-35"/>
-      <point x="191" y="-35" type="curve" smooth="yes"/>
-      <point x="282" y="-35"/>
-      <point x="317" y="-84"/>
-      <point x="337" y="-159" type="curve" smooth="yes"/>
-      <point x="347" y="-197" type="line" smooth="yes"/>
-      <point x="377" y="-309"/>
-      <point x="430" y="-368"/>
-      <point x="539" y="-368" type="curve" smooth="yes"/>
-      <point x="652" y="-368"/>
-      <point x="722" y="-303"/>
-      <point x="722" y="-164" type="curve" smooth="yes"/>
-      <point x="722" y="-77"/>
-      <point x="689" y="-1"/>
-      <point x="639" y="57" type="curve"/>
-      <point x="558" y="4" type="line"/>
-      <point x="591" y="-36"/>
-      <point x="624" y="-97"/>
-      <point x="624" y="-174" type="curve" smooth="yes"/>
-      <point x="624" y="-237"/>
-      <point x="598" y="-278"/>
-      <point x="540" y="-278" type="curve" smooth="yes"/>
-      <point x="489" y="-278"/>
-      <point x="462" y="-243"/>
-      <point x="442" y="-172" type="curve" smooth="yes"/>
-      <point x="431" y="-131" type="line" smooth="yes"/>
-      <point x="418" y="-83"/>
-      <point x="396" y="-36"/>
-      <point x="360" y="-8" type="curve"/>
-      <point x="362" y="0" type="line"/>
-      <point x="612" y="0" type="line"/>
+      <point x="48" y="0" type="line"/>
       <point x="659" y="0" type="line"/>
       <point x="659" y="327" type="line" smooth="yes"/>
       <point x="659" y="498"/>
@@ -59,29 +15,72 @@
       <point x="154" y="613"/>
       <point x="48" y="498"/>
       <point x="48" y="326" type="curve" smooth="yes"/>
-      <point x="48" y="2" type="line"/>
-      <point x="76" y="25" type="line"/>
-      <point x="4" y="-12"/>
-      <point x="-39" y="-84"/>
-      <point x="-39" y="-174" type="curve" smooth="yes"/>
-      <point x="-39" y="-304"/>
-      <point x="34" y="-368"/>
     </contour>
     <contour>
-      <point x="128" y="-288" type="curve" smooth="yes"/>
-      <point x="80" y="-288"/>
-      <point x="58" y="-246"/>
-      <point x="58" y="-209" type="curve"/>
-      <point x="41" y="-214" type="line"/>
-      <point x="56" y="-253" type="line"/>
-      <point x="61" y="-210"/>
-      <point x="90" y="-185"/>
-      <point x="130" y="-185" type="curve" smooth="yes"/>
-      <point x="167" y="-185"/>
-      <point x="184" y="-204"/>
-      <point x="184" y="-235" type="curve" smooth="yes"/>
-      <point x="184" y="-268"/>
-      <point x="164" y="-288"/>
+      <point x="201" y="-368" type="curve" smooth="yes"/>
+      <point x="287" y="-368"/>
+      <point x="340" y="-314"/>
+      <point x="340" y="-232" type="curve" smooth="yes"/>
+      <point x="340" y="-153"/>
+      <point x="297" y="-102"/>
+      <point x="229" y="-102" type="curve" smooth="yes"/>
+      <point x="169" y="-102"/>
+      <point x="120" y="-140"/>
+      <point x="114" y="-210" type="curve"/>
+      <point x="146" y="-157" type="line"/>
+      <point x="93" y="-157" type="line"/>
+      <point x="119" y="-175" type="line"/>
+      <point x="119" y="-98"/>
+      <point x="165" y="-29"/>
+      <point x="253" y="-29" type="curve" smooth="yes"/>
+      <point x="330" y="-29"/>
+      <point x="363" y="-72"/>
+      <point x="372" y="-147" type="curve" smooth="yes"/>
+      <point x="381" y="-225" type="line" smooth="yes"/>
+      <point x="392" y="-317"/>
+      <point x="450" y="-368"/>
+      <point x="533" y="-368" type="curve" smooth="yes"/>
+      <point x="628" y="-368"/>
+      <point x="685" y="-301"/>
+      <point x="685" y="-192" type="curve" smooth="yes"/>
+      <point x="685" y="-99"/>
+      <point x="649" y="-7"/>
+      <point x="591" y="67" type="curve"/>
+      <point x="515" y="8" type="line"/>
+      <point x="560" y="-51"/>
+      <point x="587" y="-114"/>
+      <point x="587" y="-188" type="curve" smooth="yes"/>
+      <point x="587" y="-250"/>
+      <point x="570" y="-278"/>
+      <point x="533" y="-278" type="curve" smooth="yes"/>
+      <point x="498" y="-278"/>
+      <point x="478" y="-252"/>
+      <point x="472" y="-196" type="curve" smooth="yes"/>
+      <point x="463" y="-118" type="line" smooth="yes"/>
+      <point x="451" y="-16"/>
+      <point x="384" y="51"/>
+      <point x="259" y="51" type="curve" smooth="yes"/>
+      <point x="122" y="51"/>
+      <point x="28" y="-44"/>
+      <point x="28" y="-172" type="curve" smooth="yes"/>
+      <point x="28" y="-297"/>
+      <point x="105" y="-368"/>
+    </contour>
+    <contour>
+      <point x="197" y="-288" type="curve" smooth="yes"/>
+      <point x="157" y="-288"/>
+      <point x="129" y="-255"/>
+      <point x="123" y="-209" type="curve"/>
+      <point x="109" y="-214" type="line"/>
+      <point x="123" y="-251" type="line"/>
+      <point x="129" y="-205"/>
+      <point x="159" y="-172"/>
+      <point x="199" y="-172" type="curve" smooth="yes"/>
+      <point x="233" y="-172"/>
+      <point x="251" y="-192"/>
+      <point x="251" y="-230" type="curve" smooth="yes"/>
+      <point x="251" y="-267"/>
+      <point x="231" y="-288"/>
     </contour>
     <contour>
       <point x="115" y="48" type="line"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
@@ -6,98 +6,98 @@
   <anchor x="911" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="206" y="-16" type="curve" smooth="yes"/>
-      <point x="292" y="-16"/>
-      <point x="346" y="32"/>
+      <point x="211" y="-16" type="curve" smooth="yes"/>
+      <point x="284" y="-16"/>
+      <point x="341" y="24"/>
       <point x="374" y="97" type="curve"/>
       <point x="381" y="97" type="line"/>
-      <point x="415" y="23"/>
-      <point x="481" y="-16"/>
+      <point x="414" y="25"/>
+      <point x="479" y="-16"/>
       <point x="562" y="-16" type="curve" smooth="yes"/>
-      <point x="702" y="-16"/>
-      <point x="788" y="107"/>
+      <point x="699" y="-16"/>
+      <point x="788" y="103"/>
       <point x="788" y="284" type="curve" smooth="yes"/>
       <point x="788" y="314" type="line" smooth="yes"/>
-      <point x="788" y="489"/>
-      <point x="704" y="613"/>
+      <point x="788" y="497"/>
+      <point x="698" y="613"/>
       <point x="557" y="613" type="curve" smooth="yes"/>
-      <point x="470" y="613"/>
-      <point x="414" y="570"/>
+      <point x="477" y="613"/>
+      <point x="417" y="577"/>
       <point x="381" y="506" type="curve"/>
       <point x="374" y="506" type="line"/>
-      <point x="349" y="571"/>
-      <point x="295" y="613"/>
+      <point x="347" y="575"/>
+      <point x="290" y="613"/>
       <point x="213" y="613" type="curve" smooth="yes"/>
-      <point x="100" y="613"/>
-      <point x="39" y="539"/>
-      <point x="39" y="450" type="curve" smooth="yes"/>
-      <point x="39" y="386"/>
-      <point x="72" y="330"/>
-      <point x="128" y="301" type="curve"/>
-      <point x="128" y="294" type="line"/>
-      <point x="68" y="268"/>
-      <point x="31" y="217"/>
-      <point x="31" y="150" type="curve" smooth="yes"/>
-      <point x="31" y="49"/>
-      <point x="99" y="-16"/>
+      <point x="110" y="613"/>
+      <point x="39" y="549"/>
+      <point x="39" y="457" type="curve" smooth="yes"/>
+      <point x="39" y="398"/>
+      <point x="73" y="347"/>
+      <point x="128" y="321" type="curve"/>
+      <point x="128" y="314" type="line"/>
+      <point x="66" y="283"/>
+      <point x="31" y="225"/>
+      <point x="31" y="156" type="curve" smooth="yes"/>
+      <point x="31" y="55"/>
+      <point x="105" y="-16"/>
     </contour>
     <contour>
       <point x="871" y="-16" type="curve" smooth="yes"/>
-      <point x="978" y="-16"/>
-      <point x="1053" y="53"/>
-      <point x="1053" y="163" type="curve" smooth="yes"/>
-      <point x="1053" y="279"/>
-      <point x="976" y="346"/>
-      <point x="829" y="346" type="curve" smooth="yes"/>
-      <point x="253" y="346" type="line" smooth="yes"/>
-      <point x="191" y="346"/>
-      <point x="156" y="379"/>
-      <point x="156" y="429" type="curve" smooth="yes"/>
-      <point x="156" y="473"/>
+      <point x="980" y="-16"/>
+      <point x="1053" y="59"/>
+      <point x="1053" y="171" type="curve" smooth="yes"/>
+      <point x="1053" y="296"/>
+      <point x="971" y="366"/>
+      <point x="825" y="366" type="curve" smooth="yes"/>
+      <point x="243" y="366" type="line" smooth="yes"/>
+      <point x="189" y="366"/>
+      <point x="156" y="392"/>
+      <point x="156" y="436" type="curve" smooth="yes"/>
+      <point x="156" y="477"/>
       <point x="185" y="502"/>
-      <point x="234" y="502" type="curve" smooth="yes"/>
-      <point x="299" y="502"/>
-      <point x="331" y="452"/>
+      <point x="232" y="502" type="curve" smooth="yes"/>
+      <point x="297" y="502"/>
+      <point x="331" y="456"/>
       <point x="331" y="365" type="curve" smooth="yes"/>
-      <point x="331" y="227" type="line" smooth="yes"/>
-      <point x="331" y="145"/>
-      <point x="296" y="95"/>
-      <point x="230" y="95" type="curve" smooth="yes"/>
-      <point x="178" y="95"/>
-      <point x="148" y="124"/>
-      <point x="148" y="170" type="curve" smooth="yes"/>
-      <point x="148" y="216"/>
-      <point x="180" y="245"/>
-      <point x="247" y="245" type="curve" smooth="yes"/>
-      <point x="840" y="245" type="line" smooth="yes"/>
-      <point x="908" y="245"/>
-      <point x="936" y="218"/>
-      <point x="936" y="170" type="curve" smooth="yes"/>
-      <point x="936" y="122"/>
-      <point x="908" y="95"/>
+      <point x="331" y="213" type="line" smooth="yes"/>
+      <point x="331" y="137"/>
+      <point x="294" y="95"/>
+      <point x="234" y="95" type="curve" smooth="yes"/>
+      <point x="181" y="95"/>
+      <point x="148" y="125"/>
+      <point x="148" y="174" type="curve" smooth="yes"/>
+      <point x="148" y="229"/>
+      <point x="189" y="265"/>
+      <point x="251" y="265" type="curve" smooth="yes"/>
+      <point x="836" y="265" type="line" smooth="yes"/>
+      <point x="903" y="265"/>
+      <point x="936" y="236"/>
+      <point x="936" y="178" type="curve" smooth="yes"/>
+      <point x="936" y="126"/>
+      <point x="909" y="95"/>
       <point x="862" y="95" type="curve" smooth="yes"/>
-      <point x="843" y="95"/>
-      <point x="826" y="97"/>
+      <point x="840" y="95"/>
+      <point x="823" y="97"/>
       <point x="812" y="102" type="curve"/>
       <point x="783" y="-3" type="line"/>
-      <point x="812" y="-12"/>
-      <point x="841" y="-16"/>
+      <point x="809" y="-12"/>
+      <point x="838" y="-16"/>
     </contour>
     <contour>
       <point x="556" y="95" type="curve" smooth="yes"/>
-      <point x="480" y="95"/>
-      <point x="436" y="162"/>
+      <point x="479" y="95"/>
+      <point x="436" y="164"/>
       <point x="436" y="287" type="curve" smooth="yes"/>
       <point x="436" y="312" type="line" smooth="yes"/>
-      <point x="436" y="434"/>
-      <point x="481" y="502"/>
+      <point x="436" y="432"/>
+      <point x="480" y="502"/>
       <point x="556" y="502" type="curve" smooth="yes"/>
       <point x="629" y="502"/>
       <point x="670" y="433"/>
       <point x="670" y="312" type="curve" smooth="yes"/>
       <point x="670" y="287" type="line" smooth="yes"/>
-      <point x="670" y="162"/>
-      <point x="628" y="95"/>
+      <point x="670" y="164"/>
+      <point x="629" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1557"/>
-  <anchor x="1149" y="0" name="bottom"/>
-  <anchor x="821" y="597" name="top"/>
-  <anchor x="1436" y="597" name="topright"/>
+  <advance width="1599"/>
+  <anchor x="1173" y="0" name="bottom"/>
+  <anchor x="800" y="597" name="top"/>
+  <anchor x="1445" y="597" name="topright"/>
   <outline>
     <contour>
       <point x="281" y="-16" type="curve" smooth="yes"/>
@@ -39,121 +39,121 @@
       <point x="530" y="0" type="line"/>
       <point x="652" y="0" type="line"/>
       <point x="652" y="328" type="line" smooth="yes"/>
-      <point x="652" y="440"/>
-      <point x="703" y="532"/>
-      <point x="858" y="532" type="curve" smooth="yes"/>
-      <point x="877" y="532"/>
-      <point x="894" y="531"/>
-      <point x="910" y="528" type="curve"/>
-      <point x="753" y="568" type="line"/>
-      <point x="784" y="514" type="line"/>
-      <point x="760" y="489"/>
-      <point x="749" y="461"/>
-      <point x="749" y="433" type="curve" smooth="yes"/>
-      <point x="749" y="353"/>
-      <point x="817" y="307"/>
-      <point x="899" y="307" type="curve" smooth="yes"/>
-      <point x="981" y="307"/>
-      <point x="1049" y="349"/>
-      <point x="1049" y="433" type="curve" smooth="yes"/>
-      <point x="1049" y="460"/>
-      <point x="1035" y="501"/>
-      <point x="1002" y="526" type="curve"/>
-      <point x="1024" y="586" type="line"/>
-      <point x="931" y="531" type="line"/>
-      <point x="945" y="533"/>
-      <point x="958" y="534"/>
-      <point x="970" y="534" type="curve" smooth="yes"/>
-      <point x="1074" y="534"/>
-      <point x="1101" y="458"/>
-      <point x="1101" y="396" type="curve" smooth="yes"/>
-      <point x="1101" y="352" type="line"/>
-      <point x="1219" y="352" type="line"/>
-      <point x="1219" y="388" type="line" smooth="yes"/>
-      <point x="1219" y="465"/>
-      <point x="1259" y="510"/>
-      <point x="1319" y="510" type="curve" smooth="yes"/>
-      <point x="1376" y="510"/>
-      <point x="1401" y="472"/>
-      <point x="1401" y="416" type="curve" smooth="yes"/>
-      <point x="1401" y="343"/>
-      <point x="1361" y="301"/>
-      <point x="1258" y="301" type="curve" smooth="yes"/>
-      <point x="961" y="301" type="line" smooth="yes"/>
-      <point x="831" y="301"/>
-      <point x="755" y="243"/>
-      <point x="755" y="142" type="curve" smooth="yes"/>
-      <point x="755" y="59"/>
-      <point x="806" y="-16"/>
-      <point x="933" y="-16" type="curve" smooth="yes"/>
-      <point x="1020" y="-16"/>
-      <point x="1081" y="14"/>
-      <point x="1150" y="59" type="curve" smooth="yes"/>
-      <point x="1232" y="114" type="line"/>
-      <point x="1290" y="151" type="line"/>
-      <point x="1307" y="157" type="line"/>
-      <point x="1333" y="169"/>
-      <point x="1353" y="174"/>
-      <point x="1373" y="174" type="curve" smooth="yes"/>
-      <point x="1411" y="174"/>
-      <point x="1425" y="153"/>
-      <point x="1425" y="122" type="curve" smooth="yes"/>
-      <point x="1425" y="95"/>
-      <point x="1411" y="73"/>
-      <point x="1378" y="73" type="curve" smooth="yes"/>
-      <point x="1345" y="73"/>
-      <point x="1329" y="96"/>
-      <point x="1329" y="124" type="curve" smooth="yes"/>
-      <point x="1329" y="142"/>
-      <point x="1334" y="159"/>
-      <point x="1349" y="180" type="curve"/>
-      <point x="1249" y="152" type="line"/>
-      <point x="1262" y="127" type="line"/>
-      <point x="1257" y="113"/>
-      <point x="1254" y="103"/>
-      <point x="1254" y="90" type="curve" smooth="yes"/>
-      <point x="1254" y="31"/>
-      <point x="1295" y="-16"/>
-      <point x="1378" y="-16" type="curve" smooth="yes"/>
-      <point x="1466" y="-16"/>
-      <point x="1514" y="40"/>
-      <point x="1514" y="114" type="curve" smooth="yes"/>
-      <point x="1514" y="198"/>
-      <point x="1456" y="255"/>
-      <point x="1373" y="255" type="curve" smooth="yes"/>
-      <point x="1322" y="255"/>
-      <point x="1278" y="241"/>
-      <point x="1189" y="190" type="curve" smooth="yes"/>
-      <point x="1118" y="149" type="line" smooth="yes"/>
-      <point x="1049" y="109"/>
-      <point x="999" y="87"/>
-      <point x="941" y="87" type="curve" smooth="yes"/>
-      <point x="896" y="87"/>
-      <point x="872" y="109"/>
-      <point x="872" y="142" type="curve" smooth="yes"/>
-      <point x="872" y="181"/>
-      <point x="902" y="203"/>
-      <point x="966" y="203" type="curve" smooth="yes"/>
-      <point x="1280" y="203" type="line" smooth="yes"/>
-      <point x="1460" y="203"/>
-      <point x="1518" y="306"/>
-      <point x="1518" y="413" type="curve" smooth="yes"/>
-      <point x="1518" y="527"/>
-      <point x="1457" y="613"/>
-      <point x="1331" y="613" type="curve" smooth="yes"/>
-      <point x="1254" y="613"/>
-      <point x="1189" y="573"/>
-      <point x="1167" y="502" type="curve"/>
-      <point x="1160" y="502" type="line"/>
-      <point x="1129" y="573"/>
-      <point x="1060" y="613"/>
-      <point x="962" y="613" type="curve" smooth="yes"/>
-      <point x="930" y="613"/>
-      <point x="902" y="607"/>
-      <point x="877" y="596" type="curve"/>
-      <point x="919" y="596" type="line"/>
-      <point x="891" y="607"/>
-      <point x="857" y="613"/>
+      <point x="652" y="454"/>
+      <point x="726" y="530"/>
+      <point x="847" y="530" type="curve" smooth="yes"/>
+      <point x="865" y="530"/>
+      <point x="884" y="529"/>
+      <point x="897" y="528" type="curve"/>
+      <point x="781" y="548" type="line"/>
+      <point x="792" y="518" type="line"/>
+      <point x="762" y="494"/>
+      <point x="747" y="462"/>
+      <point x="747" y="422" type="curve" smooth="yes"/>
+      <point x="747" y="346"/>
+      <point x="810" y="292"/>
+      <point x="897" y="292" type="curve" smooth="yes"/>
+      <point x="984" y="292"/>
+      <point x="1047" y="349"/>
+      <point x="1047" y="422" type="curve" smooth="yes"/>
+      <point x="1047" y="470"/>
+      <point x="1030" y="503"/>
+      <point x="994" y="531" type="curve"/>
+      <point x="1008" y="568" type="line"/>
+      <point x="936" y="538" type="line"/>
+      <point x="944" y="539"/>
+      <point x="956" y="539"/>
+      <point x="969" y="539" type="curve" smooth="yes"/>
+      <point x="1061" y="539"/>
+      <point x="1102" y="490"/>
+      <point x="1102" y="396" type="curve" smooth="yes"/>
+      <point x="1102" y="323" type="line"/>
+      <point x="1220" y="323" type="line"/>
+      <point x="1220" y="390" type="line" smooth="yes"/>
+      <point x="1220" y="464"/>
+      <point x="1265" y="509"/>
+      <point x="1338" y="509" type="curve" smooth="yes"/>
+      <point x="1405" y="509"/>
+      <point x="1442" y="471"/>
+      <point x="1442" y="405" type="curve" smooth="yes"/>
+      <point x="1442" y="319"/>
+      <point x="1382" y="278"/>
+      <point x="1265" y="278" type="curve" smooth="yes"/>
+      <point x="934" y="278" type="line" smooth="yes"/>
+      <point x="824" y="278"/>
+      <point x="755" y="218"/>
+      <point x="755" y="130" type="curve" smooth="yes"/>
+      <point x="755" y="41"/>
+      <point x="827" y="-16"/>
+      <point x="935" y="-16" type="curve" smooth="yes"/>
+      <point x="985" y="-16"/>
+      <point x="1027" y="-3"/>
+      <point x="1116" y="38" type="curve" smooth="yes"/>
+      <point x="1250" y="100" type="line"/>
+      <point x="1319" y="155" type="line"/>
+      <point x="1335" y="155" type="line"/>
+      <point x="1366" y="170"/>
+      <point x="1387" y="175"/>
+      <point x="1410" y="175" type="curve" smooth="yes"/>
+      <point x="1448" y="175"/>
+      <point x="1466" y="155"/>
+      <point x="1466" y="124" type="curve" smooth="yes"/>
+      <point x="1466" y="92"/>
+      <point x="1445" y="73"/>
+      <point x="1413" y="73" type="curve" smooth="yes"/>
+      <point x="1380" y="73"/>
+      <point x="1359" y="93"/>
+      <point x="1359" y="123" type="curve" smooth="yes"/>
+      <point x="1359" y="145"/>
+      <point x="1367" y="164"/>
+      <point x="1384" y="181" type="curve"/>
+      <point x="1278" y="153" type="line"/>
+      <point x="1298" y="130" type="line"/>
+      <point x="1290" y="116"/>
+      <point x="1286" y="104"/>
+      <point x="1286" y="90" type="curve" smooth="yes"/>
+      <point x="1286" y="28"/>
+      <point x="1338" y="-16"/>
+      <point x="1415" y="-16" type="curve" smooth="yes"/>
+      <point x="1501" y="-16"/>
+      <point x="1556" y="36"/>
+      <point x="1556" y="116" type="curve" smooth="yes"/>
+      <point x="1556" y="192"/>
+      <point x="1502" y="243"/>
+      <point x="1411" y="243" type="curve" smooth="yes"/>
+      <point x="1357" y="243"/>
+      <point x="1312" y="228"/>
+      <point x="1219" y="185" type="curve" smooth="yes"/>
+      <point x="1078" y="120" type="line" smooth="yes"/>
+      <point x="1020" y="93"/>
+      <point x="985" y="84"/>
+      <point x="946" y="84" type="curve" smooth="yes"/>
+      <point x="900" y="84"/>
+      <point x="873" y="102"/>
+      <point x="873" y="134" type="curve" smooth="yes"/>
+      <point x="873" y="166"/>
+      <point x="896" y="184"/>
+      <point x="938" y="184" type="curve" smooth="yes"/>
+      <point x="1253" y="184" type="line" smooth="yes"/>
+      <point x="1433" y="184"/>
+      <point x="1560" y="278"/>
+      <point x="1560" y="414" type="curve" smooth="yes"/>
+      <point x="1560" y="534"/>
+      <point x="1490" y="613"/>
+      <point x="1362" y="613" type="curve" smooth="yes"/>
+      <point x="1273" y="613"/>
+      <point x="1201" y="570"/>
+      <point x="1169" y="498" type="curve"/>
+      <point x="1162" y="498" type="line"/>
+      <point x="1135" y="566"/>
+      <point x="1081" y="613"/>
+      <point x="972" y="613" type="curve" smooth="yes"/>
+      <point x="934" y="613"/>
+      <point x="897" y="605"/>
+      <point x="865" y="592" type="curve"/>
+      <point x="919" y="592" type="line"/>
+      <point x="891" y="605"/>
+      <point x="856" y="613"/>
       <point x="818" y="613" type="curve" smooth="yes"/>
       <point x="713" y="613"/>
       <point x="640" y="565"/>
@@ -169,19 +169,19 @@
       <point x="130" y="-16"/>
     </contour>
     <contour>
-      <point x="900" y="390" type="curve" smooth="yes"/>
-      <point x="867" y="390"/>
-      <point x="840" y="410"/>
-      <point x="840" y="450" type="curve" smooth="yes"/>
-      <point x="840" y="477"/>
-      <point x="859" y="517"/>
-      <point x="913" y="528" type="curve"/>
-      <point x="869" y="527" type="line"/>
-      <point x="937" y="521"/>
-      <point x="956" y="475"/>
-      <point x="956" y="449" type="curve" smooth="yes"/>
-      <point x="956" y="413"/>
-      <point x="936" y="390"/>
+      <point x="897" y="374" type="curve" smooth="yes"/>
+      <point x="858" y="374"/>
+      <point x="837" y="399"/>
+      <point x="837" y="434" type="curve" smooth="yes"/>
+      <point x="837" y="472"/>
+      <point x="862" y="501"/>
+      <point x="911" y="522" type="curve"/>
+      <point x="883" y="522" type="line"/>
+      <point x="932" y="501"/>
+      <point x="957" y="472"/>
+      <point x="957" y="434" type="curve" smooth="yes"/>
+      <point x="957" y="399"/>
+      <point x="936" y="374"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/t_la-malayalam.glif
@@ -56,22 +56,6 @@
       <point x="292" y="-368"/>
     </contour>
     <contour>
-      <point x="386" y="-288" type="curve" smooth="yes"/>
-      <point x="338" y="-288"/>
-      <point x="317" y="-246"/>
-      <point x="316" y="-209" type="curve"/>
-      <point x="300" y="-214" type="line"/>
-      <point x="314" y="-253" type="line"/>
-      <point x="319" y="-210"/>
-      <point x="348" y="-185"/>
-      <point x="388" y="-185" type="curve" smooth="yes"/>
-      <point x="425" y="-185"/>
-      <point x="442" y="-204"/>
-      <point x="442" y="-235" type="curve" smooth="yes"/>
-      <point x="442" y="-268"/>
-      <point x="423" y="-288"/>
-    </contour>
-    <contour>
       <point x="162" y="-16" type="curve"/>
       <point x="251" y="59" type="line"/>
       <point x="189" y="128"/>
@@ -94,6 +78,22 @@
       <point x="80" y="69"/>
     </contour>
     <contour>
+      <point x="386" y="-288" type="curve" smooth="yes"/>
+      <point x="338" y="-288"/>
+      <point x="317" y="-246"/>
+      <point x="316" y="-209" type="curve"/>
+      <point x="300" y="-214" type="line"/>
+      <point x="314" y="-253" type="line"/>
+      <point x="319" y="-210"/>
+      <point x="348" y="-185"/>
+      <point x="388" y="-185" type="curve" smooth="yes"/>
+      <point x="425" y="-185"/>
+      <point x="442" y="-204"/>
+      <point x="442" y="-235" type="curve" smooth="yes"/>
+      <point x="442" y="-268"/>
+      <point x="423" y="-288"/>
+    </contour>
+    <contour>
       <point x="799" y="-278" type="curve" smooth="yes"/>
       <point x="748" y="-278"/>
       <point x="721" y="-243"/>
@@ -106,11 +106,11 @@
       <point x="686" y="54"/>
       <point x="726" y="139"/>
       <point x="726" y="246" type="curve" smooth="yes"/>
-      <point x="726" y="366"/>
-      <point x="667" y="477"/>
-      <point x="577" y="545" type="curve"/>
-      <point x="470" y="486" type="line"/>
-      <point x="555" y="446"/>
+      <point x="726" y="365"/>
+      <point x="668" y="475"/>
+      <point x="579" y="543" type="curve"/>
+      <point x="472" y="485" type="line"/>
+      <point x="556" y="445"/>
       <point x="603" y="354"/>
       <point x="603" y="246" type="curve" smooth="yes"/>
       <point x="603" y="151"/>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,31 +1,31 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="611"/>
-  <anchor x="331" y="-213" name="bottom"/>
+  <anchor x="331" y="-235" name="bottom"/>
   <anchor x="301" y="597" name="top"/>
   <anchor x="490" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="298" y="-229" type="curve" smooth="yes"/>
-      <point x="486" y="-229"/>
-      <point x="580" y="-166"/>
-      <point x="580" y="-55" type="curve" smooth="yes"/>
-      <point x="580" y="17"/>
-      <point x="535" y="52"/>
+      <point x="305" y="-251" type="curve" smooth="yes"/>
+      <point x="486" y="-251"/>
+      <point x="580" y="-186"/>
+      <point x="580" y="-72" type="curve" smooth="yes"/>
+      <point x="580" y="0"/>
+      <point x="542" y="46"/>
       <point x="469" y="66" type="curve"/>
       <point x="469" y="74" type="line"/>
-      <point x="526" y="88"/>
-      <point x="570" y="141"/>
-      <point x="570" y="210" type="curve" smooth="yes"/>
-      <point x="570" y="307"/>
-      <point x="512" y="361"/>
-      <point x="353" y="371" type="curve" smooth="yes"/>
-      <point x="234" y="378" type="line" smooth="yes"/>
-      <point x="170" y="381"/>
-      <point x="139" y="403"/>
-      <point x="139" y="439" type="curve" smooth="yes"/>
-      <point x="139" y="482"/>
-      <point x="188" y="503"/>
+      <point x="533" y="95"/>
+      <point x="570" y="143"/>
+      <point x="570" y="207" type="curve" smooth="yes"/>
+      <point x="570" y="308"/>
+      <point x="500" y="358"/>
+      <point x="353" y="367" type="curve" smooth="yes"/>
+      <point x="234" y="374" type="line" smooth="yes"/>
+      <point x="169" y="378"/>
+      <point x="139" y="398"/>
+      <point x="139" y="434" type="curve" smooth="yes"/>
+      <point x="139" y="480"/>
+      <point x="185" y="503"/>
       <point x="285" y="503" type="curve" smooth="yes"/>
       <point x="364" y="503"/>
       <point x="430" y="488"/>
@@ -35,33 +35,33 @@
       <point x="381" y="613"/>
       <point x="289" y="613" type="curve" smooth="yes"/>
       <point x="113" y="613"/>
-      <point x="22" y="539"/>
-      <point x="22" y="428" type="curve" smooth="yes"/>
-      <point x="22" y="327"/>
-      <point x="94" y="267"/>
-      <point x="219" y="260" type="curve" smooth="yes"/>
-      <point x="341" y="252" type="line" smooth="yes"/>
-      <point x="423" y="247"/>
-      <point x="455" y="224"/>
-      <point x="455" y="186" type="curve" smooth="yes"/>
-      <point x="455" y="141"/>
-      <point x="413" y="118"/>
-      <point x="328" y="118" type="curve" smooth="yes"/>
-      <point x="59" y="118" type="line"/>
+      <point x="22" y="537"/>
+      <point x="22" y="426" type="curve" smooth="yes"/>
+      <point x="22" y="323"/>
+      <point x="94" y="262"/>
+      <point x="219" y="255" type="curve" smooth="yes"/>
+      <point x="341" y="248" type="line" smooth="yes"/>
+      <point x="417" y="244"/>
+      <point x="453" y="223"/>
+      <point x="453" y="182" type="curve" smooth="yes"/>
+      <point x="453" y="139"/>
+      <point x="414" y="114"/>
+      <point x="334" y="114" type="curve" smooth="yes"/>
+      <point x="59" y="114" type="line"/>
       <point x="59" y="13" type="line"/>
-      <point x="346" y="13" type="line" smooth="yes"/>
-      <point x="428" y="13"/>
-      <point x="459" y="-5"/>
-      <point x="459" y="-46" type="curve" smooth="yes"/>
-      <point x="459" y="-97"/>
-      <point x="405" y="-116"/>
-      <point x="300" y="-116" type="curve" smooth="yes"/>
-      <point x="204" y="-116"/>
-      <point x="126" y="-96"/>
-      <point x="77" y="-73" type="curve"/>
-      <point x="32" y="-175" type="line"/>
-      <point x="89" y="-205"/>
-      <point x="188" y="-229"/>
+      <point x="351" y="13" type="line" smooth="yes"/>
+      <point x="430" y="13"/>
+      <point x="463" y="-12"/>
+      <point x="463" y="-56" type="curve" smooth="yes"/>
+      <point x="463" y="-112"/>
+      <point x="408" y="-141"/>
+      <point x="305" y="-141" type="curve" smooth="yes"/>
+      <point x="227" y="-141"/>
+      <point x="151" y="-118"/>
+      <point x="90" y="-77" type="curve"/>
+      <point x="30" y="-169" type="line"/>
+      <point x="108" y="-221"/>
+      <point x="204" y="-251"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/tta-malayalam.glif
@@ -11,42 +11,42 @@
       <point x="493" y="-16"/>
       <point x="582" y="57"/>
       <point x="582" y="173" type="curve" smooth="yes"/>
-      <point x="582" y="275"/>
-      <point x="514" y="347"/>
-      <point x="368" y="354" type="curve" smooth="yes"/>
-      <point x="246" y="361" type="line" smooth="yes"/>
-      <point x="182" y="364"/>
-      <point x="151" y="388"/>
-      <point x="151" y="427" type="curve" smooth="yes"/>
-      <point x="151" y="478"/>
-      <point x="200" y="503"/>
-      <point x="297" y="503" type="curve" smooth="yes"/>
-      <point x="370" y="503"/>
-      <point x="442" y="488"/>
+      <point x="582" y="276"/>
+      <point x="515" y="348"/>
+      <point x="368" y="356" type="curve" smooth="yes"/>
+      <point x="246" y="363" type="line" smooth="yes"/>
+      <point x="181" y="367"/>
+      <point x="151" y="390"/>
+      <point x="151" y="429" type="curve" smooth="yes"/>
+      <point x="151" y="479"/>
+      <point x="201" y="503"/>
+      <point x="299" y="503" type="curve" smooth="yes"/>
+      <point x="371" y="503"/>
+      <point x="443" y="488"/>
       <point x="508" y="459" type="curve"/>
       <point x="551" y="560" type="line"/>
-      <point x="474" y="596"/>
-      <point x="386" y="613"/>
-      <point x="301" y="613" type="curve" smooth="yes"/>
-      <point x="131" y="613"/>
-      <point x="34" y="535"/>
-      <point x="34" y="413" type="curve" smooth="yes"/>
-      <point x="34" y="311"/>
-      <point x="111" y="249"/>
-      <point x="231" y="241" type="curve" smooth="yes"/>
-      <point x="353" y="234" type="line" smooth="yes"/>
-      <point x="435" y="229"/>
-      <point x="466" y="206"/>
-      <point x="466" y="167" type="curve" smooth="yes"/>
-      <point x="466" y="118"/>
-      <point x="419" y="94"/>
+      <point x="475" y="596"/>
+      <point x="387" y="613"/>
+      <point x="303" y="613" type="curve" smooth="yes"/>
+      <point x="132" y="613"/>
+      <point x="34" y="536"/>
+      <point x="34" y="415" type="curve" smooth="yes"/>
+      <point x="34" y="313"/>
+      <point x="110" y="250"/>
+      <point x="231" y="243" type="curve" smooth="yes"/>
+      <point x="353" y="236" type="line" smooth="yes"/>
+      <point x="434" y="231"/>
+      <point x="465" y="207"/>
+      <point x="465" y="167" type="curve" smooth="yes"/>
+      <point x="465" y="118"/>
+      <point x="418" y="94"/>
       <point x="327" y="94" type="curve" smooth="yes"/>
-      <point x="240" y="94"/>
-      <point x="158" y="119"/>
-      <point x="83" y="162" type="curve"/>
-      <point x="22" y="58" type="line"/>
-      <point x="117" y="8"/>
-      <point x="211" y="-16"/>
+      <point x="233" y="94"/>
+      <point x="149" y="118"/>
+      <point x="79" y="163" type="curve"/>
+      <point x="22" y="69" type="line"/>
+      <point x="112" y="11"/>
+      <point x="208" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
@@ -36,33 +36,39 @@
     </contour>
     <contour>
       <point x="146" y="-184" type="curve" smooth="yes"/>
-      <point x="92" y="-184"/>
-      <point x="54" y="-148"/>
-      <point x="54" y="-96" type="curve" smooth="yes"/>
-      <point x="54" y="-44"/>
-      <point x="92" y="-8"/>
-      <point x="146" y="-8" type="curve" smooth="yes"/>
-      <point x="200" y="-8"/>
-      <point x="238" y="-45"/>
-      <point x="238" y="-96" type="curve" smooth="yes"/>
-      <point x="238" y="-147"/>
-      <point x="200" y="-184"/>
+      <point x="90" y="-184"/>
+      <point x="54" y="-150"/>
+      <point x="54" y="-102" type="curve" smooth="yes"/>
+      <point x="54" y="-89"/>
+      <point x="56" y="-79"/>
+      <point x="60" y="-69" type="curve"/>
+      <point x="67" y="-69" type="line"/>
+      <point x="77" y="-108"/>
+      <point x="106" y="-130"/>
+      <point x="146" y="-130" type="curve" smooth="yes"/>
+      <point x="186" y="-130"/>
+      <point x="216" y="-108"/>
+      <point x="226" y="-69" type="curve"/>
+      <point x="233" y="-69" type="line"/>
+      <point x="237" y="-79"/>
+      <point x="239" y="-89"/>
+      <point x="239" y="-102" type="curve" smooth="yes"/>
+      <point x="239" y="-150"/>
+      <point x="202" y="-184"/>
     </contour>
     <contour>
-      <point x="146" y="-120" type="curve" smooth="yes"/>
-      <point x="199" y="-120"/>
-      <point x="246" y="-99"/>
-      <point x="276" y="-63" type="curve"/>
-      <point x="250" y="-26" type="line"/>
-      <point x="228" y="-51"/>
-      <point x="190" y="-66"/>
-      <point x="146" y="-66" type="curve" smooth="yes"/>
-      <point x="102" y="-66"/>
-      <point x="64" y="-51"/>
-      <point x="42" y="-26" type="curve"/>
-      <point x="16" y="-63" type="line"/>
-      <point x="46" y="-99"/>
-      <point x="93" y="-120"/>
+      <point x="146" y="-64" type="curve" smooth="yes"/>
+      <point x="106" y="-64"/>
+      <point x="82" y="-51"/>
+      <point x="82" y="-30" type="curve" smooth="yes"/>
+      <point x="82" y="-13"/>
+      <point x="106" y="-2"/>
+      <point x="146" y="-2" type="curve" smooth="yes"/>
+      <point x="186" y="-2"/>
+      <point x="211" y="-13"/>
+      <point x="211" y="-30" type="curve" smooth="yes"/>
+      <point x="211" y="-51"/>
+      <point x="186" y="-64"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/v_va-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/v_va-malayalam.glif
@@ -2,7 +2,6 @@
 <glyph name="v_va-malayalam" format="2">
   <advance width="1068"/>
   <anchor x="711" y="-287" name="bottom"/>
-  <anchor x="974" y="0" name="bottomright"/>
   <anchor x="570" y="597" name="top"/>
   <anchor x="936" y="597" name="topright"/>
   <outline>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/y_ya-malayalam.glif
@@ -1,97 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="1023"/>
-  <anchor x="643" y="-287" name="bottom"/>
-  <anchor x="906" y="0" name="bottomright"/>
+  <anchor x="643" y="-281" name="bottom"/>
   <anchor x="529" y="597" name="top"/>
   <anchor x="831" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="312" y="-290" type="line"/>
-      <point x="926" y="-290" type="line"/>
+      <point x="312" y="-284" type="line"/>
+      <point x="926" y="-284" type="line"/>
       <point x="926" y="126" type="line"/>
-      <point x="913" y="83" type="line"/>
-      <point x="959" y="139"/>
-      <point x="984" y="218"/>
-      <point x="984" y="314" type="curve" smooth="yes"/>
-      <point x="984" y="406"/>
-      <point x="951" y="520"/>
-      <point x="869" y="613" type="curve"/>
-      <point x="773" y="546" type="line"/>
-      <point x="822" y="485"/>
-      <point x="863" y="405"/>
-      <point x="863" y="311" type="curve" smooth="yes"/>
-      <point x="863" y="184"/>
-      <point x="809" y="95"/>
-      <point x="676" y="95" type="curve" smooth="yes"/>
-      <point x="523" y="95"/>
-      <point x="445" y="202"/>
-      <point x="445" y="363" type="curve" smooth="yes"/>
-      <point x="445" y="452"/>
-      <point x="475" y="504"/>
-      <point x="530" y="504" type="curve" smooth="yes"/>
-      <point x="583" y="504"/>
-      <point x="611" y="452"/>
-      <point x="611" y="361" type="curve" smooth="yes"/>
-      <point x="611" y="262"/>
-      <point x="581" y="171"/>
-      <point x="512" y="124" type="curve"/>
-      <point x="586" y="61" type="line"/>
-      <point x="684" y="137"/>
-      <point x="730" y="249"/>
-      <point x="730" y="367" type="curve" smooth="yes"/>
-      <point x="730" y="504"/>
-      <point x="668" y="613"/>
-      <point x="530" y="613" type="curve" smooth="yes"/>
-      <point x="395" y="613"/>
-      <point x="328" y="497"/>
-      <point x="328" y="369" type="curve" smooth="yes"/>
-      <point x="328" y="164"/>
-      <point x="461" y="-9"/>
-      <point x="694" y="-9" type="curve" smooth="yes"/>
-      <point x="719" y="-9"/>
-      <point x="744" y="-7"/>
-      <point x="772" y="-3" type="curve"/>
-      <point x="632" y="51" type="line"/>
-      <point x="644" y="-13" type="line"/>
-      <point x="565" y="-58" type="line"/>
-      <point x="312" y="-221" type="line"/>
+      <point x="904" y="83" type="line"/>
+      <point x="956" y="140"/>
+      <point x="984" y="221"/>
+      <point x="984" y="321" type="curve" smooth="yes"/>
+      <point x="984" y="422"/>
+      <point x="942" y="528"/>
+      <point x="868" y="613" type="curve"/>
+      <point x="772" y="538" type="line"/>
+      <point x="833" y="468"/>
+      <point x="864" y="394"/>
+      <point x="864" y="317" type="curve" smooth="yes"/>
+      <point x="864" y="169"/>
+      <point x="796" y="94"/>
+      <point x="660" y="94" type="curve" smooth="yes"/>
+      <point x="501" y="94"/>
+      <point x="418" y="205"/>
+      <point x="418" y="346" type="curve" smooth="yes"/>
+      <point x="418" y="445"/>
+      <point x="453" y="503"/>
+      <point x="522" y="503" type="curve" smooth="yes"/>
+      <point x="586" y="503"/>
+      <point x="616" y="446"/>
+      <point x="616" y="346" type="curve" smooth="yes"/>
+      <point x="616" y="247"/>
+      <point x="577" y="167"/>
+      <point x="505" y="121" type="curve"/>
+      <point x="581" y="63" type="line"/>
+      <point x="680" y="129"/>
+      <point x="736" y="233"/>
+      <point x="736" y="352" type="curve" smooth="yes"/>
+      <point x="736" y="497"/>
+      <point x="674" y="613"/>
+      <point x="524" y="613" type="curve" smooth="yes"/>
+      <point x="380" y="613"/>
+      <point x="298" y="477"/>
+      <point x="298" y="342" type="curve" smooth="yes"/>
+      <point x="298" y="155"/>
+      <point x="448" y="-10"/>
+      <point x="666" y="-10" type="curve" smooth="yes"/>
+      <point x="705" y="-10"/>
+      <point x="741" y="-5"/>
+      <point x="773" y="4" type="curve"/>
+      <point x="623" y="38" type="line"/>
+      <point x="623" y="-16" type="line"/>
+      <point x="562" y="-51" type="line"/>
+      <point x="312" y="-215" type="line"/>
     </contour>
     <contour>
-      <point x="453" y="-233" type="line"/>
-      <point x="834" y="20" type="line"/>
-      <point x="809" y="20" type="line"/>
-      <point x="809" y="-226" type="line"/>
-      <point x="873" y="-206" type="line"/>
-      <point x="456" y="-206" type="line"/>
+      <point x="456" y="-224" type="line"/>
+      <point x="834" y="26" type="line"/>
+      <point x="809" y="26" type="line"/>
+      <point x="809" y="-220" type="line"/>
+      <point x="873" y="-200" type="line"/>
+      <point x="456" y="-200" type="line"/>
     </contour>
     <contour>
-      <point x="361" y="-16" type="curve" smooth="yes"/>
+      <point x="363" y="-16" type="curve" smooth="yes"/>
       <point x="439" y="-16"/>
-      <point x="500" y="4"/>
-      <point x="552" y="36" type="curve"/>
+      <point x="499" y="5"/>
+      <point x="550" y="38" type="curve"/>
       <point x="464" y="111" type="line"/>
-      <point x="439" y="102"/>
-      <point x="409" y="95"/>
-      <point x="370" y="95" type="curve" smooth="yes"/>
-      <point x="225" y="95"/>
-      <point x="161" y="199"/>
-      <point x="161" y="327" type="curve" smooth="yes"/>
-      <point x="161" y="432"/>
-      <point x="208" y="502"/>
-      <point x="293" y="502" type="curve" smooth="yes"/>
-      <point x="331" y="502"/>
-      <point x="353" y="491"/>
-      <point x="376" y="470" type="curve"/>
-      <point x="439" y="554" type="line"/>
-      <point x="401" y="593"/>
-      <point x="350" y="613"/>
-      <point x="286" y="613" type="curve" smooth="yes"/>
-      <point x="123" y="613"/>
-      <point x="39" y="476"/>
-      <point x="39" y="327" type="curve" smooth="yes"/>
-      <point x="39" y="126"/>
-      <point x="165" y="-16"/>
+      <point x="439" y="101"/>
+      <point x="409" y="94"/>
+      <point x="370" y="94" type="curve" smooth="yes"/>
+      <point x="239" y="94"/>
+      <point x="159" y="183"/>
+      <point x="159" y="324" type="curve" smooth="yes"/>
+      <point x="159" y="436"/>
+      <point x="211" y="503"/>
+      <point x="297" y="503" type="curve" smooth="yes"/>
+      <point x="326" y="503"/>
+      <point x="349" y="494"/>
+      <point x="376" y="472" type="curve"/>
+      <point x="443" y="556" type="line"/>
+      <point x="403" y="596"/>
+      <point x="361" y="613"/>
+      <point x="301" y="613" type="curve" smooth="yes"/>
+      <point x="148" y="613"/>
+      <point x="39" y="493"/>
+      <point x="39" y="324" type="curve" smooth="yes"/>
+      <point x="39" y="129"/>
+      <point x="178" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ya-malayalam.glif
@@ -4,76 +4,76 @@
   <unicode hex="0D2F"/>
   <anchor x="600" y="0" name="bottom"/>
   <anchor x="906" y="0" name="bottomright"/>
-  <anchor x="529" y="597" name="top"/>
+  <anchor x="523" y="597" name="top"/>
   <anchor x="831" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="687" y="-16" type="curve" smooth="yes"/>
-      <point x="872" y="-16"/>
-      <point x="984" y="110"/>
-      <point x="984" y="314" type="curve" smooth="yes"/>
-      <point x="984" y="406"/>
-      <point x="951" y="520"/>
-      <point x="869" y="613" type="curve"/>
-      <point x="773" y="546" type="line"/>
-      <point x="822" y="485"/>
-      <point x="863" y="405"/>
-      <point x="863" y="311" type="curve" smooth="yes"/>
-      <point x="863" y="184"/>
-      <point x="809" y="95"/>
-      <point x="676" y="95" type="curve" smooth="yes"/>
-      <point x="523" y="95"/>
-      <point x="445" y="202"/>
-      <point x="445" y="363" type="curve" smooth="yes"/>
-      <point x="445" y="452"/>
-      <point x="475" y="504"/>
-      <point x="530" y="504" type="curve" smooth="yes"/>
-      <point x="583" y="504"/>
-      <point x="611" y="452"/>
-      <point x="611" y="361" type="curve" smooth="yes"/>
-      <point x="611" y="262"/>
-      <point x="581" y="171"/>
-      <point x="512" y="124" type="curve"/>
-      <point x="586" y="61" type="line"/>
-      <point x="684" y="137"/>
-      <point x="730" y="249"/>
-      <point x="730" y="367" type="curve" smooth="yes"/>
-      <point x="730" y="504"/>
-      <point x="668" y="613"/>
-      <point x="530" y="613" type="curve" smooth="yes"/>
-      <point x="395" y="613"/>
-      <point x="328" y="497"/>
-      <point x="328" y="369" type="curve" smooth="yes"/>
-      <point x="328" y="161"/>
-      <point x="464" y="-16"/>
+      <point x="666" y="-16" type="curve" smooth="yes"/>
+      <point x="864" y="-16"/>
+      <point x="984" y="111"/>
+      <point x="984" y="321" type="curve" smooth="yes"/>
+      <point x="984" y="422"/>
+      <point x="942" y="528"/>
+      <point x="868" y="613" type="curve"/>
+      <point x="772" y="538" type="line"/>
+      <point x="835" y="468"/>
+      <point x="866" y="394"/>
+      <point x="866" y="317" type="curve" smooth="yes"/>
+      <point x="866" y="173"/>
+      <point x="792" y="94"/>
+      <point x="658" y="94" type="curve" smooth="yes"/>
+      <point x="500" y="94"/>
+      <point x="418" y="205"/>
+      <point x="418" y="346" type="curve" smooth="yes"/>
+      <point x="418" y="445"/>
+      <point x="453" y="503"/>
+      <point x="522" y="503" type="curve" smooth="yes"/>
+      <point x="586" y="503"/>
+      <point x="616" y="446"/>
+      <point x="616" y="346" type="curve" smooth="yes"/>
+      <point x="616" y="247"/>
+      <point x="577" y="167"/>
+      <point x="505" y="121" type="curve"/>
+      <point x="581" y="63" type="line"/>
+      <point x="680" y="129"/>
+      <point x="736" y="233"/>
+      <point x="736" y="352" type="curve" smooth="yes"/>
+      <point x="736" y="497"/>
+      <point x="674" y="613"/>
+      <point x="524" y="613" type="curve" smooth="yes"/>
+      <point x="380" y="613"/>
+      <point x="298" y="477"/>
+      <point x="298" y="342" type="curve" smooth="yes"/>
+      <point x="298" y="152"/>
+      <point x="448" y="-16"/>
     </contour>
     <contour>
-      <point x="361" y="-16" type="curve" smooth="yes"/>
+      <point x="363" y="-16" type="curve" smooth="yes"/>
       <point x="439" y="-16"/>
-      <point x="500" y="4"/>
-      <point x="552" y="36" type="curve"/>
+      <point x="499" y="5"/>
+      <point x="550" y="38" type="curve"/>
       <point x="464" y="111" type="line"/>
-      <point x="439" y="102"/>
-      <point x="409" y="95"/>
-      <point x="370" y="95" type="curve" smooth="yes"/>
-      <point x="225" y="95"/>
-      <point x="161" y="199"/>
-      <point x="161" y="327" type="curve" smooth="yes"/>
-      <point x="161" y="432"/>
-      <point x="208" y="502"/>
-      <point x="293" y="502" type="curve" smooth="yes"/>
-      <point x="331" y="502"/>
-      <point x="353" y="491"/>
-      <point x="376" y="470" type="curve"/>
-      <point x="439" y="554" type="line"/>
-      <point x="401" y="593"/>
-      <point x="350" y="613"/>
-      <point x="286" y="613" type="curve" smooth="yes"/>
-      <point x="123" y="613"/>
-      <point x="39" y="476"/>
-      <point x="39" y="327" type="curve" smooth="yes"/>
-      <point x="39" y="126"/>
-      <point x="165" y="-16"/>
+      <point x="439" y="101"/>
+      <point x="409" y="94"/>
+      <point x="370" y="94" type="curve" smooth="yes"/>
+      <point x="237" y="94"/>
+      <point x="157" y="183"/>
+      <point x="157" y="324" type="curve" smooth="yes"/>
+      <point x="157" y="436"/>
+      <point x="210" y="503"/>
+      <point x="297" y="503" type="curve" smooth="yes"/>
+      <point x="326" y="503"/>
+      <point x="349" y="494"/>
+      <point x="376" y="472" type="curve"/>
+      <point x="443" y="556" type="line"/>
+      <point x="403" y="596"/>
+      <point x="361" y="613"/>
+      <point x="301" y="613" type="curve" smooth="yes"/>
+      <point x="148" y="613"/>
+      <point x="39" y="493"/>
+      <point x="39" y="324" type="curve" smooth="yes"/>
+      <point x="39" y="129"/>
+      <point x="178" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/kerning.plist
@@ -48126,7 +48126,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>83</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>57</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -48242,7 +48242,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>73</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48298,7 +48298,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48355,7 +48355,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>263</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>200</integer>
+      <integer>190</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>233</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -48402,7 +48402,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>133</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>93</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -48437,7 +48437,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>123</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>97</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -48465,8 +48465,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>67</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48501,7 +48499,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>153</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>103</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48630,7 +48628,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>187</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>137</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>157</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48683,7 +48681,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>263</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>197</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48741,7 +48739,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>77</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>47</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48922,8 +48920,6 @@
       <integer>-10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>57</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49009,7 +49005,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>79</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>33</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49109,8 +49105,6 @@
       <integer>60</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>103</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>73</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -49143,7 +49137,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>177</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>80</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>147</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -49225,7 +49219,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>43</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49267,8 +49261,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla-malayalam_L</key>
       <integer>-37</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>67</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49386,8 +49378,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>73</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -49501,7 +49491,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49554,7 +49544,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>193</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49604,45 +49594,47 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>77</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_braceright.loclMALM_R</key>
       <integer>50</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
-      <integer>47</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
-      <integer>47</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>147</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
-      <integer>117</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
-      <integer>40</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
-      <integer>-30</integer>
+      <integer>-20</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>90</integer>
+      <key>public.kern2.MAL_tt_tta-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
-      <integer>143</integer>
+      <integer>160</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
-      <integer>97</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_uMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>84</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>233</integer>
+      <integer>220</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
-      <integer>170</integer>
+      <integer>180</integer>
     </dict>
     <key>public.kern1.MAL_ma_lVocalicMatra-malayalam_R</key>
     <dict>
@@ -49667,7 +49659,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>113</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49718,7 +49710,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>237</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>160</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>197</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49752,7 +49744,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>73</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>27</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -49794,7 +49786,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>57</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>47</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -50009,7 +50001,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>63</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50036,7 +50028,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>27</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50065,7 +50057,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>97</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>63</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50119,7 +50111,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -50151,8 +50143,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -50340,7 +50330,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>227</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>163</integer>
+      <integer>164</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>193</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
@@ -50381,7 +50371,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>147</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>80</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>133</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50428,7 +50418,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>237</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>173</integer>
+      <integer>150</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>177</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50528,7 +50518,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>217</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>163</integer>
+      <integer>150</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>177</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -50670,7 +50660,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>107</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>57</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>57</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -50723,7 +50713,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>77</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>23</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>47</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50790,7 +50780,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>217</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>150</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>177</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50843,7 +50833,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>290</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>240</integer>
+      <integer>230</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -50930,7 +50920,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>137</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>113</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -51081,7 +51071,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>63</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -51241,6 +51231,26 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-40</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>90</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>93</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>54</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+      <key>public.kern2.MAL_quoteright.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.ODI_a-oriya-L</key>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/d_da-malayalam.glif
@@ -1,73 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
-  <advance width="689"/>
-  <anchor x="362" y="596" name="top"/>
+  <advance width="679"/>
+  <anchor x="281" y="-269" name="bottom"/>
+  <anchor x="429" y="596" name="top"/>
   <outline>
     <contour>
-      <point x="378" y="-225" type="curve" smooth="yes"/>
-      <point x="514" y="-225"/>
-      <point x="579" y="-173"/>
-      <point x="579" y="-87" type="curve" smooth="yes"/>
-      <point x="579" y="-32"/>
-      <point x="549" y="6"/>
-      <point x="488" y="19" type="curve"/>
-      <point x="488" y="29" type="line"/>
-      <point x="555" y="40"/>
-      <point x="613" y="76"/>
-      <point x="613" y="165" type="curve" smooth="yes"/>
-      <point x="613" y="228"/>
-      <point x="577" y="271"/>
-      <point x="515" y="290" type="curve"/>
-      <point x="516" y="300" type="line"/>
-      <point x="600" y="313"/>
-      <point x="641" y="375"/>
-      <point x="641" y="437" type="curve" smooth="yes"/>
-      <point x="641" y="534"/>
-      <point x="571" y="612"/>
-      <point x="410" y="612" type="curve" smooth="yes"/>
-      <point x="185" y="612"/>
-      <point x="50" y="454"/>
-      <point x="50" y="229" type="curve" smooth="yes"/>
-      <point x="50" y="143"/>
-      <point x="70" y="57"/>
-      <point x="115" y="-16" type="curve"/>
-      <point x="188" y="30" type="line"/>
-      <point x="153" y="88"/>
-      <point x="132" y="156"/>
-      <point x="132" y="231" type="curve" smooth="yes"/>
-      <point x="132" y="407"/>
-      <point x="230" y="534"/>
-      <point x="405" y="534" type="curve" smooth="yes"/>
-      <point x="514" y="534"/>
-      <point x="557" y="490"/>
-      <point x="557" y="433" type="curve" smooth="yes"/>
-      <point x="557" y="373"/>
-      <point x="510" y="337"/>
-      <point x="441" y="337" type="curve" smooth="yes"/>
-      <point x="383" y="337" type="line"/>
-      <point x="370" y="263" type="line"/>
-      <point x="412" y="263" type="line" smooth="yes"/>
-      <point x="493" y="263"/>
-      <point x="531" y="230"/>
-      <point x="531" y="166" type="curve" smooth="yes"/>
-      <point x="531" y="97"/>
-      <point x="483" y="62"/>
-      <point x="409" y="62" type="curve" smooth="yes"/>
-      <point x="335" y="62" type="line"/>
-      <point x="322" y="-12" type="line"/>
-      <point x="385" y="-12" type="line" smooth="yes"/>
-      <point x="463" y="-12"/>
-      <point x="498" y="-30"/>
-      <point x="498" y="-74" type="curve" smooth="yes"/>
-      <point x="498" y="-123"/>
-      <point x="460" y="-147"/>
-      <point x="387" y="-147" type="curve" smooth="yes"/>
-      <point x="329" y="-147"/>
-      <point x="296" y="-139"/>
-      <point x="265" y="-129" type="curve"/>
-      <point x="225" y="-201" type="line"/>
-      <point x="258" y="-215"/>
-      <point x="320" y="-225"/>
+      <point x="325" y="-285" type="curve" smooth="yes"/>
+      <point x="459" y="-285"/>
+      <point x="557" y="-219"/>
+      <point x="557" y="-105" type="curve" smooth="yes"/>
+      <point x="557" y="-42"/>
+      <point x="532" y="-5"/>
+      <point x="482" y="17" type="curve"/>
+      <point x="484" y="27" type="line"/>
+      <point x="564" y="47"/>
+      <point x="607" y="102"/>
+      <point x="607" y="175" type="curve" smooth="yes"/>
+      <point x="607" y="235"/>
+      <point x="576" y="277"/>
+      <point x="509" y="293" type="curve"/>
+      <point x="511" y="303" type="line"/>
+      <point x="595" y="320"/>
+      <point x="637" y="373"/>
+      <point x="637" y="441" type="curve" smooth="yes"/>
+      <point x="637" y="539"/>
+      <point x="559" y="612"/>
+      <point x="415" y="612" type="curve" smooth="yes"/>
+      <point x="169" y="612"/>
+      <point x="51" y="429"/>
+      <point x="51" y="247" type="curve" smooth="yes"/>
+      <point x="51" y="154"/>
+      <point x="77" y="66"/>
+      <point x="124" y="-16" type="curve"/>
+      <point x="194" y="27" type="line"/>
+      <point x="155" y="97"/>
+      <point x="135" y="170"/>
+      <point x="135" y="247" type="curve" smooth="yes"/>
+      <point x="135" y="400"/>
+      <point x="226" y="534"/>
+      <point x="409" y="534" type="curve" smooth="yes"/>
+      <point x="512" y="534"/>
+      <point x="553" y="495"/>
+      <point x="553" y="434" type="curve" smooth="yes"/>
+      <point x="553" y="374"/>
+      <point x="508" y="337"/>
+      <point x="428" y="337" type="curve" smooth="yes"/>
+      <point x="373" y="337" type="line"/>
+      <point x="360" y="263" type="line"/>
+      <point x="406" y="263" type="line" smooth="yes"/>
+      <point x="486" y="263"/>
+      <point x="523" y="231"/>
+      <point x="523" y="170" type="curve" smooth="yes"/>
+      <point x="523" y="101"/>
+      <point x="475" y="62"/>
+      <point x="389" y="62" type="curve" smooth="yes"/>
+      <point x="304" y="62" type="line"/>
+      <point x="291" y="-12" type="line"/>
+      <point x="359" y="-12" type="line" smooth="yes"/>
+      <point x="441" y="-12"/>
+      <point x="473" y="-47"/>
+      <point x="473" y="-101" type="curve" smooth="yes"/>
+      <point x="473" y="-169"/>
+      <point x="421" y="-207"/>
+      <point x="331" y="-207" type="curve" smooth="yes"/>
+      <point x="271" y="-207"/>
+      <point x="223" y="-194"/>
+      <point x="171" y="-165" type="curve"/>
+      <point x="136" y="-233" type="line"/>
+      <point x="195" y="-268"/>
+      <point x="259" y="-285"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="987"/>
-  <anchor x="623" y="0" name="bottom"/>
-  <anchor x="551" y="596" name="top"/>
-  <anchor x="917" y="596" name="topright"/>
+  <advance width="980"/>
+  <anchor x="609" y="0" name="bottom"/>
+  <anchor x="546" y="596" name="top"/>
+  <anchor x="905" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="256" y="-16" type="curve" smooth="yes"/>
-      <point x="379" y="-16"/>
-      <point x="453" y="57"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="729" y="532" type="curve" smooth="yes"/>
-      <point x="825" y="532"/>
-      <point x="868" y="490"/>
-      <point x="868" y="433" type="curve" smooth="yes"/>
-      <point x="868" y="373"/>
-      <point x="821" y="337"/>
-      <point x="752" y="337" type="curve" smooth="yes"/>
-      <point x="684" y="337" type="line"/>
-      <point x="671" y="263" type="line"/>
-      <point x="723" y="263" type="line" smooth="yes"/>
-      <point x="804" y="263"/>
-      <point x="842" y="229"/>
-      <point x="842" y="166" type="curve" smooth="yes"/>
-      <point x="842" y="97"/>
-      <point x="804" y="62"/>
-      <point x="730" y="62" type="curve" smooth="yes"/>
-      <point x="683" y="62"/>
-      <point x="652" y="73"/>
-      <point x="623" y="89" type="curve"/>
-      <point x="579" y="24" type="line"/>
-      <point x="616" y="0"/>
-      <point x="672" y="-16"/>
-      <point x="728" y="-16" type="curve" smooth="yes"/>
-      <point x="847" y="-16"/>
-      <point x="924" y="47"/>
-      <point x="924" y="156" type="curve" smooth="yes"/>
-      <point x="924" y="226"/>
-      <point x="888" y="272"/>
-      <point x="826" y="291" type="curve"/>
-      <point x="827" y="301" type="line"/>
-      <point x="911" y="314"/>
-      <point x="952" y="375"/>
-      <point x="952" y="448" type="curve" smooth="yes"/>
-      <point x="952" y="544"/>
-      <point x="883" y="612"/>
-      <point x="730" y="612" type="curve" smooth="yes"/>
-      <point x="581" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="76"/>
-      <point x="127" y="-16"/>
+      <point x="263" y="-16" type="curve" smooth="yes"/>
+      <point x="400" y="-16"/>
+      <point x="477" y="78"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="464"/>
+      <point x="607" y="532"/>
+      <point x="717" y="532" type="curve" smooth="yes"/>
+      <point x="803" y="532"/>
+      <point x="848" y="499"/>
+      <point x="848" y="435" type="curve" smooth="yes"/>
+      <point x="848" y="373"/>
+      <point x="801" y="337"/>
+      <point x="732" y="337" type="curve" smooth="yes"/>
+      <point x="664" y="337" type="line"/>
+      <point x="651" y="263" type="line"/>
+      <point x="703" y="263" type="line" smooth="yes"/>
+      <point x="784" y="263"/>
+      <point x="822" y="229"/>
+      <point x="822" y="166" type="curve" smooth="yes"/>
+      <point x="822" y="97"/>
+      <point x="784" y="62"/>
+      <point x="710" y="62" type="curve" smooth="yes"/>
+      <point x="663" y="62"/>
+      <point x="632" y="73"/>
+      <point x="603" y="89" type="curve"/>
+      <point x="559" y="24" type="line"/>
+      <point x="596" y="0"/>
+      <point x="652" y="-16"/>
+      <point x="708" y="-16" type="curve" smooth="yes"/>
+      <point x="827" y="-16"/>
+      <point x="904" y="47"/>
+      <point x="904" y="156" type="curve" smooth="yes"/>
+      <point x="904" y="226"/>
+      <point x="868" y="272"/>
+      <point x="806" y="290" type="curve"/>
+      <point x="807" y="300" type="line"/>
+      <point x="891" y="312"/>
+      <point x="932" y="375"/>
+      <point x="932" y="441" type="curve" smooth="yes"/>
+      <point x="932" y="545"/>
+      <point x="848" y="612"/>
+      <point x="717" y="612" type="curve" smooth="yes"/>
+      <point x="561" y="612"/>
+      <point x="456" y="517"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="77"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/g_ga-malayalam.glif
@@ -1,92 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ga-malayalam" format="2">
   <advance width="934"/>
-  <anchor x="428" y="-357" name="bottom"/>
-  <anchor x="529" y="596" name="top"/>
-  <anchor x="823" y="596" name="topright"/>
+  <anchor x="447" y="-367" name="bottom"/>
+  <anchor x="522" y="596" name="top"/>
+  <anchor x="816" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="613" y="-381" type="line"/>
-      <point x="700" y="-301"/>
-      <point x="741" y="-214"/>
-      <point x="741" y="-112" type="curve" smooth="yes"/>
-      <point x="741" y="2"/>
-      <point x="669" y="48"/>
-      <point x="592" y="48" type="curve" smooth="yes"/>
-      <point x="483" y="48"/>
-      <point x="436" y="-11"/>
-      <point x="401" y="-152" type="curve" smooth="yes"/>
-      <point x="397" y="-168" type="line" smooth="yes"/>
-      <point x="370" y="-276"/>
-      <point x="344" y="-308"/>
-      <point x="286" y="-308" type="curve" smooth="yes"/>
-      <point x="238" y="-308"/>
-      <point x="203" y="-277"/>
-      <point x="203" y="-206" type="curve" smooth="yes"/>
-      <point x="203" y="-127"/>
-      <point x="240" y="-61"/>
-      <point x="299" y="-1" type="curve"/>
-      <point x="277" y="-15" type="line"/>
-      <point x="388" y="-7"/>
-      <point x="456" y="67"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="702" y="532" type="curve" smooth="yes"/>
-      <point x="779" y="532"/>
-      <point x="818" y="483"/>
-      <point x="818" y="387" type="curve" smooth="yes"/>
-      <point x="818" y="235"/>
-      <point x="749" y="113"/>
-      <point x="610" y="27" type="curve"/>
-      <point x="683" y="-16" type="line"/>
-      <point x="823" y="79"/>
-      <point x="900" y="222"/>
-      <point x="900" y="387" type="curve" smooth="yes"/>
-      <point x="900" y="534"/>
-      <point x="832" y="612"/>
-      <point x="704" y="612" type="curve" smooth="yes"/>
-      <point x="577" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="101"/>
-      <point x="104" y="16"/>
-      <point x="203" y="-9" type="curve"/>
-      <point x="203" y="-19" type="line"/>
-      <point x="153" y="-74"/>
-      <point x="128" y="-141"/>
-      <point x="128" y="-216" type="curve" smooth="yes"/>
-      <point x="128" y="-333"/>
-      <point x="202" y="-378"/>
-      <point x="280" y="-378" type="curve" smooth="yes"/>
-      <point x="386" y="-378"/>
-      <point x="435" y="-318"/>
-      <point x="469" y="-173" type="curve" smooth="yes"/>
-      <point x="473" y="-156" type="line" smooth="yes"/>
-      <point x="498" y="-51"/>
-      <point x="525" y="-22"/>
-      <point x="585" y="-22" type="curve" smooth="yes"/>
-      <point x="636" y="-22"/>
-      <point x="665" y="-56"/>
-      <point x="665" y="-121" type="curve" smooth="yes"/>
-      <point x="665" y="-210"/>
-      <point x="624" y="-275"/>
-      <point x="563" y="-339" type="curve"/>
+      <point x="263" y="-9" type="curve" smooth="yes"/>
+      <point x="400" y="-9"/>
+      <point x="476" y="83"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="458"/>
+      <point x="592" y="528"/>
+      <point x="683" y="528" type="curve" smooth="yes"/>
+      <point x="765" y="528"/>
+      <point x="804" y="481"/>
+      <point x="804" y="385" type="curve" smooth="yes"/>
+      <point x="804" y="247"/>
+      <point x="734" y="117"/>
+      <point x="609" y="37" type="curve"/>
+      <point x="677" y="-9" type="line"/>
+      <point x="815" y="87"/>
+      <point x="888" y="226"/>
+      <point x="888" y="389" type="curve" smooth="yes"/>
+      <point x="888" y="531"/>
+      <point x="809" y="612"/>
+      <point x="683" y="612" type="curve" smooth="yes"/>
+      <point x="546" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="81"/>
+      <point x="137" y="-9"/>
+    </contour>
+    <contour>
+      <point x="623" y="-380" type="line"/>
+      <point x="712" y="-311"/>
+      <point x="757" y="-234"/>
+      <point x="757" y="-127" type="curve" smooth="yes"/>
+      <point x="757" y="-21"/>
+      <point x="699" y="48"/>
+      <point x="597" y="48" type="curve" smooth="yes"/>
+      <point x="496" y="48"/>
+      <point x="433" y="-11"/>
+      <point x="417" y="-121" type="curve" smooth="yes"/>
+      <point x="414" y="-141"/>
+      <point x="412" y="-179"/>
+      <point x="409" y="-199" type="curve" smooth="yes"/>
+      <point x="398" y="-271"/>
+      <point x="366" y="-306"/>
+      <point x="312" y="-306" type="curve" smooth="yes"/>
+      <point x="254" y="-306"/>
+      <point x="222" y="-269"/>
+      <point x="222" y="-199" type="curve" smooth="yes"/>
+      <point x="222" y="-117"/>
+      <point x="255" y="-48"/>
+      <point x="315" y="15" type="curve"/>
+      <point x="231" y="15" type="line"/>
+      <point x="181" y="-38"/>
+      <point x="146" y="-121"/>
+      <point x="146" y="-201" type="curve" smooth="yes"/>
+      <point x="146" y="-309"/>
+      <point x="212" y="-378"/>
+      <point x="312" y="-378" type="curve" smooth="yes"/>
+      <point x="410" y="-378"/>
+      <point x="468" y="-320"/>
+      <point x="485" y="-211" type="curve" smooth="yes"/>
+      <point x="488" y="-191"/>
+      <point x="490" y="-153"/>
+      <point x="493" y="-133" type="curve" smooth="yes"/>
+      <point x="504" y="-59"/>
+      <point x="537" y="-24"/>
+      <point x="596" y="-24" type="curve" smooth="yes"/>
+      <point x="657" y="-24"/>
+      <point x="681" y="-61"/>
+      <point x="681" y="-129" type="curve" smooth="yes"/>
+      <point x="681" y="-206"/>
+      <point x="641" y="-273"/>
+      <point x="577" y="-322" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/g_la-malayalam.glif
@@ -1,116 +1,125 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_la-malayalam" format="2">
   <advance width="934"/>
-  <anchor x="399" y="-357" name="bottom"/>
-  <anchor x="529" y="596" name="top"/>
-  <anchor x="823" y="596" name="topright"/>
+  <anchor x="404" y="-362" name="bottom"/>
+  <anchor x="522" y="596" name="top"/>
+  <anchor x="816" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="195" y="-378" type="curve" smooth="yes"/>
-      <point x="282" y="-378"/>
-      <point x="332" y="-321"/>
-      <point x="332" y="-236" type="curve" smooth="yes"/>
-      <point x="332" y="-156"/>
-      <point x="287" y="-121"/>
-      <point x="221" y="-121" type="curve" smooth="yes"/>
-      <point x="188" y="-121"/>
-      <point x="153" y="-134"/>
-      <point x="129" y="-167" type="curve"/>
-      <point x="122" y="-166" type="line"/>
-      <point x="145" y="-72"/>
-      <point x="206" y="-22"/>
-      <point x="286" y="-22" type="curve" smooth="yes"/>
-      <point x="397" y="-22"/>
-      <point x="419" y="-91"/>
-      <point x="425" y="-180" type="curve" smooth="yes"/>
-      <point x="426" y="-196" type="line" smooth="yes"/>
-      <point x="433" y="-307"/>
-      <point x="477" y="-378"/>
-      <point x="594" y="-378" type="curve" smooth="yes"/>
-      <point x="728" y="-378"/>
-      <point x="778" y="-270"/>
-      <point x="778" y="-142" type="curve" smooth="yes"/>
-      <point x="778" y="-72"/>
-      <point x="758" y="-2"/>
-      <point x="734" y="39" type="curve"/>
-      <point x="729" y="19" type="line"/>
-      <point x="840" y="112"/>
-      <point x="900" y="241"/>
-      <point x="900" y="387" type="curve" smooth="yes"/>
-      <point x="900" y="534"/>
-      <point x="832" y="612"/>
-      <point x="704" y="612" type="curve" smooth="yes"/>
-      <point x="577" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="126"/>
-      <point x="84" y="49"/>
-      <point x="155" y="12" type="curve"/>
-      <point x="155" y="2" type="line"/>
-      <point x="85" y="-46"/>
-      <point x="49" y="-122"/>
-      <point x="49" y="-209" type="curve" smooth="yes"/>
-      <point x="49" y="-328"/>
-      <point x="114" y="-378"/>
+      <point x="190" y="-378" type="curve" smooth="yes"/>
+      <point x="289" y="-378"/>
+      <point x="332" y="-293"/>
+      <point x="332" y="-239" type="curve" smooth="yes"/>
+      <point x="332" y="-169"/>
+      <point x="296" y="-121"/>
+      <point x="227" y="-121" type="curve" smooth="yes"/>
+      <point x="176" y="-121"/>
+      <point x="119" y="-155"/>
+      <point x="106" y="-236" type="curve"/>
+      <point x="143" y="-171" type="line"/>
+      <point x="84" y="-171" type="line"/>
+      <point x="116" y="-188" type="line"/>
+      <point x="132" y="-89"/>
+      <point x="187" y="-22"/>
+      <point x="283" y="-22" type="curve" smooth="yes"/>
+      <point x="365" y="-22"/>
+      <point x="405" y="-61"/>
+      <point x="421" y="-160" type="curve" smooth="yes"/>
+      <point x="428" y="-203" type="line" smooth="yes"/>
+      <point x="448" y="-323"/>
+      <point x="500" y="-378"/>
+      <point x="591" y="-378" type="curve" smooth="yes"/>
+      <point x="731" y="-378"/>
+      <point x="775" y="-232"/>
+      <point x="775" y="-136" type="curve" smooth="yes"/>
+      <point x="775" y="-66"/>
+      <point x="758" y="-4"/>
+      <point x="724" y="46" type="curve"/>
+      <point x="713" y="12" type="line"/>
+      <point x="828" y="109"/>
+      <point x="888" y="238"/>
+      <point x="888" y="389" type="curve" smooth="yes"/>
+      <point x="888" y="531"/>
+      <point x="809" y="612"/>
+      <point x="683" y="612" type="curve" smooth="yes"/>
+      <point x="546" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="117"/>
+      <point x="89" y="43"/>
+      <point x="155" y="11" type="curve"/>
+      <point x="153" y="2" type="line"/>
+      <point x="88" y="-44"/>
+      <point x="48" y="-128"/>
+      <point x="48" y="-217" type="curve" smooth="yes"/>
+      <point x="48" y="-317"/>
+      <point x="107" y="-378"/>
     </contour>
     <contour>
-      <point x="194" y="-313" type="curve" smooth="yes"/>
-      <point x="140" y="-313"/>
-      <point x="117" y="-270"/>
-      <point x="117" y="-223" type="curve"/>
-      <point x="99" y="-200" type="line"/>
-      <point x="110" y="-256" type="line"/>
-      <point x="117" y="-216"/>
-      <point x="151" y="-181"/>
+      <point x="192" y="-313" type="curve" smooth="yes"/>
+      <point x="145" y="-313"/>
+      <point x="116" y="-275"/>
+      <point x="116" y="-227" type="curve" smooth="yes"/>
+      <point x="116" y="-219"/>
+      <point x="117" y="-211"/>
+      <point x="118" y="-203" type="curve"/>
+      <point x="98" y="-218" type="line"/>
+      <point x="104" y="-267" type="line"/>
+      <point x="112" y="-224"/>
+      <point x="148" y="-181"/>
       <point x="200" y="-181" type="curve" smooth="yes"/>
       <point x="242" y="-181"/>
-      <point x="261" y="-201"/>
-      <point x="261" y="-240" type="curve" smooth="yes"/>
-      <point x="261" y="-282"/>
-      <point x="238" y="-313"/>
+      <point x="261" y="-205"/>
+      <point x="261" y="-241" type="curve" smooth="yes"/>
+      <point x="261" y="-270"/>
+      <point x="244" y="-313"/>
     </contour>
     <contour>
-      <point x="595" y="-308" type="curve" smooth="yes"/>
-      <point x="534" y="-308"/>
-      <point x="510" y="-271"/>
-      <point x="501" y="-176" type="curve" smooth="yes"/>
-      <point x="499" y="-155" type="line" smooth="yes"/>
-      <point x="490" y="-61"/>
-      <point x="459" y="0"/>
-      <point x="393" y="29" type="curve"/>
-      <point x="393" y="39" type="line"/>
-      <point x="443" y="78"/>
-      <point x="475" y="136"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="702" y="532" type="curve" smooth="yes"/>
-      <point x="779" y="532"/>
-      <point x="818" y="483"/>
-      <point x="818" y="387" type="curve" smooth="yes"/>
-      <point x="818" y="245"/>
-      <point x="758" y="135"/>
-      <point x="645" y="52" type="curve"/>
-      <point x="677" y="-4"/>
-      <point x="702" y="-55"/>
-      <point x="702" y="-155" type="curve" smooth="yes"/>
-      <point x="702" y="-228"/>
-      <point x="674" y="-308"/>
+      <point x="596" y="-308" type="curve" smooth="yes"/>
+      <point x="541" y="-308"/>
+      <point x="516" y="-274"/>
+      <point x="502" y="-188" type="curve" smooth="yes"/>
+      <point x="495" y="-145" type="line" smooth="yes"/>
+      <point x="478" y="-42"/>
+      <point x="450" y="2"/>
+      <point x="383" y="28" type="curve"/>
+      <point x="385" y="37" type="line"/>
+      <point x="449" y="74"/>
+      <point x="487" y="139"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="507" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="458"/>
+      <point x="592" y="528"/>
+      <point x="683" y="528" type="curve" smooth="yes"/>
+      <point x="765" y="528"/>
+      <point x="804" y="481"/>
+      <point x="804" y="385" type="curve" smooth="yes"/>
+      <point x="804" y="253"/>
+      <point x="739" y="129"/>
+      <point x="629" y="51" type="curve"/>
+      <point x="678" y="-7"/>
+      <point x="701" y="-69"/>
+      <point x="701" y="-140" type="curve" smooth="yes"/>
+      <point x="701" y="-203"/>
+      <point x="680" y="-308"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/g_ma-malayalam.glif
@@ -1,99 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ma-malayalam" format="2">
   <advance width="1425"/>
-  <anchor x="1042" y="0" name="bottom"/>
-  <anchor x="761" y="596" name="top"/>
-  <anchor x="1371" y="596" name="topright"/>
+  <anchor x="1026" y="0" name="bottom"/>
+  <anchor x="755" y="596" name="top"/>
+  <anchor x="1365" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="256" y="-16" type="curve" smooth="yes"/>
-      <point x="379" y="-16"/>
-      <point x="453" y="57"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="702" y="532" type="curve" smooth="yes"/>
-      <point x="779" y="532"/>
-      <point x="816" y="483"/>
-      <point x="816" y="402" type="curve" smooth="yes"/>
-      <point x="816" y="379"/>
-      <point x="813" y="356"/>
-      <point x="809" y="331" type="curve" smooth="yes"/>
-      <point x="750" y="0" type="line"/>
-      <point x="1317" y="0" type="line"/>
-      <point x="1364" y="266" type="line" smooth="yes"/>
-      <point x="1371" y="307"/>
-      <point x="1376" y="348"/>
-      <point x="1376" y="382" type="curve" smooth="yes"/>
-      <point x="1376" y="533"/>
-      <point x="1287" y="612"/>
-      <point x="1125" y="612" type="curve" smooth="yes"/>
-      <point x="1008" y="612"/>
-      <point x="930" y="564"/>
-      <point x="885" y="490" type="curve"/>
-      <point x="875" y="490" type="line"/>
-      <point x="853" y="570"/>
-      <point x="798" y="612"/>
-      <point x="704" y="612" type="curve" smooth="yes"/>
-      <point x="577" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="76"/>
-      <point x="127" y="-16"/>
+      <point x="263" y="-16" type="curve" smooth="yes"/>
+      <point x="400" y="-16"/>
+      <point x="477" y="78"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="458"/>
+      <point x="596" y="528"/>
+      <point x="692" y="528" type="curve" smooth="yes"/>
+      <point x="768" y="528"/>
+      <point x="809" y="484"/>
+      <point x="809" y="402" type="curve" smooth="yes"/>
+      <point x="809" y="380"/>
+      <point x="806" y="357"/>
+      <point x="802" y="333" type="curve" smooth="yes"/>
+      <point x="743" y="0" type="line"/>
+      <point x="1309" y="0" type="line"/>
+      <point x="1356" y="266" type="line" smooth="yes"/>
+      <point x="1363" y="307"/>
+      <point x="1368" y="348"/>
+      <point x="1368" y="382" type="curve" smooth="yes"/>
+      <point x="1368" y="533"/>
+      <point x="1279" y="612"/>
+      <point x="1117" y="612" type="curve" smooth="yes"/>
+      <point x="1000" y="612"/>
+      <point x="922" y="564"/>
+      <point x="877" y="490" type="curve"/>
+      <point x="867" y="490" type="line"/>
+      <point x="843" y="565"/>
+      <point x="788" y="612"/>
+      <point x="690" y="612" type="curve" smooth="yes"/>
+      <point x="550" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="77"/>
+      <point x="137" y="-16"/>
     </contour>
     <contour>
-      <point x="809" y="45" type="line"/>
-      <point x="841" y="45" type="line"/>
-      <point x="893" y="341" type="line" smooth="yes"/>
-      <point x="911" y="441"/>
-      <point x="954" y="498"/>
-      <point x="1041" y="498" type="curve" smooth="yes"/>
-      <point x="1099" y="498"/>
-      <point x="1125" y="471"/>
-      <point x="1125" y="423" type="curve" smooth="yes"/>
-      <point x="1125" y="334"/>
-      <point x="1037" y="257"/>
-      <point x="940" y="167" type="curve" smooth="yes"/>
+      <point x="801" y="45" type="line"/>
+      <point x="833" y="45" type="line"/>
+      <point x="886" y="345" type="line" smooth="yes"/>
+      <point x="903" y="443"/>
+      <point x="947" y="498"/>
+      <point x="1033" y="498" type="curve" smooth="yes"/>
+      <point x="1091" y="498"/>
+      <point x="1117" y="471"/>
+      <point x="1117" y="423" type="curve" smooth="yes"/>
+      <point x="1117" y="356"/>
+      <point x="1078" y="303"/>
+      <point x="932" y="167" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="919" y="42" type="line"/>
-      <point x="1046" y="161" type="line" smooth="yes"/>
-      <point x="1131" y="241"/>
-      <point x="1203" y="321"/>
-      <point x="1203" y="415" type="curve" smooth="yes"/>
-      <point x="1203" y="485"/>
-      <point x="1157" y="531"/>
-      <point x="1070" y="531" type="curve"/>
-      <point x="1075" y="504" type="line"/>
-      <point x="1075" y="577" type="line"/>
-      <point x="1061" y="539" type="line"/>
-      <point x="1071" y="541"/>
-      <point x="1082" y="542"/>
-      <point x="1095" y="542" type="curve" smooth="yes"/>
-      <point x="1226" y="542"/>
-      <point x="1293" y="489"/>
-      <point x="1293" y="370" type="curve" smooth="yes"/>
-      <point x="1293" y="344"/>
-      <point x="1288" y="306"/>
-      <point x="1282" y="269" type="curve" smooth="yes"/>
-      <point x="1243" y="45" type="line"/>
-      <point x="1286" y="74" type="line"/>
-      <point x="913" y="74" type="line"/>
+      <point x="911" y="42" type="line"/>
+      <point x="1038" y="161" type="line" smooth="yes"/>
+      <point x="1150" y="266"/>
+      <point x="1195" y="339"/>
+      <point x="1195" y="415" type="curve" smooth="yes"/>
+      <point x="1195" y="485"/>
+      <point x="1149" y="531"/>
+      <point x="1062" y="531" type="curve"/>
+      <point x="1067" y="504" type="line"/>
+      <point x="1067" y="577" type="line"/>
+      <point x="1053" y="539" type="line"/>
+      <point x="1063" y="541"/>
+      <point x="1074" y="542"/>
+      <point x="1087" y="542" type="curve" smooth="yes"/>
+      <point x="1218" y="542"/>
+      <point x="1285" y="489"/>
+      <point x="1285" y="370" type="curve" smooth="yes"/>
+      <point x="1285" y="343"/>
+      <point x="1282" y="306"/>
+      <point x="1275" y="267" type="curve" smooth="yes"/>
+      <point x="1236" y="45" type="line"/>
+      <point x="1278" y="74" type="line"/>
+      <point x="905" y="74" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/g_na-malayalam.glif
@@ -1,70 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_na-malayalam" format="2">
   <advance width="1332"/>
-  <anchor x="864" y="0" name="bottom"/>
-  <anchor x="720" y="596" name="top"/>
-  <anchor x="1257" y="596" name="topright"/>
+  <anchor x="857" y="0" name="bottom"/>
+  <anchor x="715" y="596" name="top"/>
+  <anchor x="1252" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="256" y="-16" type="curve" smooth="yes"/>
-      <point x="379" y="-16"/>
-      <point x="453" y="57"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="537" y="366" type="line" smooth="yes"/>
-      <point x="571" y="490"/>
-      <point x="618" y="528"/>
-      <point x="697" y="528" type="curve" smooth="yes"/>
-      <point x="773" y="528"/>
-      <point x="815" y="485"/>
-      <point x="815" y="410" type="curve" smooth="yes"/>
-      <point x="815" y="382"/>
-      <point x="811" y="351"/>
-      <point x="804" y="309" type="curve" smooth="yes"/>
-      <point x="749" y="0" type="line"/>
-      <point x="833" y="0" type="line"/>
-      <point x="899" y="375" type="line" smooth="yes"/>
-      <point x="917" y="477"/>
-      <point x="978" y="534"/>
-      <point x="1071" y="534" type="curve" smooth="yes"/>
-      <point x="1162" y="534"/>
-      <point x="1212" y="475"/>
-      <point x="1212" y="369" type="curve" smooth="yes"/>
-      <point x="1212" y="249"/>
-      <point x="1155" y="143"/>
-      <point x="1035" y="45" type="curve"/>
-      <point x="1093" y="-16" type="line"/>
-      <point x="1228" y="96"/>
-      <point x="1296" y="225"/>
-      <point x="1296" y="369" type="curve" smooth="yes"/>
-      <point x="1296" y="526"/>
-      <point x="1218" y="612"/>
-      <point x="1078" y="612" type="curve" smooth="yes"/>
-      <point x="988" y="612"/>
-      <point x="917" y="570"/>
-      <point x="875" y="494" type="curve"/>
-      <point x="865" y="494" type="line"/>
-      <point x="836" y="571"/>
-      <point x="776" y="612"/>
+      <point x="263" y="-16" type="curve" smooth="yes"/>
+      <point x="400" y="-16"/>
+      <point x="477" y="78"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="461"/>
+      <point x="596" y="528"/>
+      <point x="688" y="528" type="curve" smooth="yes"/>
+      <point x="767" y="528"/>
+      <point x="810" y="486"/>
+      <point x="810" y="410" type="curve" smooth="yes"/>
+      <point x="810" y="383"/>
+      <point x="805" y="352"/>
+      <point x="798" y="311" type="curve" smooth="yes"/>
+      <point x="743" y="0" type="line"/>
+      <point x="827" y="0" type="line"/>
+      <point x="893" y="373" type="line" smooth="yes"/>
+      <point x="911" y="476"/>
+      <point x="969" y="534"/>
+      <point x="1059" y="534" type="curve" smooth="yes"/>
+      <point x="1150" y="534"/>
+      <point x="1200" y="475"/>
+      <point x="1200" y="369" type="curve" smooth="yes"/>
+      <point x="1200" y="249"/>
+      <point x="1143" y="143"/>
+      <point x="1023" y="45" type="curve"/>
+      <point x="1081" y="-16" type="line"/>
+      <point x="1216" y="96"/>
+      <point x="1284" y="225"/>
+      <point x="1284" y="369" type="curve" smooth="yes"/>
+      <point x="1284" y="526"/>
+      <point x="1207" y="612"/>
+      <point x="1068" y="612" type="curve" smooth="yes"/>
+      <point x="981" y="612"/>
+      <point x="909" y="571"/>
+      <point x="866" y="499" type="curve"/>
+      <point x="856" y="499" type="line"/>
+      <point x="829" y="574"/>
+      <point x="773" y="612"/>
       <point x="688" y="612" type="curve" smooth="yes"/>
-      <point x="575" y="612"/>
-      <point x="497" y="548"/>
-      <point x="458" y="403" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="76"/>
-      <point x="127" y="-16"/>
+      <point x="548" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="77"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ga-malayalam.glif
@@ -2,51 +2,55 @@
 <glyph name="ga-malayalam" format="2">
   <advance width="934"/>
   <unicode hex="0D17"/>
-  <anchor x="478" y="0" name="bottom"/>
-  <anchor x="529" y="596" name="top"/>
-  <anchor x="823" y="596" name="topright"/>
+  <anchor x="471" y="0" name="bottom"/>
+  <anchor x="522" y="596" name="top"/>
+  <anchor x="816" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="256" y="-16" type="curve" smooth="yes"/>
-      <point x="379" y="-16"/>
-      <point x="453" y="57"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="702" y="532" type="curve" smooth="yes"/>
-      <point x="779" y="532"/>
-      <point x="818" y="483"/>
-      <point x="818" y="387" type="curve" smooth="yes"/>
-      <point x="818" y="245"/>
-      <point x="758" y="135"/>
-      <point x="636" y="51" type="curve"/>
-      <point x="683" y="-16" type="line"/>
-      <point x="823" y="79"/>
-      <point x="900" y="222"/>
-      <point x="900" y="387" type="curve" smooth="yes"/>
-      <point x="900" y="534"/>
-      <point x="832" y="612"/>
-      <point x="704" y="612" type="curve" smooth="yes"/>
-      <point x="577" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="76"/>
-      <point x="127" y="-16"/>
+      <point x="263" y="-16" type="curve" smooth="yes"/>
+      <point x="400" y="-16"/>
+      <point x="477" y="78"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="458"/>
+      <point x="592" y="528"/>
+      <point x="683" y="528" type="curve" smooth="yes"/>
+      <point x="765" y="528"/>
+      <point x="804" y="481"/>
+      <point x="804" y="385" type="curve" smooth="yes"/>
+      <point x="804" y="253"/>
+      <point x="739" y="129"/>
+      <point x="629" y="51" type="curve"/>
+      <point x="677" y="-16" type="line"/>
+      <point x="815" y="83"/>
+      <point x="888" y="223"/>
+      <point x="888" y="389" type="curve" smooth="yes"/>
+      <point x="888" y="531"/>
+      <point x="809" y="612"/>
+      <point x="683" y="612" type="curve" smooth="yes"/>
+      <point x="546" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="77"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ga-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="934"/>
   <outline>
     <component base="ga-malayalam"/>
-    <component base="halant-malayalam" xOffset="743"/>
+    <component base="halant-malayalam" xOffset="736"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/j_ja-malayalam.glif
@@ -1,231 +1,230 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1626"/>
-  <anchor x="1181" y="0" name="bottom"/>
-  <anchor x="880" y="596" name="top"/>
-  <anchor x="1523" y="596" name="topright"/>
+  <advance width="1700"/>
+  <anchor x="1221" y="-6" name="bottom"/>
+  <anchor x="903" y="596" name="top"/>
+  <anchor x="1589" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="311" y="-16" type="curve" smooth="yes"/>
+      <point x="283" y="-16" type="curve" smooth="yes"/>
       <point x="585" y="-16"/>
-      <point x="747" y="77"/>
-      <point x="868" y="317" type="curve"/>
-      <point x="890" y="371" type="line"/>
-      <point x="898" y="371" type="line"/>
-      <point x="912" y="328"/>
-      <point x="954" y="307"/>
-      <point x="1011" y="307" type="curve" smooth="yes"/>
-      <point x="1097" y="307"/>
-      <point x="1151" y="357"/>
-      <point x="1151" y="436" type="curve" smooth="yes"/>
-      <point x="1151" y="496"/>
-      <point x="1118" y="530"/>
-      <point x="1057" y="530" type="curve" smooth="yes"/>
-      <point x="1035" y="530"/>
-      <point x="1011" y="526"/>
-      <point x="988" y="518" type="curve"/>
-      <point x="975" y="543" type="line"/>
-      <point x="975" y="521" type="line"/>
-      <point x="998" y="541"/>
-      <point x="1041" y="552"/>
-      <point x="1086" y="552" type="curve" smooth="yes"/>
-      <point x="1166" y="552"/>
-      <point x="1204" y="515"/>
-      <point x="1204" y="435" type="curve" smooth="yes"/>
-      <point x="1204" y="414"/>
-      <point x="1203" y="400"/>
-      <point x="1199" y="380" type="curve" smooth="yes"/>
-      <point x="1194" y="353" type="line"/>
-      <point x="1278" y="353" type="line"/>
-      <point x="1284" y="388" type="line" smooth="yes"/>
-      <point x="1300" y="480"/>
-      <point x="1351" y="534"/>
-      <point x="1422" y="534" type="curve" smooth="yes"/>
-      <point x="1483" y="534"/>
-      <point x="1514" y="503"/>
-      <point x="1514" y="442" type="curve" smooth="yes"/>
-      <point x="1514" y="348"/>
-      <point x="1453" y="294"/>
-      <point x="1347" y="294" type="curve" smooth="yes"/>
-      <point x="1055" y="294" type="line" smooth="yes"/>
-      <point x="919" y="294"/>
-      <point x="840" y="231"/>
-      <point x="840" y="125" type="curve" smooth="yes"/>
-      <point x="840" y="36"/>
-      <point x="890" y="-16"/>
-      <point x="980" y="-16" type="curve" smooth="yes"/>
-      <point x="1025" y="-16"/>
-      <point x="1066" y="-10"/>
-      <point x="1175" y="61" type="curve" smooth="yes"/>
-      <point x="1229" y="96" type="line"/>
-      <point x="1343" y="170" type="line"/>
-      <point x="1353" y="165" type="line"/>
-      <point x="1374" y="171"/>
-      <point x="1391" y="172"/>
-      <point x="1415" y="172" type="curve" smooth="yes"/>
-      <point x="1452" y="172"/>
-      <point x="1470" y="154"/>
-      <point x="1470" y="121" type="curve" smooth="yes"/>
-      <point x="1470" y="75"/>
-      <point x="1446" y="48"/>
-      <point x="1407" y="48" type="curve" smooth="yes"/>
-      <point x="1375" y="48"/>
-      <point x="1354" y="69"/>
-      <point x="1354" y="101" type="curve" smooth="yes"/>
-      <point x="1354" y="137"/>
-      <point x="1368" y="163"/>
-      <point x="1405" y="190" type="curve"/>
-      <point x="1285" y="166" type="line"/>
-      <point x="1323" y="118" type="line"/>
-      <point x="1333" y="164" type="line"/>
-      <point x="1308" y="146"/>
-      <point x="1296" y="119"/>
-      <point x="1296" y="82" type="curve" smooth="yes"/>
-      <point x="1296" y="24"/>
-      <point x="1340" y="-16"/>
-      <point x="1405" y="-16" type="curve" smooth="yes"/>
-      <point x="1489" y="-16"/>
-      <point x="1537" y="35"/>
-      <point x="1537" y="124" type="curve" smooth="yes"/>
-      <point x="1537" y="196"/>
-      <point x="1499" y="238"/>
-      <point x="1433" y="238" type="curve" smooth="yes"/>
-      <point x="1375" y="238"/>
-      <point x="1332" y="232"/>
-      <point x="1225" y="169" type="curve" smooth="yes"/>
-      <point x="1142" y="120" type="line" smooth="yes"/>
-      <point x="1064" y="74"/>
-      <point x="1026" y="61"/>
-      <point x="992" y="61" type="curve" smooth="yes"/>
-      <point x="941" y="61"/>
-      <point x="919" y="85"/>
-      <point x="919" y="131" type="curve" smooth="yes"/>
-      <point x="919" y="189"/>
-      <point x="964" y="222"/>
-      <point x="1045" y="222" type="curve" smooth="yes"/>
-      <point x="1335" y="222" type="line" smooth="yes"/>
-      <point x="1497" y="222"/>
-      <point x="1598" y="309"/>
-      <point x="1598" y="449" type="curve" smooth="yes"/>
-      <point x="1598" y="546"/>
-      <point x="1534" y="612"/>
-      <point x="1440" y="612" type="curve" smooth="yes"/>
-      <point x="1358" y="612"/>
-      <point x="1295" y="569"/>
-      <point x="1265" y="490" type="curve"/>
-      <point x="1257" y="490" type="line"/>
-      <point x="1241" y="571"/>
-      <point x="1183" y="612"/>
-      <point x="1094" y="612" type="curve" smooth="yes"/>
-      <point x="997" y="612"/>
-      <point x="931" y="579"/>
-      <point x="873" y="469" type="curve" smooth="yes"/>
-      <point x="819" y="366" type="line" smooth="yes"/>
-      <point x="693" y="126"/>
-      <point x="531" y="61"/>
-      <point x="325" y="61" type="curve" smooth="yes"/>
-      <point x="180" y="61"/>
-      <point x="111" y="81"/>
-      <point x="111" y="147" type="curve" smooth="yes"/>
-      <point x="111" y="194"/>
-      <point x="154" y="222"/>
-      <point x="235" y="222" type="curve" smooth="yes"/>
-      <point x="543" y="222" type="line" smooth="yes"/>
-      <point x="705" y="222"/>
-      <point x="806" y="309"/>
-      <point x="806" y="449" type="curve" smooth="yes"/>
-      <point x="806" y="546"/>
-      <point x="742" y="612"/>
-      <point x="648" y="612" type="curve" smooth="yes"/>
-      <point x="566" y="612"/>
-      <point x="500" y="569"/>
-      <point x="470" y="490" type="curve"/>
-      <point x="462" y="490" type="line"/>
-      <point x="446" y="571"/>
-      <point x="391" y="612"/>
-      <point x="294" y="612" type="curve" smooth="yes"/>
-      <point x="174" y="612"/>
-      <point x="81" y="535"/>
-      <point x="81" y="435" type="curve" smooth="yes"/>
-      <point x="81" y="355"/>
-      <point x="133" y="307"/>
-      <point x="219" y="307" type="curve" smooth="yes"/>
-      <point x="305" y="307"/>
-      <point x="359" y="357"/>
-      <point x="359" y="436" type="curve" smooth="yes"/>
-      <point x="359" y="496"/>
-      <point x="326" y="530"/>
-      <point x="269" y="530" type="curve" smooth="yes"/>
-      <point x="245" y="530"/>
-      <point x="220" y="526"/>
-      <point x="196" y="518" type="curve"/>
-      <point x="183" y="543" type="line"/>
-      <point x="183" y="521" type="line"/>
-      <point x="206" y="541"/>
-      <point x="249" y="552"/>
-      <point x="294" y="552" type="curve" smooth="yes"/>
-      <point x="374" y="552"/>
-      <point x="412" y="515"/>
-      <point x="412" y="435" type="curve" smooth="yes"/>
-      <point x="412" y="414"/>
-      <point x="411" y="400"/>
-      <point x="407" y="380" type="curve" smooth="yes"/>
-      <point x="402" y="353" type="line"/>
-      <point x="486" y="353" type="line"/>
-      <point x="492" y="388" type="line" smooth="yes"/>
-      <point x="508" y="480"/>
-      <point x="559" y="534"/>
-      <point x="630" y="534" type="curve" smooth="yes"/>
-      <point x="691" y="534"/>
-      <point x="722" y="503"/>
-      <point x="722" y="442" type="curve" smooth="yes"/>
-      <point x="722" y="348"/>
-      <point x="661" y="294"/>
-      <point x="555" y="294" type="curve" smooth="yes"/>
-      <point x="245" y="294" type="line" smooth="yes"/>
-      <point x="109" y="294"/>
-      <point x="30" y="236"/>
-      <point x="30" y="140" type="curve" smooth="yes"/>
-      <point x="30" y="40"/>
-      <point x="118" y="-16"/>
+      <point x="768" y="75"/>
+      <point x="896" y="294" type="curve"/>
+      <point x="912" y="354" type="line"/>
+      <point x="921" y="354" type="line"/>
+      <point x="932" y="307"/>
+      <point x="971" y="274"/>
+      <point x="1028" y="274" type="curve" smooth="yes"/>
+      <point x="1129" y="274"/>
+      <point x="1173" y="350"/>
+      <point x="1173" y="408" type="curve" smooth="yes"/>
+      <point x="1173" y="474"/>
+      <point x="1137" y="512"/>
+      <point x="1074" y="512" type="curve" smooth="yes"/>
+      <point x="1046" y="512"/>
+      <point x="1025" y="509"/>
+      <point x="1002" y="501" type="curve"/>
+      <point x="984" y="527" type="line"/>
+      <point x="990" y="499" type="line"/>
+      <point x="1019" y="531"/>
+      <point x="1068" y="552"/>
+      <point x="1126" y="552" type="curve" smooth="yes"/>
+      <point x="1211" y="552"/>
+      <point x="1248" y="504"/>
+      <point x="1248" y="436" type="curve" smooth="yes"/>
+      <point x="1248" y="422"/>
+      <point x="1247" y="407"/>
+      <point x="1244" y="390" type="curve" smooth="yes"/>
+      <point x="1234" y="333" type="line"/>
+      <point x="1318" y="333" type="line"/>
+      <point x="1328" y="390" type="line" smooth="yes"/>
+      <point x="1344" y="481"/>
+      <point x="1402" y="534"/>
+      <point x="1483" y="534" type="curve" smooth="yes"/>
+      <point x="1549" y="534"/>
+      <point x="1585" y="499"/>
+      <point x="1585" y="433" type="curve" smooth="yes"/>
+      <point x="1585" y="328"/>
+      <point x="1512" y="264"/>
+      <point x="1369" y="264" type="curve" smooth="yes"/>
+      <point x="1033" y="264" type="line" smooth="yes"/>
+      <point x="923" y="264"/>
+      <point x="845" y="207"/>
+      <point x="845" y="114" type="curve" smooth="yes"/>
+      <point x="845" y="34"/>
+      <point x="905" y="-16"/>
+      <point x="992" y="-16" type="curve" smooth="yes"/>
+      <point x="1041" y="-16"/>
+      <point x="1077" y="-6"/>
+      <point x="1148" y="27" type="curve" smooth="yes"/>
+      <point x="1304" y="99" type="line"/>
+      <point x="1377" y="148" type="line"/>
+      <point x="1405" y="154" type="line"/>
+      <point x="1436" y="172"/>
+      <point x="1458" y="178"/>
+      <point x="1486" y="178" type="curve" smooth="yes"/>
+      <point x="1524" y="178"/>
+      <point x="1541" y="157"/>
+      <point x="1541" y="124" type="curve" smooth="yes"/>
+      <point x="1541" y="92"/>
+      <point x="1521" y="56"/>
+      <point x="1470" y="56" type="curve" smooth="yes"/>
+      <point x="1434" y="56"/>
+      <point x="1413" y="77"/>
+      <point x="1413" y="109" type="curve" smooth="yes"/>
+      <point x="1413" y="140"/>
+      <point x="1427" y="161"/>
+      <point x="1454" y="188" type="curve"/>
+      <point x="1350" y="148" type="line"/>
+      <point x="1366" y="128" type="line"/>
+      <point x="1357" y="114"/>
+      <point x="1352" y="98"/>
+      <point x="1352" y="80" type="curve" smooth="yes"/>
+      <point x="1352" y="22"/>
+      <point x="1396" y="-16"/>
+      <point x="1463" y="-16" type="curve" smooth="yes"/>
+      <point x="1571" y="-16"/>
+      <point x="1612" y="69"/>
+      <point x="1612" y="126" type="curve" smooth="yes"/>
+      <point x="1612" y="189"/>
+      <point x="1573" y="232"/>
+      <point x="1502" y="232" type="curve" smooth="yes"/>
+      <point x="1456" y="232"/>
+      <point x="1417" y="224"/>
+      <point x="1335" y="186" type="curve" smooth="yes"/>
+      <point x="1126" y="89" type="line" smooth="yes"/>
+      <point x="1078" y="67"/>
+      <point x="1041" y="58"/>
+      <point x="996" y="58" type="curve" smooth="yes"/>
+      <point x="954" y="58"/>
+      <point x="927" y="82"/>
+      <point x="927" y="119" type="curve" smooth="yes"/>
+      <point x="927" y="164"/>
+      <point x="963" y="192"/>
+      <point x="1030" y="192" type="curve" smooth="yes"/>
+      <point x="1351" y="192" type="line" smooth="yes"/>
+      <point x="1533" y="192"/>
+      <point x="1667" y="286"/>
+      <point x="1667" y="438" type="curve" smooth="yes"/>
+      <point x="1667" y="546"/>
+      <point x="1605" y="612"/>
+      <point x="1500" y="612" type="curve" smooth="yes"/>
+      <point x="1412" y="612"/>
+      <point x="1347" y="570"/>
+      <point x="1313" y="491" type="curve"/>
+      <point x="1305" y="491" type="line"/>
+      <point x="1288" y="571"/>
+      <point x="1234" y="612"/>
+      <point x="1132" y="612" type="curve" smooth="yes"/>
+      <point x="1025" y="612"/>
+      <point x="945" y="560"/>
+      <point x="898" y="457" type="curve" smooth="yes"/>
+      <point x="856" y="365" type="line" smooth="yes"/>
+      <point x="760" y="154"/>
+      <point x="583" y="61"/>
+      <point x="291" y="61" type="curve" smooth="yes"/>
+      <point x="176" y="61"/>
+      <point x="111" y="74"/>
+      <point x="111" y="129" type="curve" smooth="yes"/>
+      <point x="111" y="163"/>
+      <point x="137" y="192"/>
+      <point x="203" y="192" type="curve" smooth="yes"/>
+      <point x="503" y="192" type="line" smooth="yes"/>
+      <point x="690" y="192"/>
+      <point x="827" y="289"/>
+      <point x="827" y="445" type="curve" smooth="yes"/>
+      <point x="827" y="549"/>
+      <point x="770" y="612"/>
+      <point x="673" y="612" type="curve" smooth="yes"/>
+      <point x="589" y="612"/>
+      <point x="527" y="570"/>
+      <point x="495" y="491" type="curve"/>
+      <point x="487" y="491" type="line"/>
+      <point x="470" y="571"/>
+      <point x="416" y="612"/>
+      <point x="314" y="612" type="curve" smooth="yes"/>
+      <point x="156" y="612"/>
+      <point x="77" y="502"/>
+      <point x="77" y="413" type="curve" smooth="yes"/>
+      <point x="77" y="329"/>
+      <point x="127" y="274"/>
+      <point x="210" y="274" type="curve" smooth="yes"/>
+      <point x="311" y="274"/>
+      <point x="355" y="350"/>
+      <point x="355" y="408" type="curve" smooth="yes"/>
+      <point x="355" y="474"/>
+      <point x="319" y="512"/>
+      <point x="256" y="512" type="curve" smooth="yes"/>
+      <point x="228" y="512"/>
+      <point x="207" y="509"/>
+      <point x="184" y="501" type="curve"/>
+      <point x="166" y="527" type="line"/>
+      <point x="171" y="497" type="line"/>
+      <point x="196" y="529"/>
+      <point x="248" y="552"/>
+      <point x="309" y="552" type="curve" smooth="yes"/>
+      <point x="393" y="552"/>
+      <point x="430" y="504"/>
+      <point x="430" y="436" type="curve" smooth="yes"/>
+      <point x="430" y="422"/>
+      <point x="429" y="407"/>
+      <point x="426" y="390" type="curve" smooth="yes"/>
+      <point x="416" y="333" type="line"/>
+      <point x="500" y="333" type="line"/>
+      <point x="510" y="390" type="line" smooth="yes"/>
+      <point x="526" y="481"/>
+      <point x="580" y="534"/>
+      <point x="656" y="534" type="curve" smooth="yes"/>
+      <point x="714" y="534"/>
+      <point x="745" y="501"/>
+      <point x="745" y="440" type="curve" smooth="yes"/>
+      <point x="745" y="332"/>
+      <point x="667" y="264"/>
+      <point x="515" y="264" type="curve" smooth="yes"/>
+      <point x="206" y="264" type="line" smooth="yes"/>
+      <point x="78" y="264"/>
+      <point x="29" y="189"/>
+      <point x="29" y="127" type="curve" smooth="yes"/>
+      <point x="29" y="34"/>
+      <point x="115" y="-16"/>
     </contour>
     <contour>
-      <point x="219" y="371" type="curve" smooth="yes"/>
-      <point x="178" y="371"/>
-      <point x="157" y="393"/>
-      <point x="157" y="437" type="curve" smooth="yes"/>
-      <point x="157" y="461"/>
-      <point x="165" y="485"/>
-      <point x="179" y="503" type="curve"/>
-      <point x="157" y="505" type="line"/>
-      <point x="128" y="463" type="line"/>
-      <point x="153" y="480"/>
-      <point x="190" y="490"/>
-      <point x="227" y="490" type="curve" smooth="yes"/>
-      <point x="270" y="490"/>
-      <point x="287" y="474"/>
-      <point x="287" y="434" type="curve" smooth="yes"/>
-      <point x="287" y="395"/>
-      <point x="261" y="371"/>
+      <point x="214" y="338" type="curve" smooth="yes"/>
+      <point x="171" y="338"/>
+      <point x="147" y="367"/>
+      <point x="147" y="411" type="curve" smooth="yes"/>
+      <point x="147" y="432"/>
+      <point x="152" y="451"/>
+      <point x="162" y="473" type="curve"/>
+      <point x="137" y="473" type="line"/>
+      <point x="124" y="443" type="line"/>
+      <point x="150" y="458"/>
+      <point x="181" y="468"/>
+      <point x="216" y="468" type="curve" smooth="yes"/>
+      <point x="260" y="468"/>
+      <point x="283" y="448"/>
+      <point x="283" y="408" type="curve" smooth="yes"/>
+      <point x="283" y="377"/>
+      <point x="265" y="338"/>
     </contour>
     <contour>
-      <point x="1011" y="371" type="curve" smooth="yes"/>
-      <point x="970" y="371"/>
-      <point x="949" y="393"/>
-      <point x="949" y="437" type="curve" smooth="yes"/>
-      <point x="949" y="461"/>
-      <point x="957" y="485"/>
-      <point x="971" y="503" type="curve"/>
-      <point x="949" y="505" type="line"/>
-      <point x="920" y="463" type="line"/>
-      <point x="945" y="480"/>
-      <point x="982" y="490"/>
-      <point x="1019" y="490" type="curve" smooth="yes"/>
-      <point x="1062" y="490"/>
-      <point x="1079" y="474"/>
-      <point x="1079" y="434" type="curve" smooth="yes"/>
-      <point x="1079" y="395"/>
-      <point x="1053" y="371"/>
+      <point x="1032" y="338" type="curve" smooth="yes"/>
+      <point x="989" y="338"/>
+      <point x="965" y="367"/>
+      <point x="965" y="411" type="curve" smooth="yes"/>
+      <point x="965" y="432"/>
+      <point x="971" y="451"/>
+      <point x="980" y="473" type="curve"/>
+      <point x="955" y="473" type="line"/>
+      <point x="942" y="443" type="line"/>
+      <point x="969" y="457"/>
+      <point x="999" y="468"/>
+      <point x="1034" y="468" type="curve" smooth="yes"/>
+      <point x="1078" y="468"/>
+      <point x="1101" y="448"/>
+      <point x="1101" y="408" type="curve" smooth="yes"/>
+      <point x="1101" y="377"/>
+      <point x="1083" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/j_nya-malayalam.glif
@@ -1,194 +1,194 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2219"/>
-  <anchor x="1756" y="0" name="bottom"/>
-  <anchor x="1154" y="596" name="top"/>
-  <anchor x="2120" y="596" name="topright"/>
+  <advance width="2252"/>
+  <anchor x="1789" y="0" name="bottom"/>
+  <anchor x="1179" y="596" name="top"/>
+  <anchor x="2155" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="311" y="-16" type="curve" smooth="yes"/>
-      <point x="527" y="-16"/>
-      <point x="678" y="42"/>
-      <point x="790" y="183" type="curve"/>
-      <point x="840" y="183" type="line"/>
-      <point x="800" y="250" type="line"/>
-      <point x="799" y="241"/>
-      <point x="799" y="231"/>
-      <point x="799" y="222" type="curve" smooth="yes"/>
-      <point x="799" y="79"/>
-      <point x="876" y="-16"/>
-      <point x="1002" y="-16" type="curve" smooth="yes"/>
-      <point x="1117" y="-16"/>
-      <point x="1187" y="60"/>
-      <point x="1187" y="185" type="curve" smooth="yes"/>
-      <point x="1187" y="293"/>
-      <point x="1131" y="356"/>
-      <point x="1035" y="356" type="curve" smooth="yes"/>
-      <point x="974" y="356"/>
-      <point x="923" y="330"/>
-      <point x="887" y="281" type="curve"/>
-      <point x="851" y="287" type="line"/>
-      <point x="862" y="153" type="line"/>
-      <point x="886" y="229"/>
-      <point x="948" y="282"/>
-      <point x="1013" y="282" type="curve" smooth="yes"/>
-      <point x="1075" y="282"/>
-      <point x="1105" y="250"/>
-      <point x="1105" y="184" type="curve" smooth="yes"/>
-      <point x="1105" y="106"/>
-      <point x="1067" y="62"/>
-      <point x="1000" y="62" type="curve" smooth="yes"/>
-      <point x="919" y="62"/>
-      <point x="872" y="120"/>
-      <point x="872" y="220" type="curve" smooth="yes"/>
-      <point x="872" y="406"/>
-      <point x="975" y="534"/>
-      <point x="1125" y="534" type="curve" smooth="yes"/>
-      <point x="1232" y="534"/>
-      <point x="1288" y="479"/>
-      <point x="1288" y="372" type="curve" smooth="yes"/>
-      <point x="1288" y="354"/>
-      <point x="1286" y="335"/>
-      <point x="1282" y="314" type="curve" smooth="yes"/>
-      <point x="1226" y="0" type="line"/>
-      <point x="1310" y="0" type="line"/>
-      <point x="1369" y="333" type="line" smooth="yes"/>
-      <point x="1393" y="470"/>
-      <point x="1462" y="534"/>
-      <point x="1585" y="534" type="curve" smooth="yes"/>
-      <point x="1732" y="534"/>
-      <point x="1818" y="439"/>
-      <point x="1818" y="275" type="curve" smooth="yes"/>
-      <point x="1818" y="152"/>
-      <point x="1762" y="62"/>
-      <point x="1684" y="62" type="curve" smooth="yes"/>
-      <point x="1612" y="62"/>
-      <point x="1576" y="109"/>
-      <point x="1576" y="202" type="curve" smooth="yes"/>
-      <point x="1576" y="381"/>
-      <point x="1718" y="534"/>
-      <point x="1884" y="534" type="curve" smooth="yes"/>
-      <point x="2013" y="534"/>
-      <point x="2090" y="467"/>
-      <point x="2090" y="354" type="curve" smooth="yes"/>
-      <point x="2090" y="246"/>
-      <point x="2038" y="143"/>
-      <point x="1933" y="43" type="curve"/>
-      <point x="1994" y="-14" type="line"/>
-      <point x="2118" y="107"/>
-      <point x="2172" y="218"/>
-      <point x="2172" y="354" type="curve" smooth="yes"/>
-      <point x="2172" y="512"/>
-      <point x="2064" y="612"/>
-      <point x="1895" y="612" type="curve" smooth="yes"/>
-      <point x="1681" y="612"/>
-      <point x="1494" y="418"/>
-      <point x="1494" y="197" type="curve" smooth="yes"/>
-      <point x="1494" y="62"/>
-      <point x="1564" y="-16"/>
-      <point x="1684" y="-16" type="curve" smooth="yes"/>
-      <point x="1817" y="-16"/>
-      <point x="1900" y="96"/>
-      <point x="1900" y="275" type="curve" smooth="yes"/>
-      <point x="1900" y="479"/>
-      <point x="1779" y="612"/>
-      <point x="1594" y="612" type="curve" smooth="yes"/>
-      <point x="1480" y="612"/>
-      <point x="1395" y="567"/>
-      <point x="1348" y="480" type="curve"/>
-      <point x="1338" y="480" type="line"/>
-      <point x="1303" y="567"/>
-      <point x="1231" y="612"/>
-      <point x="1125" y="612" type="curve" smooth="yes"/>
-      <point x="1002" y="612"/>
-      <point x="898" y="553"/>
-      <point x="812" y="353" type="curve" smooth="yes"/>
-      <point x="717" y="132"/>
-      <point x="543" y="61"/>
-      <point x="325" y="61" type="curve" smooth="yes"/>
-      <point x="187" y="61"/>
-      <point x="111" y="81"/>
-      <point x="111" y="147" type="curve" smooth="yes"/>
-      <point x="111" y="194"/>
-      <point x="154" y="222"/>
-      <point x="235" y="222" type="curve" smooth="yes"/>
-      <point x="535" y="222" type="line" smooth="yes"/>
-      <point x="697" y="222"/>
-      <point x="795" y="309"/>
-      <point x="795" y="449" type="curve" smooth="yes"/>
-      <point x="795" y="544"/>
-      <point x="742" y="612"/>
-      <point x="636" y="612" type="curve" smooth="yes"/>
-      <point x="562" y="612"/>
-      <point x="500" y="569"/>
-      <point x="470" y="490" type="curve"/>
-      <point x="462" y="490" type="line"/>
-      <point x="446" y="571"/>
-      <point x="391" y="612"/>
-      <point x="294" y="612" type="curve" smooth="yes"/>
-      <point x="174" y="612"/>
-      <point x="81" y="535"/>
-      <point x="81" y="435" type="curve" smooth="yes"/>
-      <point x="81" y="355"/>
-      <point x="133" y="307"/>
-      <point x="219" y="307" type="curve" smooth="yes"/>
-      <point x="305" y="307"/>
-      <point x="359" y="357"/>
-      <point x="359" y="436" type="curve" smooth="yes"/>
-      <point x="359" y="496"/>
-      <point x="326" y="530"/>
-      <point x="269" y="530" type="curve" smooth="yes"/>
-      <point x="245" y="530"/>
-      <point x="220" y="526"/>
-      <point x="196" y="518" type="curve"/>
-      <point x="183" y="543" type="line"/>
-      <point x="183" y="521" type="line"/>
-      <point x="206" y="541"/>
-      <point x="249" y="552"/>
-      <point x="294" y="552" type="curve" smooth="yes"/>
-      <point x="374" y="552"/>
-      <point x="412" y="515"/>
-      <point x="412" y="435" type="curve" smooth="yes"/>
-      <point x="412" y="414"/>
-      <point x="411" y="400"/>
-      <point x="407" y="380" type="curve" smooth="yes"/>
-      <point x="402" y="353" type="line"/>
-      <point x="486" y="353" type="line"/>
-      <point x="492" y="388" type="line" smooth="yes"/>
-      <point x="508" y="480"/>
-      <point x="555" y="534"/>
-      <point x="618" y="534" type="curve" smooth="yes"/>
-      <point x="679" y="534"/>
-      <point x="711" y="503"/>
-      <point x="711" y="442" type="curve" smooth="yes"/>
-      <point x="711" y="348"/>
-      <point x="653" y="294"/>
-      <point x="537" y="294" type="curve" smooth="yes"/>
-      <point x="245" y="294" type="line" smooth="yes"/>
-      <point x="109" y="294"/>
-      <point x="30" y="236"/>
-      <point x="30" y="140" type="curve" smooth="yes"/>
-      <point x="30" y="40"/>
-      <point x="118" y="-16"/>
+      <point x="283" y="-16" type="curve" smooth="yes"/>
+      <point x="537" y="-16"/>
+      <point x="705" y="42"/>
+      <point x="826" y="194" type="curve"/>
+      <point x="876" y="188" type="line"/>
+      <point x="835" y="250" type="line"/>
+      <point x="834" y="241"/>
+      <point x="834" y="231"/>
+      <point x="834" y="222" type="curve" smooth="yes"/>
+      <point x="834" y="79"/>
+      <point x="911" y="-16"/>
+      <point x="1037" y="-16" type="curve" smooth="yes"/>
+      <point x="1152" y="-16"/>
+      <point x="1222" y="60"/>
+      <point x="1222" y="185" type="curve" smooth="yes"/>
+      <point x="1222" y="293"/>
+      <point x="1166" y="356"/>
+      <point x="1070" y="356" type="curve" smooth="yes"/>
+      <point x="1009" y="356"/>
+      <point x="958" y="330"/>
+      <point x="922" y="281" type="curve"/>
+      <point x="886" y="287" type="line"/>
+      <point x="897" y="153" type="line"/>
+      <point x="921" y="229"/>
+      <point x="983" y="282"/>
+      <point x="1048" y="282" type="curve" smooth="yes"/>
+      <point x="1110" y="282"/>
+      <point x="1140" y="250"/>
+      <point x="1140" y="184" type="curve" smooth="yes"/>
+      <point x="1140" y="106"/>
+      <point x="1102" y="62"/>
+      <point x="1035" y="62" type="curve" smooth="yes"/>
+      <point x="954" y="62"/>
+      <point x="907" y="120"/>
+      <point x="907" y="220" type="curve" smooth="yes"/>
+      <point x="907" y="406"/>
+      <point x="1010" y="534"/>
+      <point x="1160" y="534" type="curve" smooth="yes"/>
+      <point x="1267" y="534"/>
+      <point x="1323" y="478"/>
+      <point x="1323" y="373" type="curve" smooth="yes"/>
+      <point x="1323" y="355"/>
+      <point x="1321" y="335"/>
+      <point x="1317" y="314" type="curve" smooth="yes"/>
+      <point x="1261" y="0" type="line"/>
+      <point x="1345" y="0" type="line"/>
+      <point x="1404" y="333" type="line" smooth="yes"/>
+      <point x="1428" y="470"/>
+      <point x="1494" y="534"/>
+      <point x="1614" y="534" type="curve" smooth="yes"/>
+      <point x="1761" y="534"/>
+      <point x="1847" y="439"/>
+      <point x="1847" y="275" type="curve" smooth="yes"/>
+      <point x="1847" y="152"/>
+      <point x="1791" y="62"/>
+      <point x="1713" y="62" type="curve" smooth="yes"/>
+      <point x="1641" y="62"/>
+      <point x="1605" y="109"/>
+      <point x="1605" y="202" type="curve" smooth="yes"/>
+      <point x="1605" y="381"/>
+      <point x="1747" y="534"/>
+      <point x="1913" y="534" type="curve" smooth="yes"/>
+      <point x="2042" y="534"/>
+      <point x="2119" y="467"/>
+      <point x="2119" y="354" type="curve" smooth="yes"/>
+      <point x="2119" y="246"/>
+      <point x="2067" y="143"/>
+      <point x="1962" y="43" type="curve"/>
+      <point x="2023" y="-14" type="line"/>
+      <point x="2147" y="107"/>
+      <point x="2201" y="218"/>
+      <point x="2201" y="354" type="curve" smooth="yes"/>
+      <point x="2201" y="512"/>
+      <point x="2093" y="612"/>
+      <point x="1924" y="612" type="curve" smooth="yes"/>
+      <point x="1710" y="612"/>
+      <point x="1523" y="418"/>
+      <point x="1523" y="197" type="curve" smooth="yes"/>
+      <point x="1523" y="62"/>
+      <point x="1593" y="-16"/>
+      <point x="1713" y="-16" type="curve" smooth="yes"/>
+      <point x="1846" y="-16"/>
+      <point x="1929" y="96"/>
+      <point x="1929" y="275" type="curve" smooth="yes"/>
+      <point x="1929" y="479"/>
+      <point x="1808" y="612"/>
+      <point x="1623" y="612" type="curve" smooth="yes"/>
+      <point x="1512" y="612"/>
+      <point x="1429" y="567"/>
+      <point x="1383" y="480" type="curve"/>
+      <point x="1373" y="480" type="line"/>
+      <point x="1338" y="567"/>
+      <point x="1266" y="612"/>
+      <point x="1160" y="612" type="curve" smooth="yes"/>
+      <point x="1037" y="612"/>
+      <point x="933" y="553"/>
+      <point x="847" y="353" type="curve" smooth="yes"/>
+      <point x="750" y="127"/>
+      <point x="578" y="61"/>
+      <point x="291" y="61" type="curve" smooth="yes"/>
+      <point x="176" y="61"/>
+      <point x="111" y="74"/>
+      <point x="111" y="129" type="curve" smooth="yes"/>
+      <point x="111" y="163"/>
+      <point x="137" y="192"/>
+      <point x="203" y="192" type="curve" smooth="yes"/>
+      <point x="490" y="192" type="line" smooth="yes"/>
+      <point x="728" y="192"/>
+      <point x="823" y="322"/>
+      <point x="823" y="445" type="curve" smooth="yes"/>
+      <point x="823" y="549"/>
+      <point x="766" y="612"/>
+      <point x="670" y="612" type="curve" smooth="yes"/>
+      <point x="589" y="612"/>
+      <point x="526" y="570"/>
+      <point x="495" y="491" type="curve"/>
+      <point x="487" y="491" type="line"/>
+      <point x="470" y="571"/>
+      <point x="416" y="612"/>
+      <point x="314" y="612" type="curve" smooth="yes"/>
+      <point x="156" y="612"/>
+      <point x="77" y="502"/>
+      <point x="77" y="413" type="curve" smooth="yes"/>
+      <point x="77" y="329"/>
+      <point x="127" y="274"/>
+      <point x="210" y="274" type="curve" smooth="yes"/>
+      <point x="311" y="274"/>
+      <point x="355" y="350"/>
+      <point x="355" y="408" type="curve" smooth="yes"/>
+      <point x="355" y="474"/>
+      <point x="319" y="512"/>
+      <point x="256" y="512" type="curve" smooth="yes"/>
+      <point x="228" y="512"/>
+      <point x="207" y="509"/>
+      <point x="184" y="501" type="curve"/>
+      <point x="166" y="527" type="line"/>
+      <point x="171" y="497" type="line"/>
+      <point x="196" y="529"/>
+      <point x="248" y="552"/>
+      <point x="309" y="552" type="curve" smooth="yes"/>
+      <point x="393" y="552"/>
+      <point x="430" y="504"/>
+      <point x="430" y="436" type="curve" smooth="yes"/>
+      <point x="430" y="422"/>
+      <point x="429" y="407"/>
+      <point x="426" y="390" type="curve" smooth="yes"/>
+      <point x="416" y="333" type="line"/>
+      <point x="500" y="333" type="line"/>
+      <point x="510" y="390" type="line" smooth="yes"/>
+      <point x="526" y="481"/>
+      <point x="577" y="534"/>
+      <point x="651" y="534" type="curve" smooth="yes"/>
+      <point x="709" y="534"/>
+      <point x="741" y="501"/>
+      <point x="741" y="440" type="curve" smooth="yes"/>
+      <point x="741" y="357"/>
+      <point x="680" y="264"/>
+      <point x="500" y="264" type="curve" smooth="yes"/>
+      <point x="206" y="264" type="line" smooth="yes"/>
+      <point x="78" y="264"/>
+      <point x="29" y="189"/>
+      <point x="29" y="127" type="curve" smooth="yes"/>
+      <point x="29" y="34"/>
+      <point x="115" y="-16"/>
     </contour>
     <contour>
-      <point x="219" y="371" type="curve" smooth="yes"/>
-      <point x="178" y="371"/>
-      <point x="157" y="393"/>
-      <point x="157" y="437" type="curve" smooth="yes"/>
-      <point x="157" y="461"/>
-      <point x="165" y="485"/>
-      <point x="179" y="503" type="curve"/>
-      <point x="157" y="505" type="line"/>
-      <point x="128" y="463" type="line"/>
-      <point x="153" y="480"/>
-      <point x="190" y="490"/>
-      <point x="227" y="490" type="curve" smooth="yes"/>
-      <point x="270" y="490"/>
-      <point x="287" y="474"/>
-      <point x="287" y="434" type="curve" smooth="yes"/>
-      <point x="287" y="395"/>
-      <point x="261" y="371"/>
+      <point x="214" y="338" type="curve" smooth="yes"/>
+      <point x="171" y="338"/>
+      <point x="147" y="367"/>
+      <point x="147" y="411" type="curve" smooth="yes"/>
+      <point x="147" y="432"/>
+      <point x="152" y="451"/>
+      <point x="162" y="473" type="curve"/>
+      <point x="137" y="473" type="line"/>
+      <point x="124" y="443" type="line"/>
+      <point x="150" y="458"/>
+      <point x="181" y="468"/>
+      <point x="216" y="468" type="curve" smooth="yes"/>
+      <point x="260" y="468"/>
+      <point x="283" y="448"/>
+      <point x="283" y="408" type="curve" smooth="yes"/>
+      <point x="283" y="377"/>
+      <point x="265" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ja-malayalam.glif
@@ -1,139 +1,138 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <unicode hex="0D1C"/>
-  <anchor x="393" y="0" name="bottom"/>
-  <anchor x="489" y="596" name="top"/>
-  <anchor x="735" y="596" name="topright"/>
+  <anchor x="403" y="-6" name="bottom"/>
+  <anchor x="494" y="596" name="top"/>
+  <anchor x="771" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="161" y="-16" type="curve" smooth="yes"/>
-      <point x="214" y="-16"/>
-      <point x="269" y="2"/>
-      <point x="368" y="57" type="curve" smooth="yes"/>
-      <point x="437" y="95" type="line"/>
-      <point x="559" y="171" type="line"/>
-      <point x="570" y="161" type="line"/>
-      <point x="592" y="170"/>
-      <point x="609" y="172"/>
-      <point x="625" y="172" type="curve" smooth="yes"/>
-      <point x="660" y="172"/>
-      <point x="678" y="154"/>
-      <point x="678" y="121" type="curve" smooth="yes"/>
-      <point x="678" y="75"/>
-      <point x="654" y="48"/>
-      <point x="615" y="48" type="curve" smooth="yes"/>
-      <point x="583" y="48"/>
-      <point x="562" y="69"/>
-      <point x="562" y="101" type="curve" smooth="yes"/>
-      <point x="562" y="137"/>
-      <point x="576" y="163"/>
-      <point x="613" y="190" type="curve"/>
-      <point x="489" y="166" type="line"/>
-      <point x="528" y="108" type="line"/>
-      <point x="548" y="162" type="line"/>
-      <point x="521" y="146"/>
-      <point x="501" y="119"/>
-      <point x="501" y="79" type="curve" smooth="yes"/>
-      <point x="501" y="24"/>
-      <point x="548" y="-16"/>
-      <point x="613" y="-16" type="curve" smooth="yes"/>
-      <point x="697" y="-16"/>
-      <point x="745" y="35"/>
-      <point x="745" y="124" type="curve" smooth="yes"/>
-      <point x="745" y="196"/>
-      <point x="707" y="238"/>
-      <point x="641" y="238" type="curve" smooth="yes"/>
-      <point x="583" y="238"/>
-      <point x="544" y="225"/>
-      <point x="433" y="169" type="curve" smooth="yes"/>
-      <point x="350" y="127" type="line" smooth="yes"/>
-      <point x="239" y="71"/>
-      <point x="214" y="61"/>
-      <point x="174" y="61" type="curve" smooth="yes"/>
-      <point x="132" y="61"/>
-      <point x="109" y="85"/>
-      <point x="109" y="129" type="curve" smooth="yes"/>
-      <point x="109" y="189"/>
-      <point x="154" y="222"/>
-      <point x="235" y="222" type="curve" smooth="yes"/>
-      <point x="543" y="222" type="line" smooth="yes"/>
-      <point x="705" y="222"/>
-      <point x="806" y="309"/>
-      <point x="806" y="449" type="curve" smooth="yes"/>
-      <point x="806" y="546"/>
-      <point x="742" y="612"/>
-      <point x="648" y="612" type="curve" smooth="yes"/>
-      <point x="566" y="612"/>
-      <point x="503" y="569"/>
-      <point x="474" y="490" type="curve"/>
-      <point x="464" y="490" type="line"/>
-      <point x="449" y="571"/>
-      <point x="391" y="612"/>
-      <point x="294" y="612" type="curve" smooth="yes"/>
-      <point x="174" y="612"/>
-      <point x="81" y="535"/>
-      <point x="81" y="435" type="curve" smooth="yes"/>
-      <point x="81" y="355"/>
-      <point x="133" y="307"/>
-      <point x="219" y="307" type="curve" smooth="yes"/>
-      <point x="305" y="307"/>
-      <point x="359" y="357"/>
-      <point x="359" y="436" type="curve" smooth="yes"/>
-      <point x="359" y="496"/>
-      <point x="326" y="530"/>
-      <point x="264" y="530" type="curve" smooth="yes"/>
-      <point x="240" y="530"/>
-      <point x="220" y="526"/>
-      <point x="195" y="518" type="curve"/>
-      <point x="183" y="543" type="line"/>
-      <point x="183" y="520" type="line"/>
-      <point x="206" y="540"/>
-      <point x="249" y="552"/>
-      <point x="294" y="552" type="curve" smooth="yes"/>
-      <point x="374" y="552"/>
-      <point x="412" y="515"/>
-      <point x="412" y="435" type="curve" smooth="yes"/>
-      <point x="412" y="414"/>
-      <point x="411" y="400"/>
-      <point x="407" y="380" type="curve" smooth="yes"/>
-      <point x="402" y="353" type="line"/>
-      <point x="486" y="353" type="line"/>
-      <point x="492" y="388" type="line" smooth="yes"/>
-      <point x="508" y="480"/>
-      <point x="559" y="534"/>
-      <point x="630" y="534" type="curve" smooth="yes"/>
-      <point x="691" y="534"/>
-      <point x="722" y="503"/>
-      <point x="722" y="442" type="curve" smooth="yes"/>
-      <point x="722" y="348"/>
-      <point x="661" y="294"/>
-      <point x="555" y="294" type="curve" smooth="yes"/>
-      <point x="245" y="294" type="line" smooth="yes"/>
-      <point x="109" y="294"/>
-      <point x="30" y="231"/>
-      <point x="30" y="121" type="curve" smooth="yes"/>
-      <point x="30" y="36"/>
-      <point x="80" y="-16"/>
+      <point x="174" y="-16" type="curve" smooth="yes"/>
+      <point x="223" y="-16"/>
+      <point x="259" y="-6"/>
+      <point x="330" y="27" type="curve" smooth="yes"/>
+      <point x="486" y="99" type="line"/>
+      <point x="559" y="148" type="line"/>
+      <point x="587" y="154" type="line"/>
+      <point x="618" y="172"/>
+      <point x="640" y="178"/>
+      <point x="668" y="178" type="curve" smooth="yes"/>
+      <point x="706" y="178"/>
+      <point x="723" y="157"/>
+      <point x="723" y="124" type="curve" smooth="yes"/>
+      <point x="723" y="92"/>
+      <point x="703" y="56"/>
+      <point x="652" y="56" type="curve" smooth="yes"/>
+      <point x="616" y="56"/>
+      <point x="595" y="77"/>
+      <point x="595" y="109" type="curve" smooth="yes"/>
+      <point x="595" y="140"/>
+      <point x="609" y="161"/>
+      <point x="636" y="188" type="curve"/>
+      <point x="532" y="148" type="line"/>
+      <point x="548" y="128" type="line"/>
+      <point x="539" y="114"/>
+      <point x="534" y="98"/>
+      <point x="534" y="80" type="curve" smooth="yes"/>
+      <point x="534" y="22"/>
+      <point x="578" y="-16"/>
+      <point x="645" y="-16" type="curve" smooth="yes"/>
+      <point x="753" y="-16"/>
+      <point x="794" y="69"/>
+      <point x="794" y="126" type="curve" smooth="yes"/>
+      <point x="794" y="189"/>
+      <point x="755" y="232"/>
+      <point x="684" y="232" type="curve" smooth="yes"/>
+      <point x="638" y="232"/>
+      <point x="599" y="224"/>
+      <point x="517" y="186" type="curve" smooth="yes"/>
+      <point x="308" y="89" type="line" smooth="yes"/>
+      <point x="260" y="67"/>
+      <point x="223" y="58"/>
+      <point x="178" y="58" type="curve" smooth="yes"/>
+      <point x="136" y="58"/>
+      <point x="109" y="82"/>
+      <point x="109" y="119" type="curve" smooth="yes"/>
+      <point x="109" y="164"/>
+      <point x="145" y="192"/>
+      <point x="212" y="192" type="curve" smooth="yes"/>
+      <point x="533" y="192" type="line" smooth="yes"/>
+      <point x="715" y="192"/>
+      <point x="849" y="286"/>
+      <point x="849" y="438" type="curve" smooth="yes"/>
+      <point x="849" y="546"/>
+      <point x="787" y="612"/>
+      <point x="682" y="612" type="curve" smooth="yes"/>
+      <point x="594" y="612"/>
+      <point x="529" y="570"/>
+      <point x="495" y="491" type="curve"/>
+      <point x="487" y="491" type="line"/>
+      <point x="470" y="571"/>
+      <point x="416" y="612"/>
+      <point x="314" y="612" type="curve" smooth="yes"/>
+      <point x="156" y="612"/>
+      <point x="77" y="502"/>
+      <point x="77" y="413" type="curve" smooth="yes"/>
+      <point x="77" y="329"/>
+      <point x="127" y="274"/>
+      <point x="210" y="274" type="curve" smooth="yes"/>
+      <point x="311" y="274"/>
+      <point x="355" y="350"/>
+      <point x="355" y="408" type="curve" smooth="yes"/>
+      <point x="355" y="474"/>
+      <point x="319" y="512"/>
+      <point x="256" y="512" type="curve" smooth="yes"/>
+      <point x="228" y="512"/>
+      <point x="207" y="509"/>
+      <point x="184" y="501" type="curve"/>
+      <point x="166" y="527" type="line"/>
+      <point x="171" y="497" type="line"/>
+      <point x="196" y="529"/>
+      <point x="248" y="552"/>
+      <point x="309" y="552" type="curve" smooth="yes"/>
+      <point x="393" y="552"/>
+      <point x="430" y="504"/>
+      <point x="430" y="436" type="curve" smooth="yes"/>
+      <point x="430" y="422"/>
+      <point x="429" y="407"/>
+      <point x="426" y="390" type="curve" smooth="yes"/>
+      <point x="416" y="333" type="line"/>
+      <point x="500" y="333" type="line"/>
+      <point x="510" y="390" type="line" smooth="yes"/>
+      <point x="526" y="481"/>
+      <point x="584" y="534"/>
+      <point x="665" y="534" type="curve" smooth="yes"/>
+      <point x="731" y="534"/>
+      <point x="767" y="499"/>
+      <point x="767" y="433" type="curve" smooth="yes"/>
+      <point x="767" y="328"/>
+      <point x="694" y="264"/>
+      <point x="551" y="264" type="curve" smooth="yes"/>
+      <point x="215" y="264" type="line" smooth="yes"/>
+      <point x="105" y="264"/>
+      <point x="27" y="207"/>
+      <point x="27" y="114" type="curve" smooth="yes"/>
+      <point x="27" y="34"/>
+      <point x="87" y="-16"/>
     </contour>
     <contour>
-      <point x="219" y="371" type="curve" smooth="yes"/>
-      <point x="178" y="371"/>
-      <point x="157" y="393"/>
-      <point x="157" y="437" type="curve" smooth="yes"/>
-      <point x="157" y="461"/>
-      <point x="165" y="485"/>
-      <point x="179" y="503" type="curve"/>
-      <point x="157" y="505" type="line"/>
-      <point x="128" y="463" type="line"/>
-      <point x="153" y="480"/>
-      <point x="190" y="490"/>
-      <point x="227" y="490" type="curve" smooth="yes"/>
-      <point x="270" y="490"/>
-      <point x="287" y="474"/>
-      <point x="287" y="434" type="curve" smooth="yes"/>
-      <point x="287" y="395"/>
-      <point x="261" y="371"/>
+      <point x="214" y="338" type="curve" smooth="yes"/>
+      <point x="171" y="338"/>
+      <point x="147" y="367"/>
+      <point x="147" y="411" type="curve" smooth="yes"/>
+      <point x="147" y="432"/>
+      <point x="152" y="451"/>
+      <point x="162" y="473" type="curve"/>
+      <point x="137" y="473" type="line"/>
+      <point x="124" y="443" type="line"/>
+      <point x="150" y="458"/>
+      <point x="181" y="468"/>
+      <point x="216" y="468" type="curve" smooth="yes"/>
+      <point x="260" y="468"/>
+      <point x="283" y="448"/>
+      <point x="283" y="408" type="curve" smooth="yes"/>
+      <point x="283" y="377"/>
+      <point x="265" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="655"/>
+    <component base="halant-malayalam" xOffset="691"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="440"/>
+    <component base="lVocalicMatra-malayalam" xOffset="450" yOffset="-6"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="441"/>
+    <component base="llVocalicMatra-malayalam" xOffset="451" yOffset="-6"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/kC_hillu-malayalam.glif
@@ -2,114 +2,112 @@
 <glyph name="kChillu-malayalam" format="2">
   <advance width="1066"/>
   <unicode hex="0D7F"/>
-  <guideline x="1046"/>
-  <anchor x="690" y="0" name="bottom"/>
-  <anchor x="375" y="596" name="top"/>
+  <anchor x="615" y="0" name="bottom"/>
+  <anchor x="406" y="596" name="top"/>
   <outline>
     <contour>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="321" y="26"/>
-      <point x="348" y="90" type="curve"/>
-      <point x="358" y="90" type="line"/>
-      <point x="385" y="23"/>
-      <point x="432" y="-16"/>
-      <point x="514" y="-16" type="curve" smooth="yes"/>
-      <point x="587" y="-16"/>
-      <point x="643" y="14"/>
-      <point x="680" y="84" type="curve"/>
-      <point x="690" y="84" type="line"/>
-      <point x="709" y="23"/>
-      <point x="755" y="-16"/>
-      <point x="836" y="-16" type="curve" smooth="yes"/>
-      <point x="944" y="-16"/>
-      <point x="1005" y="60"/>
-      <point x="1005" y="170" type="curve" smooth="yes"/>
-      <point x="1005" y="261"/>
-      <point x="944" y="333"/>
-      <point x="816" y="333" type="curve" smooth="yes"/>
-      <point x="776" y="333" type="line"/>
-      <point x="730" y="259" type="line"/>
-      <point x="797" y="259" type="line" smooth="yes"/>
-      <point x="893" y="259"/>
-      <point x="920" y="219"/>
-      <point x="920" y="171" type="curve" smooth="yes"/>
-      <point x="920" y="105"/>
-      <point x="889" y="62"/>
-      <point x="828" y="62" type="curve" smooth="yes"/>
-      <point x="769" y="62"/>
-      <point x="736" y="98"/>
-      <point x="736" y="162" type="curve" smooth="yes"/>
-      <point x="736" y="252"/>
-      <point x="808" y="330"/>
-      <point x="892" y="435" type="curve" smooth="yes"/>
-      <point x="957" y="516"/>
-      <point x="1005" y="580"/>
-      <point x="1005" y="679" type="curve" smooth="yes"/>
-      <point x="1005" y="758"/>
-      <point x="957" y="810"/>
-      <point x="857" y="810" type="curve" smooth="yes"/>
-      <point x="808" y="810"/>
-      <point x="759" y="800"/>
-      <point x="705" y="769" type="curve"/>
-      <point x="731" y="700" type="line"/>
-      <point x="774" y="723"/>
-      <point x="815" y="732"/>
-      <point x="846" y="732" type="curve" smooth="yes"/>
-      <point x="901" y="732"/>
-      <point x="922" y="706"/>
-      <point x="922" y="667" type="curve" smooth="yes"/>
-      <point x="922" y="601"/>
-      <point x="886" y="545"/>
-      <point x="823" y="464" type="curve" smooth="yes"/>
-      <point x="800" y="434"/>
-      <point x="781" y="409"/>
-      <point x="768" y="377" type="curve"/>
-      <point x="717" y="377" type="line"/>
-      <point x="757" y="340" type="line"/>
-      <point x="758" y="352"/>
-      <point x="758" y="364"/>
-      <point x="758" y="376" type="curve" smooth="yes"/>
-      <point x="758" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="726" y="259" type="line"/>
-      <point x="726" y="333" type="line"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="557" y="-16"/>
+      <point x="614" y="18"/>
+      <point x="655" y="83" type="curve"/>
+      <point x="666" y="83" type="line"/>
+      <point x="683" y="24"/>
+      <point x="734" y="-16"/>
+      <point x="809" y="-16" type="curve" smooth="yes"/>
+      <point x="920" y="-16"/>
+      <point x="1000" y="77"/>
+      <point x="1000" y="186" type="curve" smooth="yes"/>
+      <point x="1000" y="289"/>
+      <point x="931" y="353"/>
+      <point x="813" y="353" type="curve" smooth="yes"/>
+      <point x="788" y="353" type="line"/>
+      <point x="741" y="279" type="line"/>
+      <point x="810" y="279" type="line" smooth="yes"/>
+      <point x="885" y="279"/>
+      <point x="916" y="243"/>
+      <point x="916" y="181" type="curve" smooth="yes"/>
+      <point x="916" y="111"/>
+      <point x="873" y="62"/>
+      <point x="811" y="62" type="curve" smooth="yes"/>
+      <point x="755" y="62"/>
+      <point x="722" y="94"/>
+      <point x="722" y="149" type="curve" smooth="yes"/>
+      <point x="722" y="211"/>
+      <point x="764" y="287"/>
+      <point x="882" y="432" type="curve" smooth="yes"/>
+      <point x="968" y="538"/>
+      <point x="1001" y="604"/>
+      <point x="1001" y="675" type="curve" smooth="yes"/>
+      <point x="1001" y="752"/>
+      <point x="953" y="810"/>
+      <point x="860" y="810" type="curve" smooth="yes"/>
+      <point x="802" y="810"/>
+      <point x="753" y="796"/>
+      <point x="697" y="759" type="curve"/>
+      <point x="735" y="692" type="line"/>
+      <point x="776" y="719"/>
+      <point x="815" y="731"/>
+      <point x="853" y="731" type="curve" smooth="yes"/>
+      <point x="897" y="731"/>
+      <point x="918" y="710"/>
+      <point x="918" y="667" type="curve" smooth="yes"/>
+      <point x="918" y="619"/>
+      <point x="882" y="553"/>
+      <point x="814" y="467" type="curve" smooth="yes"/>
+      <point x="782" y="427"/>
+      <point x="764" y="393"/>
+      <point x="751" y="360" type="curve"/>
+      <point x="743" y="360" type="line"/>
+      <point x="746" y="383"/>
+      <point x="748" y="405"/>
+      <point x="748" y="425" type="curve" smooth="yes"/>
+      <point x="748" y="544"/>
+      <point x="694" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="707" y="279" type="line"/>
+      <point x="727" y="353" type="line"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="521" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="209"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="658" y="534"/>
+      <point x="685" y="484"/>
+      <point x="685" y="407" type="curve" smooth="yes"/>
+      <point x="685" y="316"/>
+      <point x="643" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/k_ka-malayalam.glif
@@ -1,99 +1,98 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ka-malayalam" format="2">
   <advance width="1454"/>
-  <guideline x="1405"/>
-  <anchor x="1049" y="0" name="bottom"/>
-  <anchor x="798" y="596" name="top"/>
-  <anchor x="1326" y="596" name="topright"/>
+  <anchor x="991" y="0" name="bottom"/>
+  <anchor x="846" y="596" name="top"/>
+  <anchor x="1374" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="316" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="380" y="23"/>
-      <point x="434" y="-16"/>
-      <point x="518" y="-16" type="curve" smooth="yes"/>
-      <point x="688" y="-16"/>
-      <point x="772" y="175"/>
-      <point x="772" y="385" type="curve" smooth="yes"/>
-      <point x="772" y="519"/>
-      <point x="713" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="258"/>
-      <point x="233" y="258" type="curve" smooth="yes"/>
-      <point x="918" y="258" type="line" smooth="yes"/>
-      <point x="1031" y="258"/>
-      <point x="1056" y="218"/>
-      <point x="1056" y="164" type="curve" smooth="yes"/>
-      <point x="1056" y="112"/>
-      <point x="1036" y="62"/>
-      <point x="985" y="62" type="curve" smooth="yes"/>
-      <point x="927" y="62"/>
-      <point x="901" y="110"/>
-      <point x="901" y="182" type="curve" smooth="yes"/>
-      <point x="901" y="381"/>
-      <point x="991" y="533"/>
-      <point x="1150" y="533" type="curve" smooth="yes"/>
-      <point x="1268" y="533"/>
-      <point x="1327" y="460"/>
-      <point x="1327" y="343" type="curve" smooth="yes"/>
-      <point x="1327" y="212"/>
-      <point x="1271" y="127"/>
-      <point x="1185" y="37" type="curve"/>
-      <point x="1246" y="-16" type="line"/>
-      <point x="1349" y="86"/>
-      <point x="1410" y="201"/>
-      <point x="1410" y="350" type="curve" smooth="yes"/>
-      <point x="1410" y="510"/>
-      <point x="1320" y="612"/>
-      <point x="1148" y="612" type="curve" smooth="yes"/>
-      <point x="944" y="612"/>
-      <point x="820" y="440"/>
-      <point x="820" y="187" type="curve" smooth="yes"/>
-      <point x="820" y="76"/>
-      <point x="869" y="-16"/>
-      <point x="988" y="-16" type="curve" smooth="yes"/>
-      <point x="1085" y="-16"/>
-      <point x="1139" y="65"/>
-      <point x="1139" y="163" type="curve" smooth="yes"/>
-      <point x="1139" y="258"/>
-      <point x="1091" y="332"/>
-      <point x="923" y="332" type="curve" smooth="yes"/>
-      <point x="242" y="332" type="line" smooth="yes"/>
-      <point x="106" y="332"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="956" y="279" type="line" smooth="yes"/>
+      <point x="1029" y="279"/>
+      <point x="1063" y="248"/>
+      <point x="1063" y="178" type="curve" smooth="yes"/>
+      <point x="1063" y="137"/>
+      <point x="1044" y="62"/>
+      <point x="975" y="62" type="curve" smooth="yes"/>
+      <point x="920" y="62"/>
+      <point x="892" y="100"/>
+      <point x="892" y="179" type="curve" smooth="yes"/>
+      <point x="892" y="319"/>
+      <point x="965" y="533"/>
+      <point x="1155" y="533" type="curve" smooth="yes"/>
+      <point x="1265" y="533"/>
+      <point x="1320" y="465"/>
+      <point x="1320" y="343" type="curve" smooth="yes"/>
+      <point x="1320" y="236"/>
+      <point x="1281" y="141"/>
+      <point x="1179" y="43" type="curve"/>
+      <point x="1238" y="-16" type="line"/>
+      <point x="1349" y="91"/>
+      <point x="1402" y="222"/>
+      <point x="1402" y="350" type="curve" smooth="yes"/>
+      <point x="1402" y="512"/>
+      <point x="1318" y="612"/>
+      <point x="1164" y="612" type="curve" smooth="yes"/>
+      <point x="930" y="612"/>
+      <point x="811" y="381"/>
+      <point x="811" y="181" type="curve" smooth="yes"/>
+      <point x="811" y="59"/>
+      <point x="871" y="-16"/>
+      <point x="969" y="-16" type="curve" smooth="yes"/>
+      <point x="1086" y="-16"/>
+      <point x="1145" y="85"/>
+      <point x="1145" y="184" type="curve" smooth="yes"/>
+      <point x="1145" y="293"/>
+      <point x="1081" y="353"/>
+      <point x="960" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="515" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="661" y="534"/>
-      <point x="690" y="478"/>
-      <point x="690" y="397" type="curve" smooth="yes"/>
-      <point x="690" y="229"/>
-      <point x="640" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/k_la-malayalam.glif
@@ -1,145 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_la-malayalam" format="2">
   <advance width="1061"/>
-  <anchor x="546" y="-357" name="bottom"/>
-  <anchor x="604" y="596" name="top"/>
-  <anchor x="942" y="556" name="topright"/>
+  <anchor x="551" y="-362" name="bottom"/>
+  <anchor x="599" y="596" name="top"/>
+  <anchor x="936" y="556" name="topright"/>
   <outline>
     <contour>
-      <point x="342" y="-378" type="curve" smooth="yes"/>
-      <point x="429" y="-378"/>
-      <point x="479" y="-321"/>
-      <point x="479" y="-236" type="curve" smooth="yes"/>
-      <point x="479" y="-156"/>
-      <point x="434" y="-121"/>
-      <point x="368" y="-121" type="curve" smooth="yes"/>
-      <point x="334" y="-121"/>
-      <point x="301" y="-134"/>
-      <point x="278" y="-167" type="curve"/>
-      <point x="230" y="-162" type="line"/>
-      <point x="265" y="-184" type="line"/>
-      <point x="284" y="-78"/>
-      <point x="348" y="-22"/>
-      <point x="433" y="-22" type="curve" smooth="yes"/>
-      <point x="544" y="-22"/>
-      <point x="566" y="-91"/>
-      <point x="572" y="-180" type="curve" smooth="yes"/>
-      <point x="573" y="-196" type="line" smooth="yes"/>
-      <point x="580" y="-307"/>
-      <point x="624" y="-378"/>
-      <point x="741" y="-378" type="curve" smooth="yes"/>
-      <point x="875" y="-378"/>
-      <point x="925" y="-270"/>
-      <point x="925" y="-132" type="curve" smooth="yes"/>
-      <point x="925" y="-57"/>
-      <point x="902" y="7"/>
-      <point x="875" y="48" type="curve"/>
-      <point x="812" y="10" type="line"/>
-      <point x="828" y="-20"/>
-      <point x="849" y="-69"/>
-      <point x="849" y="-145" type="curve" smooth="yes"/>
-      <point x="849" y="-228"/>
-      <point x="821" y="-308"/>
-      <point x="742" y="-308" type="curve" smooth="yes"/>
-      <point x="681" y="-308"/>
-      <point x="657" y="-271"/>
-      <point x="648" y="-176" type="curve" smooth="yes"/>
-      <point x="646" y="-155" type="line" smooth="yes"/>
-      <point x="640" y="-91"/>
-      <point x="625" y="-41"/>
-      <point x="591" y="-7" type="curve"/>
-      <point x="592" y="3" type="line"/>
-      <point x="714" y="49"/>
-      <point x="774" y="208"/>
-      <point x="774" y="375" type="curve" smooth="yes"/>
-      <point x="774" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="802" y="259" type="line" smooth="yes"/>
-      <point x="884" y="259"/>
-      <point x="919" y="227"/>
-      <point x="919" y="165" type="curve" smooth="yes"/>
-      <point x="919" y="112"/>
-      <point x="895" y="60"/>
-      <point x="822" y="60" type="curve" smooth="yes"/>
-      <point x="797" y="60"/>
-      <point x="776" y="66"/>
-      <point x="761" y="73" type="curve"/>
-      <point x="730" y="3" type="line"/>
-      <point x="753" y="-9"/>
-      <point x="787" y="-16"/>
-      <point x="824" y="-16" type="curve" smooth="yes"/>
-      <point x="940" y="-16"/>
-      <point x="1001" y="59"/>
-      <point x="1001" y="168" type="curve" smooth="yes"/>
-      <point x="1001" y="267"/>
-      <point x="942" y="333"/>
-      <point x="810" y="333" type="curve" smooth="yes"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="316" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="359" y="75"/>
-      <point x="373" y="56"/>
-      <point x="389" y="46" type="curve"/>
-      <point x="388" y="35" type="line"/>
-      <point x="265" y="11"/>
-      <point x="196" y="-89"/>
-      <point x="196" y="-209" type="curve" smooth="yes"/>
-      <point x="196" y="-328"/>
-      <point x="261" y="-378"/>
+      <point x="334" y="-378" type="curve" smooth="yes"/>
+      <point x="433" y="-378"/>
+      <point x="479" y="-300"/>
+      <point x="479" y="-234" type="curve" smooth="yes"/>
+      <point x="479" y="-166"/>
+      <point x="444" y="-121"/>
+      <point x="381" y="-121" type="curve" smooth="yes"/>
+      <point x="333" y="-121"/>
+      <point x="267" y="-155"/>
+      <point x="253" y="-236" type="curve"/>
+      <point x="288" y="-175" type="line"/>
+      <point x="229" y="-175" type="line"/>
+      <point x="263" y="-201" type="line"/>
+      <point x="280" y="-94"/>
+      <point x="362" y="-22"/>
+      <point x="446" y="-22" type="curve" smooth="yes"/>
+      <point x="524" y="-22"/>
+      <point x="553" y="-61"/>
+      <point x="569" y="-160" type="curve" smooth="yes"/>
+      <point x="576" y="-203" type="line" smooth="yes"/>
+      <point x="596" y="-323"/>
+      <point x="645" y="-378"/>
+      <point x="736" y="-378" type="curve" smooth="yes"/>
+      <point x="878" y="-378"/>
+      <point x="922" y="-231"/>
+      <point x="922" y="-135" type="curve" smooth="yes"/>
+      <point x="922" y="-59"/>
+      <point x="902" y="0"/>
+      <point x="872" y="46" type="curve"/>
+      <point x="810" y="10" type="line"/>
+      <point x="833" y="-30"/>
+      <point x="848" y="-77"/>
+      <point x="848" y="-139" type="curve" smooth="yes"/>
+      <point x="848" y="-202"/>
+      <point x="829" y="-308"/>
+      <point x="743" y="-308" type="curve" smooth="yes"/>
+      <point x="687" y="-308"/>
+      <point x="662" y="-274"/>
+      <point x="648" y="-188" type="curve" smooth="yes"/>
+      <point x="641" y="-145" type="line" smooth="yes"/>
+      <point x="629" y="-68"/>
+      <point x="612" y="-26"/>
+      <point x="576" y="-1" type="curve"/>
+      <point x="578" y="10" type="line"/>
+      <point x="730" y="75"/>
+      <point x="769" y="279"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="793" y="279" type="line" smooth="yes"/>
+      <point x="872" y="279"/>
+      <point x="912" y="245"/>
+      <point x="912" y="178" type="curve" smooth="yes"/>
+      <point x="912" y="105"/>
+      <point x="871" y="60"/>
+      <point x="807" y="60" type="curve" smooth="yes"/>
+      <point x="785" y="60"/>
+      <point x="766" y="63"/>
+      <point x="748" y="70" type="curve"/>
+      <point x="725" y="-2" type="line"/>
+      <point x="748" y="-12"/>
+      <point x="773" y="-16"/>
+      <point x="801" y="-16" type="curve" smooth="yes"/>
+      <point x="914" y="-16"/>
+      <point x="993" y="65"/>
+      <point x="993" y="180" type="curve" smooth="yes"/>
+      <point x="993" y="289"/>
+      <point x="920" y="353"/>
+      <point x="796" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="351" y="70"/>
+      <point x="363" y="51"/>
+      <point x="381" y="38" type="curve"/>
+      <point x="379" y="27" type="line"/>
+      <point x="270" y="-6"/>
+      <point x="196" y="-113"/>
+      <point x="196" y="-227" type="curve" smooth="yes"/>
+      <point x="196" y="-321"/>
+      <point x="256" y="-378"/>
     </contour>
     <contour>
-      <point x="341" y="-313" type="curve" smooth="yes"/>
-      <point x="287" y="-313"/>
-      <point x="264" y="-270"/>
-      <point x="264" y="-223" type="curve"/>
-      <point x="246" y="-200" type="line"/>
-      <point x="257" y="-256" type="line"/>
-      <point x="264" y="-216"/>
-      <point x="298" y="-181"/>
-      <point x="347" y="-181" type="curve" smooth="yes"/>
-      <point x="389" y="-181"/>
-      <point x="408" y="-201"/>
-      <point x="408" y="-240" type="curve" smooth="yes"/>
-      <point x="408" y="-282"/>
-      <point x="385" y="-313"/>
+      <point x="337" y="-313" type="curve" smooth="yes"/>
+      <point x="291" y="-313"/>
+      <point x="263" y="-276"/>
+      <point x="263" y="-227" type="curve" smooth="yes"/>
+      <point x="263" y="-219"/>
+      <point x="264" y="-211"/>
+      <point x="266" y="-203" type="curve"/>
+      <point x="246" y="-218" type="line"/>
+      <point x="255" y="-268" type="line"/>
+      <point x="263" y="-224"/>
+      <point x="304" y="-181"/>
+      <point x="357" y="-181" type="curve" smooth="yes"/>
+      <point x="393" y="-181"/>
+      <point x="409" y="-202"/>
+      <point x="409" y="-236" type="curve" smooth="yes"/>
+      <point x="409" y="-270"/>
+      <point x="390" y="-313"/>
     </contour>
     <contour>
-      <point x="523" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="229"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.glif
@@ -1,116 +1,115 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam" format="2">
   <advance width="1726"/>
-  <guideline x="1643"/>
-  <anchor x="1235" y="0" name="bottom"/>
-  <anchor x="937" y="596" name="top"/>
-  <anchor x="1662" y="596" name="topright"/>
+  <anchor x="1228" y="0" name="bottom"/>
+  <anchor x="932" y="596" name="top"/>
+  <anchor x="1657" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="183" y="-16" type="curve" smooth="yes"/>
-      <point x="261" y="-16"/>
-      <point x="317" y="26"/>
-      <point x="344" y="90" type="curve"/>
-      <point x="354" y="90" type="line"/>
-      <point x="381" y="23"/>
-      <point x="435" y="-16"/>
-      <point x="525" y="-16" type="curve" smooth="yes"/>
-      <point x="691" y="-16"/>
-      <point x="775" y="173"/>
-      <point x="775" y="372" type="curve" smooth="yes"/>
-      <point x="775" y="517"/>
-      <point x="714" y="612"/>
-      <point x="587" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="369" y="505"/>
-      <point x="339" y="325" type="curve" smooth="yes"/>
-      <point x="334" y="293"/>
-      <point x="329" y="248"/>
-      <point x="325" y="224" type="curve" smooth="yes"/>
-      <point x="307" y="112"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
       <point x="258" y="62"/>
-      <point x="193" y="62" type="curve" smooth="yes"/>
-      <point x="132" y="62"/>
-      <point x="102" y="95"/>
-      <point x="102" y="151" type="curve" smooth="yes"/>
-      <point x="102" y="218"/>
-      <point x="147" y="265"/>
-      <point x="235" y="265" type="curve" smooth="yes"/>
-      <point x="806" y="265" type="line" smooth="yes"/>
-      <point x="895" y="265"/>
-      <point x="923" y="233"/>
-      <point x="923" y="186" type="curve" smooth="yes"/>
-      <point x="923" y="123"/>
-      <point x="890" y="90"/>
-      <point x="836" y="57" type="curve"/>
-      <point x="846" y="0" type="line"/>
-      <point x="1590" y="0" type="line"/>
-      <point x="1695" y="596" type="line"/>
-      <point x="1643" y="596" type="line"/>
-      <point x="1554" y="414"/>
-      <point x="1442" y="320"/>
-      <point x="1293" y="320" type="curve" smooth="yes"/>
-      <point x="1194" y="320"/>
-      <point x="1142" y="365"/>
-      <point x="1142" y="437" type="curve" smooth="yes"/>
-      <point x="1142" y="495"/>
-      <point x="1172" y="534"/>
-      <point x="1227" y="534" type="curve" smooth="yes"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="801" y="279" type="line" smooth="yes"/>
+      <point x="878" y="279"/>
+      <point x="917" y="248"/>
+      <point x="917" y="185" type="curve" smooth="yes"/>
+      <point x="917" y="137"/>
+      <point x="893" y="102"/>
+      <point x="830" y="58" type="curve"/>
+      <point x="840" y="0" type="line"/>
+      <point x="1584" y="0" type="line"/>
+      <point x="1689" y="596" type="line"/>
+      <point x="1639" y="596" type="line"/>
+      <point x="1533" y="421"/>
+      <point x="1399" y="320"/>
+      <point x="1267" y="320" type="curve" smooth="yes"/>
+      <point x="1184" y="320"/>
+      <point x="1137" y="360"/>
+      <point x="1137" y="430" type="curve" smooth="yes"/>
+      <point x="1137" y="490"/>
+      <point x="1177" y="534"/>
+      <point x="1231" y="534" type="curve" smooth="yes"/>
       <point x="1271" y="534"/>
-      <point x="1293" y="510"/>
-      <point x="1293" y="465" type="curve" smooth="yes"/>
-      <point x="1293" y="445"/>
-      <point x="1291" y="428"/>
-      <point x="1288" y="411" type="curve" smooth="yes"/>
-      <point x="1226" y="61" type="line"/>
-      <point x="1308" y="61" type="line"/>
-      <point x="1371" y="407" type="line" smooth="yes"/>
-      <point x="1376" y="435"/>
-      <point x="1376" y="458"/>
-      <point x="1376" y="471" type="curve" smooth="yes"/>
-      <point x="1376" y="553"/>
-      <point x="1324" y="612"/>
-      <point x="1227" y="612" type="curve" smooth="yes"/>
-      <point x="1122" y="612"/>
-      <point x="1059" y="547"/>
-      <point x="1059" y="443" type="curve" smooth="yes"/>
-      <point x="1059" y="315"/>
-      <point x="1161" y="242"/>
-      <point x="1294" y="242" type="curve" smooth="yes"/>
-      <point x="1405" y="242"/>
-      <point x="1495" y="284"/>
-      <point x="1558" y="358" type="curve"/>
-      <point x="1568" y="354" type="line"/>
-      <point x="1513" y="40" type="line"/>
-      <point x="1559" y="74" type="line"/>
-      <point x="915" y="74" type="line"/>
-      <point x="917" y="43" type="line"/>
-      <point x="973" y="74"/>
-      <point x="1007" y="123"/>
-      <point x="1007" y="187" type="curve" smooth="yes"/>
-      <point x="1007" y="279"/>
-      <point x="953" y="339"/>
-      <point x="812" y="339" type="curve" smooth="yes"/>
-      <point x="242" y="339" type="line" smooth="yes"/>
-      <point x="106" y="339"/>
-      <point x="18" y="268"/>
-      <point x="18" y="150" type="curve" smooth="yes"/>
-      <point x="18" y="50"/>
-      <point x="74" y="-16"/>
+      <point x="1292" y="514"/>
+      <point x="1292" y="474" type="curve" smooth="yes"/>
+      <point x="1292" y="463"/>
+      <point x="1291" y="452"/>
+      <point x="1289" y="440" type="curve" smooth="yes"/>
+      <point x="1222" y="61" type="line"/>
+      <point x="1304" y="61" type="line"/>
+      <point x="1370" y="435" type="line" smooth="yes"/>
+      <point x="1373" y="452"/>
+      <point x="1375" y="469"/>
+      <point x="1375" y="483" type="curve" smooth="yes"/>
+      <point x="1375" y="563"/>
+      <point x="1326" y="612"/>
+      <point x="1244" y="612" type="curve" smooth="yes"/>
+      <point x="1135" y="612"/>
+      <point x="1056" y="534"/>
+      <point x="1056" y="425" type="curve" smooth="yes"/>
+      <point x="1056" y="316"/>
+      <point x="1137" y="244"/>
+      <point x="1261" y="244" type="curve" smooth="yes"/>
+      <point x="1370" y="244"/>
+      <point x="1474" y="293"/>
+      <point x="1562" y="390" type="curve"/>
+      <point x="1570" y="390" type="line"/>
+      <point x="1508" y="40" type="line"/>
+      <point x="1554" y="74" type="line"/>
+      <point x="946" y="74" type="line"/>
+      <point x="944" y="80" type="line"/>
+      <point x="977" y="109"/>
+      <point x="1000" y="154"/>
+      <point x="1000" y="200" type="curve" smooth="yes"/>
+      <point x="1000" y="294"/>
+      <point x="939" y="353"/>
+      <point x="809" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="521" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="408" y="117"/>
-      <point x="408" y="202" type="curve" smooth="yes"/>
-      <point x="408" y="352"/>
-      <point x="463" y="534"/>
-      <point x="589" y="534" type="curve" smooth="yes"/>
-      <point x="661" y="534"/>
-      <point x="688" y="480"/>
-      <point x="688" y="380" type="curve" smooth="yes"/>
-      <point x="688" y="231"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1726"/>
   <outline>
     <component base="k_ssa-malayalam"/>
-    <component base="halant-malayalam" xOffset="1582"/>
+    <component base="halant-malayalam" xOffset="1577"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/k_ta-malayalam.glif
@@ -1,114 +1,114 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ta-malayalam" format="2">
   <advance width="1820"/>
-  <anchor x="1367" y="0" name="bottom"/>
-  <anchor x="895" y="596" name="top"/>
-  <anchor x="1704" y="596" name="topright"/>
+  <anchor x="1357" y="0" name="bottom"/>
+  <anchor x="891" y="596" name="top"/>
+  <anchor x="1696" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="316" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="380" y="23"/>
-      <point x="434" y="-16"/>
-      <point x="524" y="-16" type="curve" smooth="yes"/>
-      <point x="689" y="-16"/>
-      <point x="774" y="175"/>
-      <point x="774" y="375" type="curve" smooth="yes"/>
-      <point x="774" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="903" y="259" type="line"/>
-      <point x="911" y="333" type="line"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
+      <point x="939" y="-16" type="curve"/>
+      <point x="1003" y="31" type="line"/>
+      <point x="959" y="92"/>
+      <point x="941" y="161"/>
+      <point x="941" y="236" type="curve" smooth="yes"/>
+      <point x="941" y="404"/>
+      <point x="1044" y="534"/>
+      <point x="1211" y="534" type="curve" smooth="yes"/>
+      <point x="1353" y="534"/>
+      <point x="1420" y="426"/>
+      <point x="1420" y="292" type="curve" smooth="yes"/>
+      <point x="1420" y="194"/>
+      <point x="1379" y="62"/>
+      <point x="1282" y="62" type="curve" smooth="yes"/>
+      <point x="1217" y="62"/>
+      <point x="1182" y="107"/>
+      <point x="1182" y="193" type="curve" smooth="yes"/>
+      <point x="1182" y="355"/>
+      <point x="1319" y="534"/>
+      <point x="1506" y="534" type="curve" smooth="yes"/>
+      <point x="1639" y="534"/>
+      <point x="1687" y="467"/>
+      <point x="1687" y="358" type="curve" smooth="yes"/>
+      <point x="1687" y="257"/>
+      <point x="1637" y="148"/>
+      <point x="1528" y="45" type="curve"/>
+      <point x="1591" y="-16" type="line"/>
+      <point x="1721" y="107"/>
+      <point x="1770" y="236"/>
+      <point x="1770" y="362" type="curve" smooth="yes"/>
+      <point x="1770" y="515"/>
+      <point x="1684" y="612"/>
+      <point x="1516" y="612" type="curve" smooth="yes"/>
+      <point x="1273" y="612"/>
+      <point x="1099" y="378"/>
+      <point x="1099" y="190" type="curve" smooth="yes"/>
+      <point x="1099" y="66"/>
+      <point x="1168" y="-16"/>
+      <point x="1275" y="-16" type="curve" smooth="yes"/>
+      <point x="1444" y="-16"/>
+      <point x="1506" y="162"/>
+      <point x="1506" y="290" type="curve" smooth="yes"/>
+      <point x="1506" y="462"/>
+      <point x="1404" y="612"/>
+      <point x="1220" y="612" type="curve" smooth="yes"/>
+      <point x="996" y="612"/>
+      <point x="859" y="429"/>
+      <point x="859" y="235" type="curve" smooth="yes"/>
+      <point x="859" y="143"/>
+      <point x="885" y="58"/>
     </contour>
     <contour>
-      <point x="523" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="229"/>
-      <point x="638" y="62"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="915" y="279" type="line"/>
+      <point x="915" y="353" type="line"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="956" y="-16" type="curve"/>
-      <point x="1022" y="32" type="line"/>
-      <point x="978" y="87"/>
-      <point x="953" y="165"/>
-      <point x="953" y="248" type="curve" smooth="yes"/>
-      <point x="953" y="421"/>
-      <point x="1056" y="534"/>
-      <point x="1214" y="534" type="curve" smooth="yes"/>
-      <point x="1356" y="534"/>
-      <point x="1434" y="443"/>
-      <point x="1434" y="275" type="curve" smooth="yes"/>
-      <point x="1434" y="136"/>
-      <point x="1389" y="62"/>
-      <point x="1303" y="62" type="curve" smooth="yes"/>
-      <point x="1232" y="62"/>
-      <point x="1196" y="109"/>
-      <point x="1196" y="199" type="curve" smooth="yes"/>
-      <point x="1196" y="387"/>
-      <point x="1329" y="534"/>
-      <point x="1500" y="534" type="curve" smooth="yes"/>
-      <point x="1622" y="534"/>
-      <point x="1686" y="466"/>
-      <point x="1686" y="336" type="curve" smooth="yes"/>
-      <point x="1686" y="218"/>
-      <point x="1637" y="128"/>
-      <point x="1528" y="48" type="curve"/>
-      <point x="1579" y="-16" type="line"/>
-      <point x="1707" y="79"/>
-      <point x="1768" y="193"/>
-      <point x="1768" y="336" type="curve" smooth="yes"/>
-      <point x="1768" y="513"/>
-      <point x="1672" y="612"/>
-      <point x="1502" y="612" type="curve" smooth="yes"/>
-      <point x="1296" y="612"/>
-      <point x="1114" y="418"/>
-      <point x="1114" y="199" type="curve" smooth="yes"/>
-      <point x="1114" y="62"/>
-      <point x="1183" y="-16"/>
-      <point x="1303" y="-16" type="curve" smooth="yes"/>
-      <point x="1433" y="-16"/>
-      <point x="1520" y="100"/>
-      <point x="1520" y="275" type="curve" smooth="yes"/>
-      <point x="1520" y="475"/>
-      <point x="1398" y="612"/>
-      <point x="1218" y="612" type="curve" smooth="yes"/>
-      <point x="1013" y="612"/>
-      <point x="871" y="463"/>
-      <point x="871" y="248" type="curve" smooth="yes"/>
-      <point x="871" y="143"/>
-      <point x="899" y="56"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/k_tta-malayalam.glif
@@ -1,128 +1,119 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_tta-malayalam" format="2">
   <advance width="1060"/>
-  <anchor x="683" y="-362" name="bottom"/>
-  <anchor x="604" y="596" name="top"/>
-  <anchor x="942" y="556" name="topright"/>
+  <anchor x="736" y="-362" name="bottom"/>
+  <anchor x="599" y="596" name="top"/>
+  <anchor x="936" y="556" name="topright"/>
   <outline>
     <contour>
-      <point x="719" y="-378" type="curve" smooth="yes"/>
-      <point x="840" y="-378"/>
-      <point x="898" y="-324"/>
-      <point x="898" y="-244" type="curve" smooth="yes"/>
-      <point x="898" y="-180"/>
-      <point x="866" y="-136"/>
-      <point x="745" y="-129" type="curve" smooth="yes"/>
-      <point x="712" y="-127" type="line" smooth="yes"/>
-      <point x="656" y="-124"/>
-      <point x="630" y="-108"/>
-      <point x="630" y="-75" type="curve" smooth="yes"/>
-      <point x="630" y="-42"/>
-      <point x="660" y="-17"/>
-      <point x="741" y="-17" type="curve" smooth="yes"/>
-      <point x="800" y="-17"/>
-      <point x="851" y="-26"/>
-      <point x="893" y="-42" type="curve"/>
-      <point x="922" y="16" type="line"/>
-      <point x="878" y="36"/>
-      <point x="817" y="48"/>
-      <point x="755" y="48" type="curve" smooth="yes"/>
-      <point x="721" y="48"/>
-      <point x="692" y="43"/>
-      <point x="664" y="34" type="curve"/>
-      <point x="659" y="41" type="line"/>
-      <point x="736" y="112"/>
-      <point x="774" y="241"/>
-      <point x="774" y="375" type="curve" smooth="yes"/>
-      <point x="774" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="802" y="259" type="line" smooth="yes"/>
-      <point x="884" y="259"/>
-      <point x="919" y="227"/>
-      <point x="919" y="165" type="curve" smooth="yes"/>
-      <point x="919" y="112"/>
-      <point x="895" y="60"/>
-      <point x="822" y="60" type="curve" smooth="yes"/>
-      <point x="797" y="60"/>
-      <point x="776" y="66"/>
-      <point x="761" y="73" type="curve"/>
-      <point x="730" y="3" type="line"/>
-      <point x="753" y="-9"/>
-      <point x="787" y="-16"/>
-      <point x="824" y="-16" type="curve" smooth="yes"/>
-      <point x="940" y="-16"/>
-      <point x="1001" y="59"/>
-      <point x="1001" y="168" type="curve" smooth="yes"/>
-      <point x="1001" y="267"/>
-      <point x="942" y="333"/>
-      <point x="810" y="333" type="curve" smooth="yes"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="316" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="380" y="23"/>
-      <point x="434" y="-16"/>
-      <point x="524" y="-16" type="curve" smooth="yes"/>
-      <point x="540" y="-16"/>
-      <point x="559" y="-13"/>
-      <point x="576" y="-7" type="curve"/>
-      <point x="581" y="-14" type="line"/>
-      <point x="564" y="-36"/>
-      <point x="554" y="-58"/>
-      <point x="554" y="-87" type="curve" smooth="yes"/>
-      <point x="554" y="-151"/>
-      <point x="602" y="-192"/>
-      <point x="693" y="-197" type="curve" smooth="yes"/>
-      <point x="729" y="-199" type="line" smooth="yes"/>
-      <point x="814" y="-204"/>
-      <point x="822" y="-228"/>
-      <point x="822" y="-252" type="curve" smooth="yes"/>
-      <point x="822" y="-286"/>
-      <point x="794" y="-313"/>
-      <point x="719" y="-313" type="curve" smooth="yes"/>
-      <point x="636" y="-313"/>
-      <point x="583" y="-295"/>
-      <point x="542" y="-271" type="curve"/>
-      <point x="505" y="-328" type="line"/>
-      <point x="555" y="-360"/>
-      <point x="629" y="-378"/>
+      <point x="725" y="-378" type="curve" smooth="yes"/>
+      <point x="862" y="-378"/>
+      <point x="930" y="-318"/>
+      <point x="930" y="-242" type="curve" smooth="yes"/>
+      <point x="930" y="-180"/>
+      <point x="896" y="-139"/>
+      <point x="796" y="-130" type="curve" smooth="yes"/>
+      <point x="727" y="-124" type="line" smooth="yes"/>
+      <point x="687" y="-121"/>
+      <point x="668" y="-107"/>
+      <point x="668" y="-81" type="curve" smooth="yes"/>
+      <point x="668" y="-45"/>
+      <point x="704" y="-16"/>
+      <point x="788" y="-16" type="curve" smooth="yes"/>
+      <point x="846" y="-16"/>
+      <point x="888" y="-25"/>
+      <point x="929" y="-44" type="curve"/>
+      <point x="953" y="13" type="line"/>
+      <point x="939" y="20"/>
+      <point x="922" y="26"/>
+      <point x="905" y="30" type="curve"/>
+      <point x="907" y="39" type="line"/>
+      <point x="960" y="68"/>
+      <point x="994" y="119"/>
+      <point x="994" y="189" type="curve" smooth="yes"/>
+      <point x="994" y="288"/>
+      <point x="925" y="353"/>
+      <point x="796" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="793" y="279" type="line" smooth="yes"/>
+      <point x="876" y="279"/>
+      <point x="913" y="244"/>
+      <point x="913" y="175" type="curve" smooth="yes"/>
+      <point x="913" y="110"/>
+      <point x="870" y="60"/>
+      <point x="807" y="60" type="curve" smooth="yes"/>
+      <point x="786" y="60"/>
+      <point x="768" y="63"/>
+      <point x="753" y="69" type="curve"/>
+      <point x="737" y="29" type="line"/>
+      <point x="767" y="47" type="line"/>
+      <point x="669" y="41"/>
+      <point x="593" y="-11"/>
+      <point x="593" y="-89" type="curve" smooth="yes"/>
+      <point x="593" y="-149"/>
+      <point x="636" y="-189"/>
+      <point x="714" y="-196" type="curve" smooth="yes"/>
+      <point x="783" y="-202" type="line" smooth="yes"/>
+      <point x="842" y="-207"/>
+      <point x="855" y="-224"/>
+      <point x="855" y="-250" type="curve" smooth="yes"/>
+      <point x="855" y="-284"/>
+      <point x="822" y="-313"/>
+      <point x="731" y="-313" type="curve" smooth="yes"/>
+      <point x="670" y="-313"/>
+      <point x="618" y="-300"/>
+      <point x="574" y="-272" type="curve"/>
+      <point x="543" y="-332" type="line"/>
+      <point x="591" y="-362"/>
+      <point x="653" y="-378"/>
     </contour>
     <contour>
-      <point x="523" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="229"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ka-malayalam.glif
@@ -2,80 +2,80 @@
 <glyph name="ka-malayalam" format="2">
   <advance width="1061"/>
   <unicode hex="0D15"/>
-  <anchor x="616" y="0" name="bottom"/>
-  <anchor x="604" y="596" name="top"/>
-  <anchor x="942" y="556" name="topright"/>
+  <anchor x="609" y="0" name="bottom"/>
+  <anchor x="599" y="596" name="top"/>
+  <anchor x="936" y="556" name="topright"/>
   <outline>
     <contour>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="317" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="379" y="23"/>
-      <point x="434" y="-16"/>
-      <point x="524" y="-16" type="curve" smooth="yes"/>
-      <point x="689" y="-16"/>
-      <point x="774" y="175"/>
-      <point x="774" y="375" type="curve" smooth="yes"/>
-      <point x="774" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="802" y="259" type="line" smooth="yes"/>
-      <point x="884" y="259"/>
-      <point x="919" y="227"/>
-      <point x="919" y="165" type="curve" smooth="yes"/>
-      <point x="919" y="112"/>
-      <point x="895" y="60"/>
-      <point x="822" y="60" type="curve" smooth="yes"/>
-      <point x="797" y="60"/>
-      <point x="776" y="66"/>
-      <point x="761" y="73" type="curve"/>
-      <point x="730" y="3" type="line"/>
-      <point x="753" y="-9"/>
-      <point x="787" y="-16"/>
-      <point x="824" y="-16" type="curve" smooth="yes"/>
-      <point x="940" y="-16"/>
-      <point x="1001" y="59"/>
-      <point x="1001" y="168" type="curve" smooth="yes"/>
-      <point x="1001" y="267"/>
-      <point x="942" y="333"/>
-      <point x="810" y="333" type="curve" smooth="yes"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="793" y="279" type="line" smooth="yes"/>
+      <point x="873" y="279"/>
+      <point x="913" y="245"/>
+      <point x="913" y="178" type="curve" smooth="yes"/>
+      <point x="913" y="105"/>
+      <point x="872" y="60"/>
+      <point x="807" y="60" type="curve" smooth="yes"/>
+      <point x="786" y="60"/>
+      <point x="767" y="63"/>
+      <point x="750" y="69" type="curve"/>
+      <point x="727" y="-3" type="line"/>
+      <point x="749" y="-12"/>
+      <point x="774" y="-16"/>
+      <point x="801" y="-16" type="curve" smooth="yes"/>
+      <point x="915" y="-16"/>
+      <point x="994" y="65"/>
+      <point x="994" y="180" type="curve" smooth="yes"/>
+      <point x="994" y="289"/>
+      <point x="921" y="353"/>
+      <point x="796" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="523" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="229"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/m_la-malayalam.glif
@@ -1,53 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="m_la-malayalam" format="2">
   <advance width="692"/>
-  <anchor x="230" y="-357" name="bottom"/>
-  <anchor x="407" y="596" name="top"/>
-  <anchor x="635" y="596" name="topright"/>
+  <anchor x="230" y="-362" name="bottom"/>
+  <anchor x="402" y="596" name="top"/>
+  <anchor x="630" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="26" y="-378" type="curve" smooth="yes"/>
-      <point x="113" y="-378"/>
-      <point x="163" y="-321"/>
-      <point x="163" y="-236" type="curve" smooth="yes"/>
-      <point x="163" y="-156"/>
-      <point x="118" y="-121"/>
-      <point x="52" y="-121" type="curve" smooth="yes"/>
-      <point x="19" y="-121"/>
-      <point x="-14" y="-134"/>
-      <point x="-37" y="-167" type="curve"/>
-      <point x="-47" y="-166" type="line"/>
-      <point x="-24" y="-72"/>
-      <point x="37" y="-22"/>
-      <point x="117" y="-22" type="curve" smooth="yes"/>
-      <point x="228" y="-22"/>
-      <point x="250" y="-91"/>
-      <point x="256" y="-180" type="curve" smooth="yes"/>
-      <point x="257" y="-196" type="line" smooth="yes"/>
-      <point x="264" y="-307"/>
-      <point x="308" y="-378"/>
-      <point x="425" y="-378" type="curve" smooth="yes"/>
-      <point x="559" y="-378"/>
-      <point x="609" y="-270"/>
-      <point x="609" y="-132" type="curve" smooth="yes"/>
-      <point x="609" y="-57"/>
-      <point x="586" y="7"/>
-      <point x="559" y="48" type="curve"/>
-      <point x="496" y="10" type="line"/>
-      <point x="512" y="-20"/>
-      <point x="533" y="-69"/>
-      <point x="533" y="-145" type="curve" smooth="yes"/>
-      <point x="533" y="-228"/>
-      <point x="505" y="-308"/>
-      <point x="426" y="-308" type="curve" smooth="yes"/>
-      <point x="365" y="-308"/>
-      <point x="341" y="-271"/>
-      <point x="332" y="-176" type="curve" smooth="yes"/>
-      <point x="330" y="-155" type="line" smooth="yes"/>
-      <point x="324" y="-89"/>
-      <point x="307" y="-38"/>
-      <point x="269" y="-10" type="curve"/>
-      <point x="270" y="0" type="line"/>
+      <point x="10" y="0" type="line"/>
       <point x="576" y="0" type="line"/>
       <point x="623" y="266" type="line" smooth="yes"/>
       <point x="631" y="313"/>
@@ -59,30 +18,75 @@
       <point x="218" y="612"/>
       <point x="102" y="520"/>
       <point x="74" y="360" type="curve" smooth="yes"/>
-      <point x="10" y="0" type="line"/>
-      <point x="42" y="0" type="line"/>
-      <point x="42" y="35" type="line"/>
-      <point x="-59" y="1"/>
-      <point x="-120" y="-95"/>
-      <point x="-120" y="-209" type="curve" smooth="yes"/>
-      <point x="-120" y="-328"/>
-      <point x="-55" y="-378"/>
     </contour>
     <contour>
-      <point x="25" y="-313" type="curve" smooth="yes"/>
-      <point x="-29" y="-313"/>
-      <point x="-52" y="-270"/>
-      <point x="-52" y="-223" type="curve"/>
-      <point x="-70" y="-200" type="line"/>
-      <point x="-59" y="-256" type="line"/>
-      <point x="-52" y="-216"/>
-      <point x="-18" y="-181"/>
-      <point x="31" y="-181" type="curve" smooth="yes"/>
-      <point x="73" y="-181"/>
-      <point x="92" y="-201"/>
-      <point x="92" y="-240" type="curve" smooth="yes"/>
-      <point x="92" y="-282"/>
-      <point x="69" y="-313"/>
+      <point x="95" y="-378" type="curve" smooth="yes"/>
+      <point x="199" y="-378"/>
+      <point x="237" y="-293"/>
+      <point x="237" y="-219" type="curve" smooth="yes"/>
+      <point x="237" y="-147"/>
+      <point x="208" y="-104"/>
+      <point x="144" y="-104" type="curve" smooth="yes"/>
+      <point x="88" y="-104"/>
+      <point x="41" y="-142"/>
+      <point x="28" y="-196" type="curve"/>
+      <point x="70" y="-157" type="line"/>
+      <point x="20" y="-141" type="line"/>
+      <point x="31" y="-201" type="line"/>
+      <point x="46" y="-88"/>
+      <point x="106" y="-18"/>
+      <point x="191" y="-18" type="curve" smooth="yes"/>
+      <point x="258" y="-18"/>
+      <point x="289" y="-56"/>
+      <point x="289" y="-153" type="curve" smooth="yes"/>
+      <point x="289" y="-236" type="line" smooth="yes"/>
+      <point x="289" y="-325"/>
+      <point x="330" y="-378"/>
+      <point x="408" y="-378" type="curve" smooth="yes"/>
+      <point x="528" y="-378"/>
+      <point x="561" y="-254"/>
+      <point x="561" y="-172" type="curve" smooth="yes"/>
+      <point x="561" y="-96"/>
+      <point x="541" y="-23"/>
+      <point x="501" y="45" type="curve"/>
+      <point x="438" y="8" type="line"/>
+      <point x="472" y="-50"/>
+      <point x="488" y="-106"/>
+      <point x="488" y="-170" type="curve" smooth="yes"/>
+      <point x="488" y="-224"/>
+      <point x="473" y="-308"/>
+      <point x="412" y="-308" type="curve" smooth="yes"/>
+      <point x="377" y="-308"/>
+      <point x="361" y="-285"/>
+      <point x="361" y="-224" type="curve" smooth="yes"/>
+      <point x="361" y="-141" type="line" smooth="yes"/>
+      <point x="361" y="-27"/>
+      <point x="314" y="32"/>
+      <point x="198" y="32" type="curve" smooth="yes"/>
+      <point x="36" y="32"/>
+      <point x="-35" y="-102"/>
+      <point x="-35" y="-231" type="curve" smooth="yes"/>
+      <point x="-35" y="-318"/>
+      <point x="9" y="-378"/>
+    </contour>
+    <contour>
+      <point x="97" y="-312" type="curve" smooth="yes"/>
+      <point x="54" y="-312"/>
+      <point x="31" y="-285"/>
+      <point x="31" y="-241" type="curve" smooth="yes"/>
+      <point x="31" y="-228"/>
+      <point x="32" y="-217"/>
+      <point x="35" y="-205" type="curve"/>
+      <point x="10" y="-221" type="line"/>
+      <point x="22" y="-250" type="line"/>
+      <point x="34" y="-198"/>
+      <point x="70" y="-164"/>
+      <point x="112" y="-164" type="curve" smooth="yes"/>
+      <point x="151" y="-164"/>
+      <point x="166" y="-185"/>
+      <point x="166" y="-223" type="curve" smooth="yes"/>
+      <point x="166" y="-275"/>
+      <point x="140" y="-312"/>
     </contour>
     <contour>
       <point x="68" y="45" type="line"/>
@@ -105,8 +109,8 @@
       <point x="462" y="339"/>
       <point x="462" y="415" type="curve" smooth="yes"/>
       <point x="462" y="493"/>
-      <point x="417" y="538"/>
-      <point x="336" y="541" type="curve"/>
+      <point x="417" y="539"/>
+      <point x="336" y="542" type="curve"/>
       <point x="336" y="577" type="line"/>
       <point x="322" y="550" type="line"/>
       <point x="337" y="552"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ng_ka-malayalam.glif
@@ -1,103 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng_ka-malayalam" format="2">
   <advance width="1066"/>
-  <anchor x="619" y="0" name="bottom"/>
-  <anchor x="607" y="596" name="top"/>
-  <anchor x="928" y="596" name="topright"/>
+  <anchor x="614" y="0" name="bottom"/>
+  <anchor x="604" y="596" name="top"/>
+  <anchor x="925" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="186" y="-16" type="curve" smooth="yes"/>
-      <point x="264" y="-16"/>
-      <point x="321" y="26"/>
-      <point x="348" y="90" type="curve"/>
-      <point x="358" y="90" type="line"/>
-      <point x="385" y="23"/>
-      <point x="438" y="-16"/>
-      <point x="527" y="-16" type="curve" smooth="yes"/>
-      <point x="693" y="-16"/>
-      <point x="778" y="175"/>
-      <point x="778" y="375" type="curve" smooth="yes"/>
-      <point x="778" y="519"/>
-      <point x="718" y="612"/>
-      <point x="595" y="612" type="curve" smooth="yes"/>
-      <point x="518" y="612"/>
-      <point x="456" y="572"/>
-      <point x="418" y="500" type="curve"/>
-      <point x="407" y="500" type="line"/>
-      <point x="393" y="564"/>
-      <point x="346" y="612"/>
-      <point x="254" y="612" type="curve" smooth="yes"/>
+      <point x="177" y="-16" type="curve" smooth="yes"/>
+      <point x="248" y="-16"/>
+      <point x="301" y="19"/>
+      <point x="337" y="91" type="curve"/>
+      <point x="348" y="91" type="line"/>
+      <point x="368" y="26"/>
+      <point x="420" y="-16"/>
+      <point x="500" y="-16" type="curve" smooth="yes"/>
+      <point x="711" y="-16"/>
+      <point x="774" y="265"/>
+      <point x="774" y="396" type="curve" smooth="yes"/>
+      <point x="774" y="529"/>
+      <point x="713" y="612"/>
+      <point x="604" y="612" type="curve" smooth="yes"/>
+      <point x="524" y="612"/>
+      <point x="458" y="572"/>
+      <point x="418" y="495" type="curve"/>
+      <point x="408" y="495" type="line"/>
+      <point x="397" y="562"/>
+      <point x="352" y="612"/>
+      <point x="265" y="612" type="curve" smooth="yes"/>
       <point x="157" y="612"/>
-      <point x="81" y="544"/>
-      <point x="81" y="443" type="curve" smooth="yes"/>
-      <point x="81" y="386"/>
-      <point x="108" y="337"/>
-      <point x="157" y="312" type="curve"/>
-      <point x="156" y="302" type="line"/>
-      <point x="78" y="286"/>
-      <point x="21" y="227"/>
-      <point x="21" y="141" type="curve" smooth="yes"/>
-      <point x="21" y="50"/>
-      <point x="77" y="-16"/>
+      <point x="79" y="542"/>
+      <point x="79" y="443" type="curve" smooth="yes"/>
+      <point x="79" y="393"/>
+      <point x="104" y="351"/>
+      <point x="146" y="325" type="curve"/>
+      <point x="145" y="315" type="line"/>
+      <point x="68" y="283"/>
+      <point x="20" y="215"/>
+      <point x="20" y="136" type="curve" smooth="yes"/>
+      <point x="20" y="46"/>
+      <point x="85" y="-16"/>
     </contour>
     <contour>
-      <point x="527" y="62" type="curve" smooth="yes"/>
-      <point x="443" y="62"/>
-      <point x="411" y="119"/>
-      <point x="411" y="205" type="curve" smooth="yes"/>
-      <point x="411" y="354"/>
-      <point x="465" y="534"/>
-      <point x="589" y="534" type="curve" smooth="yes"/>
-      <point x="663" y="534"/>
-      <point x="691" y="478"/>
-      <point x="691" y="377" type="curve" smooth="yes"/>
-      <point x="691" y="229"/>
-      <point x="642" y="62"/>
-    </contour>
-    <contour>
-      <point x="828" y="-16" type="curve" smooth="yes"/>
-      <point x="944" y="-16"/>
-      <point x="1005" y="59"/>
-      <point x="1005" y="168" type="curve" smooth="yes"/>
-      <point x="1005" y="267"/>
-      <point x="946" y="333"/>
-      <point x="814" y="333" type="curve" smooth="yes"/>
-      <point x="287" y="333" type="line" smooth="yes"/>
-      <point x="198" y="333"/>
-      <point x="163" y="379"/>
-      <point x="163" y="435" type="curve" smooth="yes"/>
-      <point x="163" y="495"/>
+      <point x="806" y="-16" type="curve" smooth="yes"/>
+      <point x="920" y="-16"/>
+      <point x="999" y="65"/>
+      <point x="999" y="180" type="curve" smooth="yes"/>
+      <point x="999" y="289"/>
+      <point x="926" y="353"/>
+      <point x="801" y="353" type="curve" smooth="yes"/>
+      <point x="274" y="353" type="line" smooth="yes"/>
+      <point x="202" y="353"/>
+      <point x="159" y="385"/>
+      <point x="159" y="440" type="curve" smooth="yes"/>
+      <point x="159" y="495"/>
       <point x="202" y="534"/>
-      <point x="265" y="534" type="curve" smooth="yes"/>
-      <point x="331" y="534"/>
-      <point x="361" y="492"/>
-      <point x="361" y="430" type="curve" smooth="yes"/>
-      <point x="361" y="410"/>
-      <point x="358" y="384"/>
-      <point x="352" y="353" type="curve" smooth="yes"/>
-      <point x="328" y="221" type="line" smooth="yes"/>
-      <point x="308" y="109"/>
-      <point x="261" y="62"/>
-      <point x="196" y="62" type="curve" smooth="yes"/>
-      <point x="135" y="62"/>
-      <point x="105" y="95"/>
-      <point x="105" y="148" type="curve" smooth="yes"/>
-      <point x="105" y="214"/>
-      <point x="149" y="259"/>
-      <point x="237" y="259" type="curve" smooth="yes"/>
-      <point x="806" y="259" type="line" smooth="yes"/>
-      <point x="888" y="259"/>
-      <point x="923" y="227"/>
-      <point x="923" y="165" type="curve" smooth="yes"/>
-      <point x="923" y="112"/>
-      <point x="899" y="60"/>
-      <point x="826" y="60" type="curve" smooth="yes"/>
-      <point x="801" y="60"/>
-      <point x="780" y="66"/>
-      <point x="765" y="73" type="curve"/>
-      <point x="734" y="3" type="line"/>
-      <point x="757" y="-9"/>
-      <point x="791" y="-16"/>
+      <point x="264" y="534" type="curve" smooth="yes"/>
+      <point x="332" y="534"/>
+      <point x="358" y="497"/>
+      <point x="358" y="438" type="curve" smooth="yes"/>
+      <point x="358" y="420"/>
+      <point x="356" y="400"/>
+      <point x="352" y="378" type="curve" smooth="yes"/>
+      <point x="323" y="212" type="line" smooth="yes"/>
+      <point x="306" y="114"/>
+      <point x="260" y="62"/>
+      <point x="192" y="62" type="curve" smooth="yes"/>
+      <point x="138" y="62"/>
+      <point x="105" y="94"/>
+      <point x="105" y="146" type="curve" smooth="yes"/>
+      <point x="105" y="228"/>
+      <point x="165" y="279"/>
+      <point x="261" y="279" type="curve" smooth="yes"/>
+      <point x="798" y="279" type="line" smooth="yes"/>
+      <point x="878" y="279"/>
+      <point x="918" y="245"/>
+      <point x="918" y="178" type="curve" smooth="yes"/>
+      <point x="918" y="105"/>
+      <point x="877" y="60"/>
+      <point x="812" y="60" type="curve" smooth="yes"/>
+      <point x="791" y="60"/>
+      <point x="772" y="63"/>
+      <point x="755" y="69" type="curve"/>
+      <point x="732" y="-3" type="line"/>
+      <point x="754" y="-12"/>
+      <point x="779" y="-16"/>
+    </contour>
+    <contour>
+      <point x="505" y="62" type="curve" smooth="yes"/>
+      <point x="439" y="62"/>
+      <point x="406" y="107"/>
+      <point x="406" y="195" type="curve" smooth="yes"/>
+      <point x="406" y="303"/>
+      <point x="446" y="534"/>
+      <point x="595" y="534" type="curve" smooth="yes"/>
+      <point x="657" y="534"/>
+      <point x="689" y="488"/>
+      <point x="689" y="402" type="curve" smooth="yes"/>
+      <point x="689" y="286"/>
+      <point x="642" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,192 +1,193 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1542"/>
-  <anchor x="1098" y="16" name="bottom"/>
-  <anchor x="859" y="596" name="top"/>
-  <anchor x="1467" y="596" name="topright"/>
+  <advance width="1592"/>
+  <anchor x="1113" y="-6" name="bottom"/>
+  <anchor x="849" y="596" name="top"/>
+  <anchor x="1481" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="260" y="-16" type="curve" smooth="yes"/>
-      <point x="375" y="-16"/>
-      <point x="445" y="60"/>
-      <point x="445" y="185" type="curve" smooth="yes"/>
-      <point x="445" y="293"/>
-      <point x="389" y="356"/>
-      <point x="293" y="356" type="curve" smooth="yes"/>
-      <point x="232" y="356"/>
-      <point x="181" y="330"/>
-      <point x="145" y="281" type="curve"/>
-      <point x="109" y="287" type="line"/>
-      <point x="120" y="153" type="line"/>
-      <point x="144" y="229"/>
-      <point x="206" y="282"/>
-      <point x="271" y="282" type="curve" smooth="yes"/>
-      <point x="333" y="282"/>
-      <point x="363" y="250"/>
-      <point x="363" y="184" type="curve" smooth="yes"/>
-      <point x="363" y="106"/>
-      <point x="325" y="62"/>
-      <point x="258" y="62" type="curve" smooth="yes"/>
-      <point x="177" y="62"/>
-      <point x="130" y="120"/>
-      <point x="130" y="220" type="curve" smooth="yes"/>
-      <point x="130" y="406"/>
-      <point x="233" y="534"/>
+      <point x="245" y="-16" type="curve" smooth="yes"/>
+      <point x="378" y="-16"/>
+      <point x="440" y="94"/>
+      <point x="440" y="191" type="curve" smooth="yes"/>
+      <point x="440" y="293"/>
+      <point x="386" y="356"/>
+      <point x="288" y="356" type="curve" smooth="yes"/>
+      <point x="230" y="356"/>
+      <point x="179" y="331"/>
+      <point x="145" y="289" type="curve"/>
+      <point x="110" y="296" type="line"/>
+      <point x="114" y="153" type="line"/>
+      <point x="139" y="229"/>
+      <point x="205" y="282"/>
+      <point x="272" y="282" type="curve" smooth="yes"/>
+      <point x="331" y="282"/>
+      <point x="358" y="249"/>
+      <point x="358" y="189" type="curve" smooth="yes"/>
+      <point x="358" y="128"/>
+      <point x="327" y="62"/>
+      <point x="247" y="62" type="curve" smooth="yes"/>
+      <point x="173" y="62"/>
+      <point x="129" y="124"/>
+      <point x="129" y="231" type="curve" smooth="yes"/>
+      <point x="129" y="376"/>
+      <point x="207" y="534"/>
       <point x="383" y="534" type="curve" smooth="yes"/>
-      <point x="490" y="534"/>
-      <point x="546" y="479"/>
-      <point x="546" y="372" type="curve" smooth="yes"/>
-      <point x="546" y="354"/>
-      <point x="544" y="335"/>
-      <point x="540" y="314" type="curve" smooth="yes"/>
-      <point x="484" y="0" type="line"/>
-      <point x="568" y="0" type="line"/>
-      <point x="627" y="333" type="line" smooth="yes"/>
-      <point x="651" y="470"/>
-      <point x="720" y="545"/>
-      <point x="843" y="545" type="curve" smooth="yes"/>
-      <point x="861" y="545"/>
-      <point x="881" y="544"/>
-      <point x="894" y="543" type="curve"/>
-      <point x="858" y="586" type="line"/>
-      <point x="858" y="534" type="line"/>
-      <point x="818" y="517"/>
-      <point x="792" y="484"/>
-      <point x="792" y="431" type="curve" smooth="yes"/>
-      <point x="792" y="360"/>
-      <point x="843" y="310"/>
-      <point x="930" y="310" type="curve" smooth="yes"/>
-      <point x="1021" y="310"/>
-      <point x="1073" y="367"/>
-      <point x="1073" y="447" type="curve" smooth="yes"/>
-      <point x="1073" y="486"/>
-      <point x="1056" y="525"/>
-      <point x="1009" y="546" type="curve"/>
-      <point x="1017" y="604" type="line"/>
-      <point x="950" y="553" type="line"/>
-      <point x="963" y="555"/>
-      <point x="979" y="556"/>
-      <point x="1001" y="556" type="curve" smooth="yes"/>
-      <point x="1088" y="556"/>
-      <point x="1130" y="515"/>
-      <point x="1130" y="435" type="curve" smooth="yes"/>
-      <point x="1130" y="414"/>
-      <point x="1129" y="400"/>
-      <point x="1125" y="380" type="curve" smooth="yes"/>
-      <point x="1120" y="353" type="line"/>
-      <point x="1204" y="353" type="line"/>
-      <point x="1210" y="388" type="line" smooth="yes"/>
-      <point x="1226" y="480"/>
-      <point x="1277" y="534"/>
-      <point x="1344" y="534" type="curve" smooth="yes"/>
-      <point x="1405" y="534"/>
-      <point x="1436" y="503"/>
-      <point x="1436" y="442" type="curve" smooth="yes"/>
-      <point x="1436" y="348"/>
-      <point x="1375" y="294"/>
-      <point x="1269" y="294" type="curve" smooth="yes"/>
-      <point x="959" y="294" type="line" smooth="yes"/>
-      <point x="823" y="294"/>
-      <point x="744" y="231"/>
-      <point x="744" y="121" type="curve" smooth="yes"/>
-      <point x="744" y="36"/>
-      <point x="794" y="-16"/>
-      <point x="875" y="-16" type="curve" smooth="yes"/>
-      <point x="928" y="-16"/>
-      <point x="983" y="3"/>
-      <point x="1082" y="58" type="curve" smooth="yes"/>
-      <point x="1151" y="96" type="line"/>
-      <point x="1268" y="159" type="line"/>
-      <point x="1278" y="161" type="line"/>
-      <point x="1300" y="170"/>
-      <point x="1317" y="172"/>
-      <point x="1339" y="172" type="curve" smooth="yes"/>
-      <point x="1374" y="172"/>
-      <point x="1392" y="154"/>
-      <point x="1392" y="121" type="curve" smooth="yes"/>
-      <point x="1392" y="75"/>
-      <point x="1368" y="48"/>
-      <point x="1329" y="48" type="curve" smooth="yes"/>
-      <point x="1297" y="48"/>
-      <point x="1276" y="69"/>
-      <point x="1276" y="101" type="curve" smooth="yes"/>
-      <point x="1276" y="137"/>
-      <point x="1290" y="163"/>
-      <point x="1327" y="190" type="curve"/>
-      <point x="1202" y="166" type="line"/>
-      <point x="1245" y="108" type="line"/>
-      <point x="1261" y="160" type="line"/>
-      <point x="1235" y="142"/>
-      <point x="1219" y="115"/>
-      <point x="1219" y="80" type="curve" smooth="yes"/>
-      <point x="1219" y="24"/>
-      <point x="1262" y="-16"/>
-      <point x="1327" y="-16" type="curve" smooth="yes"/>
-      <point x="1411" y="-16"/>
-      <point x="1459" y="35"/>
-      <point x="1459" y="124" type="curve" smooth="yes"/>
-      <point x="1459" y="196"/>
-      <point x="1421" y="238"/>
-      <point x="1355" y="238" type="curve" smooth="yes"/>
-      <point x="1297" y="238"/>
-      <point x="1258" y="225"/>
-      <point x="1147" y="169" type="curve" smooth="yes"/>
-      <point x="1064" y="127" type="line" smooth="yes"/>
-      <point x="953" y="71"/>
-      <point x="928" y="61"/>
-      <point x="888" y="61" type="curve" smooth="yes"/>
-      <point x="846" y="61"/>
-      <point x="823" y="85"/>
-      <point x="823" y="129" type="curve" smooth="yes"/>
-      <point x="823" y="189"/>
-      <point x="868" y="222"/>
-      <point x="949" y="222" type="curve" smooth="yes"/>
-      <point x="1257" y="222" type="line" smooth="yes"/>
-      <point x="1419" y="222"/>
-      <point x="1520" y="309"/>
-      <point x="1520" y="449" type="curve" smooth="yes"/>
-      <point x="1520" y="546"/>
-      <point x="1456" y="612"/>
-      <point x="1362" y="612" type="curve" smooth="yes"/>
-      <point x="1284" y="612"/>
-      <point x="1220" y="569"/>
-      <point x="1191" y="490" type="curve"/>
-      <point x="1181" y="490" type="line"/>
-      <point x="1166" y="571"/>
-      <point x="1107" y="612"/>
-      <point x="1015" y="612" type="curve" smooth="yes"/>
-      <point x="971" y="612"/>
-      <point x="939" y="604"/>
-      <point x="914" y="592" type="curve"/>
-      <point x="930" y="544" type="line"/>
-      <point x="982" y="524"/>
-      <point x="998" y="495"/>
-      <point x="998" y="456" type="curve" smooth="yes"/>
-      <point x="998" y="415"/>
-      <point x="977" y="380"/>
-      <point x="932" y="380" type="curve" smooth="yes"/>
-      <point x="891" y="380"/>
-      <point x="866" y="407"/>
-      <point x="866" y="449" type="curve" smooth="yes"/>
-      <point x="866" y="500"/>
-      <point x="901" y="550"/>
-      <point x="992" y="550" type="curve"/>
-      <point x="1000" y="575" type="line"/>
-      <point x="976" y="594"/>
-      <point x="934" y="612"/>
+      <point x="489" y="534"/>
+      <point x="541" y="474"/>
+      <point x="541" y="380" type="curve" smooth="yes"/>
+      <point x="541" y="359"/>
+      <point x="539" y="339"/>
+      <point x="535" y="316" type="curve" smooth="yes"/>
+      <point x="479" y="0" type="line"/>
+      <point x="563" y="0" type="line"/>
+      <point x="622" y="333" type="line" smooth="yes"/>
+      <point x="647" y="475"/>
+      <point x="725" y="548"/>
+      <point x="857" y="548" type="curve" smooth="yes"/>
+      <point x="868" y="548"/>
+      <point x="880" y="547"/>
+      <point x="891" y="546" type="curve"/>
+      <point x="847" y="565" type="line"/>
+      <point x="847" y="538" type="line"/>
+      <point x="809" y="512"/>
+      <point x="784" y="465"/>
+      <point x="784" y="415" type="curve" smooth="yes"/>
+      <point x="784" y="341"/>
+      <point x="837" y="286"/>
+      <point x="918" y="286" type="curve" smooth="yes"/>
+      <point x="1035" y="286"/>
+      <point x="1075" y="375"/>
+      <point x="1075" y="440" type="curve" smooth="yes"/>
+      <point x="1075" y="485"/>
+      <point x="1057" y="522"/>
+      <point x="1027" y="545" type="curve"/>
+      <point x="1045" y="582" type="line"/>
+      <point x="994" y="551" type="line"/>
+      <point x="1003" y="553"/>
+      <point x="1014" y="554"/>
+      <point x="1026" y="554" type="curve" smooth="yes"/>
+      <point x="1105" y="554"/>
+      <point x="1140" y="505"/>
+      <point x="1140" y="436" type="curve" smooth="yes"/>
+      <point x="1140" y="422"/>
+      <point x="1139" y="407"/>
+      <point x="1136" y="390" type="curve" smooth="yes"/>
+      <point x="1126" y="333" type="line"/>
+      <point x="1210" y="333" type="line"/>
+      <point x="1220" y="390" type="line" smooth="yes"/>
+      <point x="1236" y="481"/>
+      <point x="1294" y="534"/>
+      <point x="1375" y="534" type="curve" smooth="yes"/>
+      <point x="1441" y="534"/>
+      <point x="1477" y="499"/>
+      <point x="1477" y="433" type="curve" smooth="yes"/>
+      <point x="1477" y="328"/>
+      <point x="1404" y="264"/>
+      <point x="1261" y="264" type="curve" smooth="yes"/>
+      <point x="925" y="264" type="line" smooth="yes"/>
+      <point x="815" y="264"/>
+      <point x="737" y="207"/>
+      <point x="737" y="114" type="curve" smooth="yes"/>
+      <point x="737" y="34"/>
+      <point x="797" y="-16"/>
+      <point x="884" y="-16" type="curve" smooth="yes"/>
+      <point x="933" y="-16"/>
+      <point x="969" y="-6"/>
+      <point x="1040" y="27" type="curve" smooth="yes"/>
+      <point x="1196" y="99" type="line"/>
+      <point x="1269" y="148" type="line"/>
+      <point x="1297" y="154" type="line"/>
+      <point x="1328" y="172"/>
+      <point x="1350" y="178"/>
+      <point x="1378" y="178" type="curve" smooth="yes"/>
+      <point x="1416" y="178"/>
+      <point x="1433" y="157"/>
+      <point x="1433" y="124" type="curve" smooth="yes"/>
+      <point x="1433" y="92"/>
+      <point x="1413" y="56"/>
+      <point x="1362" y="56" type="curve" smooth="yes"/>
+      <point x="1326" y="56"/>
+      <point x="1305" y="77"/>
+      <point x="1305" y="109" type="curve" smooth="yes"/>
+      <point x="1305" y="140"/>
+      <point x="1319" y="161"/>
+      <point x="1346" y="188" type="curve"/>
+      <point x="1242" y="148" type="line"/>
+      <point x="1258" y="128" type="line"/>
+      <point x="1249" y="114"/>
+      <point x="1244" y="98"/>
+      <point x="1244" y="80" type="curve" smooth="yes"/>
+      <point x="1244" y="22"/>
+      <point x="1288" y="-16"/>
+      <point x="1355" y="-16" type="curve" smooth="yes"/>
+      <point x="1463" y="-16"/>
+      <point x="1504" y="69"/>
+      <point x="1504" y="126" type="curve" smooth="yes"/>
+      <point x="1504" y="189"/>
+      <point x="1465" y="232"/>
+      <point x="1394" y="232" type="curve" smooth="yes"/>
+      <point x="1348" y="232"/>
+      <point x="1309" y="224"/>
+      <point x="1227" y="186" type="curve" smooth="yes"/>
+      <point x="1018" y="89" type="line" smooth="yes"/>
+      <point x="970" y="67"/>
+      <point x="933" y="58"/>
+      <point x="888" y="58" type="curve" smooth="yes"/>
+      <point x="846" y="58"/>
+      <point x="819" y="82"/>
+      <point x="819" y="119" type="curve" smooth="yes"/>
+      <point x="819" y="164"/>
+      <point x="855" y="192"/>
+      <point x="922" y="192" type="curve" smooth="yes"/>
+      <point x="1243" y="192" type="line" smooth="yes"/>
+      <point x="1425" y="192"/>
+      <point x="1559" y="286"/>
+      <point x="1559" y="438" type="curve" smooth="yes"/>
+      <point x="1559" y="546"/>
+      <point x="1497" y="612"/>
+      <point x="1392" y="612" type="curve" smooth="yes"/>
+      <point x="1304" y="612"/>
+      <point x="1239" y="570"/>
+      <point x="1205" y="491" type="curve"/>
+      <point x="1197" y="491" type="line"/>
+      <point x="1180" y="571"/>
+      <point x="1128" y="612"/>
+      <point x="1028" y="612" type="curve" smooth="yes"/>
+      <point x="994" y="612"/>
+      <point x="961" y="607"/>
+      <point x="931" y="596" type="curve"/>
+      <point x="954" y="594" type="line"/>
+      <point x="927" y="604"/>
+      <point x="893" y="612"/>
       <point x="854" y="612" type="curve" smooth="yes"/>
-      <point x="738" y="612"/>
-      <point x="652" y="567"/>
-      <point x="605" y="480" type="curve"/>
-      <point x="595" y="480" type="line"/>
-      <point x="562" y="567"/>
+      <point x="741" y="612"/>
+      <point x="655" y="565"/>
+      <point x="606" y="477" type="curve"/>
+      <point x="596" y="477" type="line"/>
+      <point x="563" y="566"/>
       <point x="489" y="612"/>
       <point x="385" y="612" type="curve" smooth="yes"/>
-      <point x="189" y="612"/>
-      <point x="50" y="449"/>
-      <point x="50" y="229" type="curve" smooth="yes"/>
-      <point x="50" y="79"/>
-      <point x="135" y="-16"/>
+      <point x="147" y="612"/>
+      <point x="49" y="401"/>
+      <point x="49" y="229" type="curve" smooth="yes"/>
+      <point x="49" y="79"/>
+      <point x="128" y="-16"/>
+    </contour>
+    <contour>
+      <point x="924" y="356" type="curve" smooth="yes"/>
+      <point x="884" y="356"/>
+      <point x="861" y="383"/>
+      <point x="861" y="424" type="curve" smooth="yes"/>
+      <point x="861" y="484"/>
+      <point x="903" y="533"/>
+      <point x="986" y="553" type="curve"/>
+      <point x="921" y="553" type="line"/>
+      <point x="979" y="532"/>
+      <point x="1002" y="497"/>
+      <point x="1002" y="446" type="curve" smooth="yes"/>
+      <point x="1002" y="406"/>
+      <point x="977" y="356"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/rr_rra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/rr_rra-malayalam.glif
@@ -1,38 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="rr_rra-malayalam" format="2">
-  <advance width="730"/>
+  <advance width="720"/>
   <anchor x="271" y="-327" name="bottom"/>
   <anchor x="412" y="596" name="top"/>
   <anchor x="623" y="596" name="topright"/>
   <outline>
-    <contour>
-      <point x="154" y="-343" type="curve"/>
-      <point x="209" y="-297" type="line"/>
-      <point x="189" y="-270"/>
-      <point x="166" y="-230"/>
-      <point x="166" y="-160" type="curve" smooth="yes"/>
-      <point x="166" y="-71"/>
-      <point x="210" y="13"/>
-      <point x="319" y="13" type="curve" smooth="yes"/>
-      <point x="387" y="13"/>
-      <point x="438" y="-24"/>
-      <point x="438" y="-109" type="curve" smooth="yes"/>
-      <point x="438" y="-188"/>
-      <point x="395" y="-242"/>
-      <point x="333" y="-292" type="curve"/>
-      <point x="378" y="-343" type="line"/>
-      <point x="463" y="-281"/>
-      <point x="513" y="-208"/>
-      <point x="513" y="-106" type="curve" smooth="yes"/>
-      <point x="513" y="21"/>
-      <point x="434" y="83"/>
-      <point x="318" y="83" type="curve" smooth="yes"/>
-      <point x="165" y="83"/>
-      <point x="91" y="-33"/>
-      <point x="91" y="-161" type="curve" smooth="yes"/>
-      <point x="91" y="-241"/>
-      <point x="114" y="-300"/>
-    </contour>
     <contour>
       <point x="170" y="-16" type="curve"/>
       <point x="228" y="45" type="line"/>
@@ -60,6 +32,34 @@
       <point x="53" y="256" type="curve" smooth="yes"/>
       <point x="53" y="144"/>
       <point x="94" y="48"/>
+    </contour>
+    <contour>
+      <point x="154" y="-343" type="curve"/>
+      <point x="209" y="-297" type="line"/>
+      <point x="189" y="-270"/>
+      <point x="166" y="-230"/>
+      <point x="166" y="-160" type="curve" smooth="yes"/>
+      <point x="166" y="-71"/>
+      <point x="210" y="13"/>
+      <point x="319" y="13" type="curve" smooth="yes"/>
+      <point x="387" y="13"/>
+      <point x="438" y="-24"/>
+      <point x="438" y="-109" type="curve" smooth="yes"/>
+      <point x="438" y="-188"/>
+      <point x="395" y="-242"/>
+      <point x="333" y="-292" type="curve"/>
+      <point x="378" y="-343" type="line"/>
+      <point x="463" y="-281"/>
+      <point x="513" y="-208"/>
+      <point x="513" y="-106" type="curve" smooth="yes"/>
+      <point x="513" y="21"/>
+      <point x="434" y="83"/>
+      <point x="318" y="83" type="curve" smooth="yes"/>
+      <point x="165" y="83"/>
+      <point x="91" y="-33"/>
+      <point x="91" y="-161" type="curve" smooth="yes"/>
+      <point x="91" y="-241"/>
+      <point x="114" y="-300"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/t_la-malayalam.glif
@@ -1,136 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_la-malayalam" format="2">
   <advance width="1005"/>
-  <anchor x="481" y="-357" name="bottom"/>
-  <anchor x="558" y="596" name="top"/>
-  <anchor x="885" y="596" name="topright"/>
+  <anchor x="494" y="-362" name="bottom"/>
+  <anchor x="554" y="596" name="top"/>
+  <anchor x="881" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="277" y="-378" type="curve" smooth="yes"/>
-      <point x="364" y="-378"/>
-      <point x="414" y="-321"/>
-      <point x="414" y="-236" type="curve" smooth="yes"/>
-      <point x="414" y="-156"/>
-      <point x="369" y="-121"/>
-      <point x="303" y="-121" type="curve" smooth="yes"/>
-      <point x="270" y="-121"/>
-      <point x="238" y="-134"/>
-      <point x="214" y="-167" type="curve"/>
-      <point x="204" y="-166" type="line"/>
-      <point x="227" y="-72"/>
-      <point x="288" y="-22"/>
-      <point x="368" y="-22" type="curve" smooth="yes"/>
-      <point x="479" y="-22"/>
-      <point x="501" y="-91"/>
-      <point x="507" y="-180" type="curve" smooth="yes"/>
-      <point x="508" y="-196" type="line" smooth="yes"/>
-      <point x="515" y="-307"/>
-      <point x="559" y="-378"/>
-      <point x="676" y="-378" type="curve" smooth="yes"/>
-      <point x="810" y="-378"/>
-      <point x="860" y="-270"/>
-      <point x="860" y="-132" type="curve" smooth="yes"/>
-      <point x="860" y="-59"/>
-      <point x="838" y="3"/>
-      <point x="812" y="44" type="curve"/>
-      <point x="802" y="18" type="line"/>
-      <point x="901" y="106"/>
-      <point x="949" y="210"/>
-      <point x="949" y="336" type="curve" smooth="yes"/>
-      <point x="949" y="513"/>
-      <point x="853" y="612"/>
-      <point x="683" y="612" type="curve" smooth="yes"/>
-      <point x="477" y="612"/>
-      <point x="295" y="418"/>
-      <point x="295" y="199" type="curve" smooth="yes"/>
-      <point x="295" y="139"/>
-      <point x="310" y="88"/>
-      <point x="348" y="50" type="curve"/>
-      <point x="345" y="40" type="line"/>
-      <point x="210" y="21"/>
-      <point x="131" y="-82"/>
-      <point x="131" y="-209" type="curve" smooth="yes"/>
-      <point x="131" y="-328"/>
-      <point x="196" y="-378"/>
+      <point x="276" y="-378" type="curve" smooth="yes"/>
+      <point x="375" y="-378"/>
+      <point x="421" y="-300"/>
+      <point x="421" y="-234" type="curve" smooth="yes"/>
+      <point x="421" y="-166"/>
+      <point x="386" y="-121"/>
+      <point x="323" y="-121" type="curve" smooth="yes"/>
+      <point x="275" y="-121"/>
+      <point x="209" y="-155"/>
+      <point x="195" y="-236" type="curve"/>
+      <point x="230" y="-175" type="line"/>
+      <point x="171" y="-175" type="line"/>
+      <point x="205" y="-201" type="line"/>
+      <point x="222" y="-94"/>
+      <point x="304" y="-22"/>
+      <point x="388" y="-22" type="curve" smooth="yes"/>
+      <point x="466" y="-22"/>
+      <point x="495" y="-61"/>
+      <point x="511" y="-160" type="curve" smooth="yes"/>
+      <point x="518" y="-203" type="line" smooth="yes"/>
+      <point x="538" y="-323"/>
+      <point x="587" y="-378"/>
+      <point x="678" y="-378" type="curve" smooth="yes"/>
+      <point x="820" y="-378"/>
+      <point x="864" y="-231"/>
+      <point x="864" y="-135" type="curve" smooth="yes"/>
+      <point x="864" y="-59"/>
+      <point x="844" y="0"/>
+      <point x="814" y="46" type="curve"/>
+      <point x="813" y="21" type="line"/>
+      <point x="914" y="132"/>
+      <point x="955" y="249"/>
+      <point x="955" y="362" type="curve" smooth="yes"/>
+      <point x="955" y="515"/>
+      <point x="870" y="612"/>
+      <point x="704" y="612" type="curve" smooth="yes"/>
+      <point x="638" y="612"/>
+      <point x="578" y="595"/>
+      <point x="524" y="567" type="curve"/>
+      <point x="566" y="564" type="line"/>
+      <point x="524" y="594"/>
+      <point x="471" y="612"/>
+      <point x="408" y="612" type="curve" smooth="yes"/>
+      <point x="185" y="612"/>
+      <point x="49" y="429"/>
+      <point x="49" y="235" type="curve" smooth="yes"/>
+      <point x="49" y="143"/>
+      <point x="75" y="58"/>
+      <point x="129" y="-16" type="curve"/>
+      <point x="193" y="31" type="line"/>
+      <point x="149" y="92"/>
+      <point x="131" y="161"/>
+      <point x="131" y="236" type="curve" smooth="yes"/>
+      <point x="131" y="404"/>
+      <point x="233" y="534"/>
+      <point x="399" y="534" type="curve" smooth="yes"/>
+      <point x="431" y="534"/>
+      <point x="459" y="528"/>
+      <point x="484" y="518" type="curve"/>
+      <point x="483" y="542" type="line"/>
+      <point x="361" y="458"/>
+      <point x="285" y="314"/>
+      <point x="285" y="190" type="curve" smooth="yes"/>
+      <point x="285" y="129"/>
+      <point x="306" y="79"/>
+      <point x="338" y="43" type="curve"/>
+      <point x="336" y="32" type="line"/>
+      <point x="214" y="7"/>
+      <point x="138" y="-111"/>
+      <point x="138" y="-227" type="curve" smooth="yes"/>
+      <point x="138" y="-321"/>
+      <point x="198" y="-378"/>
     </contour>
     <contour>
-      <point x="677" y="-308" type="curve" smooth="yes"/>
-      <point x="616" y="-308"/>
-      <point x="592" y="-271"/>
-      <point x="583" y="-176" type="curve" smooth="yes"/>
-      <point x="581" y="-155" type="line" smooth="yes"/>
-      <point x="575" y="-96"/>
-      <point x="562" y="-52"/>
-      <point x="526" y="-17" type="curve"/>
-      <point x="528" y="-7" type="line"/>
-      <point x="638" y="18"/>
-      <point x="701" y="127"/>
-      <point x="701" y="275" type="curve" smooth="yes"/>
-      <point x="701" y="392"/>
-      <point x="660" y="487"/>
-      <point x="589" y="546" type="curve"/>
-      <point x="518" y="503" type="line"/>
-      <point x="581" y="463"/>
-      <point x="615" y="385"/>
-      <point x="615" y="275" type="curve" smooth="yes"/>
-      <point x="615" y="136"/>
-      <point x="570" y="62"/>
-      <point x="484" y="62" type="curve" smooth="yes"/>
-      <point x="413" y="62"/>
-      <point x="377" y="109"/>
-      <point x="377" y="199" type="curve" smooth="yes"/>
-      <point x="377" y="387"/>
-      <point x="510" y="534"/>
-      <point x="681" y="534" type="curve" smooth="yes"/>
-      <point x="803" y="534"/>
-      <point x="867" y="466"/>
-      <point x="867" y="336" type="curve" smooth="yes"/>
-      <point x="867" y="218"/>
-      <point x="818" y="128"/>
-      <point x="722" y="43" type="curve"/>
-      <point x="746" y="11"/>
-      <point x="784" y="-52"/>
-      <point x="784" y="-145" type="curve" smooth="yes"/>
-      <point x="784" y="-228"/>
-      <point x="756" y="-308"/>
+      <point x="279" y="-313" type="curve" smooth="yes"/>
+      <point x="233" y="-313"/>
+      <point x="205" y="-276"/>
+      <point x="205" y="-227" type="curve" smooth="yes"/>
+      <point x="205" y="-219"/>
+      <point x="206" y="-211"/>
+      <point x="208" y="-203" type="curve"/>
+      <point x="188" y="-218" type="line"/>
+      <point x="197" y="-268" type="line"/>
+      <point x="205" y="-224"/>
+      <point x="246" y="-181"/>
+      <point x="299" y="-181" type="curve" smooth="yes"/>
+      <point x="335" y="-181"/>
+      <point x="351" y="-202"/>
+      <point x="351" y="-236" type="curve" smooth="yes"/>
+      <point x="351" y="-270"/>
+      <point x="332" y="-313"/>
     </contour>
     <contour>
-      <point x="276" y="-313" type="curve" smooth="yes"/>
-      <point x="222" y="-313"/>
-      <point x="199" y="-270"/>
-      <point x="199" y="-223" type="curve"/>
-      <point x="181" y="-200" type="line"/>
-      <point x="192" y="-256" type="line"/>
-      <point x="199" y="-216"/>
-      <point x="233" y="-181"/>
-      <point x="282" y="-181" type="curve" smooth="yes"/>
-      <point x="324" y="-181"/>
-      <point x="343" y="-201"/>
-      <point x="343" y="-240" type="curve" smooth="yes"/>
-      <point x="343" y="-282"/>
-      <point x="320" y="-313"/>
+      <point x="468" y="62" type="curve" smooth="yes"/>
+      <point x="403" y="62"/>
+      <point x="368" y="107"/>
+      <point x="368" y="193" type="curve" smooth="yes"/>
+      <point x="368" y="308"/>
+      <point x="437" y="431"/>
+      <point x="544" y="493" type="curve"/>
+      <point x="521" y="497" type="line"/>
+      <point x="578" y="454"/>
+      <point x="606" y="379"/>
+      <point x="606" y="292" type="curve" smooth="yes"/>
+      <point x="606" y="194"/>
+      <point x="565" y="62"/>
     </contour>
     <contour>
-      <point x="137" y="-16" type="curve"/>
-      <point x="203" y="32" type="line"/>
-      <point x="159" y="87"/>
-      <point x="134" y="165"/>
-      <point x="134" y="248" type="curve" smooth="yes"/>
-      <point x="134" y="421"/>
-      <point x="237" y="534"/>
-      <point x="395" y="534" type="curve" smooth="yes"/>
-      <point x="444" y="534"/>
-      <point x="485" y="523"/>
-      <point x="518" y="503" type="curve"/>
-      <point x="589" y="546" type="line"/>
-      <point x="539" y="588"/>
-      <point x="474" y="612"/>
-      <point x="399" y="612" type="curve" smooth="yes"/>
-      <point x="194" y="612"/>
-      <point x="52" y="463"/>
-      <point x="52" y="248" type="curve" smooth="yes"/>
-      <point x="52" y="143"/>
-      <point x="80" y="56"/>
+      <point x="685" y="-308" type="curve" smooth="yes"/>
+      <point x="629" y="-308"/>
+      <point x="604" y="-274"/>
+      <point x="590" y="-188" type="curve" smooth="yes"/>
+      <point x="583" y="-145" type="line" smooth="yes"/>
+      <point x="571" y="-69"/>
+      <point x="561" y="-28"/>
+      <point x="533" y="-3" type="curve"/>
+      <point x="535" y="8" type="line"/>
+      <point x="653" y="48"/>
+      <point x="692" y="187"/>
+      <point x="692" y="290" type="curve" smooth="yes"/>
+      <point x="692" y="394"/>
+      <point x="655" y="489"/>
+      <point x="586" y="549" type="curve"/>
+      <point x="597" y="518" type="line"/>
+      <point x="627" y="528"/>
+      <point x="660" y="534"/>
+      <point x="694" y="534" type="curve" smooth="yes"/>
+      <point x="825" y="534"/>
+      <point x="872" y="467"/>
+      <point x="872" y="358" type="curve" smooth="yes"/>
+      <point x="872" y="257"/>
+      <point x="822" y="148"/>
+      <point x="713" y="45" type="curve"/>
+      <point x="766" y="-8"/>
+      <point x="790" y="-65"/>
+      <point x="790" y="-139" type="curve" smooth="yes"/>
+      <point x="790" y="-202"/>
+      <point x="771" y="-308"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ta-malayalam.glif
@@ -2,61 +2,61 @@
 <glyph name="ta-malayalam" format="2">
   <advance width="1005"/>
   <unicode hex="0D24"/>
-  <anchor x="548" y="0" name="bottom"/>
-  <anchor x="558" y="596" name="top"/>
-  <anchor x="885" y="596" name="topright"/>
+  <anchor x="542" y="0" name="bottom"/>
+  <anchor x="554" y="596" name="top"/>
+  <anchor x="881" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="137" y="-16" type="curve"/>
-      <point x="203" y="32" type="line"/>
-      <point x="159" y="87"/>
-      <point x="134" y="165"/>
-      <point x="134" y="248" type="curve" smooth="yes"/>
-      <point x="134" y="421"/>
-      <point x="237" y="534"/>
-      <point x="395" y="534" type="curve" smooth="yes"/>
-      <point x="537" y="534"/>
-      <point x="615" y="443"/>
-      <point x="615" y="275" type="curve" smooth="yes"/>
-      <point x="615" y="136"/>
-      <point x="570" y="62"/>
-      <point x="484" y="62" type="curve" smooth="yes"/>
-      <point x="413" y="62"/>
-      <point x="377" y="109"/>
-      <point x="377" y="199" type="curve" smooth="yes"/>
-      <point x="377" y="387"/>
-      <point x="510" y="534"/>
-      <point x="681" y="534" type="curve" smooth="yes"/>
-      <point x="803" y="534"/>
-      <point x="867" y="466"/>
-      <point x="867" y="336" type="curve" smooth="yes"/>
-      <point x="867" y="218"/>
-      <point x="818" y="128"/>
-      <point x="709" y="48" type="curve"/>
-      <point x="760" y="-16" type="line"/>
-      <point x="888" y="79"/>
-      <point x="949" y="193"/>
-      <point x="949" y="336" type="curve" smooth="yes"/>
-      <point x="949" y="513"/>
-      <point x="853" y="612"/>
-      <point x="683" y="612" type="curve" smooth="yes"/>
-      <point x="477" y="612"/>
-      <point x="295" y="418"/>
-      <point x="295" y="199" type="curve" smooth="yes"/>
-      <point x="295" y="62"/>
-      <point x="364" y="-16"/>
-      <point x="484" y="-16" type="curve" smooth="yes"/>
-      <point x="614" y="-16"/>
-      <point x="701" y="100"/>
-      <point x="701" y="275" type="curve" smooth="yes"/>
-      <point x="701" y="475"/>
-      <point x="579" y="612"/>
-      <point x="399" y="612" type="curve" smooth="yes"/>
-      <point x="194" y="612"/>
-      <point x="52" y="463"/>
-      <point x="52" y="248" type="curve" smooth="yes"/>
-      <point x="52" y="143"/>
-      <point x="80" y="56"/>
+      <point x="129" y="-16" type="curve"/>
+      <point x="193" y="31" type="line"/>
+      <point x="149" y="92"/>
+      <point x="131" y="161"/>
+      <point x="131" y="236" type="curve" smooth="yes"/>
+      <point x="131" y="404"/>
+      <point x="233" y="534"/>
+      <point x="399" y="534" type="curve" smooth="yes"/>
+      <point x="540" y="534"/>
+      <point x="606" y="426"/>
+      <point x="606" y="292" type="curve" smooth="yes"/>
+      <point x="606" y="194"/>
+      <point x="565" y="62"/>
+      <point x="468" y="62" type="curve" smooth="yes"/>
+      <point x="403" y="62"/>
+      <point x="368" y="107"/>
+      <point x="368" y="193" type="curve" smooth="yes"/>
+      <point x="368" y="355"/>
+      <point x="506" y="534"/>
+      <point x="694" y="534" type="curve" smooth="yes"/>
+      <point x="823" y="534"/>
+      <point x="870" y="467"/>
+      <point x="870" y="358" type="curve" smooth="yes"/>
+      <point x="870" y="257"/>
+      <point x="820" y="148"/>
+      <point x="711" y="45" type="curve"/>
+      <point x="774" y="-16" type="line"/>
+      <point x="902" y="105"/>
+      <point x="953" y="236"/>
+      <point x="953" y="362" type="curve" smooth="yes"/>
+      <point x="953" y="515"/>
+      <point x="869" y="612"/>
+      <point x="704" y="612" type="curve" smooth="yes"/>
+      <point x="460" y="612"/>
+      <point x="285" y="378"/>
+      <point x="285" y="190" type="curve" smooth="yes"/>
+      <point x="285" y="66"/>
+      <point x="354" y="-16"/>
+      <point x="461" y="-16" type="curve" smooth="yes"/>
+      <point x="630" y="-16"/>
+      <point x="692" y="162"/>
+      <point x="692" y="290" type="curve" smooth="yes"/>
+      <point x="692" y="462"/>
+      <point x="591" y="612"/>
+      <point x="408" y="612" type="curve" smooth="yes"/>
+      <point x="185" y="612"/>
+      <point x="49" y="429"/>
+      <point x="49" y="235" type="curve" smooth="yes"/>
+      <point x="49" y="143"/>
+      <point x="75" y="58"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1005"/>
   <outline>
     <component base="ta-malayalam"/>
-    <component base="halant-malayalam" xOffset="805"/>
+    <component base="halant-malayalam" xOffset="801"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="597"/>
-  <anchor x="300" y="0" name="bottom"/>
-  <anchor x="282" y="596" name="top"/>
-  <anchor x="421" y="596" name="topright"/>
+  <anchor x="229" y="-271" name="bottom"/>
+  <anchor x="349" y="596" name="top"/>
+  <anchor x="488" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="234" y="-225" type="curve" smooth="yes"/>
-      <point x="400" y="-225"/>
-      <point x="493" y="-177"/>
-      <point x="493" y="-78" type="curve" smooth="yes"/>
-      <point x="493" y="-21"/>
-      <point x="462" y="12"/>
-      <point x="402" y="28" type="curve"/>
-      <point x="403" y="38" type="line"/>
-      <point x="488" y="58"/>
-      <point x="530" y="123"/>
-      <point x="530" y="198" type="curve" smooth="yes"/>
-      <point x="530" y="289"/>
-      <point x="484" y="348"/>
-      <point x="354" y="355" type="curve" smooth="yes"/>
-      <point x="258" y="360" type="line" smooth="yes"/>
-      <point x="185" y="364"/>
-      <point x="152" y="392"/>
-      <point x="152" y="438" type="curve" smooth="yes"/>
-      <point x="152" y="496"/>
-      <point x="205" y="532"/>
-      <point x="304" y="532" type="curve" smooth="yes"/>
-      <point x="396" y="532"/>
-      <point x="454" y="511"/>
-      <point x="513" y="479" type="curve"/>
-      <point x="556" y="550" type="line"/>
-      <point x="490" y="587"/>
-      <point x="414" y="612"/>
-      <point x="314" y="612" type="curve" smooth="yes"/>
-      <point x="163" y="612"/>
-      <point x="64" y="549"/>
-      <point x="64" y="428" type="curve" smooth="yes"/>
-      <point x="64" y="339"/>
-      <point x="122" y="288"/>
-      <point x="223" y="273" type="curve"/>
-      <point x="344" y="266" type="line" smooth="yes"/>
-      <point x="420" y="262"/>
-      <point x="444" y="231"/>
-      <point x="444" y="183" type="curve" smooth="yes"/>
-      <point x="444" y="113"/>
-      <point x="388" y="80"/>
-      <point x="304" y="80" type="curve" smooth="yes"/>
-      <point x="48" y="80" type="line"/>
-      <point x="35" y="6" type="line"/>
-      <point x="238" y="6" type="line" smooth="yes"/>
-      <point x="362" y="6"/>
-      <point x="411" y="-27"/>
-      <point x="411" y="-71" type="curve" smooth="yes"/>
-      <point x="411" y="-127"/>
-      <point x="354" y="-147"/>
-      <point x="247" y="-147" type="curve" smooth="yes"/>
-      <point x="144" y="-147"/>
-      <point x="72" y="-125"/>
-      <point x="17" y="-98" type="curve"/>
-      <point x="-28" y="-165" type="line"/>
-      <point x="27" y="-197"/>
-      <point x="125" y="-225"/>
+      <point x="213" y="-277" type="curve" smooth="yes"/>
+      <point x="394" y="-277"/>
+      <point x="481" y="-183"/>
+      <point x="481" y="-84" type="curve" smooth="yes"/>
+      <point x="481" y="-23"/>
+      <point x="455" y="17"/>
+      <point x="398" y="39" type="curve"/>
+      <point x="399" y="49" type="line"/>
+      <point x="478" y="69"/>
+      <point x="524" y="121"/>
+      <point x="524" y="192" type="curve" smooth="yes"/>
+      <point x="524" y="285"/>
+      <point x="471" y="341"/>
+      <point x="347" y="353" type="curve" smooth="yes"/>
+      <point x="241" y="363" type="line" smooth="yes"/>
+      <point x="177" y="369"/>
+      <point x="150" y="394"/>
+      <point x="150" y="439" type="curve" smooth="yes"/>
+      <point x="150" y="491"/>
+      <point x="196" y="534"/>
+      <point x="310" y="534" type="curve" smooth="yes"/>
+      <point x="395" y="534"/>
+      <point x="459" y="518"/>
+      <point x="525" y="484" type="curve"/>
+      <point x="561" y="553" type="line"/>
+      <point x="482" y="594"/>
+      <point x="408" y="612"/>
+      <point x="317" y="612" type="curve" smooth="yes"/>
+      <point x="136" y="612"/>
+      <point x="64" y="522"/>
+      <point x="64" y="430" type="curve" smooth="yes"/>
+      <point x="64" y="342"/>
+      <point x="124" y="284"/>
+      <point x="221" y="275" type="curve" smooth="yes"/>
+      <point x="327" y="265" type="line" smooth="yes"/>
+      <point x="410" y="257"/>
+      <point x="438" y="231"/>
+      <point x="438" y="181" type="curve" smooth="yes"/>
+      <point x="438" y="117"/>
+      <point x="380" y="80"/>
+      <point x="278" y="80" type="curve" smooth="yes"/>
+      <point x="44" y="80" type="line"/>
+      <point x="31" y="6" type="line"/>
+      <point x="278" y="6" type="line" smooth="yes"/>
+      <point x="367" y="6"/>
+      <point x="400" y="-28"/>
+      <point x="400" y="-84" type="curve" smooth="yes"/>
+      <point x="400" y="-140"/>
+      <point x="354" y="-199"/>
+      <point x="220" y="-199" type="curve" smooth="yes"/>
+      <point x="137" y="-199"/>
+      <point x="62" y="-176"/>
+      <point x="7" y="-132" type="curve"/>
+      <point x="-40" y="-192" type="line"/>
+      <point x="30" y="-247"/>
+      <point x="118" y="-277"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/tta-malayalam.glif
@@ -2,51 +2,51 @@
 <glyph name="tta-malayalam" format="2">
   <advance width="599"/>
   <unicode hex="0D1F"/>
-  <anchor x="254" y="0" name="bottom"/>
-  <anchor x="340" y="596" name="top"/>
-  <anchor x="479" y="596" name="topright"/>
+  <anchor x="260" y="0" name="bottom"/>
+  <anchor x="348" y="596" name="top"/>
+  <anchor x="487" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="280" y="-16" type="curve" smooth="yes"/>
-      <point x="418" y="-16"/>
-      <point x="524" y="41"/>
-      <point x="524" y="178" type="curve" smooth="yes"/>
-      <point x="524" y="279"/>
-      <point x="467" y="337"/>
-      <point x="341" y="343" type="curve" smooth="yes"/>
-      <point x="255" y="347" type="line" smooth="yes"/>
-      <point x="177" y="351"/>
-      <point x="148" y="385"/>
-      <point x="148" y="429" type="curve" smooth="yes"/>
-      <point x="148" y="492"/>
-      <point x="201" y="532"/>
-      <point x="301" y="532" type="curve" smooth="yes"/>
-      <point x="393" y="532"/>
-      <point x="451" y="511"/>
-      <point x="510" y="479" type="curve"/>
-      <point x="553" y="550" type="line"/>
-      <point x="487" y="587"/>
-      <point x="411" y="612"/>
-      <point x="311" y="612" type="curve" smooth="yes"/>
-      <point x="167" y="612"/>
-      <point x="62" y="549"/>
-      <point x="62" y="416" type="curve" smooth="yes"/>
-      <point x="62" y="328"/>
-      <point x="114" y="264"/>
-      <point x="239" y="258" type="curve" smooth="yes"/>
-      <point x="320" y="254" type="line" smooth="yes"/>
-      <point x="407" y="250"/>
-      <point x="438" y="223"/>
-      <point x="438" y="168" type="curve" smooth="yes"/>
-      <point x="438" y="97"/>
-      <point x="375" y="65"/>
-      <point x="289" y="65" type="curve" smooth="yes"/>
-      <point x="191" y="65"/>
-      <point x="126" y="99"/>
-      <point x="59" y="151" type="curve"/>
-      <point x="3" y="80" type="line"/>
-      <point x="77" y="20"/>
-      <point x="168" y="-16"/>
+      <point x="276" y="-16" type="curve" smooth="yes"/>
+      <point x="453" y="-16"/>
+      <point x="528" y="75"/>
+      <point x="528" y="172" type="curve" smooth="yes"/>
+      <point x="528" y="270"/>
+      <point x="471" y="329"/>
+      <point x="363" y="339" type="curve" smooth="yes"/>
+      <point x="252" y="349" type="line" smooth="yes"/>
+      <point x="186" y="355"/>
+      <point x="155" y="378"/>
+      <point x="155" y="429" type="curve" smooth="yes"/>
+      <point x="155" y="484"/>
+      <point x="207" y="532"/>
+      <point x="329" y="532" type="curve" smooth="yes"/>
+      <point x="403" y="532"/>
+      <point x="468" y="517"/>
+      <point x="527" y="485" type="curve"/>
+      <point x="563" y="556" type="line"/>
+      <point x="490" y="595"/>
+      <point x="422" y="612"/>
+      <point x="337" y="612" type="curve" smooth="yes"/>
+      <point x="136" y="612"/>
+      <point x="69" y="509"/>
+      <point x="69" y="421" type="curve" smooth="yes"/>
+      <point x="69" y="332"/>
+      <point x="127" y="271"/>
+      <point x="234" y="261" type="curve" smooth="yes"/>
+      <point x="345" y="251" type="line" smooth="yes"/>
+      <point x="413" y="245"/>
+      <point x="442" y="215"/>
+      <point x="442" y="164" type="curve" smooth="yes"/>
+      <point x="442" y="115"/>
+      <point x="398" y="64"/>
+      <point x="284" y="64" type="curve" smooth="yes"/>
+      <point x="193" y="64"/>
+      <point x="114" y="96"/>
+      <point x="51" y="144" type="curve"/>
+      <point x="-1" y="76" type="line"/>
+      <point x="78" y="17"/>
+      <point x="172" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/tta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/tta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="599"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="halant-malayalam" xOffset="399"/>
+    <component base="halant-malayalam" xOffset="407"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="599"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="301"/>
+    <component base="lVocalicMatra-malayalam" xOffset="307"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="599"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="302"/>
+    <component base="llVocalicMatra-malayalam" xOffset="308"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/uuM_atra-malayalam.glif
@@ -4,65 +4,71 @@
   <unicode hex="0D42"/>
   <outline>
     <contour>
-      <point x="42" y="31" type="curve"/>
-      <point x="126" y="31" type="line"/>
-      <point x="208" y="171"/>
-      <point x="254" y="309"/>
-      <point x="254" y="411" type="curve" smooth="yes"/>
-      <point x="254" y="532"/>
-      <point x="193" y="600"/>
-      <point x="76" y="610" type="curve" smooth="yes"/>
-      <point x="52" y="612" type="line"/>
-      <point x="38" y="534" type="line"/>
-      <point x="131" y="527"/>
-      <point x="172" y="489"/>
-      <point x="172" y="408" type="curve" smooth="yes"/>
-      <point x="172" y="307"/>
-      <point x="120" y="157"/>
+      <point x="52" y="34" type="curve"/>
+      <point x="134" y="34" type="line"/>
+      <point x="211" y="160"/>
+      <point x="263" y="312"/>
+      <point x="263" y="411" type="curve" smooth="yes"/>
+      <point x="263" y="541"/>
+      <point x="200" y="612"/>
+      <point x="80" y="612" type="curve" smooth="yes"/>
+      <point x="60" y="612" type="line"/>
+      <point x="46" y="535" type="line"/>
+      <point x="140" y="535"/>
+      <point x="181" y="499"/>
+      <point x="181" y="409" type="curve" smooth="yes"/>
+      <point x="181" y="311"/>
+      <point x="128" y="158"/>
     </contour>
     <contour>
-      <point x="73" y="-259" type="curve" smooth="yes"/>
-      <point x="179" y="-259"/>
-      <point x="259" y="-183"/>
-      <point x="259" y="-82" type="curve" smooth="yes"/>
-      <point x="259" y="12"/>
-      <point x="186" y="82"/>
-      <point x="88" y="82" type="curve" smooth="yes"/>
-      <point x="-15" y="82"/>
+      <point x="72" y="-185" type="curve" smooth="yes"/>
+      <point x="11" y="-185"/>
+      <point x="-31" y="-150"/>
+      <point x="-31" y="-99" type="curve" smooth="yes"/>
+      <point x="-31" y="-84"/>
+      <point x="-29" y="-74"/>
+      <point x="-24" y="-63" type="curve"/>
+      <point x="-18" y="-63" type="line"/>
+      <point x="-4" y="-101"/>
+      <point x="30" y="-127"/>
+      <point x="78" y="-127" type="curve" smooth="yes"/>
+      <point x="125" y="-127"/>
+      <point x="160" y="-103"/>
+      <point x="182" y="-63" type="curve"/>
+      <point x="187" y="-63" type="line"/>
+      <point x="188" y="-69"/>
+      <point x="188" y="-77"/>
+      <point x="188" y="-82" type="curve" smooth="yes"/>
+      <point x="188" y="-127"/>
+      <point x="161" y="-185"/>
+    </contour>
+    <contour>
+      <point x="70" y="-259" type="curve" smooth="yes"/>
+      <point x="174" y="-259"/>
+      <point x="253" y="-183"/>
+      <point x="253" y="-82" type="curve" smooth="yes"/>
+      <point x="253" y="12"/>
+      <point x="181" y="82"/>
+      <point x="85" y="82" type="curve" smooth="yes"/>
+      <point x="-16" y="82"/>
       <point x="-99" y="2"/>
       <point x="-99" y="-97" type="curve" smooth="yes"/>
       <point x="-99" y="-193"/>
-      <point x="-28" y="-259"/>
+      <point x="-29" y="-259"/>
     </contour>
     <contour>
-      <point x="75" y="-185" type="curve" smooth="yes"/>
-      <point x="11" y="-185"/>
-      <point x="-27" y="-149"/>
-      <point x="-27" y="-91" type="curve" smooth="yes"/>
-      <point x="-27" y="-28"/>
-      <point x="19" y="17"/>
-      <point x="86" y="17" type="curve" smooth="yes"/>
-      <point x="147" y="17"/>
-      <point x="187" y="-21"/>
-      <point x="187" y="-78" type="curve" smooth="yes"/>
-      <point x="187" y="-140"/>
-      <point x="141" y="-185"/>
-    </contour>
-    <contour>
-      <point x="104" y="-113" type="curve" smooth="yes"/>
-      <point x="144" y="-113"/>
-      <point x="180" y="-106"/>
-      <point x="215" y="-87" type="curve"/>
-      <point x="198" y="-49" type="line"/>
-      <point x="182" y="-52"/>
-      <point x="164" y="-53"/>
-      <point x="144" y="-53" type="curve" smooth="yes"/>
-      <point x="99" y="-53"/>
-      <point x="17" y="-45"/>
-      <point x="-21" y="-30" type="curve"/>
-      <point x="-49" y="-62" type="line"/>
-      <point x="-9" y="-96"/>
-      <point x="45" y="-113"/>
+      <point x="77" y="-57" type="curve" smooth="yes"/>
+      <point x="38" y="-57"/>
+      <point x="9" y="-38"/>
+      <point x="9" y="-13" type="curve" smooth="yes"/>
+      <point x="9" y="8"/>
+      <point x="36" y="24"/>
+      <point x="94" y="24" type="curve" smooth="yes"/>
+      <point x="146" y="24"/>
+      <point x="163" y="12"/>
+      <point x="163" y="-7" type="curve" smooth="yes"/>
+      <point x="163" y="-33"/>
+      <point x="129" y="-57"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/y_ya-malayalam.glif
@@ -1,96 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="1008"/>
-  <anchor x="495" y="-322" name="bottom"/>
-  <anchor x="573" y="596" name="top"/>
-  <anchor x="879" y="596" name="topright"/>
+  <anchor x="507" y="-306" name="bottom"/>
+  <anchor x="568" y="596" name="top"/>
+  <anchor x="874" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="207" y="-322" type="line"/>
-      <point x="779" y="-322" type="line"/>
-      <point x="846" y="72" type="line"/>
-      <point x="828" y="37" type="line"/>
-      <point x="916" y="99"/>
-      <point x="969" y="211"/>
-      <point x="969" y="351" type="curve" smooth="yes"/>
-      <point x="969" y="455"/>
-      <point x="944" y="542"/>
-      <point x="894" y="612" type="curve"/>
-      <point x="825" y="569" type="line"/>
-      <point x="866" y="513"/>
-      <point x="887" y="439"/>
-      <point x="887" y="351" type="curve" smooth="yes"/>
-      <point x="887" y="178"/>
-      <point x="792" y="62"/>
-      <point x="651" y="62" type="curve" smooth="yes"/>
-      <point x="514" y="62"/>
-      <point x="432" y="158"/>
-      <point x="432" y="319" type="curve" smooth="yes"/>
-      <point x="432" y="447"/>
-      <point x="484" y="534"/>
-      <point x="560" y="534" type="curve" smooth="yes"/>
-      <point x="616" y="534"/>
-      <point x="643" y="494"/>
-      <point x="643" y="412" type="curve" smooth="yes"/>
-      <point x="643" y="281"/>
-      <point x="580" y="162"/>
-      <point x="476" y="96" type="curve"/>
-      <point x="524" y="37" type="line"/>
-      <point x="658" y="124"/>
-      <point x="725" y="248"/>
-      <point x="725" y="412" type="curve" smooth="yes"/>
-      <point x="725" y="544"/>
-      <point x="674" y="612"/>
-      <point x="576" y="612" type="curve" smooth="yes"/>
-      <point x="445" y="612"/>
-      <point x="352" y="490"/>
-      <point x="352" y="317" type="curve" smooth="yes"/>
-      <point x="352" y="125"/>
-      <point x="480" y="-16"/>
-      <point x="651" y="-16" type="curve" smooth="yes"/>
-      <point x="659" y="-16"/>
-      <point x="666" y="-16"/>
-      <point x="674" y="-15" type="curve"/>
-      <point x="611" y="29" type="line"/>
-      <point x="622" y="-25" type="line"/>
-      <point x="536" y="-72" type="line"/>
-      <point x="217" y="-264" type="line"/>
+      <point x="202" y="-306" type="line"/>
+      <point x="772" y="-306" type="line"/>
+      <point x="845" y="105" type="line"/>
+      <point x="824" y="67" type="line"/>
+      <point x="913" y="142"/>
+      <point x="959" y="256"/>
+      <point x="959" y="357" type="curve" smooth="yes"/>
+      <point x="959" y="449"/>
+      <point x="930" y="539"/>
+      <point x="877" y="612" type="curve"/>
+      <point x="810" y="566" type="line"/>
+      <point x="856" y="502"/>
+      <point x="879" y="434"/>
+      <point x="879" y="358" type="curve" smooth="yes"/>
+      <point x="879" y="225"/>
+      <point x="794" y="62"/>
+      <point x="623" y="62" type="curve" smooth="yes"/>
+      <point x="474" y="62"/>
+      <point x="389" y="157"/>
+      <point x="389" y="308" type="curve" smooth="yes"/>
+      <point x="389" y="399"/>
+      <point x="435" y="534"/>
+      <point x="557" y="534" type="curve" smooth="yes"/>
+      <point x="618" y="534"/>
+      <point x="650" y="488"/>
+      <point x="650" y="405" type="curve" smooth="yes"/>
+      <point x="650" y="301"/>
+      <point x="576" y="164"/>
+      <point x="459" y="102" type="curve"/>
+      <point x="512" y="53" type="line"/>
+      <point x="652" y="128"/>
+      <point x="732" y="293"/>
+      <point x="732" y="412" type="curve" smooth="yes"/>
+      <point x="732" y="536"/>
+      <point x="672" y="612"/>
+      <point x="564" y="612" type="curve" smooth="yes"/>
+      <point x="402" y="612"/>
+      <point x="308" y="448"/>
+      <point x="308" y="314" type="curve" smooth="yes"/>
+      <point x="308" y="132"/>
+      <point x="434" y="-12"/>
+      <point x="615" y="-12" type="curve" smooth="yes"/>
+      <point x="642" y="-12"/>
+      <point x="667" y="-9"/>
+      <point x="690" y="-4" type="curve"/>
+      <point x="598" y="29" type="line"/>
+      <point x="594" y="-23" type="line"/>
+      <point x="522" y="-57" type="line"/>
+      <point x="213" y="-248" type="line"/>
     </contour>
     <contour>
-      <point x="295" y="-295" type="line"/>
-      <point x="774" y="-5" type="line"/>
-      <point x="751" y="-5" type="line"/>
-      <point x="704" y="-270" type="line"/>
-      <point x="741" y="-257" type="line"/>
-      <point x="302" y="-257" type="line"/>
+      <point x="296" y="-277" type="line"/>
+      <point x="770" y="15" type="line"/>
+      <point x="747" y="15" type="line"/>
+      <point x="700" y="-254" type="line"/>
+      <point x="737" y="-241" type="line"/>
+      <point x="302" y="-241" type="line"/>
     </contour>
     <contour>
-      <point x="342" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="455" y="-2"/>
-      <point x="507" y="31" type="curve"/>
-      <point x="453" y="85" type="line"/>
-      <point x="420" y="69"/>
-      <point x="389" y="62"/>
-      <point x="346" y="62" type="curve" smooth="yes"/>
-      <point x="216" y="62"/>
-      <point x="141" y="148"/>
-      <point x="141" y="295" type="curve" smooth="yes"/>
-      <point x="141" y="441"/>
-      <point x="209" y="535"/>
-      <point x="314" y="535" type="curve" smooth="yes"/>
-      <point x="361" y="535"/>
-      <point x="391" y="520"/>
-      <point x="416" y="484" type="curve"/>
-      <point x="464" y="534" type="line"/>
-      <point x="435" y="586"/>
-      <point x="385" y="612"/>
-      <point x="314" y="612" type="curve" smooth="yes"/>
-      <point x="163" y="612"/>
-      <point x="61" y="483"/>
-      <point x="61" y="293" type="curve" smooth="yes"/>
-      <point x="61" y="102"/>
-      <point x="169" y="-16"/>
+      <point x="323" y="-16" type="curve" smooth="yes"/>
+      <point x="383" y="-16"/>
+      <point x="440" y="0"/>
+      <point x="486" y="35" type="curve"/>
+      <point x="434" y="90" type="line"/>
+      <point x="405" y="71"/>
+      <point x="375" y="62"/>
+      <point x="338" y="62" type="curve" smooth="yes"/>
+      <point x="210" y="62"/>
+      <point x="136" y="142"/>
+      <point x="136" y="275" type="curve" smooth="yes"/>
+      <point x="136" y="377"/>
+      <point x="187" y="534"/>
+      <point x="322" y="534" type="curve" smooth="yes"/>
+      <point x="364" y="534"/>
+      <point x="387" y="522"/>
+      <point x="411" y="493" type="curve"/>
+      <point x="471" y="542" type="line"/>
+      <point x="433" y="591"/>
+      <point x="392" y="612"/>
+      <point x="332" y="612" type="curve" smooth="yes"/>
+      <point x="133" y="612"/>
+      <point x="56" y="415"/>
+      <point x="56" y="277" type="curve" smooth="yes"/>
+      <point x="56" y="104"/>
+      <point x="160" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ya-malayalam.glif
@@ -2,78 +2,78 @@
 <glyph name="ya-malayalam" format="2">
   <advance width="1008"/>
   <unicode hex="0D2F"/>
-  <anchor x="553" y="0" name="bottom"/>
-  <anchor x="810" y="-16" name="bottomright"/>
-  <anchor x="573" y="596" name="top"/>
-  <anchor x="879" y="596" name="topright"/>
+  <anchor x="546" y="0" name="bottom"/>
+  <anchor x="804" y="-16" name="bottomright"/>
+  <anchor x="568" y="596" name="top"/>
+  <anchor x="874" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="653" y="-16" type="curve" smooth="yes"/>
+      <point x="615" y="-16" type="curve" smooth="yes"/>
       <point x="841" y="-16"/>
-      <point x="969" y="133"/>
-      <point x="969" y="351" type="curve" smooth="yes"/>
-      <point x="969" y="455"/>
-      <point x="944" y="542"/>
-      <point x="894" y="612" type="curve"/>
-      <point x="825" y="569" type="line"/>
-      <point x="866" y="513"/>
-      <point x="887" y="439"/>
-      <point x="887" y="351" type="curve" smooth="yes"/>
-      <point x="887" y="178"/>
-      <point x="792" y="62"/>
-      <point x="651" y="62" type="curve" smooth="yes"/>
-      <point x="514" y="62"/>
-      <point x="432" y="158"/>
-      <point x="432" y="319" type="curve" smooth="yes"/>
-      <point x="432" y="447"/>
-      <point x="484" y="534"/>
-      <point x="560" y="534" type="curve" smooth="yes"/>
-      <point x="616" y="534"/>
-      <point x="643" y="494"/>
-      <point x="643" y="412" type="curve" smooth="yes"/>
-      <point x="643" y="281"/>
-      <point x="580" y="162"/>
-      <point x="476" y="96" type="curve"/>
-      <point x="524" y="37" type="line"/>
-      <point x="658" y="124"/>
-      <point x="725" y="248"/>
-      <point x="725" y="412" type="curve" smooth="yes"/>
-      <point x="725" y="544"/>
-      <point x="674" y="612"/>
-      <point x="576" y="612" type="curve" smooth="yes"/>
-      <point x="445" y="612"/>
-      <point x="352" y="490"/>
-      <point x="352" y="317" type="curve" smooth="yes"/>
-      <point x="352" y="126"/>
-      <point x="480" y="-16"/>
+      <point x="959" y="188"/>
+      <point x="959" y="357" type="curve" smooth="yes"/>
+      <point x="959" y="449"/>
+      <point x="930" y="539"/>
+      <point x="877" y="612" type="curve"/>
+      <point x="810" y="566" type="line"/>
+      <point x="856" y="502"/>
+      <point x="879" y="434"/>
+      <point x="879" y="358" type="curve" smooth="yes"/>
+      <point x="879" y="225"/>
+      <point x="794" y="62"/>
+      <point x="623" y="62" type="curve" smooth="yes"/>
+      <point x="474" y="62"/>
+      <point x="389" y="157"/>
+      <point x="389" y="308" type="curve" smooth="yes"/>
+      <point x="389" y="399"/>
+      <point x="435" y="534"/>
+      <point x="557" y="534" type="curve" smooth="yes"/>
+      <point x="618" y="534"/>
+      <point x="650" y="488"/>
+      <point x="650" y="405" type="curve" smooth="yes"/>
+      <point x="650" y="301"/>
+      <point x="576" y="164"/>
+      <point x="459" y="102" type="curve"/>
+      <point x="512" y="53" type="line"/>
+      <point x="652" y="128"/>
+      <point x="732" y="293"/>
+      <point x="732" y="412" type="curve" smooth="yes"/>
+      <point x="732" y="536"/>
+      <point x="672" y="612"/>
+      <point x="564" y="612" type="curve" smooth="yes"/>
+      <point x="402" y="612"/>
+      <point x="308" y="448"/>
+      <point x="308" y="314" type="curve" smooth="yes"/>
+      <point x="308" y="130"/>
+      <point x="434" y="-16"/>
     </contour>
     <contour>
-      <point x="342" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="455" y="-2"/>
-      <point x="507" y="31" type="curve"/>
-      <point x="453" y="85" type="line"/>
-      <point x="420" y="69"/>
-      <point x="389" y="62"/>
-      <point x="346" y="62" type="curve" smooth="yes"/>
-      <point x="216" y="62"/>
-      <point x="141" y="148"/>
-      <point x="141" y="295" type="curve" smooth="yes"/>
-      <point x="141" y="441"/>
-      <point x="209" y="535"/>
-      <point x="314" y="535" type="curve" smooth="yes"/>
-      <point x="361" y="535"/>
-      <point x="391" y="520"/>
-      <point x="416" y="484" type="curve"/>
-      <point x="464" y="534" type="line"/>
-      <point x="435" y="586"/>
-      <point x="385" y="612"/>
-      <point x="314" y="612" type="curve" smooth="yes"/>
-      <point x="163" y="612"/>
-      <point x="61" y="483"/>
-      <point x="61" y="293" type="curve" smooth="yes"/>
-      <point x="61" y="102"/>
-      <point x="169" y="-16"/>
+      <point x="323" y="-16" type="curve" smooth="yes"/>
+      <point x="383" y="-16"/>
+      <point x="440" y="0"/>
+      <point x="486" y="35" type="curve"/>
+      <point x="434" y="90" type="line"/>
+      <point x="405" y="71"/>
+      <point x="375" y="62"/>
+      <point x="338" y="62" type="curve" smooth="yes"/>
+      <point x="210" y="62"/>
+      <point x="136" y="142"/>
+      <point x="136" y="275" type="curve" smooth="yes"/>
+      <point x="136" y="377"/>
+      <point x="187" y="534"/>
+      <point x="322" y="534" type="curve" smooth="yes"/>
+      <point x="364" y="534"/>
+      <point x="387" y="522"/>
+      <point x="411" y="493" type="curve"/>
+      <point x="471" y="542" type="line"/>
+      <point x="433" y="591"/>
+      <point x="392" y="612"/>
+      <point x="332" y="612" type="curve" smooth="yes"/>
+      <point x="133" y="612"/>
+      <point x="56" y="415"/>
+      <point x="56" y="277" type="curve" smooth="yes"/>
+      <point x="56" y="104"/>
+      <point x="160" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ya-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ya-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1008"/>
   <outline>
     <component base="ya-malayalam"/>
-    <component base="halant-malayalam" xOffset="799"/>
+    <component base="halant-malayalam" xOffset="794"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/kerning.plist
@@ -47536,8 +47536,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -47647,7 +47645,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47703,7 +47701,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>80</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47756,7 +47754,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>180</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -47803,7 +47801,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -47838,7 +47836,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -47866,8 +47864,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47902,7 +47898,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47971,7 +47967,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48031,7 +48027,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48080,7 +48076,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48138,7 +48134,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48179,7 +48175,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48315,8 +48311,6 @@
       <integer>-30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48345,7 +48339,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48393,8 +48387,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>10</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>0</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>0</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48480,8 +48472,6 @@
       <integer>50</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48514,7 +48504,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48591,8 +48581,6 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48636,8 +48624,6 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48757,8 +48743,6 @@
       <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48866,7 +48850,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48913,7 +48897,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48959,41 +48943,39 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>50</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_braceright.loclMALM_R</key>
-      <integer>40</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
       <integer>20</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>40</integer>
-      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>70</integer>
-      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
+      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
+      <integer>60</integer>
+      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
-      <integer>110</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
-      <integer>100</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
       <integer>20</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
       <integer>-20</integer>
-      <key>public.kern2.MAL_rVocalic-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
-      <integer>90</integer>
-      <key>public.kern2.MAL_uMatra-malayalam_L</key>
       <integer>80</integer>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>60</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>220</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
       <integer>150</integer>
     </dict>
@@ -49020,7 +49002,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49069,7 +49051,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49102,8 +49084,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -49143,7 +49123,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49346,7 +49326,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49372,8 +49352,6 @@
       <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49400,7 +49378,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49456,7 +49434,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -49488,8 +49466,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49599,8 +49575,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_p_pa-malayalam_L</key>
@@ -49667,7 +49641,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
@@ -49712,7 +49686,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49753,7 +49727,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49843,7 +49817,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>150</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49984,8 +49958,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -50033,8 +50005,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50097,7 +50067,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50150,7 +50120,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>240</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>170</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -50235,7 +50205,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -50274,7 +50244,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>130</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50370,8 +50340,6 @@
       <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
-      <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
@@ -50476,7 +50444,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_ng_ka-malayalam_L</key>
@@ -50528,6 +50496,24 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-30</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>-20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>50</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.Man-georgian</key>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/d_da-malayalam.glif
@@ -1,73 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
-  <advance width="689"/>
-  <anchor x="362" y="596" name="top"/>
+  <advance width="679"/>
+  <anchor x="281" y="-269" name="bottom"/>
+  <anchor x="429" y="596" name="top"/>
   <outline>
     <contour>
-      <point x="378" y="-225" type="curve" smooth="yes"/>
-      <point x="514" y="-225"/>
-      <point x="579" y="-173"/>
-      <point x="579" y="-87" type="curve" smooth="yes"/>
-      <point x="579" y="-32"/>
-      <point x="549" y="6"/>
-      <point x="488" y="19" type="curve"/>
-      <point x="488" y="29" type="line"/>
-      <point x="555" y="40"/>
-      <point x="613" y="76"/>
-      <point x="613" y="165" type="curve" smooth="yes"/>
-      <point x="613" y="228"/>
-      <point x="577" y="271"/>
-      <point x="515" y="290" type="curve"/>
-      <point x="516" y="300" type="line"/>
-      <point x="600" y="313"/>
-      <point x="641" y="375"/>
-      <point x="641" y="437" type="curve" smooth="yes"/>
-      <point x="641" y="534"/>
-      <point x="571" y="612"/>
-      <point x="410" y="612" type="curve" smooth="yes"/>
-      <point x="185" y="612"/>
-      <point x="50" y="454"/>
-      <point x="50" y="229" type="curve" smooth="yes"/>
-      <point x="50" y="143"/>
-      <point x="70" y="57"/>
-      <point x="115" y="-16" type="curve"/>
-      <point x="188" y="30" type="line"/>
-      <point x="153" y="88"/>
-      <point x="132" y="156"/>
-      <point x="132" y="231" type="curve" smooth="yes"/>
-      <point x="132" y="407"/>
-      <point x="230" y="534"/>
-      <point x="405" y="534" type="curve" smooth="yes"/>
-      <point x="514" y="534"/>
-      <point x="557" y="490"/>
-      <point x="557" y="433" type="curve" smooth="yes"/>
-      <point x="557" y="373"/>
-      <point x="510" y="337"/>
-      <point x="441" y="337" type="curve" smooth="yes"/>
-      <point x="383" y="337" type="line"/>
-      <point x="370" y="263" type="line"/>
-      <point x="412" y="263" type="line" smooth="yes"/>
-      <point x="493" y="263"/>
-      <point x="531" y="230"/>
-      <point x="531" y="166" type="curve" smooth="yes"/>
-      <point x="531" y="97"/>
-      <point x="483" y="62"/>
-      <point x="409" y="62" type="curve" smooth="yes"/>
-      <point x="335" y="62" type="line"/>
-      <point x="322" y="-12" type="line"/>
-      <point x="385" y="-12" type="line" smooth="yes"/>
-      <point x="463" y="-12"/>
-      <point x="498" y="-30"/>
-      <point x="498" y="-74" type="curve" smooth="yes"/>
-      <point x="498" y="-123"/>
-      <point x="460" y="-147"/>
-      <point x="387" y="-147" type="curve" smooth="yes"/>
-      <point x="329" y="-147"/>
-      <point x="296" y="-139"/>
-      <point x="265" y="-129" type="curve"/>
-      <point x="225" y="-201" type="line"/>
-      <point x="258" y="-215"/>
-      <point x="320" y="-225"/>
+      <point x="325" y="-285" type="curve" smooth="yes"/>
+      <point x="459" y="-285"/>
+      <point x="557" y="-219"/>
+      <point x="557" y="-105" type="curve" smooth="yes"/>
+      <point x="557" y="-42"/>
+      <point x="532" y="-5"/>
+      <point x="482" y="17" type="curve"/>
+      <point x="484" y="27" type="line"/>
+      <point x="564" y="47"/>
+      <point x="607" y="102"/>
+      <point x="607" y="175" type="curve" smooth="yes"/>
+      <point x="607" y="235"/>
+      <point x="576" y="277"/>
+      <point x="509" y="293" type="curve"/>
+      <point x="511" y="303" type="line"/>
+      <point x="595" y="320"/>
+      <point x="637" y="373"/>
+      <point x="637" y="441" type="curve" smooth="yes"/>
+      <point x="637" y="539"/>
+      <point x="559" y="612"/>
+      <point x="415" y="612" type="curve" smooth="yes"/>
+      <point x="169" y="612"/>
+      <point x="51" y="429"/>
+      <point x="51" y="247" type="curve" smooth="yes"/>
+      <point x="51" y="154"/>
+      <point x="77" y="66"/>
+      <point x="124" y="-16" type="curve"/>
+      <point x="194" y="27" type="line"/>
+      <point x="155" y="97"/>
+      <point x="135" y="170"/>
+      <point x="135" y="247" type="curve" smooth="yes"/>
+      <point x="135" y="400"/>
+      <point x="226" y="534"/>
+      <point x="409" y="534" type="curve" smooth="yes"/>
+      <point x="512" y="534"/>
+      <point x="553" y="495"/>
+      <point x="553" y="434" type="curve" smooth="yes"/>
+      <point x="553" y="374"/>
+      <point x="508" y="337"/>
+      <point x="428" y="337" type="curve" smooth="yes"/>
+      <point x="373" y="337" type="line"/>
+      <point x="360" y="263" type="line"/>
+      <point x="406" y="263" type="line" smooth="yes"/>
+      <point x="486" y="263"/>
+      <point x="523" y="231"/>
+      <point x="523" y="170" type="curve" smooth="yes"/>
+      <point x="523" y="101"/>
+      <point x="475" y="62"/>
+      <point x="389" y="62" type="curve" smooth="yes"/>
+      <point x="304" y="62" type="line"/>
+      <point x="291" y="-12" type="line"/>
+      <point x="359" y="-12" type="line" smooth="yes"/>
+      <point x="441" y="-12"/>
+      <point x="473" y="-47"/>
+      <point x="473" y="-101" type="curve" smooth="yes"/>
+      <point x="473" y="-169"/>
+      <point x="421" y="-207"/>
+      <point x="331" y="-207" type="curve" smooth="yes"/>
+      <point x="271" y="-207"/>
+      <point x="223" y="-194"/>
+      <point x="171" y="-165" type="curve"/>
+      <point x="136" y="-233" type="line"/>
+      <point x="195" y="-268"/>
+      <point x="259" y="-285"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="987"/>
-  <anchor x="623" y="0" name="bottom"/>
-  <anchor x="551" y="596" name="top"/>
-  <anchor x="917" y="596" name="topright"/>
+  <advance width="980"/>
+  <anchor x="609" y="0" name="bottom"/>
+  <anchor x="546" y="596" name="top"/>
+  <anchor x="905" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="256" y="-16" type="curve" smooth="yes"/>
-      <point x="379" y="-16"/>
-      <point x="453" y="57"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="729" y="532" type="curve" smooth="yes"/>
-      <point x="825" y="532"/>
-      <point x="868" y="490"/>
-      <point x="868" y="433" type="curve" smooth="yes"/>
-      <point x="868" y="373"/>
-      <point x="821" y="337"/>
-      <point x="752" y="337" type="curve" smooth="yes"/>
-      <point x="684" y="337" type="line"/>
-      <point x="671" y="263" type="line"/>
-      <point x="723" y="263" type="line" smooth="yes"/>
-      <point x="804" y="263"/>
-      <point x="842" y="229"/>
-      <point x="842" y="166" type="curve" smooth="yes"/>
-      <point x="842" y="97"/>
-      <point x="804" y="62"/>
-      <point x="730" y="62" type="curve" smooth="yes"/>
-      <point x="683" y="62"/>
-      <point x="652" y="73"/>
-      <point x="623" y="89" type="curve"/>
-      <point x="579" y="24" type="line"/>
-      <point x="616" y="0"/>
-      <point x="672" y="-16"/>
-      <point x="728" y="-16" type="curve" smooth="yes"/>
-      <point x="847" y="-16"/>
-      <point x="924" y="47"/>
-      <point x="924" y="156" type="curve" smooth="yes"/>
-      <point x="924" y="226"/>
-      <point x="888" y="272"/>
-      <point x="826" y="291" type="curve"/>
-      <point x="827" y="301" type="line"/>
-      <point x="911" y="314"/>
-      <point x="952" y="375"/>
-      <point x="952" y="448" type="curve" smooth="yes"/>
-      <point x="952" y="544"/>
-      <point x="883" y="612"/>
-      <point x="730" y="612" type="curve" smooth="yes"/>
-      <point x="581" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="76"/>
-      <point x="127" y="-16"/>
+      <point x="263" y="-16" type="curve" smooth="yes"/>
+      <point x="400" y="-16"/>
+      <point x="477" y="78"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="464"/>
+      <point x="607" y="532"/>
+      <point x="717" y="532" type="curve" smooth="yes"/>
+      <point x="803" y="532"/>
+      <point x="848" y="499"/>
+      <point x="848" y="435" type="curve" smooth="yes"/>
+      <point x="848" y="373"/>
+      <point x="801" y="337"/>
+      <point x="732" y="337" type="curve" smooth="yes"/>
+      <point x="664" y="337" type="line"/>
+      <point x="651" y="263" type="line"/>
+      <point x="703" y="263" type="line" smooth="yes"/>
+      <point x="784" y="263"/>
+      <point x="822" y="229"/>
+      <point x="822" y="166" type="curve" smooth="yes"/>
+      <point x="822" y="97"/>
+      <point x="784" y="62"/>
+      <point x="710" y="62" type="curve" smooth="yes"/>
+      <point x="663" y="62"/>
+      <point x="632" y="73"/>
+      <point x="603" y="89" type="curve"/>
+      <point x="559" y="24" type="line"/>
+      <point x="596" y="0"/>
+      <point x="652" y="-16"/>
+      <point x="708" y="-16" type="curve" smooth="yes"/>
+      <point x="827" y="-16"/>
+      <point x="904" y="47"/>
+      <point x="904" y="156" type="curve" smooth="yes"/>
+      <point x="904" y="226"/>
+      <point x="868" y="272"/>
+      <point x="806" y="290" type="curve"/>
+      <point x="807" y="300" type="line"/>
+      <point x="891" y="312"/>
+      <point x="932" y="375"/>
+      <point x="932" y="441" type="curve" smooth="yes"/>
+      <point x="932" y="545"/>
+      <point x="848" y="612"/>
+      <point x="717" y="612" type="curve" smooth="yes"/>
+      <point x="561" y="612"/>
+      <point x="456" y="517"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="77"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/g_ga-malayalam.glif
@@ -1,92 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ga-malayalam" format="2">
   <advance width="934"/>
-  <anchor x="428" y="-357" name="bottom"/>
-  <anchor x="529" y="596" name="top"/>
-  <anchor x="823" y="596" name="topright"/>
+  <anchor x="447" y="-367" name="bottom"/>
+  <anchor x="522" y="596" name="top"/>
+  <anchor x="816" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="613" y="-381" type="line"/>
-      <point x="700" y="-301"/>
-      <point x="741" y="-214"/>
-      <point x="741" y="-112" type="curve" smooth="yes"/>
-      <point x="741" y="2"/>
-      <point x="669" y="48"/>
-      <point x="592" y="48" type="curve" smooth="yes"/>
-      <point x="483" y="48"/>
-      <point x="436" y="-11"/>
-      <point x="401" y="-152" type="curve" smooth="yes"/>
-      <point x="397" y="-168" type="line" smooth="yes"/>
-      <point x="370" y="-276"/>
-      <point x="344" y="-308"/>
-      <point x="286" y="-308" type="curve" smooth="yes"/>
-      <point x="238" y="-308"/>
-      <point x="203" y="-277"/>
-      <point x="203" y="-206" type="curve" smooth="yes"/>
-      <point x="203" y="-127"/>
-      <point x="240" y="-61"/>
-      <point x="299" y="-1" type="curve"/>
-      <point x="277" y="-15" type="line"/>
-      <point x="388" y="-7"/>
-      <point x="456" y="67"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="702" y="532" type="curve" smooth="yes"/>
-      <point x="779" y="532"/>
-      <point x="818" y="483"/>
-      <point x="818" y="387" type="curve" smooth="yes"/>
-      <point x="818" y="235"/>
-      <point x="749" y="113"/>
-      <point x="610" y="27" type="curve"/>
-      <point x="683" y="-16" type="line"/>
-      <point x="823" y="79"/>
-      <point x="900" y="222"/>
-      <point x="900" y="387" type="curve" smooth="yes"/>
-      <point x="900" y="534"/>
-      <point x="832" y="612"/>
-      <point x="704" y="612" type="curve" smooth="yes"/>
-      <point x="577" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="101"/>
-      <point x="104" y="16"/>
-      <point x="203" y="-9" type="curve"/>
-      <point x="203" y="-19" type="line"/>
-      <point x="153" y="-74"/>
-      <point x="128" y="-141"/>
-      <point x="128" y="-216" type="curve" smooth="yes"/>
-      <point x="128" y="-333"/>
-      <point x="202" y="-378"/>
-      <point x="280" y="-378" type="curve" smooth="yes"/>
-      <point x="386" y="-378"/>
-      <point x="435" y="-318"/>
-      <point x="469" y="-173" type="curve" smooth="yes"/>
-      <point x="473" y="-156" type="line" smooth="yes"/>
-      <point x="498" y="-51"/>
-      <point x="525" y="-22"/>
-      <point x="585" y="-22" type="curve" smooth="yes"/>
-      <point x="636" y="-22"/>
-      <point x="665" y="-56"/>
-      <point x="665" y="-121" type="curve" smooth="yes"/>
-      <point x="665" y="-210"/>
-      <point x="624" y="-275"/>
-      <point x="563" y="-339" type="curve"/>
+      <point x="263" y="-9" type="curve" smooth="yes"/>
+      <point x="400" y="-9"/>
+      <point x="476" y="83"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="458"/>
+      <point x="592" y="528"/>
+      <point x="683" y="528" type="curve" smooth="yes"/>
+      <point x="765" y="528"/>
+      <point x="804" y="481"/>
+      <point x="804" y="385" type="curve" smooth="yes"/>
+      <point x="804" y="247"/>
+      <point x="734" y="117"/>
+      <point x="609" y="37" type="curve"/>
+      <point x="677" y="-9" type="line"/>
+      <point x="815" y="87"/>
+      <point x="888" y="226"/>
+      <point x="888" y="389" type="curve" smooth="yes"/>
+      <point x="888" y="531"/>
+      <point x="809" y="612"/>
+      <point x="683" y="612" type="curve" smooth="yes"/>
+      <point x="546" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="81"/>
+      <point x="137" y="-9"/>
+    </contour>
+    <contour>
+      <point x="623" y="-380" type="line"/>
+      <point x="712" y="-311"/>
+      <point x="757" y="-234"/>
+      <point x="757" y="-127" type="curve" smooth="yes"/>
+      <point x="757" y="-21"/>
+      <point x="699" y="48"/>
+      <point x="597" y="48" type="curve" smooth="yes"/>
+      <point x="496" y="48"/>
+      <point x="433" y="-11"/>
+      <point x="417" y="-121" type="curve" smooth="yes"/>
+      <point x="414" y="-141"/>
+      <point x="412" y="-179"/>
+      <point x="409" y="-199" type="curve" smooth="yes"/>
+      <point x="398" y="-271"/>
+      <point x="366" y="-306"/>
+      <point x="312" y="-306" type="curve" smooth="yes"/>
+      <point x="254" y="-306"/>
+      <point x="222" y="-269"/>
+      <point x="222" y="-199" type="curve" smooth="yes"/>
+      <point x="222" y="-117"/>
+      <point x="255" y="-48"/>
+      <point x="315" y="15" type="curve"/>
+      <point x="231" y="15" type="line"/>
+      <point x="181" y="-38"/>
+      <point x="146" y="-121"/>
+      <point x="146" y="-201" type="curve" smooth="yes"/>
+      <point x="146" y="-309"/>
+      <point x="212" y="-378"/>
+      <point x="312" y="-378" type="curve" smooth="yes"/>
+      <point x="410" y="-378"/>
+      <point x="468" y="-320"/>
+      <point x="485" y="-211" type="curve" smooth="yes"/>
+      <point x="488" y="-191"/>
+      <point x="490" y="-153"/>
+      <point x="493" y="-133" type="curve" smooth="yes"/>
+      <point x="504" y="-59"/>
+      <point x="537" y="-24"/>
+      <point x="596" y="-24" type="curve" smooth="yes"/>
+      <point x="657" y="-24"/>
+      <point x="681" y="-61"/>
+      <point x="681" y="-129" type="curve" smooth="yes"/>
+      <point x="681" y="-206"/>
+      <point x="641" y="-273"/>
+      <point x="577" y="-322" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/g_la-malayalam.glif
@@ -1,116 +1,125 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_la-malayalam" format="2">
   <advance width="934"/>
-  <anchor x="399" y="-357" name="bottom"/>
-  <anchor x="529" y="596" name="top"/>
-  <anchor x="823" y="596" name="topright"/>
+  <anchor x="404" y="-362" name="bottom"/>
+  <anchor x="522" y="596" name="top"/>
+  <anchor x="816" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="195" y="-378" type="curve" smooth="yes"/>
-      <point x="282" y="-378"/>
-      <point x="332" y="-321"/>
-      <point x="332" y="-236" type="curve" smooth="yes"/>
-      <point x="332" y="-156"/>
-      <point x="287" y="-121"/>
-      <point x="221" y="-121" type="curve" smooth="yes"/>
-      <point x="188" y="-121"/>
-      <point x="153" y="-134"/>
-      <point x="129" y="-167" type="curve"/>
-      <point x="122" y="-166" type="line"/>
-      <point x="145" y="-72"/>
-      <point x="206" y="-22"/>
-      <point x="286" y="-22" type="curve" smooth="yes"/>
-      <point x="397" y="-22"/>
-      <point x="419" y="-91"/>
-      <point x="425" y="-180" type="curve" smooth="yes"/>
-      <point x="426" y="-196" type="line" smooth="yes"/>
-      <point x="433" y="-307"/>
-      <point x="477" y="-378"/>
-      <point x="594" y="-378" type="curve" smooth="yes"/>
-      <point x="728" y="-378"/>
-      <point x="778" y="-270"/>
-      <point x="778" y="-142" type="curve" smooth="yes"/>
-      <point x="778" y="-72"/>
-      <point x="758" y="-2"/>
-      <point x="734" y="39" type="curve"/>
-      <point x="729" y="19" type="line"/>
-      <point x="840" y="112"/>
-      <point x="900" y="241"/>
-      <point x="900" y="387" type="curve" smooth="yes"/>
-      <point x="900" y="534"/>
-      <point x="832" y="612"/>
-      <point x="704" y="612" type="curve" smooth="yes"/>
-      <point x="577" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="126"/>
-      <point x="84" y="49"/>
-      <point x="155" y="12" type="curve"/>
-      <point x="155" y="2" type="line"/>
-      <point x="85" y="-46"/>
-      <point x="49" y="-122"/>
-      <point x="49" y="-209" type="curve" smooth="yes"/>
-      <point x="49" y="-328"/>
-      <point x="114" y="-378"/>
+      <point x="190" y="-378" type="curve" smooth="yes"/>
+      <point x="289" y="-378"/>
+      <point x="332" y="-293"/>
+      <point x="332" y="-239" type="curve" smooth="yes"/>
+      <point x="332" y="-169"/>
+      <point x="296" y="-121"/>
+      <point x="227" y="-121" type="curve" smooth="yes"/>
+      <point x="176" y="-121"/>
+      <point x="119" y="-155"/>
+      <point x="106" y="-236" type="curve"/>
+      <point x="143" y="-171" type="line"/>
+      <point x="84" y="-171" type="line"/>
+      <point x="116" y="-188" type="line"/>
+      <point x="132" y="-89"/>
+      <point x="187" y="-22"/>
+      <point x="283" y="-22" type="curve" smooth="yes"/>
+      <point x="365" y="-22"/>
+      <point x="405" y="-61"/>
+      <point x="421" y="-160" type="curve" smooth="yes"/>
+      <point x="428" y="-203" type="line" smooth="yes"/>
+      <point x="448" y="-323"/>
+      <point x="500" y="-378"/>
+      <point x="591" y="-378" type="curve" smooth="yes"/>
+      <point x="731" y="-378"/>
+      <point x="775" y="-232"/>
+      <point x="775" y="-136" type="curve" smooth="yes"/>
+      <point x="775" y="-66"/>
+      <point x="758" y="-4"/>
+      <point x="724" y="46" type="curve"/>
+      <point x="713" y="12" type="line"/>
+      <point x="828" y="109"/>
+      <point x="888" y="238"/>
+      <point x="888" y="389" type="curve" smooth="yes"/>
+      <point x="888" y="531"/>
+      <point x="809" y="612"/>
+      <point x="683" y="612" type="curve" smooth="yes"/>
+      <point x="546" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="117"/>
+      <point x="89" y="43"/>
+      <point x="155" y="11" type="curve"/>
+      <point x="153" y="2" type="line"/>
+      <point x="88" y="-44"/>
+      <point x="48" y="-128"/>
+      <point x="48" y="-217" type="curve" smooth="yes"/>
+      <point x="48" y="-317"/>
+      <point x="107" y="-378"/>
     </contour>
     <contour>
-      <point x="194" y="-313" type="curve" smooth="yes"/>
-      <point x="140" y="-313"/>
-      <point x="117" y="-270"/>
-      <point x="117" y="-223" type="curve"/>
-      <point x="99" y="-200" type="line"/>
-      <point x="110" y="-256" type="line"/>
-      <point x="117" y="-216"/>
-      <point x="151" y="-181"/>
+      <point x="192" y="-313" type="curve" smooth="yes"/>
+      <point x="145" y="-313"/>
+      <point x="116" y="-275"/>
+      <point x="116" y="-227" type="curve" smooth="yes"/>
+      <point x="116" y="-219"/>
+      <point x="117" y="-211"/>
+      <point x="118" y="-203" type="curve"/>
+      <point x="98" y="-218" type="line"/>
+      <point x="104" y="-267" type="line"/>
+      <point x="112" y="-224"/>
+      <point x="148" y="-181"/>
       <point x="200" y="-181" type="curve" smooth="yes"/>
       <point x="242" y="-181"/>
-      <point x="261" y="-201"/>
-      <point x="261" y="-240" type="curve" smooth="yes"/>
-      <point x="261" y="-282"/>
-      <point x="238" y="-313"/>
+      <point x="261" y="-205"/>
+      <point x="261" y="-241" type="curve" smooth="yes"/>
+      <point x="261" y="-270"/>
+      <point x="244" y="-313"/>
     </contour>
     <contour>
-      <point x="595" y="-308" type="curve" smooth="yes"/>
-      <point x="534" y="-308"/>
-      <point x="510" y="-271"/>
-      <point x="501" y="-176" type="curve" smooth="yes"/>
-      <point x="499" y="-155" type="line" smooth="yes"/>
-      <point x="490" y="-61"/>
-      <point x="459" y="0"/>
-      <point x="393" y="29" type="curve"/>
-      <point x="393" y="39" type="line"/>
-      <point x="443" y="78"/>
-      <point x="475" y="136"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="702" y="532" type="curve" smooth="yes"/>
-      <point x="779" y="532"/>
-      <point x="818" y="483"/>
-      <point x="818" y="387" type="curve" smooth="yes"/>
-      <point x="818" y="245"/>
-      <point x="758" y="135"/>
-      <point x="645" y="52" type="curve"/>
-      <point x="677" y="-4"/>
-      <point x="702" y="-55"/>
-      <point x="702" y="-155" type="curve" smooth="yes"/>
-      <point x="702" y="-228"/>
-      <point x="674" y="-308"/>
+      <point x="596" y="-308" type="curve" smooth="yes"/>
+      <point x="541" y="-308"/>
+      <point x="516" y="-274"/>
+      <point x="502" y="-188" type="curve" smooth="yes"/>
+      <point x="495" y="-145" type="line" smooth="yes"/>
+      <point x="478" y="-42"/>
+      <point x="450" y="2"/>
+      <point x="383" y="28" type="curve"/>
+      <point x="385" y="37" type="line"/>
+      <point x="449" y="74"/>
+      <point x="487" y="139"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="507" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="458"/>
+      <point x="592" y="528"/>
+      <point x="683" y="528" type="curve" smooth="yes"/>
+      <point x="765" y="528"/>
+      <point x="804" y="481"/>
+      <point x="804" y="385" type="curve" smooth="yes"/>
+      <point x="804" y="253"/>
+      <point x="739" y="129"/>
+      <point x="629" y="51" type="curve"/>
+      <point x="678" y="-7"/>
+      <point x="701" y="-69"/>
+      <point x="701" y="-140" type="curve" smooth="yes"/>
+      <point x="701" y="-203"/>
+      <point x="680" y="-308"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/g_ma-malayalam.glif
@@ -1,99 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ma-malayalam" format="2">
   <advance width="1425"/>
-  <anchor x="1042" y="0" name="bottom"/>
-  <anchor x="761" y="596" name="top"/>
-  <anchor x="1371" y="596" name="topright"/>
+  <anchor x="1026" y="0" name="bottom"/>
+  <anchor x="755" y="596" name="top"/>
+  <anchor x="1365" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="256" y="-16" type="curve" smooth="yes"/>
-      <point x="379" y="-16"/>
-      <point x="453" y="57"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="702" y="532" type="curve" smooth="yes"/>
-      <point x="779" y="532"/>
-      <point x="816" y="483"/>
-      <point x="816" y="402" type="curve" smooth="yes"/>
-      <point x="816" y="379"/>
-      <point x="813" y="356"/>
-      <point x="809" y="331" type="curve" smooth="yes"/>
-      <point x="750" y="0" type="line"/>
-      <point x="1317" y="0" type="line"/>
-      <point x="1364" y="266" type="line" smooth="yes"/>
-      <point x="1371" y="307"/>
-      <point x="1376" y="348"/>
-      <point x="1376" y="382" type="curve" smooth="yes"/>
-      <point x="1376" y="533"/>
-      <point x="1287" y="612"/>
-      <point x="1125" y="612" type="curve" smooth="yes"/>
-      <point x="1008" y="612"/>
-      <point x="930" y="564"/>
-      <point x="885" y="490" type="curve"/>
-      <point x="875" y="490" type="line"/>
-      <point x="853" y="570"/>
-      <point x="798" y="612"/>
-      <point x="704" y="612" type="curve" smooth="yes"/>
-      <point x="577" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="76"/>
-      <point x="127" y="-16"/>
+      <point x="263" y="-16" type="curve" smooth="yes"/>
+      <point x="400" y="-16"/>
+      <point x="477" y="78"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="458"/>
+      <point x="596" y="528"/>
+      <point x="692" y="528" type="curve" smooth="yes"/>
+      <point x="768" y="528"/>
+      <point x="809" y="484"/>
+      <point x="809" y="402" type="curve" smooth="yes"/>
+      <point x="809" y="380"/>
+      <point x="806" y="357"/>
+      <point x="802" y="333" type="curve" smooth="yes"/>
+      <point x="743" y="0" type="line"/>
+      <point x="1309" y="0" type="line"/>
+      <point x="1356" y="266" type="line" smooth="yes"/>
+      <point x="1363" y="307"/>
+      <point x="1368" y="348"/>
+      <point x="1368" y="382" type="curve" smooth="yes"/>
+      <point x="1368" y="533"/>
+      <point x="1279" y="612"/>
+      <point x="1117" y="612" type="curve" smooth="yes"/>
+      <point x="1000" y="612"/>
+      <point x="922" y="564"/>
+      <point x="877" y="490" type="curve"/>
+      <point x="867" y="490" type="line"/>
+      <point x="843" y="565"/>
+      <point x="788" y="612"/>
+      <point x="690" y="612" type="curve" smooth="yes"/>
+      <point x="550" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="77"/>
+      <point x="137" y="-16"/>
     </contour>
     <contour>
-      <point x="809" y="45" type="line"/>
-      <point x="841" y="45" type="line"/>
-      <point x="893" y="341" type="line" smooth="yes"/>
-      <point x="911" y="441"/>
-      <point x="954" y="498"/>
-      <point x="1041" y="498" type="curve" smooth="yes"/>
-      <point x="1099" y="498"/>
-      <point x="1125" y="471"/>
-      <point x="1125" y="423" type="curve" smooth="yes"/>
-      <point x="1125" y="334"/>
-      <point x="1037" y="257"/>
-      <point x="940" y="167" type="curve" smooth="yes"/>
+      <point x="801" y="45" type="line"/>
+      <point x="833" y="45" type="line"/>
+      <point x="886" y="345" type="line" smooth="yes"/>
+      <point x="903" y="443"/>
+      <point x="947" y="498"/>
+      <point x="1033" y="498" type="curve" smooth="yes"/>
+      <point x="1091" y="498"/>
+      <point x="1117" y="471"/>
+      <point x="1117" y="423" type="curve" smooth="yes"/>
+      <point x="1117" y="356"/>
+      <point x="1078" y="303"/>
+      <point x="932" y="167" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="919" y="42" type="line"/>
-      <point x="1046" y="161" type="line" smooth="yes"/>
-      <point x="1131" y="241"/>
-      <point x="1203" y="321"/>
-      <point x="1203" y="415" type="curve" smooth="yes"/>
-      <point x="1203" y="485"/>
-      <point x="1157" y="531"/>
-      <point x="1070" y="531" type="curve"/>
-      <point x="1075" y="504" type="line"/>
-      <point x="1075" y="577" type="line"/>
-      <point x="1061" y="539" type="line"/>
-      <point x="1071" y="541"/>
-      <point x="1082" y="542"/>
-      <point x="1095" y="542" type="curve" smooth="yes"/>
-      <point x="1226" y="542"/>
-      <point x="1293" y="489"/>
-      <point x="1293" y="370" type="curve" smooth="yes"/>
-      <point x="1293" y="344"/>
-      <point x="1288" y="306"/>
-      <point x="1282" y="269" type="curve" smooth="yes"/>
-      <point x="1243" y="45" type="line"/>
-      <point x="1286" y="74" type="line"/>
-      <point x="913" y="74" type="line"/>
+      <point x="911" y="42" type="line"/>
+      <point x="1038" y="161" type="line" smooth="yes"/>
+      <point x="1150" y="266"/>
+      <point x="1195" y="339"/>
+      <point x="1195" y="415" type="curve" smooth="yes"/>
+      <point x="1195" y="485"/>
+      <point x="1149" y="531"/>
+      <point x="1062" y="531" type="curve"/>
+      <point x="1067" y="504" type="line"/>
+      <point x="1067" y="577" type="line"/>
+      <point x="1053" y="539" type="line"/>
+      <point x="1063" y="541"/>
+      <point x="1074" y="542"/>
+      <point x="1087" y="542" type="curve" smooth="yes"/>
+      <point x="1218" y="542"/>
+      <point x="1285" y="489"/>
+      <point x="1285" y="370" type="curve" smooth="yes"/>
+      <point x="1285" y="343"/>
+      <point x="1282" y="306"/>
+      <point x="1275" y="267" type="curve" smooth="yes"/>
+      <point x="1236" y="45" type="line"/>
+      <point x="1278" y="74" type="line"/>
+      <point x="905" y="74" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/g_na-malayalam.glif
@@ -1,70 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_na-malayalam" format="2">
   <advance width="1332"/>
-  <anchor x="864" y="0" name="bottom"/>
-  <anchor x="720" y="596" name="top"/>
-  <anchor x="1257" y="596" name="topright"/>
+  <anchor x="857" y="0" name="bottom"/>
+  <anchor x="715" y="596" name="top"/>
+  <anchor x="1252" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="256" y="-16" type="curve" smooth="yes"/>
-      <point x="379" y="-16"/>
-      <point x="453" y="57"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="537" y="366" type="line" smooth="yes"/>
-      <point x="571" y="490"/>
-      <point x="618" y="528"/>
-      <point x="697" y="528" type="curve" smooth="yes"/>
-      <point x="773" y="528"/>
-      <point x="815" y="485"/>
-      <point x="815" y="410" type="curve" smooth="yes"/>
-      <point x="815" y="382"/>
-      <point x="811" y="351"/>
-      <point x="804" y="309" type="curve" smooth="yes"/>
-      <point x="749" y="0" type="line"/>
-      <point x="833" y="0" type="line"/>
-      <point x="899" y="375" type="line" smooth="yes"/>
-      <point x="917" y="477"/>
-      <point x="978" y="534"/>
-      <point x="1071" y="534" type="curve" smooth="yes"/>
-      <point x="1162" y="534"/>
-      <point x="1212" y="475"/>
-      <point x="1212" y="369" type="curve" smooth="yes"/>
-      <point x="1212" y="249"/>
-      <point x="1155" y="143"/>
-      <point x="1035" y="45" type="curve"/>
-      <point x="1093" y="-16" type="line"/>
-      <point x="1228" y="96"/>
-      <point x="1296" y="225"/>
-      <point x="1296" y="369" type="curve" smooth="yes"/>
-      <point x="1296" y="526"/>
-      <point x="1218" y="612"/>
-      <point x="1078" y="612" type="curve" smooth="yes"/>
-      <point x="988" y="612"/>
-      <point x="917" y="570"/>
-      <point x="875" y="494" type="curve"/>
-      <point x="865" y="494" type="line"/>
-      <point x="836" y="571"/>
-      <point x="776" y="612"/>
+      <point x="263" y="-16" type="curve" smooth="yes"/>
+      <point x="400" y="-16"/>
+      <point x="477" y="78"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="461"/>
+      <point x="596" y="528"/>
+      <point x="688" y="528" type="curve" smooth="yes"/>
+      <point x="767" y="528"/>
+      <point x="810" y="486"/>
+      <point x="810" y="410" type="curve" smooth="yes"/>
+      <point x="810" y="383"/>
+      <point x="805" y="352"/>
+      <point x="798" y="311" type="curve" smooth="yes"/>
+      <point x="743" y="0" type="line"/>
+      <point x="827" y="0" type="line"/>
+      <point x="893" y="373" type="line" smooth="yes"/>
+      <point x="911" y="476"/>
+      <point x="969" y="534"/>
+      <point x="1059" y="534" type="curve" smooth="yes"/>
+      <point x="1150" y="534"/>
+      <point x="1200" y="475"/>
+      <point x="1200" y="369" type="curve" smooth="yes"/>
+      <point x="1200" y="249"/>
+      <point x="1143" y="143"/>
+      <point x="1023" y="45" type="curve"/>
+      <point x="1081" y="-16" type="line"/>
+      <point x="1216" y="96"/>
+      <point x="1284" y="225"/>
+      <point x="1284" y="369" type="curve" smooth="yes"/>
+      <point x="1284" y="526"/>
+      <point x="1207" y="612"/>
+      <point x="1068" y="612" type="curve" smooth="yes"/>
+      <point x="981" y="612"/>
+      <point x="909" y="571"/>
+      <point x="866" y="499" type="curve"/>
+      <point x="856" y="499" type="line"/>
+      <point x="829" y="574"/>
+      <point x="773" y="612"/>
       <point x="688" y="612" type="curve" smooth="yes"/>
-      <point x="575" y="612"/>
-      <point x="497" y="548"/>
-      <point x="458" y="403" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="76"/>
-      <point x="127" y="-16"/>
+      <point x="548" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="77"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ga-malayalam.glif
@@ -2,51 +2,55 @@
 <glyph name="ga-malayalam" format="2">
   <advance width="934"/>
   <unicode hex="0D17"/>
-  <anchor x="478" y="0" name="bottom"/>
-  <anchor x="529" y="596" name="top"/>
-  <anchor x="823" y="596" name="topright"/>
+  <anchor x="471" y="0" name="bottom"/>
+  <anchor x="522" y="596" name="top"/>
+  <anchor x="816" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="256" y="-16" type="curve" smooth="yes"/>
-      <point x="379" y="-16"/>
-      <point x="453" y="57"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="702" y="532" type="curve" smooth="yes"/>
-      <point x="779" y="532"/>
-      <point x="818" y="483"/>
-      <point x="818" y="387" type="curve" smooth="yes"/>
-      <point x="818" y="245"/>
-      <point x="758" y="135"/>
-      <point x="636" y="51" type="curve"/>
-      <point x="683" y="-16" type="line"/>
-      <point x="823" y="79"/>
-      <point x="900" y="222"/>
-      <point x="900" y="387" type="curve" smooth="yes"/>
-      <point x="900" y="534"/>
-      <point x="832" y="612"/>
-      <point x="704" y="612" type="curve" smooth="yes"/>
-      <point x="577" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="76"/>
-      <point x="127" y="-16"/>
+      <point x="263" y="-16" type="curve" smooth="yes"/>
+      <point x="400" y="-16"/>
+      <point x="477" y="78"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="458"/>
+      <point x="592" y="528"/>
+      <point x="683" y="528" type="curve" smooth="yes"/>
+      <point x="765" y="528"/>
+      <point x="804" y="481"/>
+      <point x="804" y="385" type="curve" smooth="yes"/>
+      <point x="804" y="253"/>
+      <point x="739" y="129"/>
+      <point x="629" y="51" type="curve"/>
+      <point x="677" y="-16" type="line"/>
+      <point x="815" y="83"/>
+      <point x="888" y="223"/>
+      <point x="888" y="389" type="curve" smooth="yes"/>
+      <point x="888" y="531"/>
+      <point x="809" y="612"/>
+      <point x="683" y="612" type="curve" smooth="yes"/>
+      <point x="546" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="77"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ga-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="934"/>
   <outline>
     <component base="ga-malayalam"/>
-    <component base="halant-malayalam" xOffset="743"/>
+    <component base="halant-malayalam" xOffset="736"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/j_ja-malayalam.glif
@@ -1,231 +1,230 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1626"/>
-  <anchor x="1181" y="0" name="bottom"/>
-  <anchor x="880" y="596" name="top"/>
-  <anchor x="1523" y="596" name="topright"/>
+  <advance width="1700"/>
+  <anchor x="1221" y="-6" name="bottom"/>
+  <anchor x="903" y="596" name="top"/>
+  <anchor x="1589" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="311" y="-16" type="curve" smooth="yes"/>
+      <point x="283" y="-16" type="curve" smooth="yes"/>
       <point x="585" y="-16"/>
-      <point x="747" y="77"/>
-      <point x="868" y="317" type="curve"/>
-      <point x="890" y="371" type="line"/>
-      <point x="898" y="371" type="line"/>
-      <point x="912" y="328"/>
-      <point x="954" y="307"/>
-      <point x="1011" y="307" type="curve" smooth="yes"/>
-      <point x="1097" y="307"/>
-      <point x="1151" y="357"/>
-      <point x="1151" y="436" type="curve" smooth="yes"/>
-      <point x="1151" y="496"/>
-      <point x="1118" y="530"/>
-      <point x="1057" y="530" type="curve" smooth="yes"/>
-      <point x="1035" y="530"/>
-      <point x="1011" y="526"/>
-      <point x="988" y="518" type="curve"/>
-      <point x="975" y="543" type="line"/>
-      <point x="975" y="521" type="line"/>
-      <point x="998" y="541"/>
-      <point x="1041" y="552"/>
-      <point x="1086" y="552" type="curve" smooth="yes"/>
-      <point x="1166" y="552"/>
-      <point x="1204" y="515"/>
-      <point x="1204" y="435" type="curve" smooth="yes"/>
-      <point x="1204" y="414"/>
-      <point x="1203" y="400"/>
-      <point x="1199" y="380" type="curve" smooth="yes"/>
-      <point x="1194" y="353" type="line"/>
-      <point x="1278" y="353" type="line"/>
-      <point x="1284" y="388" type="line" smooth="yes"/>
-      <point x="1300" y="480"/>
-      <point x="1351" y="534"/>
-      <point x="1422" y="534" type="curve" smooth="yes"/>
-      <point x="1483" y="534"/>
-      <point x="1514" y="503"/>
-      <point x="1514" y="442" type="curve" smooth="yes"/>
-      <point x="1514" y="348"/>
-      <point x="1453" y="294"/>
-      <point x="1347" y="294" type="curve" smooth="yes"/>
-      <point x="1055" y="294" type="line" smooth="yes"/>
-      <point x="919" y="294"/>
-      <point x="840" y="231"/>
-      <point x="840" y="125" type="curve" smooth="yes"/>
-      <point x="840" y="36"/>
-      <point x="890" y="-16"/>
-      <point x="980" y="-16" type="curve" smooth="yes"/>
-      <point x="1025" y="-16"/>
-      <point x="1066" y="-10"/>
-      <point x="1175" y="61" type="curve" smooth="yes"/>
-      <point x="1229" y="96" type="line"/>
-      <point x="1343" y="170" type="line"/>
-      <point x="1353" y="165" type="line"/>
-      <point x="1374" y="171"/>
-      <point x="1391" y="172"/>
-      <point x="1415" y="172" type="curve" smooth="yes"/>
-      <point x="1452" y="172"/>
-      <point x="1470" y="154"/>
-      <point x="1470" y="121" type="curve" smooth="yes"/>
-      <point x="1470" y="75"/>
-      <point x="1446" y="48"/>
-      <point x="1407" y="48" type="curve" smooth="yes"/>
-      <point x="1375" y="48"/>
-      <point x="1354" y="69"/>
-      <point x="1354" y="101" type="curve" smooth="yes"/>
-      <point x="1354" y="137"/>
-      <point x="1368" y="163"/>
-      <point x="1405" y="190" type="curve"/>
-      <point x="1285" y="166" type="line"/>
-      <point x="1323" y="118" type="line"/>
-      <point x="1333" y="164" type="line"/>
-      <point x="1308" y="146"/>
-      <point x="1296" y="119"/>
-      <point x="1296" y="82" type="curve" smooth="yes"/>
-      <point x="1296" y="24"/>
-      <point x="1340" y="-16"/>
-      <point x="1405" y="-16" type="curve" smooth="yes"/>
-      <point x="1489" y="-16"/>
-      <point x="1537" y="35"/>
-      <point x="1537" y="124" type="curve" smooth="yes"/>
-      <point x="1537" y="196"/>
-      <point x="1499" y="238"/>
-      <point x="1433" y="238" type="curve" smooth="yes"/>
-      <point x="1375" y="238"/>
-      <point x="1332" y="232"/>
-      <point x="1225" y="169" type="curve" smooth="yes"/>
-      <point x="1142" y="120" type="line" smooth="yes"/>
-      <point x="1064" y="74"/>
-      <point x="1026" y="61"/>
-      <point x="992" y="61" type="curve" smooth="yes"/>
-      <point x="941" y="61"/>
-      <point x="919" y="85"/>
-      <point x="919" y="131" type="curve" smooth="yes"/>
-      <point x="919" y="189"/>
-      <point x="964" y="222"/>
-      <point x="1045" y="222" type="curve" smooth="yes"/>
-      <point x="1335" y="222" type="line" smooth="yes"/>
-      <point x="1497" y="222"/>
-      <point x="1598" y="309"/>
-      <point x="1598" y="449" type="curve" smooth="yes"/>
-      <point x="1598" y="546"/>
-      <point x="1534" y="612"/>
-      <point x="1440" y="612" type="curve" smooth="yes"/>
-      <point x="1358" y="612"/>
-      <point x="1295" y="569"/>
-      <point x="1265" y="490" type="curve"/>
-      <point x="1257" y="490" type="line"/>
-      <point x="1241" y="571"/>
-      <point x="1183" y="612"/>
-      <point x="1094" y="612" type="curve" smooth="yes"/>
-      <point x="997" y="612"/>
-      <point x="931" y="579"/>
-      <point x="873" y="469" type="curve" smooth="yes"/>
-      <point x="819" y="366" type="line" smooth="yes"/>
-      <point x="693" y="126"/>
-      <point x="531" y="61"/>
-      <point x="325" y="61" type="curve" smooth="yes"/>
-      <point x="180" y="61"/>
-      <point x="111" y="81"/>
-      <point x="111" y="147" type="curve" smooth="yes"/>
-      <point x="111" y="194"/>
-      <point x="154" y="222"/>
-      <point x="235" y="222" type="curve" smooth="yes"/>
-      <point x="543" y="222" type="line" smooth="yes"/>
-      <point x="705" y="222"/>
-      <point x="806" y="309"/>
-      <point x="806" y="449" type="curve" smooth="yes"/>
-      <point x="806" y="546"/>
-      <point x="742" y="612"/>
-      <point x="648" y="612" type="curve" smooth="yes"/>
-      <point x="566" y="612"/>
-      <point x="500" y="569"/>
-      <point x="470" y="490" type="curve"/>
-      <point x="462" y="490" type="line"/>
-      <point x="446" y="571"/>
-      <point x="391" y="612"/>
-      <point x="294" y="612" type="curve" smooth="yes"/>
-      <point x="174" y="612"/>
-      <point x="81" y="535"/>
-      <point x="81" y="435" type="curve" smooth="yes"/>
-      <point x="81" y="355"/>
-      <point x="133" y="307"/>
-      <point x="219" y="307" type="curve" smooth="yes"/>
-      <point x="305" y="307"/>
-      <point x="359" y="357"/>
-      <point x="359" y="436" type="curve" smooth="yes"/>
-      <point x="359" y="496"/>
-      <point x="326" y="530"/>
-      <point x="269" y="530" type="curve" smooth="yes"/>
-      <point x="245" y="530"/>
-      <point x="220" y="526"/>
-      <point x="196" y="518" type="curve"/>
-      <point x="183" y="543" type="line"/>
-      <point x="183" y="521" type="line"/>
-      <point x="206" y="541"/>
-      <point x="249" y="552"/>
-      <point x="294" y="552" type="curve" smooth="yes"/>
-      <point x="374" y="552"/>
-      <point x="412" y="515"/>
-      <point x="412" y="435" type="curve" smooth="yes"/>
-      <point x="412" y="414"/>
-      <point x="411" y="400"/>
-      <point x="407" y="380" type="curve" smooth="yes"/>
-      <point x="402" y="353" type="line"/>
-      <point x="486" y="353" type="line"/>
-      <point x="492" y="388" type="line" smooth="yes"/>
-      <point x="508" y="480"/>
-      <point x="559" y="534"/>
-      <point x="630" y="534" type="curve" smooth="yes"/>
-      <point x="691" y="534"/>
-      <point x="722" y="503"/>
-      <point x="722" y="442" type="curve" smooth="yes"/>
-      <point x="722" y="348"/>
-      <point x="661" y="294"/>
-      <point x="555" y="294" type="curve" smooth="yes"/>
-      <point x="245" y="294" type="line" smooth="yes"/>
-      <point x="109" y="294"/>
-      <point x="30" y="236"/>
-      <point x="30" y="140" type="curve" smooth="yes"/>
-      <point x="30" y="40"/>
-      <point x="118" y="-16"/>
+      <point x="768" y="75"/>
+      <point x="896" y="294" type="curve"/>
+      <point x="912" y="354" type="line"/>
+      <point x="921" y="354" type="line"/>
+      <point x="932" y="307"/>
+      <point x="971" y="274"/>
+      <point x="1028" y="274" type="curve" smooth="yes"/>
+      <point x="1129" y="274"/>
+      <point x="1173" y="350"/>
+      <point x="1173" y="408" type="curve" smooth="yes"/>
+      <point x="1173" y="474"/>
+      <point x="1137" y="512"/>
+      <point x="1074" y="512" type="curve" smooth="yes"/>
+      <point x="1046" y="512"/>
+      <point x="1025" y="509"/>
+      <point x="1002" y="501" type="curve"/>
+      <point x="984" y="527" type="line"/>
+      <point x="990" y="499" type="line"/>
+      <point x="1019" y="531"/>
+      <point x="1068" y="552"/>
+      <point x="1126" y="552" type="curve" smooth="yes"/>
+      <point x="1211" y="552"/>
+      <point x="1248" y="504"/>
+      <point x="1248" y="436" type="curve" smooth="yes"/>
+      <point x="1248" y="422"/>
+      <point x="1247" y="407"/>
+      <point x="1244" y="390" type="curve" smooth="yes"/>
+      <point x="1234" y="333" type="line"/>
+      <point x="1318" y="333" type="line"/>
+      <point x="1328" y="390" type="line" smooth="yes"/>
+      <point x="1344" y="481"/>
+      <point x="1402" y="534"/>
+      <point x="1483" y="534" type="curve" smooth="yes"/>
+      <point x="1549" y="534"/>
+      <point x="1585" y="499"/>
+      <point x="1585" y="433" type="curve" smooth="yes"/>
+      <point x="1585" y="328"/>
+      <point x="1512" y="264"/>
+      <point x="1369" y="264" type="curve" smooth="yes"/>
+      <point x="1033" y="264" type="line" smooth="yes"/>
+      <point x="923" y="264"/>
+      <point x="845" y="207"/>
+      <point x="845" y="114" type="curve" smooth="yes"/>
+      <point x="845" y="34"/>
+      <point x="905" y="-16"/>
+      <point x="992" y="-16" type="curve" smooth="yes"/>
+      <point x="1041" y="-16"/>
+      <point x="1077" y="-6"/>
+      <point x="1148" y="27" type="curve" smooth="yes"/>
+      <point x="1304" y="99" type="line"/>
+      <point x="1377" y="148" type="line"/>
+      <point x="1405" y="154" type="line"/>
+      <point x="1436" y="172"/>
+      <point x="1458" y="178"/>
+      <point x="1486" y="178" type="curve" smooth="yes"/>
+      <point x="1524" y="178"/>
+      <point x="1541" y="157"/>
+      <point x="1541" y="124" type="curve" smooth="yes"/>
+      <point x="1541" y="92"/>
+      <point x="1521" y="56"/>
+      <point x="1470" y="56" type="curve" smooth="yes"/>
+      <point x="1434" y="56"/>
+      <point x="1413" y="77"/>
+      <point x="1413" y="109" type="curve" smooth="yes"/>
+      <point x="1413" y="140"/>
+      <point x="1427" y="161"/>
+      <point x="1454" y="188" type="curve"/>
+      <point x="1350" y="148" type="line"/>
+      <point x="1366" y="128" type="line"/>
+      <point x="1357" y="114"/>
+      <point x="1352" y="98"/>
+      <point x="1352" y="80" type="curve" smooth="yes"/>
+      <point x="1352" y="22"/>
+      <point x="1396" y="-16"/>
+      <point x="1463" y="-16" type="curve" smooth="yes"/>
+      <point x="1571" y="-16"/>
+      <point x="1612" y="69"/>
+      <point x="1612" y="126" type="curve" smooth="yes"/>
+      <point x="1612" y="189"/>
+      <point x="1573" y="232"/>
+      <point x="1502" y="232" type="curve" smooth="yes"/>
+      <point x="1456" y="232"/>
+      <point x="1417" y="224"/>
+      <point x="1335" y="186" type="curve" smooth="yes"/>
+      <point x="1126" y="89" type="line" smooth="yes"/>
+      <point x="1078" y="67"/>
+      <point x="1041" y="58"/>
+      <point x="996" y="58" type="curve" smooth="yes"/>
+      <point x="954" y="58"/>
+      <point x="927" y="82"/>
+      <point x="927" y="119" type="curve" smooth="yes"/>
+      <point x="927" y="164"/>
+      <point x="963" y="192"/>
+      <point x="1030" y="192" type="curve" smooth="yes"/>
+      <point x="1351" y="192" type="line" smooth="yes"/>
+      <point x="1533" y="192"/>
+      <point x="1667" y="286"/>
+      <point x="1667" y="438" type="curve" smooth="yes"/>
+      <point x="1667" y="546"/>
+      <point x="1605" y="612"/>
+      <point x="1500" y="612" type="curve" smooth="yes"/>
+      <point x="1412" y="612"/>
+      <point x="1347" y="570"/>
+      <point x="1313" y="491" type="curve"/>
+      <point x="1305" y="491" type="line"/>
+      <point x="1288" y="571"/>
+      <point x="1234" y="612"/>
+      <point x="1132" y="612" type="curve" smooth="yes"/>
+      <point x="1025" y="612"/>
+      <point x="945" y="560"/>
+      <point x="898" y="457" type="curve" smooth="yes"/>
+      <point x="856" y="365" type="line" smooth="yes"/>
+      <point x="760" y="154"/>
+      <point x="583" y="61"/>
+      <point x="291" y="61" type="curve" smooth="yes"/>
+      <point x="176" y="61"/>
+      <point x="111" y="74"/>
+      <point x="111" y="129" type="curve" smooth="yes"/>
+      <point x="111" y="163"/>
+      <point x="137" y="192"/>
+      <point x="203" y="192" type="curve" smooth="yes"/>
+      <point x="503" y="192" type="line" smooth="yes"/>
+      <point x="690" y="192"/>
+      <point x="827" y="289"/>
+      <point x="827" y="445" type="curve" smooth="yes"/>
+      <point x="827" y="549"/>
+      <point x="770" y="612"/>
+      <point x="673" y="612" type="curve" smooth="yes"/>
+      <point x="589" y="612"/>
+      <point x="527" y="570"/>
+      <point x="495" y="491" type="curve"/>
+      <point x="487" y="491" type="line"/>
+      <point x="470" y="571"/>
+      <point x="416" y="612"/>
+      <point x="314" y="612" type="curve" smooth="yes"/>
+      <point x="156" y="612"/>
+      <point x="77" y="502"/>
+      <point x="77" y="413" type="curve" smooth="yes"/>
+      <point x="77" y="329"/>
+      <point x="127" y="274"/>
+      <point x="210" y="274" type="curve" smooth="yes"/>
+      <point x="311" y="274"/>
+      <point x="355" y="350"/>
+      <point x="355" y="408" type="curve" smooth="yes"/>
+      <point x="355" y="474"/>
+      <point x="319" y="512"/>
+      <point x="256" y="512" type="curve" smooth="yes"/>
+      <point x="228" y="512"/>
+      <point x="207" y="509"/>
+      <point x="184" y="501" type="curve"/>
+      <point x="166" y="527" type="line"/>
+      <point x="171" y="497" type="line"/>
+      <point x="196" y="529"/>
+      <point x="248" y="552"/>
+      <point x="309" y="552" type="curve" smooth="yes"/>
+      <point x="393" y="552"/>
+      <point x="430" y="504"/>
+      <point x="430" y="436" type="curve" smooth="yes"/>
+      <point x="430" y="422"/>
+      <point x="429" y="407"/>
+      <point x="426" y="390" type="curve" smooth="yes"/>
+      <point x="416" y="333" type="line"/>
+      <point x="500" y="333" type="line"/>
+      <point x="510" y="390" type="line" smooth="yes"/>
+      <point x="526" y="481"/>
+      <point x="580" y="534"/>
+      <point x="656" y="534" type="curve" smooth="yes"/>
+      <point x="714" y="534"/>
+      <point x="745" y="501"/>
+      <point x="745" y="440" type="curve" smooth="yes"/>
+      <point x="745" y="332"/>
+      <point x="667" y="264"/>
+      <point x="515" y="264" type="curve" smooth="yes"/>
+      <point x="206" y="264" type="line" smooth="yes"/>
+      <point x="78" y="264"/>
+      <point x="29" y="189"/>
+      <point x="29" y="127" type="curve" smooth="yes"/>
+      <point x="29" y="34"/>
+      <point x="115" y="-16"/>
     </contour>
     <contour>
-      <point x="219" y="371" type="curve" smooth="yes"/>
-      <point x="178" y="371"/>
-      <point x="157" y="393"/>
-      <point x="157" y="437" type="curve" smooth="yes"/>
-      <point x="157" y="461"/>
-      <point x="165" y="485"/>
-      <point x="179" y="503" type="curve"/>
-      <point x="157" y="505" type="line"/>
-      <point x="128" y="463" type="line"/>
-      <point x="153" y="480"/>
-      <point x="190" y="490"/>
-      <point x="227" y="490" type="curve" smooth="yes"/>
-      <point x="270" y="490"/>
-      <point x="287" y="474"/>
-      <point x="287" y="434" type="curve" smooth="yes"/>
-      <point x="287" y="395"/>
-      <point x="261" y="371"/>
+      <point x="214" y="338" type="curve" smooth="yes"/>
+      <point x="171" y="338"/>
+      <point x="147" y="367"/>
+      <point x="147" y="411" type="curve" smooth="yes"/>
+      <point x="147" y="432"/>
+      <point x="152" y="451"/>
+      <point x="162" y="473" type="curve"/>
+      <point x="137" y="473" type="line"/>
+      <point x="124" y="443" type="line"/>
+      <point x="150" y="458"/>
+      <point x="181" y="468"/>
+      <point x="216" y="468" type="curve" smooth="yes"/>
+      <point x="260" y="468"/>
+      <point x="283" y="448"/>
+      <point x="283" y="408" type="curve" smooth="yes"/>
+      <point x="283" y="377"/>
+      <point x="265" y="338"/>
     </contour>
     <contour>
-      <point x="1011" y="371" type="curve" smooth="yes"/>
-      <point x="970" y="371"/>
-      <point x="949" y="393"/>
-      <point x="949" y="437" type="curve" smooth="yes"/>
-      <point x="949" y="461"/>
-      <point x="957" y="485"/>
-      <point x="971" y="503" type="curve"/>
-      <point x="949" y="505" type="line"/>
-      <point x="920" y="463" type="line"/>
-      <point x="945" y="480"/>
-      <point x="982" y="490"/>
-      <point x="1019" y="490" type="curve" smooth="yes"/>
-      <point x="1062" y="490"/>
-      <point x="1079" y="474"/>
-      <point x="1079" y="434" type="curve" smooth="yes"/>
-      <point x="1079" y="395"/>
-      <point x="1053" y="371"/>
+      <point x="1032" y="338" type="curve" smooth="yes"/>
+      <point x="989" y="338"/>
+      <point x="965" y="367"/>
+      <point x="965" y="411" type="curve" smooth="yes"/>
+      <point x="965" y="432"/>
+      <point x="971" y="451"/>
+      <point x="980" y="473" type="curve"/>
+      <point x="955" y="473" type="line"/>
+      <point x="942" y="443" type="line"/>
+      <point x="969" y="457"/>
+      <point x="999" y="468"/>
+      <point x="1034" y="468" type="curve" smooth="yes"/>
+      <point x="1078" y="468"/>
+      <point x="1101" y="448"/>
+      <point x="1101" y="408" type="curve" smooth="yes"/>
+      <point x="1101" y="377"/>
+      <point x="1083" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/j_nya-malayalam.glif
@@ -1,194 +1,194 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2219"/>
-  <anchor x="1756" y="0" name="bottom"/>
-  <anchor x="1154" y="596" name="top"/>
-  <anchor x="2120" y="596" name="topright"/>
+  <advance width="2252"/>
+  <anchor x="1789" y="0" name="bottom"/>
+  <anchor x="1179" y="596" name="top"/>
+  <anchor x="2155" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="311" y="-16" type="curve" smooth="yes"/>
-      <point x="527" y="-16"/>
-      <point x="678" y="42"/>
-      <point x="790" y="183" type="curve"/>
-      <point x="840" y="183" type="line"/>
-      <point x="800" y="250" type="line"/>
-      <point x="799" y="241"/>
-      <point x="799" y="231"/>
-      <point x="799" y="222" type="curve" smooth="yes"/>
-      <point x="799" y="79"/>
-      <point x="876" y="-16"/>
-      <point x="1002" y="-16" type="curve" smooth="yes"/>
-      <point x="1117" y="-16"/>
-      <point x="1187" y="60"/>
-      <point x="1187" y="185" type="curve" smooth="yes"/>
-      <point x="1187" y="293"/>
-      <point x="1131" y="356"/>
-      <point x="1035" y="356" type="curve" smooth="yes"/>
-      <point x="974" y="356"/>
-      <point x="923" y="330"/>
-      <point x="887" y="281" type="curve"/>
-      <point x="851" y="287" type="line"/>
-      <point x="862" y="153" type="line"/>
-      <point x="886" y="229"/>
-      <point x="948" y="282"/>
-      <point x="1013" y="282" type="curve" smooth="yes"/>
-      <point x="1075" y="282"/>
-      <point x="1105" y="250"/>
-      <point x="1105" y="184" type="curve" smooth="yes"/>
-      <point x="1105" y="106"/>
-      <point x="1067" y="62"/>
-      <point x="1000" y="62" type="curve" smooth="yes"/>
-      <point x="919" y="62"/>
-      <point x="872" y="120"/>
-      <point x="872" y="220" type="curve" smooth="yes"/>
-      <point x="872" y="406"/>
-      <point x="975" y="534"/>
-      <point x="1125" y="534" type="curve" smooth="yes"/>
-      <point x="1232" y="534"/>
-      <point x="1288" y="479"/>
-      <point x="1288" y="372" type="curve" smooth="yes"/>
-      <point x="1288" y="354"/>
-      <point x="1286" y="335"/>
-      <point x="1282" y="314" type="curve" smooth="yes"/>
-      <point x="1226" y="0" type="line"/>
-      <point x="1310" y="0" type="line"/>
-      <point x="1369" y="333" type="line" smooth="yes"/>
-      <point x="1393" y="470"/>
-      <point x="1462" y="534"/>
-      <point x="1585" y="534" type="curve" smooth="yes"/>
-      <point x="1732" y="534"/>
-      <point x="1818" y="439"/>
-      <point x="1818" y="275" type="curve" smooth="yes"/>
-      <point x="1818" y="152"/>
-      <point x="1762" y="62"/>
-      <point x="1684" y="62" type="curve" smooth="yes"/>
-      <point x="1612" y="62"/>
-      <point x="1576" y="109"/>
-      <point x="1576" y="202" type="curve" smooth="yes"/>
-      <point x="1576" y="381"/>
-      <point x="1718" y="534"/>
-      <point x="1884" y="534" type="curve" smooth="yes"/>
-      <point x="2013" y="534"/>
-      <point x="2090" y="467"/>
-      <point x="2090" y="354" type="curve" smooth="yes"/>
-      <point x="2090" y="246"/>
-      <point x="2038" y="143"/>
-      <point x="1933" y="43" type="curve"/>
-      <point x="1994" y="-14" type="line"/>
-      <point x="2118" y="107"/>
-      <point x="2172" y="218"/>
-      <point x="2172" y="354" type="curve" smooth="yes"/>
-      <point x="2172" y="512"/>
-      <point x="2064" y="612"/>
-      <point x="1895" y="612" type="curve" smooth="yes"/>
-      <point x="1681" y="612"/>
-      <point x="1494" y="418"/>
-      <point x="1494" y="197" type="curve" smooth="yes"/>
-      <point x="1494" y="62"/>
-      <point x="1564" y="-16"/>
-      <point x="1684" y="-16" type="curve" smooth="yes"/>
-      <point x="1817" y="-16"/>
-      <point x="1900" y="96"/>
-      <point x="1900" y="275" type="curve" smooth="yes"/>
-      <point x="1900" y="479"/>
-      <point x="1779" y="612"/>
-      <point x="1594" y="612" type="curve" smooth="yes"/>
-      <point x="1480" y="612"/>
-      <point x="1395" y="567"/>
-      <point x="1348" y="480" type="curve"/>
-      <point x="1338" y="480" type="line"/>
-      <point x="1303" y="567"/>
-      <point x="1231" y="612"/>
-      <point x="1125" y="612" type="curve" smooth="yes"/>
-      <point x="1002" y="612"/>
-      <point x="898" y="553"/>
-      <point x="812" y="353" type="curve" smooth="yes"/>
-      <point x="717" y="132"/>
-      <point x="543" y="61"/>
-      <point x="325" y="61" type="curve" smooth="yes"/>
-      <point x="187" y="61"/>
-      <point x="111" y="81"/>
-      <point x="111" y="147" type="curve" smooth="yes"/>
-      <point x="111" y="194"/>
-      <point x="154" y="222"/>
-      <point x="235" y="222" type="curve" smooth="yes"/>
-      <point x="535" y="222" type="line" smooth="yes"/>
-      <point x="697" y="222"/>
-      <point x="795" y="309"/>
-      <point x="795" y="449" type="curve" smooth="yes"/>
-      <point x="795" y="544"/>
-      <point x="742" y="612"/>
-      <point x="636" y="612" type="curve" smooth="yes"/>
-      <point x="562" y="612"/>
-      <point x="500" y="569"/>
-      <point x="470" y="490" type="curve"/>
-      <point x="462" y="490" type="line"/>
-      <point x="446" y="571"/>
-      <point x="391" y="612"/>
-      <point x="294" y="612" type="curve" smooth="yes"/>
-      <point x="174" y="612"/>
-      <point x="81" y="535"/>
-      <point x="81" y="435" type="curve" smooth="yes"/>
-      <point x="81" y="355"/>
-      <point x="133" y="307"/>
-      <point x="219" y="307" type="curve" smooth="yes"/>
-      <point x="305" y="307"/>
-      <point x="359" y="357"/>
-      <point x="359" y="436" type="curve" smooth="yes"/>
-      <point x="359" y="496"/>
-      <point x="326" y="530"/>
-      <point x="269" y="530" type="curve" smooth="yes"/>
-      <point x="245" y="530"/>
-      <point x="220" y="526"/>
-      <point x="196" y="518" type="curve"/>
-      <point x="183" y="543" type="line"/>
-      <point x="183" y="521" type="line"/>
-      <point x="206" y="541"/>
-      <point x="249" y="552"/>
-      <point x="294" y="552" type="curve" smooth="yes"/>
-      <point x="374" y="552"/>
-      <point x="412" y="515"/>
-      <point x="412" y="435" type="curve" smooth="yes"/>
-      <point x="412" y="414"/>
-      <point x="411" y="400"/>
-      <point x="407" y="380" type="curve" smooth="yes"/>
-      <point x="402" y="353" type="line"/>
-      <point x="486" y="353" type="line"/>
-      <point x="492" y="388" type="line" smooth="yes"/>
-      <point x="508" y="480"/>
-      <point x="555" y="534"/>
-      <point x="618" y="534" type="curve" smooth="yes"/>
-      <point x="679" y="534"/>
-      <point x="711" y="503"/>
-      <point x="711" y="442" type="curve" smooth="yes"/>
-      <point x="711" y="348"/>
-      <point x="653" y="294"/>
-      <point x="537" y="294" type="curve" smooth="yes"/>
-      <point x="245" y="294" type="line" smooth="yes"/>
-      <point x="109" y="294"/>
-      <point x="30" y="236"/>
-      <point x="30" y="140" type="curve" smooth="yes"/>
-      <point x="30" y="40"/>
-      <point x="118" y="-16"/>
+      <point x="283" y="-16" type="curve" smooth="yes"/>
+      <point x="537" y="-16"/>
+      <point x="705" y="42"/>
+      <point x="826" y="194" type="curve"/>
+      <point x="876" y="188" type="line"/>
+      <point x="835" y="250" type="line"/>
+      <point x="834" y="241"/>
+      <point x="834" y="231"/>
+      <point x="834" y="222" type="curve" smooth="yes"/>
+      <point x="834" y="79"/>
+      <point x="911" y="-16"/>
+      <point x="1037" y="-16" type="curve" smooth="yes"/>
+      <point x="1152" y="-16"/>
+      <point x="1222" y="60"/>
+      <point x="1222" y="185" type="curve" smooth="yes"/>
+      <point x="1222" y="293"/>
+      <point x="1166" y="356"/>
+      <point x="1070" y="356" type="curve" smooth="yes"/>
+      <point x="1009" y="356"/>
+      <point x="958" y="330"/>
+      <point x="922" y="281" type="curve"/>
+      <point x="886" y="287" type="line"/>
+      <point x="897" y="153" type="line"/>
+      <point x="921" y="229"/>
+      <point x="983" y="282"/>
+      <point x="1048" y="282" type="curve" smooth="yes"/>
+      <point x="1110" y="282"/>
+      <point x="1140" y="250"/>
+      <point x="1140" y="184" type="curve" smooth="yes"/>
+      <point x="1140" y="106"/>
+      <point x="1102" y="62"/>
+      <point x="1035" y="62" type="curve" smooth="yes"/>
+      <point x="954" y="62"/>
+      <point x="907" y="120"/>
+      <point x="907" y="220" type="curve" smooth="yes"/>
+      <point x="907" y="406"/>
+      <point x="1010" y="534"/>
+      <point x="1160" y="534" type="curve" smooth="yes"/>
+      <point x="1267" y="534"/>
+      <point x="1323" y="478"/>
+      <point x="1323" y="373" type="curve" smooth="yes"/>
+      <point x="1323" y="355"/>
+      <point x="1321" y="335"/>
+      <point x="1317" y="314" type="curve" smooth="yes"/>
+      <point x="1261" y="0" type="line"/>
+      <point x="1345" y="0" type="line"/>
+      <point x="1404" y="333" type="line" smooth="yes"/>
+      <point x="1428" y="470"/>
+      <point x="1494" y="534"/>
+      <point x="1614" y="534" type="curve" smooth="yes"/>
+      <point x="1761" y="534"/>
+      <point x="1847" y="439"/>
+      <point x="1847" y="275" type="curve" smooth="yes"/>
+      <point x="1847" y="152"/>
+      <point x="1791" y="62"/>
+      <point x="1713" y="62" type="curve" smooth="yes"/>
+      <point x="1641" y="62"/>
+      <point x="1605" y="109"/>
+      <point x="1605" y="202" type="curve" smooth="yes"/>
+      <point x="1605" y="381"/>
+      <point x="1747" y="534"/>
+      <point x="1913" y="534" type="curve" smooth="yes"/>
+      <point x="2042" y="534"/>
+      <point x="2119" y="467"/>
+      <point x="2119" y="354" type="curve" smooth="yes"/>
+      <point x="2119" y="246"/>
+      <point x="2067" y="143"/>
+      <point x="1962" y="43" type="curve"/>
+      <point x="2023" y="-14" type="line"/>
+      <point x="2147" y="107"/>
+      <point x="2201" y="218"/>
+      <point x="2201" y="354" type="curve" smooth="yes"/>
+      <point x="2201" y="512"/>
+      <point x="2093" y="612"/>
+      <point x="1924" y="612" type="curve" smooth="yes"/>
+      <point x="1710" y="612"/>
+      <point x="1523" y="418"/>
+      <point x="1523" y="197" type="curve" smooth="yes"/>
+      <point x="1523" y="62"/>
+      <point x="1593" y="-16"/>
+      <point x="1713" y="-16" type="curve" smooth="yes"/>
+      <point x="1846" y="-16"/>
+      <point x="1929" y="96"/>
+      <point x="1929" y="275" type="curve" smooth="yes"/>
+      <point x="1929" y="479"/>
+      <point x="1808" y="612"/>
+      <point x="1623" y="612" type="curve" smooth="yes"/>
+      <point x="1512" y="612"/>
+      <point x="1429" y="567"/>
+      <point x="1383" y="480" type="curve"/>
+      <point x="1373" y="480" type="line"/>
+      <point x="1338" y="567"/>
+      <point x="1266" y="612"/>
+      <point x="1160" y="612" type="curve" smooth="yes"/>
+      <point x="1037" y="612"/>
+      <point x="933" y="553"/>
+      <point x="847" y="353" type="curve" smooth="yes"/>
+      <point x="750" y="127"/>
+      <point x="578" y="61"/>
+      <point x="291" y="61" type="curve" smooth="yes"/>
+      <point x="176" y="61"/>
+      <point x="111" y="74"/>
+      <point x="111" y="129" type="curve" smooth="yes"/>
+      <point x="111" y="163"/>
+      <point x="137" y="192"/>
+      <point x="203" y="192" type="curve" smooth="yes"/>
+      <point x="490" y="192" type="line" smooth="yes"/>
+      <point x="728" y="192"/>
+      <point x="823" y="322"/>
+      <point x="823" y="445" type="curve" smooth="yes"/>
+      <point x="823" y="549"/>
+      <point x="766" y="612"/>
+      <point x="670" y="612" type="curve" smooth="yes"/>
+      <point x="589" y="612"/>
+      <point x="526" y="570"/>
+      <point x="495" y="491" type="curve"/>
+      <point x="487" y="491" type="line"/>
+      <point x="470" y="571"/>
+      <point x="416" y="612"/>
+      <point x="314" y="612" type="curve" smooth="yes"/>
+      <point x="156" y="612"/>
+      <point x="77" y="502"/>
+      <point x="77" y="413" type="curve" smooth="yes"/>
+      <point x="77" y="329"/>
+      <point x="127" y="274"/>
+      <point x="210" y="274" type="curve" smooth="yes"/>
+      <point x="311" y="274"/>
+      <point x="355" y="350"/>
+      <point x="355" y="408" type="curve" smooth="yes"/>
+      <point x="355" y="474"/>
+      <point x="319" y="512"/>
+      <point x="256" y="512" type="curve" smooth="yes"/>
+      <point x="228" y="512"/>
+      <point x="207" y="509"/>
+      <point x="184" y="501" type="curve"/>
+      <point x="166" y="527" type="line"/>
+      <point x="171" y="497" type="line"/>
+      <point x="196" y="529"/>
+      <point x="248" y="552"/>
+      <point x="309" y="552" type="curve" smooth="yes"/>
+      <point x="393" y="552"/>
+      <point x="430" y="504"/>
+      <point x="430" y="436" type="curve" smooth="yes"/>
+      <point x="430" y="422"/>
+      <point x="429" y="407"/>
+      <point x="426" y="390" type="curve" smooth="yes"/>
+      <point x="416" y="333" type="line"/>
+      <point x="500" y="333" type="line"/>
+      <point x="510" y="390" type="line" smooth="yes"/>
+      <point x="526" y="481"/>
+      <point x="577" y="534"/>
+      <point x="651" y="534" type="curve" smooth="yes"/>
+      <point x="709" y="534"/>
+      <point x="741" y="501"/>
+      <point x="741" y="440" type="curve" smooth="yes"/>
+      <point x="741" y="357"/>
+      <point x="680" y="264"/>
+      <point x="500" y="264" type="curve" smooth="yes"/>
+      <point x="206" y="264" type="line" smooth="yes"/>
+      <point x="78" y="264"/>
+      <point x="29" y="189"/>
+      <point x="29" y="127" type="curve" smooth="yes"/>
+      <point x="29" y="34"/>
+      <point x="115" y="-16"/>
     </contour>
     <contour>
-      <point x="219" y="371" type="curve" smooth="yes"/>
-      <point x="178" y="371"/>
-      <point x="157" y="393"/>
-      <point x="157" y="437" type="curve" smooth="yes"/>
-      <point x="157" y="461"/>
-      <point x="165" y="485"/>
-      <point x="179" y="503" type="curve"/>
-      <point x="157" y="505" type="line"/>
-      <point x="128" y="463" type="line"/>
-      <point x="153" y="480"/>
-      <point x="190" y="490"/>
-      <point x="227" y="490" type="curve" smooth="yes"/>
-      <point x="270" y="490"/>
-      <point x="287" y="474"/>
-      <point x="287" y="434" type="curve" smooth="yes"/>
-      <point x="287" y="395"/>
-      <point x="261" y="371"/>
+      <point x="214" y="338" type="curve" smooth="yes"/>
+      <point x="171" y="338"/>
+      <point x="147" y="367"/>
+      <point x="147" y="411" type="curve" smooth="yes"/>
+      <point x="147" y="432"/>
+      <point x="152" y="451"/>
+      <point x="162" y="473" type="curve"/>
+      <point x="137" y="473" type="line"/>
+      <point x="124" y="443" type="line"/>
+      <point x="150" y="458"/>
+      <point x="181" y="468"/>
+      <point x="216" y="468" type="curve" smooth="yes"/>
+      <point x="260" y="468"/>
+      <point x="283" y="448"/>
+      <point x="283" y="408" type="curve" smooth="yes"/>
+      <point x="283" y="377"/>
+      <point x="265" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ja-malayalam.glif
@@ -1,139 +1,138 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <unicode hex="0D1C"/>
-  <anchor x="393" y="0" name="bottom"/>
-  <anchor x="489" y="596" name="top"/>
-  <anchor x="735" y="596" name="topright"/>
+  <anchor x="403" y="-6" name="bottom"/>
+  <anchor x="494" y="596" name="top"/>
+  <anchor x="771" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="161" y="-16" type="curve" smooth="yes"/>
-      <point x="214" y="-16"/>
-      <point x="269" y="2"/>
-      <point x="368" y="57" type="curve" smooth="yes"/>
-      <point x="437" y="95" type="line"/>
-      <point x="559" y="171" type="line"/>
-      <point x="570" y="161" type="line"/>
-      <point x="592" y="170"/>
-      <point x="609" y="172"/>
-      <point x="625" y="172" type="curve" smooth="yes"/>
-      <point x="660" y="172"/>
-      <point x="678" y="154"/>
-      <point x="678" y="121" type="curve" smooth="yes"/>
-      <point x="678" y="75"/>
-      <point x="654" y="48"/>
-      <point x="615" y="48" type="curve" smooth="yes"/>
-      <point x="583" y="48"/>
-      <point x="562" y="69"/>
-      <point x="562" y="101" type="curve" smooth="yes"/>
-      <point x="562" y="137"/>
-      <point x="576" y="163"/>
-      <point x="613" y="190" type="curve"/>
-      <point x="489" y="166" type="line"/>
-      <point x="528" y="108" type="line"/>
-      <point x="548" y="162" type="line"/>
-      <point x="521" y="146"/>
-      <point x="501" y="119"/>
-      <point x="501" y="79" type="curve" smooth="yes"/>
-      <point x="501" y="24"/>
-      <point x="548" y="-16"/>
-      <point x="613" y="-16" type="curve" smooth="yes"/>
-      <point x="697" y="-16"/>
-      <point x="745" y="35"/>
-      <point x="745" y="124" type="curve" smooth="yes"/>
-      <point x="745" y="196"/>
-      <point x="707" y="238"/>
-      <point x="641" y="238" type="curve" smooth="yes"/>
-      <point x="583" y="238"/>
-      <point x="544" y="225"/>
-      <point x="433" y="169" type="curve" smooth="yes"/>
-      <point x="350" y="127" type="line" smooth="yes"/>
-      <point x="239" y="71"/>
-      <point x="214" y="61"/>
-      <point x="174" y="61" type="curve" smooth="yes"/>
-      <point x="132" y="61"/>
-      <point x="109" y="85"/>
-      <point x="109" y="129" type="curve" smooth="yes"/>
-      <point x="109" y="189"/>
-      <point x="154" y="222"/>
-      <point x="235" y="222" type="curve" smooth="yes"/>
-      <point x="543" y="222" type="line" smooth="yes"/>
-      <point x="705" y="222"/>
-      <point x="806" y="309"/>
-      <point x="806" y="449" type="curve" smooth="yes"/>
-      <point x="806" y="546"/>
-      <point x="742" y="612"/>
-      <point x="648" y="612" type="curve" smooth="yes"/>
-      <point x="566" y="612"/>
-      <point x="503" y="569"/>
-      <point x="474" y="490" type="curve"/>
-      <point x="464" y="490" type="line"/>
-      <point x="449" y="571"/>
-      <point x="391" y="612"/>
-      <point x="294" y="612" type="curve" smooth="yes"/>
-      <point x="174" y="612"/>
-      <point x="81" y="535"/>
-      <point x="81" y="435" type="curve" smooth="yes"/>
-      <point x="81" y="355"/>
-      <point x="133" y="307"/>
-      <point x="219" y="307" type="curve" smooth="yes"/>
-      <point x="305" y="307"/>
-      <point x="359" y="357"/>
-      <point x="359" y="436" type="curve" smooth="yes"/>
-      <point x="359" y="496"/>
-      <point x="326" y="530"/>
-      <point x="264" y="530" type="curve" smooth="yes"/>
-      <point x="240" y="530"/>
-      <point x="220" y="526"/>
-      <point x="195" y="518" type="curve"/>
-      <point x="183" y="543" type="line"/>
-      <point x="183" y="520" type="line"/>
-      <point x="206" y="540"/>
-      <point x="249" y="552"/>
-      <point x="294" y="552" type="curve" smooth="yes"/>
-      <point x="374" y="552"/>
-      <point x="412" y="515"/>
-      <point x="412" y="435" type="curve" smooth="yes"/>
-      <point x="412" y="414"/>
-      <point x="411" y="400"/>
-      <point x="407" y="380" type="curve" smooth="yes"/>
-      <point x="402" y="353" type="line"/>
-      <point x="486" y="353" type="line"/>
-      <point x="492" y="388" type="line" smooth="yes"/>
-      <point x="508" y="480"/>
-      <point x="559" y="534"/>
-      <point x="630" y="534" type="curve" smooth="yes"/>
-      <point x="691" y="534"/>
-      <point x="722" y="503"/>
-      <point x="722" y="442" type="curve" smooth="yes"/>
-      <point x="722" y="348"/>
-      <point x="661" y="294"/>
-      <point x="555" y="294" type="curve" smooth="yes"/>
-      <point x="245" y="294" type="line" smooth="yes"/>
-      <point x="109" y="294"/>
-      <point x="30" y="231"/>
-      <point x="30" y="121" type="curve" smooth="yes"/>
-      <point x="30" y="36"/>
-      <point x="80" y="-16"/>
+      <point x="174" y="-16" type="curve" smooth="yes"/>
+      <point x="223" y="-16"/>
+      <point x="259" y="-6"/>
+      <point x="330" y="27" type="curve" smooth="yes"/>
+      <point x="486" y="99" type="line"/>
+      <point x="559" y="148" type="line"/>
+      <point x="587" y="154" type="line"/>
+      <point x="618" y="172"/>
+      <point x="640" y="178"/>
+      <point x="668" y="178" type="curve" smooth="yes"/>
+      <point x="706" y="178"/>
+      <point x="723" y="157"/>
+      <point x="723" y="124" type="curve" smooth="yes"/>
+      <point x="723" y="92"/>
+      <point x="703" y="56"/>
+      <point x="652" y="56" type="curve" smooth="yes"/>
+      <point x="616" y="56"/>
+      <point x="595" y="77"/>
+      <point x="595" y="109" type="curve" smooth="yes"/>
+      <point x="595" y="140"/>
+      <point x="609" y="161"/>
+      <point x="636" y="188" type="curve"/>
+      <point x="532" y="148" type="line"/>
+      <point x="548" y="128" type="line"/>
+      <point x="539" y="114"/>
+      <point x="534" y="98"/>
+      <point x="534" y="80" type="curve" smooth="yes"/>
+      <point x="534" y="22"/>
+      <point x="578" y="-16"/>
+      <point x="645" y="-16" type="curve" smooth="yes"/>
+      <point x="753" y="-16"/>
+      <point x="794" y="69"/>
+      <point x="794" y="126" type="curve" smooth="yes"/>
+      <point x="794" y="189"/>
+      <point x="755" y="232"/>
+      <point x="684" y="232" type="curve" smooth="yes"/>
+      <point x="638" y="232"/>
+      <point x="599" y="224"/>
+      <point x="517" y="186" type="curve" smooth="yes"/>
+      <point x="308" y="89" type="line" smooth="yes"/>
+      <point x="260" y="67"/>
+      <point x="223" y="58"/>
+      <point x="178" y="58" type="curve" smooth="yes"/>
+      <point x="136" y="58"/>
+      <point x="109" y="82"/>
+      <point x="109" y="119" type="curve" smooth="yes"/>
+      <point x="109" y="164"/>
+      <point x="145" y="192"/>
+      <point x="212" y="192" type="curve" smooth="yes"/>
+      <point x="533" y="192" type="line" smooth="yes"/>
+      <point x="715" y="192"/>
+      <point x="849" y="286"/>
+      <point x="849" y="438" type="curve" smooth="yes"/>
+      <point x="849" y="546"/>
+      <point x="787" y="612"/>
+      <point x="682" y="612" type="curve" smooth="yes"/>
+      <point x="594" y="612"/>
+      <point x="529" y="570"/>
+      <point x="495" y="491" type="curve"/>
+      <point x="487" y="491" type="line"/>
+      <point x="470" y="571"/>
+      <point x="416" y="612"/>
+      <point x="314" y="612" type="curve" smooth="yes"/>
+      <point x="156" y="612"/>
+      <point x="77" y="502"/>
+      <point x="77" y="413" type="curve" smooth="yes"/>
+      <point x="77" y="329"/>
+      <point x="127" y="274"/>
+      <point x="210" y="274" type="curve" smooth="yes"/>
+      <point x="311" y="274"/>
+      <point x="355" y="350"/>
+      <point x="355" y="408" type="curve" smooth="yes"/>
+      <point x="355" y="474"/>
+      <point x="319" y="512"/>
+      <point x="256" y="512" type="curve" smooth="yes"/>
+      <point x="228" y="512"/>
+      <point x="207" y="509"/>
+      <point x="184" y="501" type="curve"/>
+      <point x="166" y="527" type="line"/>
+      <point x="171" y="497" type="line"/>
+      <point x="196" y="529"/>
+      <point x="248" y="552"/>
+      <point x="309" y="552" type="curve" smooth="yes"/>
+      <point x="393" y="552"/>
+      <point x="430" y="504"/>
+      <point x="430" y="436" type="curve" smooth="yes"/>
+      <point x="430" y="422"/>
+      <point x="429" y="407"/>
+      <point x="426" y="390" type="curve" smooth="yes"/>
+      <point x="416" y="333" type="line"/>
+      <point x="500" y="333" type="line"/>
+      <point x="510" y="390" type="line" smooth="yes"/>
+      <point x="526" y="481"/>
+      <point x="584" y="534"/>
+      <point x="665" y="534" type="curve" smooth="yes"/>
+      <point x="731" y="534"/>
+      <point x="767" y="499"/>
+      <point x="767" y="433" type="curve" smooth="yes"/>
+      <point x="767" y="328"/>
+      <point x="694" y="264"/>
+      <point x="551" y="264" type="curve" smooth="yes"/>
+      <point x="215" y="264" type="line" smooth="yes"/>
+      <point x="105" y="264"/>
+      <point x="27" y="207"/>
+      <point x="27" y="114" type="curve" smooth="yes"/>
+      <point x="27" y="34"/>
+      <point x="87" y="-16"/>
     </contour>
     <contour>
-      <point x="219" y="371" type="curve" smooth="yes"/>
-      <point x="178" y="371"/>
-      <point x="157" y="393"/>
-      <point x="157" y="437" type="curve" smooth="yes"/>
-      <point x="157" y="461"/>
-      <point x="165" y="485"/>
-      <point x="179" y="503" type="curve"/>
-      <point x="157" y="505" type="line"/>
-      <point x="128" y="463" type="line"/>
-      <point x="153" y="480"/>
-      <point x="190" y="490"/>
-      <point x="227" y="490" type="curve" smooth="yes"/>
-      <point x="270" y="490"/>
-      <point x="287" y="474"/>
-      <point x="287" y="434" type="curve" smooth="yes"/>
-      <point x="287" y="395"/>
-      <point x="261" y="371"/>
+      <point x="214" y="338" type="curve" smooth="yes"/>
+      <point x="171" y="338"/>
+      <point x="147" y="367"/>
+      <point x="147" y="411" type="curve" smooth="yes"/>
+      <point x="147" y="432"/>
+      <point x="152" y="451"/>
+      <point x="162" y="473" type="curve"/>
+      <point x="137" y="473" type="line"/>
+      <point x="124" y="443" type="line"/>
+      <point x="150" y="458"/>
+      <point x="181" y="468"/>
+      <point x="216" y="468" type="curve" smooth="yes"/>
+      <point x="260" y="468"/>
+      <point x="283" y="448"/>
+      <point x="283" y="408" type="curve" smooth="yes"/>
+      <point x="283" y="377"/>
+      <point x="265" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="655"/>
+    <component base="halant-malayalam" xOffset="691"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="440"/>
+    <component base="lVocalicMatra-malayalam" xOffset="450" yOffset="-6"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="441"/>
+    <component base="llVocalicMatra-malayalam" xOffset="451" yOffset="-6"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
@@ -2,114 +2,112 @@
 <glyph name="kChillu-malayalam" format="2">
   <advance width="1066"/>
   <unicode hex="0D7F"/>
-  <guideline x="1046"/>
-  <anchor x="690" y="0" name="bottom"/>
-  <anchor x="375" y="596" name="top"/>
+  <anchor x="615" y="0" name="bottom"/>
+  <anchor x="406" y="596" name="top"/>
   <outline>
     <contour>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="321" y="26"/>
-      <point x="348" y="90" type="curve"/>
-      <point x="358" y="90" type="line"/>
-      <point x="385" y="23"/>
-      <point x="432" y="-16"/>
-      <point x="514" y="-16" type="curve" smooth="yes"/>
-      <point x="587" y="-16"/>
-      <point x="643" y="14"/>
-      <point x="680" y="84" type="curve"/>
-      <point x="690" y="84" type="line"/>
-      <point x="709" y="23"/>
-      <point x="755" y="-16"/>
-      <point x="836" y="-16" type="curve" smooth="yes"/>
-      <point x="944" y="-16"/>
-      <point x="1005" y="60"/>
-      <point x="1005" y="170" type="curve" smooth="yes"/>
-      <point x="1005" y="261"/>
-      <point x="944" y="333"/>
-      <point x="816" y="333" type="curve" smooth="yes"/>
-      <point x="776" y="333" type="line"/>
-      <point x="730" y="259" type="line"/>
-      <point x="797" y="259" type="line" smooth="yes"/>
-      <point x="893" y="259"/>
-      <point x="920" y="219"/>
-      <point x="920" y="171" type="curve" smooth="yes"/>
-      <point x="920" y="105"/>
-      <point x="889" y="62"/>
-      <point x="828" y="62" type="curve" smooth="yes"/>
-      <point x="769" y="62"/>
-      <point x="736" y="98"/>
-      <point x="736" y="162" type="curve" smooth="yes"/>
-      <point x="736" y="252"/>
-      <point x="808" y="330"/>
-      <point x="892" y="435" type="curve" smooth="yes"/>
-      <point x="957" y="516"/>
-      <point x="1005" y="580"/>
-      <point x="1005" y="679" type="curve" smooth="yes"/>
-      <point x="1005" y="758"/>
-      <point x="957" y="810"/>
-      <point x="857" y="810" type="curve" smooth="yes"/>
-      <point x="808" y="810"/>
-      <point x="759" y="800"/>
-      <point x="705" y="769" type="curve"/>
-      <point x="731" y="700" type="line"/>
-      <point x="774" y="723"/>
-      <point x="815" y="732"/>
-      <point x="846" y="732" type="curve" smooth="yes"/>
-      <point x="901" y="732"/>
-      <point x="922" y="706"/>
-      <point x="922" y="667" type="curve" smooth="yes"/>
-      <point x="922" y="601"/>
-      <point x="886" y="545"/>
-      <point x="823" y="464" type="curve" smooth="yes"/>
-      <point x="800" y="434"/>
-      <point x="781" y="409"/>
-      <point x="768" y="377" type="curve"/>
-      <point x="717" y="377" type="line"/>
-      <point x="757" y="340" type="line"/>
-      <point x="758" y="352"/>
-      <point x="758" y="364"/>
-      <point x="758" y="376" type="curve" smooth="yes"/>
-      <point x="758" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="726" y="259" type="line"/>
-      <point x="726" y="333" type="line"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="557" y="-16"/>
+      <point x="614" y="18"/>
+      <point x="655" y="83" type="curve"/>
+      <point x="666" y="83" type="line"/>
+      <point x="683" y="24"/>
+      <point x="734" y="-16"/>
+      <point x="809" y="-16" type="curve" smooth="yes"/>
+      <point x="920" y="-16"/>
+      <point x="1000" y="77"/>
+      <point x="1000" y="186" type="curve" smooth="yes"/>
+      <point x="1000" y="289"/>
+      <point x="931" y="353"/>
+      <point x="813" y="353" type="curve" smooth="yes"/>
+      <point x="788" y="353" type="line"/>
+      <point x="741" y="279" type="line"/>
+      <point x="810" y="279" type="line" smooth="yes"/>
+      <point x="885" y="279"/>
+      <point x="916" y="243"/>
+      <point x="916" y="181" type="curve" smooth="yes"/>
+      <point x="916" y="111"/>
+      <point x="873" y="62"/>
+      <point x="811" y="62" type="curve" smooth="yes"/>
+      <point x="755" y="62"/>
+      <point x="722" y="94"/>
+      <point x="722" y="149" type="curve" smooth="yes"/>
+      <point x="722" y="211"/>
+      <point x="764" y="287"/>
+      <point x="882" y="432" type="curve" smooth="yes"/>
+      <point x="968" y="538"/>
+      <point x="1001" y="604"/>
+      <point x="1001" y="675" type="curve" smooth="yes"/>
+      <point x="1001" y="752"/>
+      <point x="953" y="810"/>
+      <point x="860" y="810" type="curve" smooth="yes"/>
+      <point x="802" y="810"/>
+      <point x="753" y="796"/>
+      <point x="697" y="759" type="curve"/>
+      <point x="735" y="692" type="line"/>
+      <point x="776" y="719"/>
+      <point x="815" y="731"/>
+      <point x="853" y="731" type="curve" smooth="yes"/>
+      <point x="897" y="731"/>
+      <point x="918" y="710"/>
+      <point x="918" y="667" type="curve" smooth="yes"/>
+      <point x="918" y="619"/>
+      <point x="882" y="553"/>
+      <point x="814" y="467" type="curve" smooth="yes"/>
+      <point x="782" y="427"/>
+      <point x="764" y="393"/>
+      <point x="751" y="360" type="curve"/>
+      <point x="743" y="360" type="line"/>
+      <point x="746" y="383"/>
+      <point x="748" y="405"/>
+      <point x="748" y="425" type="curve" smooth="yes"/>
+      <point x="748" y="544"/>
+      <point x="694" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="707" y="279" type="line"/>
+      <point x="727" y="353" type="line"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="521" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="209"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="658" y="534"/>
+      <point x="685" y="484"/>
+      <point x="685" y="407" type="curve" smooth="yes"/>
+      <point x="685" y="316"/>
+      <point x="643" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/k_ka-malayalam.glif
@@ -1,99 +1,98 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ka-malayalam" format="2">
   <advance width="1454"/>
-  <guideline x="1405"/>
-  <anchor x="1049" y="0" name="bottom"/>
-  <anchor x="798" y="596" name="top"/>
-  <anchor x="1326" y="596" name="topright"/>
+  <anchor x="991" y="0" name="bottom"/>
+  <anchor x="846" y="596" name="top"/>
+  <anchor x="1374" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="316" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="380" y="23"/>
-      <point x="434" y="-16"/>
-      <point x="518" y="-16" type="curve" smooth="yes"/>
-      <point x="688" y="-16"/>
-      <point x="772" y="175"/>
-      <point x="772" y="385" type="curve" smooth="yes"/>
-      <point x="772" y="519"/>
-      <point x="713" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="258"/>
-      <point x="233" y="258" type="curve" smooth="yes"/>
-      <point x="918" y="258" type="line" smooth="yes"/>
-      <point x="1031" y="258"/>
-      <point x="1056" y="218"/>
-      <point x="1056" y="164" type="curve" smooth="yes"/>
-      <point x="1056" y="112"/>
-      <point x="1036" y="62"/>
-      <point x="985" y="62" type="curve" smooth="yes"/>
-      <point x="927" y="62"/>
-      <point x="901" y="110"/>
-      <point x="901" y="182" type="curve" smooth="yes"/>
-      <point x="901" y="381"/>
-      <point x="991" y="533"/>
-      <point x="1150" y="533" type="curve" smooth="yes"/>
-      <point x="1268" y="533"/>
-      <point x="1327" y="460"/>
-      <point x="1327" y="343" type="curve" smooth="yes"/>
-      <point x="1327" y="212"/>
-      <point x="1271" y="127"/>
-      <point x="1185" y="37" type="curve"/>
-      <point x="1246" y="-16" type="line"/>
-      <point x="1349" y="86"/>
-      <point x="1410" y="201"/>
-      <point x="1410" y="350" type="curve" smooth="yes"/>
-      <point x="1410" y="510"/>
-      <point x="1320" y="612"/>
-      <point x="1148" y="612" type="curve" smooth="yes"/>
-      <point x="944" y="612"/>
-      <point x="820" y="440"/>
-      <point x="820" y="187" type="curve" smooth="yes"/>
-      <point x="820" y="76"/>
-      <point x="869" y="-16"/>
-      <point x="988" y="-16" type="curve" smooth="yes"/>
-      <point x="1085" y="-16"/>
-      <point x="1139" y="65"/>
-      <point x="1139" y="163" type="curve" smooth="yes"/>
-      <point x="1139" y="258"/>
-      <point x="1091" y="332"/>
-      <point x="923" y="332" type="curve" smooth="yes"/>
-      <point x="242" y="332" type="line" smooth="yes"/>
-      <point x="106" y="332"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="956" y="279" type="line" smooth="yes"/>
+      <point x="1029" y="279"/>
+      <point x="1063" y="248"/>
+      <point x="1063" y="178" type="curve" smooth="yes"/>
+      <point x="1063" y="137"/>
+      <point x="1044" y="62"/>
+      <point x="975" y="62" type="curve" smooth="yes"/>
+      <point x="920" y="62"/>
+      <point x="892" y="100"/>
+      <point x="892" y="179" type="curve" smooth="yes"/>
+      <point x="892" y="319"/>
+      <point x="965" y="533"/>
+      <point x="1155" y="533" type="curve" smooth="yes"/>
+      <point x="1265" y="533"/>
+      <point x="1320" y="465"/>
+      <point x="1320" y="343" type="curve" smooth="yes"/>
+      <point x="1320" y="236"/>
+      <point x="1281" y="141"/>
+      <point x="1179" y="43" type="curve"/>
+      <point x="1238" y="-16" type="line"/>
+      <point x="1349" y="91"/>
+      <point x="1402" y="222"/>
+      <point x="1402" y="350" type="curve" smooth="yes"/>
+      <point x="1402" y="512"/>
+      <point x="1318" y="612"/>
+      <point x="1164" y="612" type="curve" smooth="yes"/>
+      <point x="930" y="612"/>
+      <point x="811" y="381"/>
+      <point x="811" y="181" type="curve" smooth="yes"/>
+      <point x="811" y="59"/>
+      <point x="871" y="-16"/>
+      <point x="969" y="-16" type="curve" smooth="yes"/>
+      <point x="1086" y="-16"/>
+      <point x="1145" y="85"/>
+      <point x="1145" y="184" type="curve" smooth="yes"/>
+      <point x="1145" y="293"/>
+      <point x="1081" y="353"/>
+      <point x="960" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="515" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="661" y="534"/>
-      <point x="690" y="478"/>
-      <point x="690" y="397" type="curve" smooth="yes"/>
-      <point x="690" y="229"/>
-      <point x="640" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/k_la-malayalam.glif
@@ -1,145 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_la-malayalam" format="2">
   <advance width="1061"/>
-  <anchor x="546" y="-357" name="bottom"/>
-  <anchor x="604" y="596" name="top"/>
-  <anchor x="942" y="556" name="topright"/>
+  <anchor x="551" y="-362" name="bottom"/>
+  <anchor x="599" y="596" name="top"/>
+  <anchor x="936" y="556" name="topright"/>
   <outline>
     <contour>
-      <point x="342" y="-378" type="curve" smooth="yes"/>
-      <point x="429" y="-378"/>
-      <point x="479" y="-321"/>
-      <point x="479" y="-236" type="curve" smooth="yes"/>
-      <point x="479" y="-156"/>
-      <point x="434" y="-121"/>
-      <point x="368" y="-121" type="curve" smooth="yes"/>
-      <point x="334" y="-121"/>
-      <point x="301" y="-134"/>
-      <point x="278" y="-167" type="curve"/>
-      <point x="230" y="-162" type="line"/>
-      <point x="265" y="-184" type="line"/>
-      <point x="284" y="-78"/>
-      <point x="348" y="-22"/>
-      <point x="433" y="-22" type="curve" smooth="yes"/>
-      <point x="544" y="-22"/>
-      <point x="566" y="-91"/>
-      <point x="572" y="-180" type="curve" smooth="yes"/>
-      <point x="573" y="-196" type="line" smooth="yes"/>
-      <point x="580" y="-307"/>
-      <point x="624" y="-378"/>
-      <point x="741" y="-378" type="curve" smooth="yes"/>
-      <point x="875" y="-378"/>
-      <point x="925" y="-270"/>
-      <point x="925" y="-132" type="curve" smooth="yes"/>
-      <point x="925" y="-57"/>
-      <point x="902" y="7"/>
-      <point x="875" y="48" type="curve"/>
-      <point x="812" y="10" type="line"/>
-      <point x="828" y="-20"/>
-      <point x="849" y="-69"/>
-      <point x="849" y="-145" type="curve" smooth="yes"/>
-      <point x="849" y="-228"/>
-      <point x="821" y="-308"/>
-      <point x="742" y="-308" type="curve" smooth="yes"/>
-      <point x="681" y="-308"/>
-      <point x="657" y="-271"/>
-      <point x="648" y="-176" type="curve" smooth="yes"/>
-      <point x="646" y="-155" type="line" smooth="yes"/>
-      <point x="640" y="-91"/>
-      <point x="625" y="-41"/>
-      <point x="591" y="-7" type="curve"/>
-      <point x="592" y="3" type="line"/>
-      <point x="714" y="49"/>
-      <point x="774" y="208"/>
-      <point x="774" y="375" type="curve" smooth="yes"/>
-      <point x="774" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="802" y="259" type="line" smooth="yes"/>
-      <point x="884" y="259"/>
-      <point x="919" y="227"/>
-      <point x="919" y="165" type="curve" smooth="yes"/>
-      <point x="919" y="112"/>
-      <point x="895" y="60"/>
-      <point x="822" y="60" type="curve" smooth="yes"/>
-      <point x="797" y="60"/>
-      <point x="776" y="66"/>
-      <point x="761" y="73" type="curve"/>
-      <point x="730" y="3" type="line"/>
-      <point x="753" y="-9"/>
-      <point x="787" y="-16"/>
-      <point x="824" y="-16" type="curve" smooth="yes"/>
-      <point x="940" y="-16"/>
-      <point x="1001" y="59"/>
-      <point x="1001" y="168" type="curve" smooth="yes"/>
-      <point x="1001" y="267"/>
-      <point x="942" y="333"/>
-      <point x="810" y="333" type="curve" smooth="yes"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="316" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="359" y="75"/>
-      <point x="373" y="56"/>
-      <point x="389" y="46" type="curve"/>
-      <point x="388" y="35" type="line"/>
-      <point x="265" y="11"/>
-      <point x="196" y="-89"/>
-      <point x="196" y="-209" type="curve" smooth="yes"/>
-      <point x="196" y="-328"/>
-      <point x="261" y="-378"/>
+      <point x="334" y="-378" type="curve" smooth="yes"/>
+      <point x="433" y="-378"/>
+      <point x="479" y="-300"/>
+      <point x="479" y="-234" type="curve" smooth="yes"/>
+      <point x="479" y="-166"/>
+      <point x="444" y="-121"/>
+      <point x="381" y="-121" type="curve" smooth="yes"/>
+      <point x="333" y="-121"/>
+      <point x="267" y="-155"/>
+      <point x="253" y="-236" type="curve"/>
+      <point x="288" y="-175" type="line"/>
+      <point x="229" y="-175" type="line"/>
+      <point x="263" y="-201" type="line"/>
+      <point x="280" y="-94"/>
+      <point x="362" y="-22"/>
+      <point x="446" y="-22" type="curve" smooth="yes"/>
+      <point x="524" y="-22"/>
+      <point x="553" y="-61"/>
+      <point x="569" y="-160" type="curve" smooth="yes"/>
+      <point x="576" y="-203" type="line" smooth="yes"/>
+      <point x="596" y="-323"/>
+      <point x="645" y="-378"/>
+      <point x="736" y="-378" type="curve" smooth="yes"/>
+      <point x="878" y="-378"/>
+      <point x="922" y="-231"/>
+      <point x="922" y="-135" type="curve" smooth="yes"/>
+      <point x="922" y="-59"/>
+      <point x="902" y="0"/>
+      <point x="872" y="46" type="curve"/>
+      <point x="810" y="10" type="line"/>
+      <point x="833" y="-30"/>
+      <point x="848" y="-77"/>
+      <point x="848" y="-139" type="curve" smooth="yes"/>
+      <point x="848" y="-202"/>
+      <point x="829" y="-308"/>
+      <point x="743" y="-308" type="curve" smooth="yes"/>
+      <point x="687" y="-308"/>
+      <point x="662" y="-274"/>
+      <point x="648" y="-188" type="curve" smooth="yes"/>
+      <point x="641" y="-145" type="line" smooth="yes"/>
+      <point x="629" y="-68"/>
+      <point x="612" y="-26"/>
+      <point x="576" y="-1" type="curve"/>
+      <point x="578" y="10" type="line"/>
+      <point x="730" y="75"/>
+      <point x="769" y="279"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="793" y="279" type="line" smooth="yes"/>
+      <point x="872" y="279"/>
+      <point x="912" y="245"/>
+      <point x="912" y="178" type="curve" smooth="yes"/>
+      <point x="912" y="105"/>
+      <point x="871" y="60"/>
+      <point x="807" y="60" type="curve" smooth="yes"/>
+      <point x="785" y="60"/>
+      <point x="766" y="63"/>
+      <point x="748" y="70" type="curve"/>
+      <point x="725" y="-2" type="line"/>
+      <point x="748" y="-12"/>
+      <point x="773" y="-16"/>
+      <point x="801" y="-16" type="curve" smooth="yes"/>
+      <point x="914" y="-16"/>
+      <point x="993" y="65"/>
+      <point x="993" y="180" type="curve" smooth="yes"/>
+      <point x="993" y="289"/>
+      <point x="920" y="353"/>
+      <point x="796" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="351" y="70"/>
+      <point x="363" y="51"/>
+      <point x="381" y="38" type="curve"/>
+      <point x="379" y="27" type="line"/>
+      <point x="270" y="-6"/>
+      <point x="196" y="-113"/>
+      <point x="196" y="-227" type="curve" smooth="yes"/>
+      <point x="196" y="-321"/>
+      <point x="256" y="-378"/>
     </contour>
     <contour>
-      <point x="341" y="-313" type="curve" smooth="yes"/>
-      <point x="287" y="-313"/>
-      <point x="264" y="-270"/>
-      <point x="264" y="-223" type="curve"/>
-      <point x="246" y="-200" type="line"/>
-      <point x="257" y="-256" type="line"/>
-      <point x="264" y="-216"/>
-      <point x="298" y="-181"/>
-      <point x="347" y="-181" type="curve" smooth="yes"/>
-      <point x="389" y="-181"/>
-      <point x="408" y="-201"/>
-      <point x="408" y="-240" type="curve" smooth="yes"/>
-      <point x="408" y="-282"/>
-      <point x="385" y="-313"/>
+      <point x="337" y="-313" type="curve" smooth="yes"/>
+      <point x="291" y="-313"/>
+      <point x="263" y="-276"/>
+      <point x="263" y="-227" type="curve" smooth="yes"/>
+      <point x="263" y="-219"/>
+      <point x="264" y="-211"/>
+      <point x="266" y="-203" type="curve"/>
+      <point x="246" y="-218" type="line"/>
+      <point x="255" y="-268" type="line"/>
+      <point x="263" y="-224"/>
+      <point x="304" y="-181"/>
+      <point x="357" y="-181" type="curve" smooth="yes"/>
+      <point x="393" y="-181"/>
+      <point x="409" y="-202"/>
+      <point x="409" y="-236" type="curve" smooth="yes"/>
+      <point x="409" y="-270"/>
+      <point x="390" y="-313"/>
     </contour>
     <contour>
-      <point x="523" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="229"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
@@ -1,116 +1,115 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam" format="2">
   <advance width="1726"/>
-  <guideline x="1643"/>
-  <anchor x="1235" y="0" name="bottom"/>
-  <anchor x="937" y="596" name="top"/>
-  <anchor x="1662" y="596" name="topright"/>
+  <anchor x="1228" y="0" name="bottom"/>
+  <anchor x="932" y="596" name="top"/>
+  <anchor x="1657" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="183" y="-16" type="curve" smooth="yes"/>
-      <point x="261" y="-16"/>
-      <point x="317" y="26"/>
-      <point x="344" y="90" type="curve"/>
-      <point x="354" y="90" type="line"/>
-      <point x="381" y="23"/>
-      <point x="435" y="-16"/>
-      <point x="525" y="-16" type="curve" smooth="yes"/>
-      <point x="691" y="-16"/>
-      <point x="775" y="173"/>
-      <point x="775" y="372" type="curve" smooth="yes"/>
-      <point x="775" y="517"/>
-      <point x="714" y="612"/>
-      <point x="587" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="369" y="505"/>
-      <point x="339" y="325" type="curve" smooth="yes"/>
-      <point x="334" y="293"/>
-      <point x="329" y="248"/>
-      <point x="325" y="224" type="curve" smooth="yes"/>
-      <point x="307" y="112"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
       <point x="258" y="62"/>
-      <point x="193" y="62" type="curve" smooth="yes"/>
-      <point x="132" y="62"/>
-      <point x="102" y="95"/>
-      <point x="102" y="151" type="curve" smooth="yes"/>
-      <point x="102" y="218"/>
-      <point x="147" y="265"/>
-      <point x="235" y="265" type="curve" smooth="yes"/>
-      <point x="806" y="265" type="line" smooth="yes"/>
-      <point x="895" y="265"/>
-      <point x="923" y="233"/>
-      <point x="923" y="186" type="curve" smooth="yes"/>
-      <point x="923" y="123"/>
-      <point x="890" y="90"/>
-      <point x="836" y="57" type="curve"/>
-      <point x="846" y="0" type="line"/>
-      <point x="1590" y="0" type="line"/>
-      <point x="1695" y="596" type="line"/>
-      <point x="1643" y="596" type="line"/>
-      <point x="1554" y="414"/>
-      <point x="1442" y="320"/>
-      <point x="1293" y="320" type="curve" smooth="yes"/>
-      <point x="1194" y="320"/>
-      <point x="1142" y="365"/>
-      <point x="1142" y="437" type="curve" smooth="yes"/>
-      <point x="1142" y="495"/>
-      <point x="1172" y="534"/>
-      <point x="1227" y="534" type="curve" smooth="yes"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="801" y="279" type="line" smooth="yes"/>
+      <point x="878" y="279"/>
+      <point x="917" y="248"/>
+      <point x="917" y="185" type="curve" smooth="yes"/>
+      <point x="917" y="137"/>
+      <point x="893" y="102"/>
+      <point x="830" y="58" type="curve"/>
+      <point x="840" y="0" type="line"/>
+      <point x="1584" y="0" type="line"/>
+      <point x="1689" y="596" type="line"/>
+      <point x="1639" y="596" type="line"/>
+      <point x="1533" y="421"/>
+      <point x="1399" y="320"/>
+      <point x="1267" y="320" type="curve" smooth="yes"/>
+      <point x="1184" y="320"/>
+      <point x="1137" y="360"/>
+      <point x="1137" y="430" type="curve" smooth="yes"/>
+      <point x="1137" y="490"/>
+      <point x="1177" y="534"/>
+      <point x="1231" y="534" type="curve" smooth="yes"/>
       <point x="1271" y="534"/>
-      <point x="1293" y="510"/>
-      <point x="1293" y="465" type="curve" smooth="yes"/>
-      <point x="1293" y="445"/>
-      <point x="1291" y="428"/>
-      <point x="1288" y="411" type="curve" smooth="yes"/>
-      <point x="1226" y="61" type="line"/>
-      <point x="1308" y="61" type="line"/>
-      <point x="1371" y="407" type="line" smooth="yes"/>
-      <point x="1376" y="435"/>
-      <point x="1376" y="458"/>
-      <point x="1376" y="471" type="curve" smooth="yes"/>
-      <point x="1376" y="553"/>
-      <point x="1324" y="612"/>
-      <point x="1227" y="612" type="curve" smooth="yes"/>
-      <point x="1122" y="612"/>
-      <point x="1059" y="547"/>
-      <point x="1059" y="443" type="curve" smooth="yes"/>
-      <point x="1059" y="315"/>
-      <point x="1161" y="242"/>
-      <point x="1294" y="242" type="curve" smooth="yes"/>
-      <point x="1405" y="242"/>
-      <point x="1495" y="284"/>
-      <point x="1558" y="358" type="curve"/>
-      <point x="1568" y="354" type="line"/>
-      <point x="1513" y="40" type="line"/>
-      <point x="1559" y="74" type="line"/>
-      <point x="915" y="74" type="line"/>
-      <point x="917" y="43" type="line"/>
-      <point x="973" y="74"/>
-      <point x="1007" y="123"/>
-      <point x="1007" y="187" type="curve" smooth="yes"/>
-      <point x="1007" y="279"/>
-      <point x="953" y="339"/>
-      <point x="812" y="339" type="curve" smooth="yes"/>
-      <point x="242" y="339" type="line" smooth="yes"/>
-      <point x="106" y="339"/>
-      <point x="18" y="268"/>
-      <point x="18" y="150" type="curve" smooth="yes"/>
-      <point x="18" y="50"/>
-      <point x="74" y="-16"/>
+      <point x="1292" y="514"/>
+      <point x="1292" y="474" type="curve" smooth="yes"/>
+      <point x="1292" y="463"/>
+      <point x="1291" y="452"/>
+      <point x="1289" y="440" type="curve" smooth="yes"/>
+      <point x="1222" y="61" type="line"/>
+      <point x="1304" y="61" type="line"/>
+      <point x="1370" y="435" type="line" smooth="yes"/>
+      <point x="1373" y="452"/>
+      <point x="1375" y="469"/>
+      <point x="1375" y="483" type="curve" smooth="yes"/>
+      <point x="1375" y="563"/>
+      <point x="1326" y="612"/>
+      <point x="1244" y="612" type="curve" smooth="yes"/>
+      <point x="1135" y="612"/>
+      <point x="1056" y="534"/>
+      <point x="1056" y="425" type="curve" smooth="yes"/>
+      <point x="1056" y="316"/>
+      <point x="1137" y="244"/>
+      <point x="1261" y="244" type="curve" smooth="yes"/>
+      <point x="1370" y="244"/>
+      <point x="1474" y="293"/>
+      <point x="1562" y="390" type="curve"/>
+      <point x="1570" y="390" type="line"/>
+      <point x="1508" y="40" type="line"/>
+      <point x="1554" y="74" type="line"/>
+      <point x="946" y="74" type="line"/>
+      <point x="944" y="80" type="line"/>
+      <point x="977" y="109"/>
+      <point x="1000" y="154"/>
+      <point x="1000" y="200" type="curve" smooth="yes"/>
+      <point x="1000" y="294"/>
+      <point x="939" y="353"/>
+      <point x="809" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="521" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="408" y="117"/>
-      <point x="408" y="202" type="curve" smooth="yes"/>
-      <point x="408" y="352"/>
-      <point x="463" y="534"/>
-      <point x="589" y="534" type="curve" smooth="yes"/>
-      <point x="661" y="534"/>
-      <point x="688" y="480"/>
-      <point x="688" y="380" type="curve" smooth="yes"/>
-      <point x="688" y="231"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1726"/>
   <outline>
     <component base="k_ssa-malayalam"/>
-    <component base="halant-malayalam" xOffset="1582"/>
+    <component base="halant-malayalam" xOffset="1577"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/k_ta-malayalam.glif
@@ -1,114 +1,114 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ta-malayalam" format="2">
   <advance width="1820"/>
-  <anchor x="1367" y="0" name="bottom"/>
-  <anchor x="895" y="596" name="top"/>
-  <anchor x="1704" y="596" name="topright"/>
+  <anchor x="1357" y="0" name="bottom"/>
+  <anchor x="891" y="596" name="top"/>
+  <anchor x="1696" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="316" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="380" y="23"/>
-      <point x="434" y="-16"/>
-      <point x="524" y="-16" type="curve" smooth="yes"/>
-      <point x="689" y="-16"/>
-      <point x="774" y="175"/>
-      <point x="774" y="375" type="curve" smooth="yes"/>
-      <point x="774" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="903" y="259" type="line"/>
-      <point x="911" y="333" type="line"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
+      <point x="939" y="-16" type="curve"/>
+      <point x="1003" y="31" type="line"/>
+      <point x="959" y="92"/>
+      <point x="941" y="161"/>
+      <point x="941" y="236" type="curve" smooth="yes"/>
+      <point x="941" y="404"/>
+      <point x="1044" y="534"/>
+      <point x="1211" y="534" type="curve" smooth="yes"/>
+      <point x="1353" y="534"/>
+      <point x="1420" y="426"/>
+      <point x="1420" y="292" type="curve" smooth="yes"/>
+      <point x="1420" y="194"/>
+      <point x="1379" y="62"/>
+      <point x="1282" y="62" type="curve" smooth="yes"/>
+      <point x="1217" y="62"/>
+      <point x="1182" y="107"/>
+      <point x="1182" y="193" type="curve" smooth="yes"/>
+      <point x="1182" y="355"/>
+      <point x="1319" y="534"/>
+      <point x="1506" y="534" type="curve" smooth="yes"/>
+      <point x="1639" y="534"/>
+      <point x="1687" y="467"/>
+      <point x="1687" y="358" type="curve" smooth="yes"/>
+      <point x="1687" y="257"/>
+      <point x="1637" y="148"/>
+      <point x="1528" y="45" type="curve"/>
+      <point x="1591" y="-16" type="line"/>
+      <point x="1721" y="107"/>
+      <point x="1770" y="236"/>
+      <point x="1770" y="362" type="curve" smooth="yes"/>
+      <point x="1770" y="515"/>
+      <point x="1684" y="612"/>
+      <point x="1516" y="612" type="curve" smooth="yes"/>
+      <point x="1273" y="612"/>
+      <point x="1099" y="378"/>
+      <point x="1099" y="190" type="curve" smooth="yes"/>
+      <point x="1099" y="66"/>
+      <point x="1168" y="-16"/>
+      <point x="1275" y="-16" type="curve" smooth="yes"/>
+      <point x="1444" y="-16"/>
+      <point x="1506" y="162"/>
+      <point x="1506" y="290" type="curve" smooth="yes"/>
+      <point x="1506" y="462"/>
+      <point x="1404" y="612"/>
+      <point x="1220" y="612" type="curve" smooth="yes"/>
+      <point x="996" y="612"/>
+      <point x="859" y="429"/>
+      <point x="859" y="235" type="curve" smooth="yes"/>
+      <point x="859" y="143"/>
+      <point x="885" y="58"/>
     </contour>
     <contour>
-      <point x="523" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="229"/>
-      <point x="638" y="62"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="915" y="279" type="line"/>
+      <point x="915" y="353" type="line"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="956" y="-16" type="curve"/>
-      <point x="1022" y="32" type="line"/>
-      <point x="978" y="87"/>
-      <point x="953" y="165"/>
-      <point x="953" y="248" type="curve" smooth="yes"/>
-      <point x="953" y="421"/>
-      <point x="1056" y="534"/>
-      <point x="1214" y="534" type="curve" smooth="yes"/>
-      <point x="1356" y="534"/>
-      <point x="1434" y="443"/>
-      <point x="1434" y="275" type="curve" smooth="yes"/>
-      <point x="1434" y="136"/>
-      <point x="1389" y="62"/>
-      <point x="1303" y="62" type="curve" smooth="yes"/>
-      <point x="1232" y="62"/>
-      <point x="1196" y="109"/>
-      <point x="1196" y="199" type="curve" smooth="yes"/>
-      <point x="1196" y="387"/>
-      <point x="1329" y="534"/>
-      <point x="1500" y="534" type="curve" smooth="yes"/>
-      <point x="1622" y="534"/>
-      <point x="1686" y="466"/>
-      <point x="1686" y="336" type="curve" smooth="yes"/>
-      <point x="1686" y="218"/>
-      <point x="1637" y="128"/>
-      <point x="1528" y="48" type="curve"/>
-      <point x="1579" y="-16" type="line"/>
-      <point x="1707" y="79"/>
-      <point x="1768" y="193"/>
-      <point x="1768" y="336" type="curve" smooth="yes"/>
-      <point x="1768" y="513"/>
-      <point x="1672" y="612"/>
-      <point x="1502" y="612" type="curve" smooth="yes"/>
-      <point x="1296" y="612"/>
-      <point x="1114" y="418"/>
-      <point x="1114" y="199" type="curve" smooth="yes"/>
-      <point x="1114" y="62"/>
-      <point x="1183" y="-16"/>
-      <point x="1303" y="-16" type="curve" smooth="yes"/>
-      <point x="1433" y="-16"/>
-      <point x="1520" y="100"/>
-      <point x="1520" y="275" type="curve" smooth="yes"/>
-      <point x="1520" y="475"/>
-      <point x="1398" y="612"/>
-      <point x="1218" y="612" type="curve" smooth="yes"/>
-      <point x="1013" y="612"/>
-      <point x="871" y="463"/>
-      <point x="871" y="248" type="curve" smooth="yes"/>
-      <point x="871" y="143"/>
-      <point x="899" y="56"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/k_tta-malayalam.glif
@@ -1,128 +1,119 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_tta-malayalam" format="2">
   <advance width="1060"/>
-  <anchor x="683" y="-362" name="bottom"/>
-  <anchor x="604" y="596" name="top"/>
-  <anchor x="942" y="556" name="topright"/>
+  <anchor x="736" y="-362" name="bottom"/>
+  <anchor x="599" y="596" name="top"/>
+  <anchor x="936" y="556" name="topright"/>
   <outline>
     <contour>
-      <point x="719" y="-378" type="curve" smooth="yes"/>
-      <point x="840" y="-378"/>
-      <point x="898" y="-324"/>
-      <point x="898" y="-244" type="curve" smooth="yes"/>
-      <point x="898" y="-180"/>
-      <point x="866" y="-136"/>
-      <point x="745" y="-129" type="curve" smooth="yes"/>
-      <point x="712" y="-127" type="line" smooth="yes"/>
-      <point x="656" y="-124"/>
-      <point x="630" y="-108"/>
-      <point x="630" y="-75" type="curve" smooth="yes"/>
-      <point x="630" y="-42"/>
-      <point x="660" y="-17"/>
-      <point x="741" y="-17" type="curve" smooth="yes"/>
-      <point x="800" y="-17"/>
-      <point x="851" y="-26"/>
-      <point x="893" y="-42" type="curve"/>
-      <point x="922" y="16" type="line"/>
-      <point x="878" y="36"/>
-      <point x="817" y="48"/>
-      <point x="755" y="48" type="curve" smooth="yes"/>
-      <point x="721" y="48"/>
-      <point x="692" y="43"/>
-      <point x="664" y="34" type="curve"/>
-      <point x="659" y="41" type="line"/>
-      <point x="736" y="112"/>
-      <point x="774" y="241"/>
-      <point x="774" y="375" type="curve" smooth="yes"/>
-      <point x="774" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="802" y="259" type="line" smooth="yes"/>
-      <point x="884" y="259"/>
-      <point x="919" y="227"/>
-      <point x="919" y="165" type="curve" smooth="yes"/>
-      <point x="919" y="112"/>
-      <point x="895" y="60"/>
-      <point x="822" y="60" type="curve" smooth="yes"/>
-      <point x="797" y="60"/>
-      <point x="776" y="66"/>
-      <point x="761" y="73" type="curve"/>
-      <point x="730" y="3" type="line"/>
-      <point x="753" y="-9"/>
-      <point x="787" y="-16"/>
-      <point x="824" y="-16" type="curve" smooth="yes"/>
-      <point x="940" y="-16"/>
-      <point x="1001" y="59"/>
-      <point x="1001" y="168" type="curve" smooth="yes"/>
-      <point x="1001" y="267"/>
-      <point x="942" y="333"/>
-      <point x="810" y="333" type="curve" smooth="yes"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="316" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="380" y="23"/>
-      <point x="434" y="-16"/>
-      <point x="524" y="-16" type="curve" smooth="yes"/>
-      <point x="540" y="-16"/>
-      <point x="559" y="-13"/>
-      <point x="576" y="-7" type="curve"/>
-      <point x="581" y="-14" type="line"/>
-      <point x="564" y="-36"/>
-      <point x="554" y="-58"/>
-      <point x="554" y="-87" type="curve" smooth="yes"/>
-      <point x="554" y="-151"/>
-      <point x="602" y="-192"/>
-      <point x="693" y="-197" type="curve" smooth="yes"/>
-      <point x="729" y="-199" type="line" smooth="yes"/>
-      <point x="814" y="-204"/>
-      <point x="822" y="-228"/>
-      <point x="822" y="-252" type="curve" smooth="yes"/>
-      <point x="822" y="-286"/>
-      <point x="794" y="-313"/>
-      <point x="719" y="-313" type="curve" smooth="yes"/>
-      <point x="636" y="-313"/>
-      <point x="583" y="-295"/>
-      <point x="542" y="-271" type="curve"/>
-      <point x="505" y="-328" type="line"/>
-      <point x="555" y="-360"/>
-      <point x="629" y="-378"/>
+      <point x="725" y="-378" type="curve" smooth="yes"/>
+      <point x="862" y="-378"/>
+      <point x="930" y="-318"/>
+      <point x="930" y="-242" type="curve" smooth="yes"/>
+      <point x="930" y="-180"/>
+      <point x="896" y="-139"/>
+      <point x="796" y="-130" type="curve" smooth="yes"/>
+      <point x="727" y="-124" type="line" smooth="yes"/>
+      <point x="687" y="-121"/>
+      <point x="668" y="-107"/>
+      <point x="668" y="-81" type="curve" smooth="yes"/>
+      <point x="668" y="-45"/>
+      <point x="704" y="-16"/>
+      <point x="788" y="-16" type="curve" smooth="yes"/>
+      <point x="846" y="-16"/>
+      <point x="888" y="-25"/>
+      <point x="929" y="-44" type="curve"/>
+      <point x="953" y="13" type="line"/>
+      <point x="939" y="20"/>
+      <point x="922" y="26"/>
+      <point x="905" y="30" type="curve"/>
+      <point x="907" y="39" type="line"/>
+      <point x="960" y="68"/>
+      <point x="994" y="119"/>
+      <point x="994" y="189" type="curve" smooth="yes"/>
+      <point x="994" y="288"/>
+      <point x="925" y="353"/>
+      <point x="796" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="793" y="279" type="line" smooth="yes"/>
+      <point x="876" y="279"/>
+      <point x="913" y="244"/>
+      <point x="913" y="175" type="curve" smooth="yes"/>
+      <point x="913" y="110"/>
+      <point x="870" y="60"/>
+      <point x="807" y="60" type="curve" smooth="yes"/>
+      <point x="786" y="60"/>
+      <point x="768" y="63"/>
+      <point x="753" y="69" type="curve"/>
+      <point x="737" y="29" type="line"/>
+      <point x="767" y="47" type="line"/>
+      <point x="669" y="41"/>
+      <point x="593" y="-11"/>
+      <point x="593" y="-89" type="curve" smooth="yes"/>
+      <point x="593" y="-149"/>
+      <point x="636" y="-189"/>
+      <point x="714" y="-196" type="curve" smooth="yes"/>
+      <point x="783" y="-202" type="line" smooth="yes"/>
+      <point x="842" y="-207"/>
+      <point x="855" y="-224"/>
+      <point x="855" y="-250" type="curve" smooth="yes"/>
+      <point x="855" y="-284"/>
+      <point x="822" y="-313"/>
+      <point x="731" y="-313" type="curve" smooth="yes"/>
+      <point x="670" y="-313"/>
+      <point x="618" y="-300"/>
+      <point x="574" y="-272" type="curve"/>
+      <point x="543" y="-332" type="line"/>
+      <point x="591" y="-362"/>
+      <point x="653" y="-378"/>
     </contour>
     <contour>
-      <point x="523" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="229"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ka-malayalam.glif
@@ -2,80 +2,80 @@
 <glyph name="ka-malayalam" format="2">
   <advance width="1061"/>
   <unicode hex="0D15"/>
-  <anchor x="616" y="0" name="bottom"/>
-  <anchor x="604" y="596" name="top"/>
-  <anchor x="942" y="556" name="topright"/>
+  <anchor x="609" y="0" name="bottom"/>
+  <anchor x="599" y="596" name="top"/>
+  <anchor x="936" y="556" name="topright"/>
   <outline>
     <contour>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="317" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="379" y="23"/>
-      <point x="434" y="-16"/>
-      <point x="524" y="-16" type="curve" smooth="yes"/>
-      <point x="689" y="-16"/>
-      <point x="774" y="175"/>
-      <point x="774" y="375" type="curve" smooth="yes"/>
-      <point x="774" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="802" y="259" type="line" smooth="yes"/>
-      <point x="884" y="259"/>
-      <point x="919" y="227"/>
-      <point x="919" y="165" type="curve" smooth="yes"/>
-      <point x="919" y="112"/>
-      <point x="895" y="60"/>
-      <point x="822" y="60" type="curve" smooth="yes"/>
-      <point x="797" y="60"/>
-      <point x="776" y="66"/>
-      <point x="761" y="73" type="curve"/>
-      <point x="730" y="3" type="line"/>
-      <point x="753" y="-9"/>
-      <point x="787" y="-16"/>
-      <point x="824" y="-16" type="curve" smooth="yes"/>
-      <point x="940" y="-16"/>
-      <point x="1001" y="59"/>
-      <point x="1001" y="168" type="curve" smooth="yes"/>
-      <point x="1001" y="267"/>
-      <point x="942" y="333"/>
-      <point x="810" y="333" type="curve" smooth="yes"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="793" y="279" type="line" smooth="yes"/>
+      <point x="873" y="279"/>
+      <point x="913" y="245"/>
+      <point x="913" y="178" type="curve" smooth="yes"/>
+      <point x="913" y="105"/>
+      <point x="872" y="60"/>
+      <point x="807" y="60" type="curve" smooth="yes"/>
+      <point x="786" y="60"/>
+      <point x="767" y="63"/>
+      <point x="750" y="69" type="curve"/>
+      <point x="727" y="-3" type="line"/>
+      <point x="749" y="-12"/>
+      <point x="774" y="-16"/>
+      <point x="801" y="-16" type="curve" smooth="yes"/>
+      <point x="915" y="-16"/>
+      <point x="994" y="65"/>
+      <point x="994" y="180" type="curve" smooth="yes"/>
+      <point x="994" y="289"/>
+      <point x="921" y="353"/>
+      <point x="796" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="523" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="229"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/m_la-malayalam.glif
@@ -1,53 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="m_la-malayalam" format="2">
   <advance width="692"/>
-  <anchor x="230" y="-357" name="bottom"/>
-  <anchor x="407" y="596" name="top"/>
-  <anchor x="635" y="596" name="topright"/>
+  <anchor x="230" y="-362" name="bottom"/>
+  <anchor x="402" y="596" name="top"/>
+  <anchor x="630" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="26" y="-378" type="curve" smooth="yes"/>
-      <point x="113" y="-378"/>
-      <point x="163" y="-321"/>
-      <point x="163" y="-236" type="curve" smooth="yes"/>
-      <point x="163" y="-156"/>
-      <point x="118" y="-121"/>
-      <point x="52" y="-121" type="curve" smooth="yes"/>
-      <point x="19" y="-121"/>
-      <point x="-14" y="-134"/>
-      <point x="-37" y="-167" type="curve"/>
-      <point x="-47" y="-166" type="line"/>
-      <point x="-24" y="-72"/>
-      <point x="37" y="-22"/>
-      <point x="117" y="-22" type="curve" smooth="yes"/>
-      <point x="228" y="-22"/>
-      <point x="250" y="-91"/>
-      <point x="256" y="-180" type="curve" smooth="yes"/>
-      <point x="257" y="-196" type="line" smooth="yes"/>
-      <point x="264" y="-307"/>
-      <point x="308" y="-378"/>
-      <point x="425" y="-378" type="curve" smooth="yes"/>
-      <point x="559" y="-378"/>
-      <point x="609" y="-270"/>
-      <point x="609" y="-132" type="curve" smooth="yes"/>
-      <point x="609" y="-57"/>
-      <point x="586" y="7"/>
-      <point x="559" y="48" type="curve"/>
-      <point x="496" y="10" type="line"/>
-      <point x="512" y="-20"/>
-      <point x="533" y="-69"/>
-      <point x="533" y="-145" type="curve" smooth="yes"/>
-      <point x="533" y="-228"/>
-      <point x="505" y="-308"/>
-      <point x="426" y="-308" type="curve" smooth="yes"/>
-      <point x="365" y="-308"/>
-      <point x="341" y="-271"/>
-      <point x="332" y="-176" type="curve" smooth="yes"/>
-      <point x="330" y="-155" type="line" smooth="yes"/>
-      <point x="324" y="-89"/>
-      <point x="307" y="-38"/>
-      <point x="269" y="-10" type="curve"/>
-      <point x="270" y="0" type="line"/>
+      <point x="10" y="0" type="line"/>
       <point x="576" y="0" type="line"/>
       <point x="623" y="266" type="line" smooth="yes"/>
       <point x="631" y="313"/>
@@ -59,30 +18,75 @@
       <point x="218" y="612"/>
       <point x="102" y="520"/>
       <point x="74" y="360" type="curve" smooth="yes"/>
-      <point x="10" y="0" type="line"/>
-      <point x="42" y="0" type="line"/>
-      <point x="42" y="35" type="line"/>
-      <point x="-59" y="1"/>
-      <point x="-120" y="-95"/>
-      <point x="-120" y="-209" type="curve" smooth="yes"/>
-      <point x="-120" y="-328"/>
-      <point x="-55" y="-378"/>
     </contour>
     <contour>
-      <point x="25" y="-313" type="curve" smooth="yes"/>
-      <point x="-29" y="-313"/>
-      <point x="-52" y="-270"/>
-      <point x="-52" y="-223" type="curve"/>
-      <point x="-70" y="-200" type="line"/>
-      <point x="-59" y="-256" type="line"/>
-      <point x="-52" y="-216"/>
-      <point x="-18" y="-181"/>
-      <point x="31" y="-181" type="curve" smooth="yes"/>
-      <point x="73" y="-181"/>
-      <point x="92" y="-201"/>
-      <point x="92" y="-240" type="curve" smooth="yes"/>
-      <point x="92" y="-282"/>
-      <point x="69" y="-313"/>
+      <point x="95" y="-378" type="curve" smooth="yes"/>
+      <point x="199" y="-378"/>
+      <point x="237" y="-293"/>
+      <point x="237" y="-219" type="curve" smooth="yes"/>
+      <point x="237" y="-147"/>
+      <point x="208" y="-104"/>
+      <point x="144" y="-104" type="curve" smooth="yes"/>
+      <point x="88" y="-104"/>
+      <point x="41" y="-142"/>
+      <point x="28" y="-196" type="curve"/>
+      <point x="70" y="-157" type="line"/>
+      <point x="20" y="-141" type="line"/>
+      <point x="31" y="-201" type="line"/>
+      <point x="46" y="-88"/>
+      <point x="106" y="-18"/>
+      <point x="191" y="-18" type="curve" smooth="yes"/>
+      <point x="258" y="-18"/>
+      <point x="289" y="-56"/>
+      <point x="289" y="-153" type="curve" smooth="yes"/>
+      <point x="289" y="-236" type="line" smooth="yes"/>
+      <point x="289" y="-325"/>
+      <point x="330" y="-378"/>
+      <point x="408" y="-378" type="curve" smooth="yes"/>
+      <point x="528" y="-378"/>
+      <point x="561" y="-254"/>
+      <point x="561" y="-172" type="curve" smooth="yes"/>
+      <point x="561" y="-96"/>
+      <point x="541" y="-23"/>
+      <point x="501" y="45" type="curve"/>
+      <point x="438" y="8" type="line"/>
+      <point x="472" y="-50"/>
+      <point x="488" y="-106"/>
+      <point x="488" y="-170" type="curve" smooth="yes"/>
+      <point x="488" y="-224"/>
+      <point x="473" y="-308"/>
+      <point x="412" y="-308" type="curve" smooth="yes"/>
+      <point x="377" y="-308"/>
+      <point x="361" y="-285"/>
+      <point x="361" y="-224" type="curve" smooth="yes"/>
+      <point x="361" y="-141" type="line" smooth="yes"/>
+      <point x="361" y="-27"/>
+      <point x="314" y="32"/>
+      <point x="198" y="32" type="curve" smooth="yes"/>
+      <point x="36" y="32"/>
+      <point x="-35" y="-102"/>
+      <point x="-35" y="-231" type="curve" smooth="yes"/>
+      <point x="-35" y="-318"/>
+      <point x="9" y="-378"/>
+    </contour>
+    <contour>
+      <point x="97" y="-312" type="curve" smooth="yes"/>
+      <point x="54" y="-312"/>
+      <point x="31" y="-285"/>
+      <point x="31" y="-241" type="curve" smooth="yes"/>
+      <point x="31" y="-228"/>
+      <point x="32" y="-217"/>
+      <point x="35" y="-205" type="curve"/>
+      <point x="10" y="-221" type="line"/>
+      <point x="22" y="-250" type="line"/>
+      <point x="34" y="-198"/>
+      <point x="70" y="-164"/>
+      <point x="112" y="-164" type="curve" smooth="yes"/>
+      <point x="151" y="-164"/>
+      <point x="166" y="-185"/>
+      <point x="166" y="-223" type="curve" smooth="yes"/>
+      <point x="166" y="-275"/>
+      <point x="140" y="-312"/>
     </contour>
     <contour>
       <point x="68" y="45" type="line"/>
@@ -105,8 +109,8 @@
       <point x="462" y="339"/>
       <point x="462" y="415" type="curve" smooth="yes"/>
       <point x="462" y="493"/>
-      <point x="417" y="538"/>
-      <point x="336" y="541" type="curve"/>
+      <point x="417" y="539"/>
+      <point x="336" y="542" type="curve"/>
       <point x="336" y="577" type="line"/>
       <point x="322" y="550" type="line"/>
       <point x="337" y="552"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
@@ -1,103 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng_ka-malayalam" format="2">
   <advance width="1066"/>
-  <anchor x="619" y="0" name="bottom"/>
-  <anchor x="607" y="596" name="top"/>
-  <anchor x="928" y="596" name="topright"/>
+  <anchor x="614" y="0" name="bottom"/>
+  <anchor x="604" y="596" name="top"/>
+  <anchor x="925" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="186" y="-16" type="curve" smooth="yes"/>
-      <point x="264" y="-16"/>
-      <point x="321" y="26"/>
-      <point x="348" y="90" type="curve"/>
-      <point x="358" y="90" type="line"/>
-      <point x="385" y="23"/>
-      <point x="438" y="-16"/>
-      <point x="527" y="-16" type="curve" smooth="yes"/>
-      <point x="693" y="-16"/>
-      <point x="778" y="175"/>
-      <point x="778" y="375" type="curve" smooth="yes"/>
-      <point x="778" y="519"/>
-      <point x="718" y="612"/>
-      <point x="595" y="612" type="curve" smooth="yes"/>
-      <point x="518" y="612"/>
-      <point x="456" y="572"/>
-      <point x="418" y="500" type="curve"/>
-      <point x="407" y="500" type="line"/>
-      <point x="393" y="564"/>
-      <point x="346" y="612"/>
-      <point x="254" y="612" type="curve" smooth="yes"/>
+      <point x="177" y="-16" type="curve" smooth="yes"/>
+      <point x="248" y="-16"/>
+      <point x="301" y="19"/>
+      <point x="337" y="91" type="curve"/>
+      <point x="348" y="91" type="line"/>
+      <point x="368" y="26"/>
+      <point x="420" y="-16"/>
+      <point x="500" y="-16" type="curve" smooth="yes"/>
+      <point x="711" y="-16"/>
+      <point x="774" y="265"/>
+      <point x="774" y="396" type="curve" smooth="yes"/>
+      <point x="774" y="529"/>
+      <point x="713" y="612"/>
+      <point x="604" y="612" type="curve" smooth="yes"/>
+      <point x="524" y="612"/>
+      <point x="458" y="572"/>
+      <point x="418" y="495" type="curve"/>
+      <point x="408" y="495" type="line"/>
+      <point x="397" y="562"/>
+      <point x="352" y="612"/>
+      <point x="265" y="612" type="curve" smooth="yes"/>
       <point x="157" y="612"/>
-      <point x="81" y="544"/>
-      <point x="81" y="443" type="curve" smooth="yes"/>
-      <point x="81" y="386"/>
-      <point x="108" y="337"/>
-      <point x="157" y="312" type="curve"/>
-      <point x="156" y="302" type="line"/>
-      <point x="78" y="286"/>
-      <point x="21" y="227"/>
-      <point x="21" y="141" type="curve" smooth="yes"/>
-      <point x="21" y="50"/>
-      <point x="77" y="-16"/>
+      <point x="79" y="542"/>
+      <point x="79" y="443" type="curve" smooth="yes"/>
+      <point x="79" y="393"/>
+      <point x="104" y="351"/>
+      <point x="146" y="325" type="curve"/>
+      <point x="145" y="315" type="line"/>
+      <point x="68" y="283"/>
+      <point x="20" y="215"/>
+      <point x="20" y="136" type="curve" smooth="yes"/>
+      <point x="20" y="46"/>
+      <point x="85" y="-16"/>
     </contour>
     <contour>
-      <point x="527" y="62" type="curve" smooth="yes"/>
-      <point x="443" y="62"/>
-      <point x="411" y="119"/>
-      <point x="411" y="205" type="curve" smooth="yes"/>
-      <point x="411" y="354"/>
-      <point x="465" y="534"/>
-      <point x="589" y="534" type="curve" smooth="yes"/>
-      <point x="663" y="534"/>
-      <point x="691" y="478"/>
-      <point x="691" y="377" type="curve" smooth="yes"/>
-      <point x="691" y="229"/>
-      <point x="642" y="62"/>
-    </contour>
-    <contour>
-      <point x="828" y="-16" type="curve" smooth="yes"/>
-      <point x="944" y="-16"/>
-      <point x="1005" y="59"/>
-      <point x="1005" y="168" type="curve" smooth="yes"/>
-      <point x="1005" y="267"/>
-      <point x="946" y="333"/>
-      <point x="814" y="333" type="curve" smooth="yes"/>
-      <point x="287" y="333" type="line" smooth="yes"/>
-      <point x="198" y="333"/>
-      <point x="163" y="379"/>
-      <point x="163" y="435" type="curve" smooth="yes"/>
-      <point x="163" y="495"/>
+      <point x="806" y="-16" type="curve" smooth="yes"/>
+      <point x="920" y="-16"/>
+      <point x="999" y="65"/>
+      <point x="999" y="180" type="curve" smooth="yes"/>
+      <point x="999" y="289"/>
+      <point x="926" y="353"/>
+      <point x="801" y="353" type="curve" smooth="yes"/>
+      <point x="274" y="353" type="line" smooth="yes"/>
+      <point x="202" y="353"/>
+      <point x="159" y="385"/>
+      <point x="159" y="440" type="curve" smooth="yes"/>
+      <point x="159" y="495"/>
       <point x="202" y="534"/>
-      <point x="265" y="534" type="curve" smooth="yes"/>
-      <point x="331" y="534"/>
-      <point x="361" y="492"/>
-      <point x="361" y="430" type="curve" smooth="yes"/>
-      <point x="361" y="410"/>
-      <point x="358" y="384"/>
-      <point x="352" y="353" type="curve" smooth="yes"/>
-      <point x="328" y="221" type="line" smooth="yes"/>
-      <point x="308" y="109"/>
-      <point x="261" y="62"/>
-      <point x="196" y="62" type="curve" smooth="yes"/>
-      <point x="135" y="62"/>
-      <point x="105" y="95"/>
-      <point x="105" y="148" type="curve" smooth="yes"/>
-      <point x="105" y="214"/>
-      <point x="149" y="259"/>
-      <point x="237" y="259" type="curve" smooth="yes"/>
-      <point x="806" y="259" type="line" smooth="yes"/>
-      <point x="888" y="259"/>
-      <point x="923" y="227"/>
-      <point x="923" y="165" type="curve" smooth="yes"/>
-      <point x="923" y="112"/>
-      <point x="899" y="60"/>
-      <point x="826" y="60" type="curve" smooth="yes"/>
-      <point x="801" y="60"/>
-      <point x="780" y="66"/>
-      <point x="765" y="73" type="curve"/>
-      <point x="734" y="3" type="line"/>
-      <point x="757" y="-9"/>
-      <point x="791" y="-16"/>
+      <point x="264" y="534" type="curve" smooth="yes"/>
+      <point x="332" y="534"/>
+      <point x="358" y="497"/>
+      <point x="358" y="438" type="curve" smooth="yes"/>
+      <point x="358" y="420"/>
+      <point x="356" y="400"/>
+      <point x="352" y="378" type="curve" smooth="yes"/>
+      <point x="323" y="212" type="line" smooth="yes"/>
+      <point x="306" y="114"/>
+      <point x="260" y="62"/>
+      <point x="192" y="62" type="curve" smooth="yes"/>
+      <point x="138" y="62"/>
+      <point x="105" y="94"/>
+      <point x="105" y="146" type="curve" smooth="yes"/>
+      <point x="105" y="228"/>
+      <point x="165" y="279"/>
+      <point x="261" y="279" type="curve" smooth="yes"/>
+      <point x="798" y="279" type="line" smooth="yes"/>
+      <point x="878" y="279"/>
+      <point x="918" y="245"/>
+      <point x="918" y="178" type="curve" smooth="yes"/>
+      <point x="918" y="105"/>
+      <point x="877" y="60"/>
+      <point x="812" y="60" type="curve" smooth="yes"/>
+      <point x="791" y="60"/>
+      <point x="772" y="63"/>
+      <point x="755" y="69" type="curve"/>
+      <point x="732" y="-3" type="line"/>
+      <point x="754" y="-12"/>
+      <point x="779" y="-16"/>
+    </contour>
+    <contour>
+      <point x="505" y="62" type="curve" smooth="yes"/>
+      <point x="439" y="62"/>
+      <point x="406" y="107"/>
+      <point x="406" y="195" type="curve" smooth="yes"/>
+      <point x="406" y="303"/>
+      <point x="446" y="534"/>
+      <point x="595" y="534" type="curve" smooth="yes"/>
+      <point x="657" y="534"/>
+      <point x="689" y="488"/>
+      <point x="689" y="402" type="curve" smooth="yes"/>
+      <point x="689" y="286"/>
+      <point x="642" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,192 +1,193 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1542"/>
-  <anchor x="1098" y="16" name="bottom"/>
-  <anchor x="859" y="596" name="top"/>
-  <anchor x="1467" y="596" name="topright"/>
+  <advance width="1592"/>
+  <anchor x="1113" y="-6" name="bottom"/>
+  <anchor x="849" y="596" name="top"/>
+  <anchor x="1481" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="260" y="-16" type="curve" smooth="yes"/>
-      <point x="375" y="-16"/>
-      <point x="445" y="60"/>
-      <point x="445" y="185" type="curve" smooth="yes"/>
-      <point x="445" y="293"/>
-      <point x="389" y="356"/>
-      <point x="293" y="356" type="curve" smooth="yes"/>
-      <point x="232" y="356"/>
-      <point x="181" y="330"/>
-      <point x="145" y="281" type="curve"/>
-      <point x="109" y="287" type="line"/>
-      <point x="120" y="153" type="line"/>
-      <point x="144" y="229"/>
-      <point x="206" y="282"/>
-      <point x="271" y="282" type="curve" smooth="yes"/>
-      <point x="333" y="282"/>
-      <point x="363" y="250"/>
-      <point x="363" y="184" type="curve" smooth="yes"/>
-      <point x="363" y="106"/>
-      <point x="325" y="62"/>
-      <point x="258" y="62" type="curve" smooth="yes"/>
-      <point x="177" y="62"/>
-      <point x="130" y="120"/>
-      <point x="130" y="220" type="curve" smooth="yes"/>
-      <point x="130" y="406"/>
-      <point x="233" y="534"/>
+      <point x="245" y="-16" type="curve" smooth="yes"/>
+      <point x="378" y="-16"/>
+      <point x="440" y="94"/>
+      <point x="440" y="191" type="curve" smooth="yes"/>
+      <point x="440" y="293"/>
+      <point x="386" y="356"/>
+      <point x="288" y="356" type="curve" smooth="yes"/>
+      <point x="230" y="356"/>
+      <point x="179" y="331"/>
+      <point x="145" y="289" type="curve"/>
+      <point x="110" y="296" type="line"/>
+      <point x="114" y="153" type="line"/>
+      <point x="139" y="229"/>
+      <point x="205" y="282"/>
+      <point x="272" y="282" type="curve" smooth="yes"/>
+      <point x="331" y="282"/>
+      <point x="358" y="249"/>
+      <point x="358" y="189" type="curve" smooth="yes"/>
+      <point x="358" y="128"/>
+      <point x="327" y="62"/>
+      <point x="247" y="62" type="curve" smooth="yes"/>
+      <point x="173" y="62"/>
+      <point x="129" y="124"/>
+      <point x="129" y="231" type="curve" smooth="yes"/>
+      <point x="129" y="376"/>
+      <point x="207" y="534"/>
       <point x="383" y="534" type="curve" smooth="yes"/>
-      <point x="490" y="534"/>
-      <point x="546" y="479"/>
-      <point x="546" y="372" type="curve" smooth="yes"/>
-      <point x="546" y="354"/>
-      <point x="544" y="335"/>
-      <point x="540" y="314" type="curve" smooth="yes"/>
-      <point x="484" y="0" type="line"/>
-      <point x="568" y="0" type="line"/>
-      <point x="627" y="333" type="line" smooth="yes"/>
-      <point x="651" y="470"/>
-      <point x="720" y="545"/>
-      <point x="843" y="545" type="curve" smooth="yes"/>
-      <point x="861" y="545"/>
-      <point x="881" y="544"/>
-      <point x="894" y="543" type="curve"/>
-      <point x="858" y="586" type="line"/>
-      <point x="858" y="534" type="line"/>
-      <point x="818" y="517"/>
-      <point x="792" y="484"/>
-      <point x="792" y="431" type="curve" smooth="yes"/>
-      <point x="792" y="360"/>
-      <point x="843" y="310"/>
-      <point x="930" y="310" type="curve" smooth="yes"/>
-      <point x="1021" y="310"/>
-      <point x="1073" y="367"/>
-      <point x="1073" y="447" type="curve" smooth="yes"/>
-      <point x="1073" y="486"/>
-      <point x="1056" y="525"/>
-      <point x="1009" y="546" type="curve"/>
-      <point x="1017" y="604" type="line"/>
-      <point x="950" y="553" type="line"/>
-      <point x="963" y="555"/>
-      <point x="979" y="556"/>
-      <point x="1001" y="556" type="curve" smooth="yes"/>
-      <point x="1088" y="556"/>
-      <point x="1130" y="515"/>
-      <point x="1130" y="435" type="curve" smooth="yes"/>
-      <point x="1130" y="414"/>
-      <point x="1129" y="400"/>
-      <point x="1125" y="380" type="curve" smooth="yes"/>
-      <point x="1120" y="353" type="line"/>
-      <point x="1204" y="353" type="line"/>
-      <point x="1210" y="388" type="line" smooth="yes"/>
-      <point x="1226" y="480"/>
-      <point x="1277" y="534"/>
-      <point x="1344" y="534" type="curve" smooth="yes"/>
-      <point x="1405" y="534"/>
-      <point x="1436" y="503"/>
-      <point x="1436" y="442" type="curve" smooth="yes"/>
-      <point x="1436" y="348"/>
-      <point x="1375" y="294"/>
-      <point x="1269" y="294" type="curve" smooth="yes"/>
-      <point x="959" y="294" type="line" smooth="yes"/>
-      <point x="823" y="294"/>
-      <point x="744" y="231"/>
-      <point x="744" y="121" type="curve" smooth="yes"/>
-      <point x="744" y="36"/>
-      <point x="794" y="-16"/>
-      <point x="875" y="-16" type="curve" smooth="yes"/>
-      <point x="928" y="-16"/>
-      <point x="983" y="3"/>
-      <point x="1082" y="58" type="curve" smooth="yes"/>
-      <point x="1151" y="96" type="line"/>
-      <point x="1268" y="159" type="line"/>
-      <point x="1278" y="161" type="line"/>
-      <point x="1300" y="170"/>
-      <point x="1317" y="172"/>
-      <point x="1339" y="172" type="curve" smooth="yes"/>
-      <point x="1374" y="172"/>
-      <point x="1392" y="154"/>
-      <point x="1392" y="121" type="curve" smooth="yes"/>
-      <point x="1392" y="75"/>
-      <point x="1368" y="48"/>
-      <point x="1329" y="48" type="curve" smooth="yes"/>
-      <point x="1297" y="48"/>
-      <point x="1276" y="69"/>
-      <point x="1276" y="101" type="curve" smooth="yes"/>
-      <point x="1276" y="137"/>
-      <point x="1290" y="163"/>
-      <point x="1327" y="190" type="curve"/>
-      <point x="1202" y="166" type="line"/>
-      <point x="1245" y="108" type="line"/>
-      <point x="1261" y="160" type="line"/>
-      <point x="1235" y="142"/>
-      <point x="1219" y="115"/>
-      <point x="1219" y="80" type="curve" smooth="yes"/>
-      <point x="1219" y="24"/>
-      <point x="1262" y="-16"/>
-      <point x="1327" y="-16" type="curve" smooth="yes"/>
-      <point x="1411" y="-16"/>
-      <point x="1459" y="35"/>
-      <point x="1459" y="124" type="curve" smooth="yes"/>
-      <point x="1459" y="196"/>
-      <point x="1421" y="238"/>
-      <point x="1355" y="238" type="curve" smooth="yes"/>
-      <point x="1297" y="238"/>
-      <point x="1258" y="225"/>
-      <point x="1147" y="169" type="curve" smooth="yes"/>
-      <point x="1064" y="127" type="line" smooth="yes"/>
-      <point x="953" y="71"/>
-      <point x="928" y="61"/>
-      <point x="888" y="61" type="curve" smooth="yes"/>
-      <point x="846" y="61"/>
-      <point x="823" y="85"/>
-      <point x="823" y="129" type="curve" smooth="yes"/>
-      <point x="823" y="189"/>
-      <point x="868" y="222"/>
-      <point x="949" y="222" type="curve" smooth="yes"/>
-      <point x="1257" y="222" type="line" smooth="yes"/>
-      <point x="1419" y="222"/>
-      <point x="1520" y="309"/>
-      <point x="1520" y="449" type="curve" smooth="yes"/>
-      <point x="1520" y="546"/>
-      <point x="1456" y="612"/>
-      <point x="1362" y="612" type="curve" smooth="yes"/>
-      <point x="1284" y="612"/>
-      <point x="1220" y="569"/>
-      <point x="1191" y="490" type="curve"/>
-      <point x="1181" y="490" type="line"/>
-      <point x="1166" y="571"/>
-      <point x="1107" y="612"/>
-      <point x="1015" y="612" type="curve" smooth="yes"/>
-      <point x="971" y="612"/>
-      <point x="939" y="604"/>
-      <point x="914" y="592" type="curve"/>
-      <point x="930" y="544" type="line"/>
-      <point x="982" y="524"/>
-      <point x="998" y="495"/>
-      <point x="998" y="456" type="curve" smooth="yes"/>
-      <point x="998" y="415"/>
-      <point x="977" y="380"/>
-      <point x="932" y="380" type="curve" smooth="yes"/>
-      <point x="891" y="380"/>
-      <point x="866" y="407"/>
-      <point x="866" y="449" type="curve" smooth="yes"/>
-      <point x="866" y="500"/>
-      <point x="901" y="550"/>
-      <point x="992" y="550" type="curve"/>
-      <point x="1000" y="575" type="line"/>
-      <point x="976" y="594"/>
-      <point x="934" y="612"/>
+      <point x="489" y="534"/>
+      <point x="541" y="474"/>
+      <point x="541" y="380" type="curve" smooth="yes"/>
+      <point x="541" y="359"/>
+      <point x="539" y="339"/>
+      <point x="535" y="316" type="curve" smooth="yes"/>
+      <point x="479" y="0" type="line"/>
+      <point x="563" y="0" type="line"/>
+      <point x="622" y="333" type="line" smooth="yes"/>
+      <point x="647" y="475"/>
+      <point x="725" y="548"/>
+      <point x="857" y="548" type="curve" smooth="yes"/>
+      <point x="868" y="548"/>
+      <point x="880" y="547"/>
+      <point x="891" y="546" type="curve"/>
+      <point x="847" y="565" type="line"/>
+      <point x="847" y="538" type="line"/>
+      <point x="809" y="512"/>
+      <point x="784" y="465"/>
+      <point x="784" y="415" type="curve" smooth="yes"/>
+      <point x="784" y="341"/>
+      <point x="837" y="286"/>
+      <point x="918" y="286" type="curve" smooth="yes"/>
+      <point x="1035" y="286"/>
+      <point x="1075" y="375"/>
+      <point x="1075" y="440" type="curve" smooth="yes"/>
+      <point x="1075" y="485"/>
+      <point x="1057" y="522"/>
+      <point x="1027" y="545" type="curve"/>
+      <point x="1045" y="582" type="line"/>
+      <point x="994" y="551" type="line"/>
+      <point x="1003" y="553"/>
+      <point x="1014" y="554"/>
+      <point x="1026" y="554" type="curve" smooth="yes"/>
+      <point x="1105" y="554"/>
+      <point x="1140" y="505"/>
+      <point x="1140" y="436" type="curve" smooth="yes"/>
+      <point x="1140" y="422"/>
+      <point x="1139" y="407"/>
+      <point x="1136" y="390" type="curve" smooth="yes"/>
+      <point x="1126" y="333" type="line"/>
+      <point x="1210" y="333" type="line"/>
+      <point x="1220" y="390" type="line" smooth="yes"/>
+      <point x="1236" y="481"/>
+      <point x="1294" y="534"/>
+      <point x="1375" y="534" type="curve" smooth="yes"/>
+      <point x="1441" y="534"/>
+      <point x="1477" y="499"/>
+      <point x="1477" y="433" type="curve" smooth="yes"/>
+      <point x="1477" y="328"/>
+      <point x="1404" y="264"/>
+      <point x="1261" y="264" type="curve" smooth="yes"/>
+      <point x="925" y="264" type="line" smooth="yes"/>
+      <point x="815" y="264"/>
+      <point x="737" y="207"/>
+      <point x="737" y="114" type="curve" smooth="yes"/>
+      <point x="737" y="34"/>
+      <point x="797" y="-16"/>
+      <point x="884" y="-16" type="curve" smooth="yes"/>
+      <point x="933" y="-16"/>
+      <point x="969" y="-6"/>
+      <point x="1040" y="27" type="curve" smooth="yes"/>
+      <point x="1196" y="99" type="line"/>
+      <point x="1269" y="148" type="line"/>
+      <point x="1297" y="154" type="line"/>
+      <point x="1328" y="172"/>
+      <point x="1350" y="178"/>
+      <point x="1378" y="178" type="curve" smooth="yes"/>
+      <point x="1416" y="178"/>
+      <point x="1433" y="157"/>
+      <point x="1433" y="124" type="curve" smooth="yes"/>
+      <point x="1433" y="92"/>
+      <point x="1413" y="56"/>
+      <point x="1362" y="56" type="curve" smooth="yes"/>
+      <point x="1326" y="56"/>
+      <point x="1305" y="77"/>
+      <point x="1305" y="109" type="curve" smooth="yes"/>
+      <point x="1305" y="140"/>
+      <point x="1319" y="161"/>
+      <point x="1346" y="188" type="curve"/>
+      <point x="1242" y="148" type="line"/>
+      <point x="1258" y="128" type="line"/>
+      <point x="1249" y="114"/>
+      <point x="1244" y="98"/>
+      <point x="1244" y="80" type="curve" smooth="yes"/>
+      <point x="1244" y="22"/>
+      <point x="1288" y="-16"/>
+      <point x="1355" y="-16" type="curve" smooth="yes"/>
+      <point x="1463" y="-16"/>
+      <point x="1504" y="69"/>
+      <point x="1504" y="126" type="curve" smooth="yes"/>
+      <point x="1504" y="189"/>
+      <point x="1465" y="232"/>
+      <point x="1394" y="232" type="curve" smooth="yes"/>
+      <point x="1348" y="232"/>
+      <point x="1309" y="224"/>
+      <point x="1227" y="186" type="curve" smooth="yes"/>
+      <point x="1018" y="89" type="line" smooth="yes"/>
+      <point x="970" y="67"/>
+      <point x="933" y="58"/>
+      <point x="888" y="58" type="curve" smooth="yes"/>
+      <point x="846" y="58"/>
+      <point x="819" y="82"/>
+      <point x="819" y="119" type="curve" smooth="yes"/>
+      <point x="819" y="164"/>
+      <point x="855" y="192"/>
+      <point x="922" y="192" type="curve" smooth="yes"/>
+      <point x="1243" y="192" type="line" smooth="yes"/>
+      <point x="1425" y="192"/>
+      <point x="1559" y="286"/>
+      <point x="1559" y="438" type="curve" smooth="yes"/>
+      <point x="1559" y="546"/>
+      <point x="1497" y="612"/>
+      <point x="1392" y="612" type="curve" smooth="yes"/>
+      <point x="1304" y="612"/>
+      <point x="1239" y="570"/>
+      <point x="1205" y="491" type="curve"/>
+      <point x="1197" y="491" type="line"/>
+      <point x="1180" y="571"/>
+      <point x="1128" y="612"/>
+      <point x="1028" y="612" type="curve" smooth="yes"/>
+      <point x="994" y="612"/>
+      <point x="961" y="607"/>
+      <point x="931" y="596" type="curve"/>
+      <point x="954" y="594" type="line"/>
+      <point x="927" y="604"/>
+      <point x="893" y="612"/>
       <point x="854" y="612" type="curve" smooth="yes"/>
-      <point x="738" y="612"/>
-      <point x="652" y="567"/>
-      <point x="605" y="480" type="curve"/>
-      <point x="595" y="480" type="line"/>
-      <point x="562" y="567"/>
+      <point x="741" y="612"/>
+      <point x="655" y="565"/>
+      <point x="606" y="477" type="curve"/>
+      <point x="596" y="477" type="line"/>
+      <point x="563" y="566"/>
       <point x="489" y="612"/>
       <point x="385" y="612" type="curve" smooth="yes"/>
-      <point x="189" y="612"/>
-      <point x="50" y="449"/>
-      <point x="50" y="229" type="curve" smooth="yes"/>
-      <point x="50" y="79"/>
-      <point x="135" y="-16"/>
+      <point x="147" y="612"/>
+      <point x="49" y="401"/>
+      <point x="49" y="229" type="curve" smooth="yes"/>
+      <point x="49" y="79"/>
+      <point x="128" y="-16"/>
+    </contour>
+    <contour>
+      <point x="924" y="356" type="curve" smooth="yes"/>
+      <point x="884" y="356"/>
+      <point x="861" y="383"/>
+      <point x="861" y="424" type="curve" smooth="yes"/>
+      <point x="861" y="484"/>
+      <point x="903" y="533"/>
+      <point x="986" y="553" type="curve"/>
+      <point x="921" y="553" type="line"/>
+      <point x="979" y="532"/>
+      <point x="1002" y="497"/>
+      <point x="1002" y="446" type="curve" smooth="yes"/>
+      <point x="1002" y="406"/>
+      <point x="977" y="356"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/rr_rra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/rr_rra-malayalam.glif
@@ -1,38 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="rr_rra-malayalam" format="2">
-  <advance width="730"/>
+  <advance width="720"/>
   <anchor x="271" y="-327" name="bottom"/>
   <anchor x="412" y="596" name="top"/>
   <anchor x="623" y="596" name="topright"/>
   <outline>
-    <contour>
-      <point x="154" y="-343" type="curve"/>
-      <point x="209" y="-297" type="line"/>
-      <point x="189" y="-270"/>
-      <point x="166" y="-230"/>
-      <point x="166" y="-160" type="curve" smooth="yes"/>
-      <point x="166" y="-71"/>
-      <point x="210" y="13"/>
-      <point x="319" y="13" type="curve" smooth="yes"/>
-      <point x="387" y="13"/>
-      <point x="438" y="-24"/>
-      <point x="438" y="-109" type="curve" smooth="yes"/>
-      <point x="438" y="-188"/>
-      <point x="395" y="-242"/>
-      <point x="333" y="-292" type="curve"/>
-      <point x="378" y="-343" type="line"/>
-      <point x="463" y="-281"/>
-      <point x="513" y="-208"/>
-      <point x="513" y="-106" type="curve" smooth="yes"/>
-      <point x="513" y="21"/>
-      <point x="434" y="83"/>
-      <point x="318" y="83" type="curve" smooth="yes"/>
-      <point x="165" y="83"/>
-      <point x="91" y="-33"/>
-      <point x="91" y="-161" type="curve" smooth="yes"/>
-      <point x="91" y="-241"/>
-      <point x="114" y="-300"/>
-    </contour>
     <contour>
       <point x="170" y="-16" type="curve"/>
       <point x="228" y="45" type="line"/>
@@ -60,6 +32,34 @@
       <point x="53" y="256" type="curve" smooth="yes"/>
       <point x="53" y="144"/>
       <point x="94" y="48"/>
+    </contour>
+    <contour>
+      <point x="154" y="-343" type="curve"/>
+      <point x="209" y="-297" type="line"/>
+      <point x="189" y="-270"/>
+      <point x="166" y="-230"/>
+      <point x="166" y="-160" type="curve" smooth="yes"/>
+      <point x="166" y="-71"/>
+      <point x="210" y="13"/>
+      <point x="319" y="13" type="curve" smooth="yes"/>
+      <point x="387" y="13"/>
+      <point x="438" y="-24"/>
+      <point x="438" y="-109" type="curve" smooth="yes"/>
+      <point x="438" y="-188"/>
+      <point x="395" y="-242"/>
+      <point x="333" y="-292" type="curve"/>
+      <point x="378" y="-343" type="line"/>
+      <point x="463" y="-281"/>
+      <point x="513" y="-208"/>
+      <point x="513" y="-106" type="curve" smooth="yes"/>
+      <point x="513" y="21"/>
+      <point x="434" y="83"/>
+      <point x="318" y="83" type="curve" smooth="yes"/>
+      <point x="165" y="83"/>
+      <point x="91" y="-33"/>
+      <point x="91" y="-161" type="curve" smooth="yes"/>
+      <point x="91" y="-241"/>
+      <point x="114" y="-300"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/t_la-malayalam.glif
@@ -1,136 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_la-malayalam" format="2">
   <advance width="1005"/>
-  <anchor x="481" y="-357" name="bottom"/>
-  <anchor x="558" y="596" name="top"/>
-  <anchor x="885" y="596" name="topright"/>
+  <anchor x="494" y="-362" name="bottom"/>
+  <anchor x="554" y="596" name="top"/>
+  <anchor x="881" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="277" y="-378" type="curve" smooth="yes"/>
-      <point x="364" y="-378"/>
-      <point x="414" y="-321"/>
-      <point x="414" y="-236" type="curve" smooth="yes"/>
-      <point x="414" y="-156"/>
-      <point x="369" y="-121"/>
-      <point x="303" y="-121" type="curve" smooth="yes"/>
-      <point x="270" y="-121"/>
-      <point x="238" y="-134"/>
-      <point x="214" y="-167" type="curve"/>
-      <point x="204" y="-166" type="line"/>
-      <point x="227" y="-72"/>
-      <point x="288" y="-22"/>
-      <point x="368" y="-22" type="curve" smooth="yes"/>
-      <point x="479" y="-22"/>
-      <point x="501" y="-91"/>
-      <point x="507" y="-180" type="curve" smooth="yes"/>
-      <point x="508" y="-196" type="line" smooth="yes"/>
-      <point x="515" y="-307"/>
-      <point x="559" y="-378"/>
-      <point x="676" y="-378" type="curve" smooth="yes"/>
-      <point x="810" y="-378"/>
-      <point x="860" y="-270"/>
-      <point x="860" y="-132" type="curve" smooth="yes"/>
-      <point x="860" y="-59"/>
-      <point x="838" y="3"/>
-      <point x="812" y="44" type="curve"/>
-      <point x="802" y="18" type="line"/>
-      <point x="901" y="106"/>
-      <point x="949" y="210"/>
-      <point x="949" y="336" type="curve" smooth="yes"/>
-      <point x="949" y="513"/>
-      <point x="853" y="612"/>
-      <point x="683" y="612" type="curve" smooth="yes"/>
-      <point x="477" y="612"/>
-      <point x="295" y="418"/>
-      <point x="295" y="199" type="curve" smooth="yes"/>
-      <point x="295" y="139"/>
-      <point x="310" y="88"/>
-      <point x="348" y="50" type="curve"/>
-      <point x="345" y="40" type="line"/>
-      <point x="210" y="21"/>
-      <point x="131" y="-82"/>
-      <point x="131" y="-209" type="curve" smooth="yes"/>
-      <point x="131" y="-328"/>
-      <point x="196" y="-378"/>
+      <point x="276" y="-378" type="curve" smooth="yes"/>
+      <point x="375" y="-378"/>
+      <point x="421" y="-300"/>
+      <point x="421" y="-234" type="curve" smooth="yes"/>
+      <point x="421" y="-166"/>
+      <point x="386" y="-121"/>
+      <point x="323" y="-121" type="curve" smooth="yes"/>
+      <point x="275" y="-121"/>
+      <point x="209" y="-155"/>
+      <point x="195" y="-236" type="curve"/>
+      <point x="230" y="-175" type="line"/>
+      <point x="171" y="-175" type="line"/>
+      <point x="205" y="-201" type="line"/>
+      <point x="222" y="-94"/>
+      <point x="304" y="-22"/>
+      <point x="388" y="-22" type="curve" smooth="yes"/>
+      <point x="466" y="-22"/>
+      <point x="495" y="-61"/>
+      <point x="511" y="-160" type="curve" smooth="yes"/>
+      <point x="518" y="-203" type="line" smooth="yes"/>
+      <point x="538" y="-323"/>
+      <point x="587" y="-378"/>
+      <point x="678" y="-378" type="curve" smooth="yes"/>
+      <point x="820" y="-378"/>
+      <point x="864" y="-231"/>
+      <point x="864" y="-135" type="curve" smooth="yes"/>
+      <point x="864" y="-59"/>
+      <point x="844" y="0"/>
+      <point x="814" y="46" type="curve"/>
+      <point x="813" y="21" type="line"/>
+      <point x="914" y="132"/>
+      <point x="955" y="249"/>
+      <point x="955" y="362" type="curve" smooth="yes"/>
+      <point x="955" y="515"/>
+      <point x="870" y="612"/>
+      <point x="704" y="612" type="curve" smooth="yes"/>
+      <point x="638" y="612"/>
+      <point x="578" y="595"/>
+      <point x="524" y="567" type="curve"/>
+      <point x="566" y="564" type="line"/>
+      <point x="524" y="594"/>
+      <point x="471" y="612"/>
+      <point x="408" y="612" type="curve" smooth="yes"/>
+      <point x="185" y="612"/>
+      <point x="49" y="429"/>
+      <point x="49" y="235" type="curve" smooth="yes"/>
+      <point x="49" y="143"/>
+      <point x="75" y="58"/>
+      <point x="129" y="-16" type="curve"/>
+      <point x="193" y="31" type="line"/>
+      <point x="149" y="92"/>
+      <point x="131" y="161"/>
+      <point x="131" y="236" type="curve" smooth="yes"/>
+      <point x="131" y="404"/>
+      <point x="233" y="534"/>
+      <point x="399" y="534" type="curve" smooth="yes"/>
+      <point x="431" y="534"/>
+      <point x="459" y="528"/>
+      <point x="484" y="518" type="curve"/>
+      <point x="483" y="542" type="line"/>
+      <point x="361" y="458"/>
+      <point x="285" y="314"/>
+      <point x="285" y="190" type="curve" smooth="yes"/>
+      <point x="285" y="129"/>
+      <point x="306" y="79"/>
+      <point x="338" y="43" type="curve"/>
+      <point x="336" y="32" type="line"/>
+      <point x="214" y="7"/>
+      <point x="138" y="-111"/>
+      <point x="138" y="-227" type="curve" smooth="yes"/>
+      <point x="138" y="-321"/>
+      <point x="198" y="-378"/>
     </contour>
     <contour>
-      <point x="677" y="-308" type="curve" smooth="yes"/>
-      <point x="616" y="-308"/>
-      <point x="592" y="-271"/>
-      <point x="583" y="-176" type="curve" smooth="yes"/>
-      <point x="581" y="-155" type="line" smooth="yes"/>
-      <point x="575" y="-96"/>
-      <point x="562" y="-52"/>
-      <point x="526" y="-17" type="curve"/>
-      <point x="528" y="-7" type="line"/>
-      <point x="638" y="18"/>
-      <point x="701" y="127"/>
-      <point x="701" y="275" type="curve" smooth="yes"/>
-      <point x="701" y="392"/>
-      <point x="660" y="487"/>
-      <point x="589" y="546" type="curve"/>
-      <point x="518" y="503" type="line"/>
-      <point x="581" y="463"/>
-      <point x="615" y="385"/>
-      <point x="615" y="275" type="curve" smooth="yes"/>
-      <point x="615" y="136"/>
-      <point x="570" y="62"/>
-      <point x="484" y="62" type="curve" smooth="yes"/>
-      <point x="413" y="62"/>
-      <point x="377" y="109"/>
-      <point x="377" y="199" type="curve" smooth="yes"/>
-      <point x="377" y="387"/>
-      <point x="510" y="534"/>
-      <point x="681" y="534" type="curve" smooth="yes"/>
-      <point x="803" y="534"/>
-      <point x="867" y="466"/>
-      <point x="867" y="336" type="curve" smooth="yes"/>
-      <point x="867" y="218"/>
-      <point x="818" y="128"/>
-      <point x="722" y="43" type="curve"/>
-      <point x="746" y="11"/>
-      <point x="784" y="-52"/>
-      <point x="784" y="-145" type="curve" smooth="yes"/>
-      <point x="784" y="-228"/>
-      <point x="756" y="-308"/>
+      <point x="279" y="-313" type="curve" smooth="yes"/>
+      <point x="233" y="-313"/>
+      <point x="205" y="-276"/>
+      <point x="205" y="-227" type="curve" smooth="yes"/>
+      <point x="205" y="-219"/>
+      <point x="206" y="-211"/>
+      <point x="208" y="-203" type="curve"/>
+      <point x="188" y="-218" type="line"/>
+      <point x="197" y="-268" type="line"/>
+      <point x="205" y="-224"/>
+      <point x="246" y="-181"/>
+      <point x="299" y="-181" type="curve" smooth="yes"/>
+      <point x="335" y="-181"/>
+      <point x="351" y="-202"/>
+      <point x="351" y="-236" type="curve" smooth="yes"/>
+      <point x="351" y="-270"/>
+      <point x="332" y="-313"/>
     </contour>
     <contour>
-      <point x="276" y="-313" type="curve" smooth="yes"/>
-      <point x="222" y="-313"/>
-      <point x="199" y="-270"/>
-      <point x="199" y="-223" type="curve"/>
-      <point x="181" y="-200" type="line"/>
-      <point x="192" y="-256" type="line"/>
-      <point x="199" y="-216"/>
-      <point x="233" y="-181"/>
-      <point x="282" y="-181" type="curve" smooth="yes"/>
-      <point x="324" y="-181"/>
-      <point x="343" y="-201"/>
-      <point x="343" y="-240" type="curve" smooth="yes"/>
-      <point x="343" y="-282"/>
-      <point x="320" y="-313"/>
+      <point x="468" y="62" type="curve" smooth="yes"/>
+      <point x="403" y="62"/>
+      <point x="368" y="107"/>
+      <point x="368" y="193" type="curve" smooth="yes"/>
+      <point x="368" y="308"/>
+      <point x="437" y="431"/>
+      <point x="544" y="493" type="curve"/>
+      <point x="521" y="497" type="line"/>
+      <point x="578" y="454"/>
+      <point x="606" y="379"/>
+      <point x="606" y="292" type="curve" smooth="yes"/>
+      <point x="606" y="194"/>
+      <point x="565" y="62"/>
     </contour>
     <contour>
-      <point x="137" y="-16" type="curve"/>
-      <point x="203" y="32" type="line"/>
-      <point x="159" y="87"/>
-      <point x="134" y="165"/>
-      <point x="134" y="248" type="curve" smooth="yes"/>
-      <point x="134" y="421"/>
-      <point x="237" y="534"/>
-      <point x="395" y="534" type="curve" smooth="yes"/>
-      <point x="444" y="534"/>
-      <point x="485" y="523"/>
-      <point x="518" y="503" type="curve"/>
-      <point x="589" y="546" type="line"/>
-      <point x="539" y="588"/>
-      <point x="474" y="612"/>
-      <point x="399" y="612" type="curve" smooth="yes"/>
-      <point x="194" y="612"/>
-      <point x="52" y="463"/>
-      <point x="52" y="248" type="curve" smooth="yes"/>
-      <point x="52" y="143"/>
-      <point x="80" y="56"/>
+      <point x="685" y="-308" type="curve" smooth="yes"/>
+      <point x="629" y="-308"/>
+      <point x="604" y="-274"/>
+      <point x="590" y="-188" type="curve" smooth="yes"/>
+      <point x="583" y="-145" type="line" smooth="yes"/>
+      <point x="571" y="-69"/>
+      <point x="561" y="-28"/>
+      <point x="533" y="-3" type="curve"/>
+      <point x="535" y="8" type="line"/>
+      <point x="653" y="48"/>
+      <point x="692" y="187"/>
+      <point x="692" y="290" type="curve" smooth="yes"/>
+      <point x="692" y="394"/>
+      <point x="655" y="489"/>
+      <point x="586" y="549" type="curve"/>
+      <point x="597" y="518" type="line"/>
+      <point x="627" y="528"/>
+      <point x="660" y="534"/>
+      <point x="694" y="534" type="curve" smooth="yes"/>
+      <point x="825" y="534"/>
+      <point x="872" y="467"/>
+      <point x="872" y="358" type="curve" smooth="yes"/>
+      <point x="872" y="257"/>
+      <point x="822" y="148"/>
+      <point x="713" y="45" type="curve"/>
+      <point x="766" y="-8"/>
+      <point x="790" y="-65"/>
+      <point x="790" y="-139" type="curve" smooth="yes"/>
+      <point x="790" y="-202"/>
+      <point x="771" y="-308"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ta-malayalam.glif
@@ -2,61 +2,61 @@
 <glyph name="ta-malayalam" format="2">
   <advance width="1005"/>
   <unicode hex="0D24"/>
-  <anchor x="548" y="0" name="bottom"/>
-  <anchor x="558" y="596" name="top"/>
-  <anchor x="885" y="596" name="topright"/>
+  <anchor x="542" y="0" name="bottom"/>
+  <anchor x="554" y="596" name="top"/>
+  <anchor x="881" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="137" y="-16" type="curve"/>
-      <point x="203" y="32" type="line"/>
-      <point x="159" y="87"/>
-      <point x="134" y="165"/>
-      <point x="134" y="248" type="curve" smooth="yes"/>
-      <point x="134" y="421"/>
-      <point x="237" y="534"/>
-      <point x="395" y="534" type="curve" smooth="yes"/>
-      <point x="537" y="534"/>
-      <point x="615" y="443"/>
-      <point x="615" y="275" type="curve" smooth="yes"/>
-      <point x="615" y="136"/>
-      <point x="570" y="62"/>
-      <point x="484" y="62" type="curve" smooth="yes"/>
-      <point x="413" y="62"/>
-      <point x="377" y="109"/>
-      <point x="377" y="199" type="curve" smooth="yes"/>
-      <point x="377" y="387"/>
-      <point x="510" y="534"/>
-      <point x="681" y="534" type="curve" smooth="yes"/>
-      <point x="803" y="534"/>
-      <point x="867" y="466"/>
-      <point x="867" y="336" type="curve" smooth="yes"/>
-      <point x="867" y="218"/>
-      <point x="818" y="128"/>
-      <point x="709" y="48" type="curve"/>
-      <point x="760" y="-16" type="line"/>
-      <point x="888" y="79"/>
-      <point x="949" y="193"/>
-      <point x="949" y="336" type="curve" smooth="yes"/>
-      <point x="949" y="513"/>
-      <point x="853" y="612"/>
-      <point x="683" y="612" type="curve" smooth="yes"/>
-      <point x="477" y="612"/>
-      <point x="295" y="418"/>
-      <point x="295" y="199" type="curve" smooth="yes"/>
-      <point x="295" y="62"/>
-      <point x="364" y="-16"/>
-      <point x="484" y="-16" type="curve" smooth="yes"/>
-      <point x="614" y="-16"/>
-      <point x="701" y="100"/>
-      <point x="701" y="275" type="curve" smooth="yes"/>
-      <point x="701" y="475"/>
-      <point x="579" y="612"/>
-      <point x="399" y="612" type="curve" smooth="yes"/>
-      <point x="194" y="612"/>
-      <point x="52" y="463"/>
-      <point x="52" y="248" type="curve" smooth="yes"/>
-      <point x="52" y="143"/>
-      <point x="80" y="56"/>
+      <point x="129" y="-16" type="curve"/>
+      <point x="193" y="31" type="line"/>
+      <point x="149" y="92"/>
+      <point x="131" y="161"/>
+      <point x="131" y="236" type="curve" smooth="yes"/>
+      <point x="131" y="404"/>
+      <point x="233" y="534"/>
+      <point x="399" y="534" type="curve" smooth="yes"/>
+      <point x="540" y="534"/>
+      <point x="606" y="426"/>
+      <point x="606" y="292" type="curve" smooth="yes"/>
+      <point x="606" y="194"/>
+      <point x="565" y="62"/>
+      <point x="468" y="62" type="curve" smooth="yes"/>
+      <point x="403" y="62"/>
+      <point x="368" y="107"/>
+      <point x="368" y="193" type="curve" smooth="yes"/>
+      <point x="368" y="355"/>
+      <point x="506" y="534"/>
+      <point x="694" y="534" type="curve" smooth="yes"/>
+      <point x="823" y="534"/>
+      <point x="870" y="467"/>
+      <point x="870" y="358" type="curve" smooth="yes"/>
+      <point x="870" y="257"/>
+      <point x="820" y="148"/>
+      <point x="711" y="45" type="curve"/>
+      <point x="774" y="-16" type="line"/>
+      <point x="902" y="105"/>
+      <point x="953" y="236"/>
+      <point x="953" y="362" type="curve" smooth="yes"/>
+      <point x="953" y="515"/>
+      <point x="869" y="612"/>
+      <point x="704" y="612" type="curve" smooth="yes"/>
+      <point x="460" y="612"/>
+      <point x="285" y="378"/>
+      <point x="285" y="190" type="curve" smooth="yes"/>
+      <point x="285" y="66"/>
+      <point x="354" y="-16"/>
+      <point x="461" y="-16" type="curve" smooth="yes"/>
+      <point x="630" y="-16"/>
+      <point x="692" y="162"/>
+      <point x="692" y="290" type="curve" smooth="yes"/>
+      <point x="692" y="462"/>
+      <point x="591" y="612"/>
+      <point x="408" y="612" type="curve" smooth="yes"/>
+      <point x="185" y="612"/>
+      <point x="49" y="429"/>
+      <point x="49" y="235" type="curve" smooth="yes"/>
+      <point x="49" y="143"/>
+      <point x="75" y="58"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1005"/>
   <outline>
     <component base="ta-malayalam"/>
-    <component base="halant-malayalam" xOffset="805"/>
+    <component base="halant-malayalam" xOffset="801"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="597"/>
-  <anchor x="300" y="0" name="bottom"/>
-  <anchor x="282" y="596" name="top"/>
-  <anchor x="421" y="596" name="topright"/>
+  <anchor x="229" y="-271" name="bottom"/>
+  <anchor x="349" y="596" name="top"/>
+  <anchor x="488" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="234" y="-225" type="curve" smooth="yes"/>
-      <point x="400" y="-225"/>
-      <point x="493" y="-177"/>
-      <point x="493" y="-78" type="curve" smooth="yes"/>
-      <point x="493" y="-21"/>
-      <point x="462" y="12"/>
-      <point x="402" y="28" type="curve"/>
-      <point x="403" y="38" type="line"/>
-      <point x="488" y="58"/>
-      <point x="530" y="123"/>
-      <point x="530" y="198" type="curve" smooth="yes"/>
-      <point x="530" y="289"/>
-      <point x="484" y="348"/>
-      <point x="354" y="355" type="curve" smooth="yes"/>
-      <point x="258" y="360" type="line" smooth="yes"/>
-      <point x="185" y="364"/>
-      <point x="152" y="392"/>
-      <point x="152" y="438" type="curve" smooth="yes"/>
-      <point x="152" y="496"/>
-      <point x="205" y="532"/>
-      <point x="304" y="532" type="curve" smooth="yes"/>
-      <point x="396" y="532"/>
-      <point x="454" y="511"/>
-      <point x="513" y="479" type="curve"/>
-      <point x="556" y="550" type="line"/>
-      <point x="490" y="587"/>
-      <point x="414" y="612"/>
-      <point x="314" y="612" type="curve" smooth="yes"/>
-      <point x="163" y="612"/>
-      <point x="64" y="549"/>
-      <point x="64" y="428" type="curve" smooth="yes"/>
-      <point x="64" y="339"/>
-      <point x="122" y="288"/>
-      <point x="223" y="273" type="curve"/>
-      <point x="344" y="266" type="line" smooth="yes"/>
-      <point x="420" y="262"/>
-      <point x="444" y="231"/>
-      <point x="444" y="183" type="curve" smooth="yes"/>
-      <point x="444" y="113"/>
-      <point x="388" y="80"/>
-      <point x="304" y="80" type="curve" smooth="yes"/>
-      <point x="48" y="80" type="line"/>
-      <point x="35" y="6" type="line"/>
-      <point x="238" y="6" type="line" smooth="yes"/>
-      <point x="362" y="6"/>
-      <point x="411" y="-27"/>
-      <point x="411" y="-71" type="curve" smooth="yes"/>
-      <point x="411" y="-127"/>
-      <point x="354" y="-147"/>
-      <point x="247" y="-147" type="curve" smooth="yes"/>
-      <point x="144" y="-147"/>
-      <point x="72" y="-125"/>
-      <point x="17" y="-98" type="curve"/>
-      <point x="-28" y="-165" type="line"/>
-      <point x="27" y="-197"/>
-      <point x="125" y="-225"/>
+      <point x="213" y="-277" type="curve" smooth="yes"/>
+      <point x="394" y="-277"/>
+      <point x="481" y="-183"/>
+      <point x="481" y="-84" type="curve" smooth="yes"/>
+      <point x="481" y="-23"/>
+      <point x="455" y="17"/>
+      <point x="398" y="39" type="curve"/>
+      <point x="399" y="49" type="line"/>
+      <point x="478" y="69"/>
+      <point x="524" y="121"/>
+      <point x="524" y="192" type="curve" smooth="yes"/>
+      <point x="524" y="285"/>
+      <point x="471" y="341"/>
+      <point x="347" y="353" type="curve" smooth="yes"/>
+      <point x="241" y="363" type="line" smooth="yes"/>
+      <point x="177" y="369"/>
+      <point x="150" y="394"/>
+      <point x="150" y="439" type="curve" smooth="yes"/>
+      <point x="150" y="491"/>
+      <point x="196" y="534"/>
+      <point x="310" y="534" type="curve" smooth="yes"/>
+      <point x="395" y="534"/>
+      <point x="459" y="518"/>
+      <point x="525" y="484" type="curve"/>
+      <point x="561" y="553" type="line"/>
+      <point x="482" y="594"/>
+      <point x="408" y="612"/>
+      <point x="317" y="612" type="curve" smooth="yes"/>
+      <point x="136" y="612"/>
+      <point x="64" y="522"/>
+      <point x="64" y="430" type="curve" smooth="yes"/>
+      <point x="64" y="342"/>
+      <point x="124" y="284"/>
+      <point x="221" y="275" type="curve" smooth="yes"/>
+      <point x="327" y="265" type="line" smooth="yes"/>
+      <point x="410" y="257"/>
+      <point x="438" y="231"/>
+      <point x="438" y="181" type="curve" smooth="yes"/>
+      <point x="438" y="117"/>
+      <point x="380" y="80"/>
+      <point x="278" y="80" type="curve" smooth="yes"/>
+      <point x="44" y="80" type="line"/>
+      <point x="31" y="6" type="line"/>
+      <point x="278" y="6" type="line" smooth="yes"/>
+      <point x="367" y="6"/>
+      <point x="400" y="-28"/>
+      <point x="400" y="-84" type="curve" smooth="yes"/>
+      <point x="400" y="-140"/>
+      <point x="354" y="-199"/>
+      <point x="220" y="-199" type="curve" smooth="yes"/>
+      <point x="137" y="-199"/>
+      <point x="62" y="-176"/>
+      <point x="7" y="-132" type="curve"/>
+      <point x="-40" y="-192" type="line"/>
+      <point x="30" y="-247"/>
+      <point x="118" y="-277"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/tta-malayalam.glif
@@ -2,51 +2,51 @@
 <glyph name="tta-malayalam" format="2">
   <advance width="599"/>
   <unicode hex="0D1F"/>
-  <anchor x="254" y="0" name="bottom"/>
-  <anchor x="340" y="596" name="top"/>
-  <anchor x="479" y="596" name="topright"/>
+  <anchor x="260" y="0" name="bottom"/>
+  <anchor x="348" y="596" name="top"/>
+  <anchor x="487" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="280" y="-16" type="curve" smooth="yes"/>
-      <point x="418" y="-16"/>
-      <point x="524" y="41"/>
-      <point x="524" y="178" type="curve" smooth="yes"/>
-      <point x="524" y="279"/>
-      <point x="467" y="337"/>
-      <point x="341" y="343" type="curve" smooth="yes"/>
-      <point x="255" y="347" type="line" smooth="yes"/>
-      <point x="177" y="351"/>
-      <point x="148" y="385"/>
-      <point x="148" y="429" type="curve" smooth="yes"/>
-      <point x="148" y="492"/>
-      <point x="201" y="532"/>
-      <point x="301" y="532" type="curve" smooth="yes"/>
-      <point x="393" y="532"/>
-      <point x="451" y="511"/>
-      <point x="510" y="479" type="curve"/>
-      <point x="553" y="550" type="line"/>
-      <point x="487" y="587"/>
-      <point x="411" y="612"/>
-      <point x="311" y="612" type="curve" smooth="yes"/>
-      <point x="167" y="612"/>
-      <point x="62" y="549"/>
-      <point x="62" y="416" type="curve" smooth="yes"/>
-      <point x="62" y="328"/>
-      <point x="114" y="264"/>
-      <point x="239" y="258" type="curve" smooth="yes"/>
-      <point x="320" y="254" type="line" smooth="yes"/>
-      <point x="407" y="250"/>
-      <point x="438" y="223"/>
-      <point x="438" y="168" type="curve" smooth="yes"/>
-      <point x="438" y="97"/>
-      <point x="375" y="65"/>
-      <point x="289" y="65" type="curve" smooth="yes"/>
-      <point x="191" y="65"/>
-      <point x="126" y="99"/>
-      <point x="59" y="151" type="curve"/>
-      <point x="3" y="80" type="line"/>
-      <point x="77" y="20"/>
-      <point x="168" y="-16"/>
+      <point x="276" y="-16" type="curve" smooth="yes"/>
+      <point x="453" y="-16"/>
+      <point x="528" y="75"/>
+      <point x="528" y="172" type="curve" smooth="yes"/>
+      <point x="528" y="270"/>
+      <point x="471" y="329"/>
+      <point x="363" y="339" type="curve" smooth="yes"/>
+      <point x="252" y="349" type="line" smooth="yes"/>
+      <point x="186" y="355"/>
+      <point x="155" y="378"/>
+      <point x="155" y="429" type="curve" smooth="yes"/>
+      <point x="155" y="484"/>
+      <point x="207" y="532"/>
+      <point x="329" y="532" type="curve" smooth="yes"/>
+      <point x="403" y="532"/>
+      <point x="468" y="517"/>
+      <point x="527" y="485" type="curve"/>
+      <point x="563" y="556" type="line"/>
+      <point x="490" y="595"/>
+      <point x="422" y="612"/>
+      <point x="337" y="612" type="curve" smooth="yes"/>
+      <point x="136" y="612"/>
+      <point x="69" y="509"/>
+      <point x="69" y="421" type="curve" smooth="yes"/>
+      <point x="69" y="332"/>
+      <point x="127" y="271"/>
+      <point x="234" y="261" type="curve" smooth="yes"/>
+      <point x="345" y="251" type="line" smooth="yes"/>
+      <point x="413" y="245"/>
+      <point x="442" y="215"/>
+      <point x="442" y="164" type="curve" smooth="yes"/>
+      <point x="442" y="115"/>
+      <point x="398" y="64"/>
+      <point x="284" y="64" type="curve" smooth="yes"/>
+      <point x="193" y="64"/>
+      <point x="114" y="96"/>
+      <point x="51" y="144" type="curve"/>
+      <point x="-1" y="76" type="line"/>
+      <point x="78" y="17"/>
+      <point x="172" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/tta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/tta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="599"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="halant-malayalam" xOffset="399"/>
+    <component base="halant-malayalam" xOffset="407"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="599"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="301"/>
+    <component base="lVocalicMatra-malayalam" xOffset="307"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="599"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="302"/>
+    <component base="llVocalicMatra-malayalam" xOffset="308"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
@@ -4,65 +4,71 @@
   <unicode hex="0D42"/>
   <outline>
     <contour>
-      <point x="42" y="31" type="curve"/>
-      <point x="126" y="31" type="line"/>
-      <point x="208" y="171"/>
-      <point x="254" y="309"/>
-      <point x="254" y="411" type="curve" smooth="yes"/>
-      <point x="254" y="532"/>
-      <point x="193" y="600"/>
-      <point x="76" y="610" type="curve" smooth="yes"/>
-      <point x="52" y="612" type="line"/>
-      <point x="38" y="534" type="line"/>
-      <point x="131" y="527"/>
-      <point x="172" y="489"/>
-      <point x="172" y="408" type="curve" smooth="yes"/>
-      <point x="172" y="307"/>
-      <point x="120" y="157"/>
+      <point x="52" y="34" type="curve"/>
+      <point x="134" y="34" type="line"/>
+      <point x="211" y="160"/>
+      <point x="263" y="312"/>
+      <point x="263" y="411" type="curve" smooth="yes"/>
+      <point x="263" y="541"/>
+      <point x="200" y="612"/>
+      <point x="80" y="612" type="curve" smooth="yes"/>
+      <point x="60" y="612" type="line"/>
+      <point x="46" y="535" type="line"/>
+      <point x="140" y="535"/>
+      <point x="181" y="499"/>
+      <point x="181" y="409" type="curve" smooth="yes"/>
+      <point x="181" y="311"/>
+      <point x="128" y="158"/>
     </contour>
     <contour>
-      <point x="73" y="-259" type="curve" smooth="yes"/>
-      <point x="179" y="-259"/>
-      <point x="259" y="-183"/>
-      <point x="259" y="-82" type="curve" smooth="yes"/>
-      <point x="259" y="12"/>
-      <point x="186" y="82"/>
-      <point x="88" y="82" type="curve" smooth="yes"/>
-      <point x="-15" y="82"/>
+      <point x="72" y="-185" type="curve" smooth="yes"/>
+      <point x="11" y="-185"/>
+      <point x="-31" y="-150"/>
+      <point x="-31" y="-99" type="curve" smooth="yes"/>
+      <point x="-31" y="-84"/>
+      <point x="-29" y="-74"/>
+      <point x="-24" y="-63" type="curve"/>
+      <point x="-18" y="-63" type="line"/>
+      <point x="-4" y="-101"/>
+      <point x="30" y="-127"/>
+      <point x="78" y="-127" type="curve" smooth="yes"/>
+      <point x="125" y="-127"/>
+      <point x="160" y="-103"/>
+      <point x="182" y="-63" type="curve"/>
+      <point x="187" y="-63" type="line"/>
+      <point x="188" y="-69"/>
+      <point x="188" y="-77"/>
+      <point x="188" y="-82" type="curve" smooth="yes"/>
+      <point x="188" y="-127"/>
+      <point x="161" y="-185"/>
+    </contour>
+    <contour>
+      <point x="70" y="-259" type="curve" smooth="yes"/>
+      <point x="174" y="-259"/>
+      <point x="253" y="-183"/>
+      <point x="253" y="-82" type="curve" smooth="yes"/>
+      <point x="253" y="12"/>
+      <point x="181" y="82"/>
+      <point x="85" y="82" type="curve" smooth="yes"/>
+      <point x="-16" y="82"/>
       <point x="-99" y="2"/>
       <point x="-99" y="-97" type="curve" smooth="yes"/>
       <point x="-99" y="-193"/>
-      <point x="-28" y="-259"/>
+      <point x="-29" y="-259"/>
     </contour>
     <contour>
-      <point x="75" y="-185" type="curve" smooth="yes"/>
-      <point x="11" y="-185"/>
-      <point x="-27" y="-149"/>
-      <point x="-27" y="-91" type="curve" smooth="yes"/>
-      <point x="-27" y="-28"/>
-      <point x="19" y="17"/>
-      <point x="86" y="17" type="curve" smooth="yes"/>
-      <point x="147" y="17"/>
-      <point x="187" y="-21"/>
-      <point x="187" y="-78" type="curve" smooth="yes"/>
-      <point x="187" y="-140"/>
-      <point x="141" y="-185"/>
-    </contour>
-    <contour>
-      <point x="104" y="-113" type="curve" smooth="yes"/>
-      <point x="144" y="-113"/>
-      <point x="180" y="-106"/>
-      <point x="215" y="-87" type="curve"/>
-      <point x="198" y="-49" type="line"/>
-      <point x="182" y="-52"/>
-      <point x="164" y="-53"/>
-      <point x="144" y="-53" type="curve" smooth="yes"/>
-      <point x="99" y="-53"/>
-      <point x="17" y="-45"/>
-      <point x="-21" y="-30" type="curve"/>
-      <point x="-49" y="-62" type="line"/>
-      <point x="-9" y="-96"/>
-      <point x="45" y="-113"/>
+      <point x="77" y="-57" type="curve" smooth="yes"/>
+      <point x="38" y="-57"/>
+      <point x="9" y="-38"/>
+      <point x="9" y="-13" type="curve" smooth="yes"/>
+      <point x="9" y="8"/>
+      <point x="36" y="24"/>
+      <point x="94" y="24" type="curve" smooth="yes"/>
+      <point x="146" y="24"/>
+      <point x="163" y="12"/>
+      <point x="163" y="-7" type="curve" smooth="yes"/>
+      <point x="163" y="-33"/>
+      <point x="129" y="-57"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/y_ya-malayalam.glif
@@ -1,96 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="1008"/>
-  <anchor x="495" y="-322" name="bottom"/>
-  <anchor x="573" y="596" name="top"/>
-  <anchor x="879" y="596" name="topright"/>
+  <anchor x="507" y="-306" name="bottom"/>
+  <anchor x="568" y="596" name="top"/>
+  <anchor x="874" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="207" y="-322" type="line"/>
-      <point x="779" y="-322" type="line"/>
-      <point x="846" y="72" type="line"/>
-      <point x="828" y="37" type="line"/>
-      <point x="916" y="99"/>
-      <point x="969" y="211"/>
-      <point x="969" y="351" type="curve" smooth="yes"/>
-      <point x="969" y="455"/>
-      <point x="944" y="542"/>
-      <point x="894" y="612" type="curve"/>
-      <point x="825" y="569" type="line"/>
-      <point x="866" y="513"/>
-      <point x="887" y="439"/>
-      <point x="887" y="351" type="curve" smooth="yes"/>
-      <point x="887" y="178"/>
-      <point x="792" y="62"/>
-      <point x="651" y="62" type="curve" smooth="yes"/>
-      <point x="514" y="62"/>
-      <point x="432" y="158"/>
-      <point x="432" y="319" type="curve" smooth="yes"/>
-      <point x="432" y="447"/>
-      <point x="484" y="534"/>
-      <point x="560" y="534" type="curve" smooth="yes"/>
-      <point x="616" y="534"/>
-      <point x="643" y="494"/>
-      <point x="643" y="412" type="curve" smooth="yes"/>
-      <point x="643" y="281"/>
-      <point x="580" y="162"/>
-      <point x="476" y="96" type="curve"/>
-      <point x="524" y="37" type="line"/>
-      <point x="658" y="124"/>
-      <point x="725" y="248"/>
-      <point x="725" y="412" type="curve" smooth="yes"/>
-      <point x="725" y="544"/>
-      <point x="674" y="612"/>
-      <point x="576" y="612" type="curve" smooth="yes"/>
-      <point x="445" y="612"/>
-      <point x="352" y="490"/>
-      <point x="352" y="317" type="curve" smooth="yes"/>
-      <point x="352" y="125"/>
-      <point x="480" y="-16"/>
-      <point x="651" y="-16" type="curve" smooth="yes"/>
-      <point x="659" y="-16"/>
-      <point x="666" y="-16"/>
-      <point x="674" y="-15" type="curve"/>
-      <point x="611" y="29" type="line"/>
-      <point x="622" y="-25" type="line"/>
-      <point x="536" y="-72" type="line"/>
-      <point x="217" y="-264" type="line"/>
+      <point x="202" y="-306" type="line"/>
+      <point x="772" y="-306" type="line"/>
+      <point x="845" y="105" type="line"/>
+      <point x="824" y="67" type="line"/>
+      <point x="913" y="142"/>
+      <point x="959" y="256"/>
+      <point x="959" y="357" type="curve" smooth="yes"/>
+      <point x="959" y="449"/>
+      <point x="930" y="539"/>
+      <point x="877" y="612" type="curve"/>
+      <point x="810" y="566" type="line"/>
+      <point x="856" y="502"/>
+      <point x="879" y="434"/>
+      <point x="879" y="358" type="curve" smooth="yes"/>
+      <point x="879" y="225"/>
+      <point x="794" y="62"/>
+      <point x="623" y="62" type="curve" smooth="yes"/>
+      <point x="474" y="62"/>
+      <point x="389" y="157"/>
+      <point x="389" y="308" type="curve" smooth="yes"/>
+      <point x="389" y="399"/>
+      <point x="435" y="534"/>
+      <point x="557" y="534" type="curve" smooth="yes"/>
+      <point x="618" y="534"/>
+      <point x="650" y="488"/>
+      <point x="650" y="405" type="curve" smooth="yes"/>
+      <point x="650" y="301"/>
+      <point x="576" y="164"/>
+      <point x="459" y="102" type="curve"/>
+      <point x="512" y="53" type="line"/>
+      <point x="652" y="128"/>
+      <point x="732" y="293"/>
+      <point x="732" y="412" type="curve" smooth="yes"/>
+      <point x="732" y="536"/>
+      <point x="672" y="612"/>
+      <point x="564" y="612" type="curve" smooth="yes"/>
+      <point x="402" y="612"/>
+      <point x="308" y="448"/>
+      <point x="308" y="314" type="curve" smooth="yes"/>
+      <point x="308" y="132"/>
+      <point x="434" y="-12"/>
+      <point x="615" y="-12" type="curve" smooth="yes"/>
+      <point x="642" y="-12"/>
+      <point x="667" y="-9"/>
+      <point x="690" y="-4" type="curve"/>
+      <point x="598" y="29" type="line"/>
+      <point x="594" y="-23" type="line"/>
+      <point x="522" y="-57" type="line"/>
+      <point x="213" y="-248" type="line"/>
     </contour>
     <contour>
-      <point x="295" y="-295" type="line"/>
-      <point x="774" y="-5" type="line"/>
-      <point x="751" y="-5" type="line"/>
-      <point x="704" y="-270" type="line"/>
-      <point x="741" y="-257" type="line"/>
-      <point x="302" y="-257" type="line"/>
+      <point x="296" y="-277" type="line"/>
+      <point x="770" y="15" type="line"/>
+      <point x="747" y="15" type="line"/>
+      <point x="700" y="-254" type="line"/>
+      <point x="737" y="-241" type="line"/>
+      <point x="302" y="-241" type="line"/>
     </contour>
     <contour>
-      <point x="342" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="455" y="-2"/>
-      <point x="507" y="31" type="curve"/>
-      <point x="453" y="85" type="line"/>
-      <point x="420" y="69"/>
-      <point x="389" y="62"/>
-      <point x="346" y="62" type="curve" smooth="yes"/>
-      <point x="216" y="62"/>
-      <point x="141" y="148"/>
-      <point x="141" y="295" type="curve" smooth="yes"/>
-      <point x="141" y="441"/>
-      <point x="209" y="535"/>
-      <point x="314" y="535" type="curve" smooth="yes"/>
-      <point x="361" y="535"/>
-      <point x="391" y="520"/>
-      <point x="416" y="484" type="curve"/>
-      <point x="464" y="534" type="line"/>
-      <point x="435" y="586"/>
-      <point x="385" y="612"/>
-      <point x="314" y="612" type="curve" smooth="yes"/>
-      <point x="163" y="612"/>
-      <point x="61" y="483"/>
-      <point x="61" y="293" type="curve" smooth="yes"/>
-      <point x="61" y="102"/>
-      <point x="169" y="-16"/>
+      <point x="323" y="-16" type="curve" smooth="yes"/>
+      <point x="383" y="-16"/>
+      <point x="440" y="0"/>
+      <point x="486" y="35" type="curve"/>
+      <point x="434" y="90" type="line"/>
+      <point x="405" y="71"/>
+      <point x="375" y="62"/>
+      <point x="338" y="62" type="curve" smooth="yes"/>
+      <point x="210" y="62"/>
+      <point x="136" y="142"/>
+      <point x="136" y="275" type="curve" smooth="yes"/>
+      <point x="136" y="377"/>
+      <point x="187" y="534"/>
+      <point x="322" y="534" type="curve" smooth="yes"/>
+      <point x="364" y="534"/>
+      <point x="387" y="522"/>
+      <point x="411" y="493" type="curve"/>
+      <point x="471" y="542" type="line"/>
+      <point x="433" y="591"/>
+      <point x="392" y="612"/>
+      <point x="332" y="612" type="curve" smooth="yes"/>
+      <point x="133" y="612"/>
+      <point x="56" y="415"/>
+      <point x="56" y="277" type="curve" smooth="yes"/>
+      <point x="56" y="104"/>
+      <point x="160" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ya-malayalam.glif
@@ -2,78 +2,78 @@
 <glyph name="ya-malayalam" format="2">
   <advance width="1008"/>
   <unicode hex="0D2F"/>
-  <anchor x="553" y="0" name="bottom"/>
-  <anchor x="810" y="-16" name="bottomright"/>
-  <anchor x="573" y="596" name="top"/>
-  <anchor x="879" y="596" name="topright"/>
+  <anchor x="546" y="0" name="bottom"/>
+  <anchor x="804" y="-16" name="bottomright"/>
+  <anchor x="568" y="596" name="top"/>
+  <anchor x="874" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="653" y="-16" type="curve" smooth="yes"/>
+      <point x="615" y="-16" type="curve" smooth="yes"/>
       <point x="841" y="-16"/>
-      <point x="969" y="133"/>
-      <point x="969" y="351" type="curve" smooth="yes"/>
-      <point x="969" y="455"/>
-      <point x="944" y="542"/>
-      <point x="894" y="612" type="curve"/>
-      <point x="825" y="569" type="line"/>
-      <point x="866" y="513"/>
-      <point x="887" y="439"/>
-      <point x="887" y="351" type="curve" smooth="yes"/>
-      <point x="887" y="178"/>
-      <point x="792" y="62"/>
-      <point x="651" y="62" type="curve" smooth="yes"/>
-      <point x="514" y="62"/>
-      <point x="432" y="158"/>
-      <point x="432" y="319" type="curve" smooth="yes"/>
-      <point x="432" y="447"/>
-      <point x="484" y="534"/>
-      <point x="560" y="534" type="curve" smooth="yes"/>
-      <point x="616" y="534"/>
-      <point x="643" y="494"/>
-      <point x="643" y="412" type="curve" smooth="yes"/>
-      <point x="643" y="281"/>
-      <point x="580" y="162"/>
-      <point x="476" y="96" type="curve"/>
-      <point x="524" y="37" type="line"/>
-      <point x="658" y="124"/>
-      <point x="725" y="248"/>
-      <point x="725" y="412" type="curve" smooth="yes"/>
-      <point x="725" y="544"/>
-      <point x="674" y="612"/>
-      <point x="576" y="612" type="curve" smooth="yes"/>
-      <point x="445" y="612"/>
-      <point x="352" y="490"/>
-      <point x="352" y="317" type="curve" smooth="yes"/>
-      <point x="352" y="126"/>
-      <point x="480" y="-16"/>
+      <point x="959" y="188"/>
+      <point x="959" y="357" type="curve" smooth="yes"/>
+      <point x="959" y="449"/>
+      <point x="930" y="539"/>
+      <point x="877" y="612" type="curve"/>
+      <point x="810" y="566" type="line"/>
+      <point x="856" y="502"/>
+      <point x="879" y="434"/>
+      <point x="879" y="358" type="curve" smooth="yes"/>
+      <point x="879" y="225"/>
+      <point x="794" y="62"/>
+      <point x="623" y="62" type="curve" smooth="yes"/>
+      <point x="474" y="62"/>
+      <point x="389" y="157"/>
+      <point x="389" y="308" type="curve" smooth="yes"/>
+      <point x="389" y="399"/>
+      <point x="435" y="534"/>
+      <point x="557" y="534" type="curve" smooth="yes"/>
+      <point x="618" y="534"/>
+      <point x="650" y="488"/>
+      <point x="650" y="405" type="curve" smooth="yes"/>
+      <point x="650" y="301"/>
+      <point x="576" y="164"/>
+      <point x="459" y="102" type="curve"/>
+      <point x="512" y="53" type="line"/>
+      <point x="652" y="128"/>
+      <point x="732" y="293"/>
+      <point x="732" y="412" type="curve" smooth="yes"/>
+      <point x="732" y="536"/>
+      <point x="672" y="612"/>
+      <point x="564" y="612" type="curve" smooth="yes"/>
+      <point x="402" y="612"/>
+      <point x="308" y="448"/>
+      <point x="308" y="314" type="curve" smooth="yes"/>
+      <point x="308" y="130"/>
+      <point x="434" y="-16"/>
     </contour>
     <contour>
-      <point x="342" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="455" y="-2"/>
-      <point x="507" y="31" type="curve"/>
-      <point x="453" y="85" type="line"/>
-      <point x="420" y="69"/>
-      <point x="389" y="62"/>
-      <point x="346" y="62" type="curve" smooth="yes"/>
-      <point x="216" y="62"/>
-      <point x="141" y="148"/>
-      <point x="141" y="295" type="curve" smooth="yes"/>
-      <point x="141" y="441"/>
-      <point x="209" y="535"/>
-      <point x="314" y="535" type="curve" smooth="yes"/>
-      <point x="361" y="535"/>
-      <point x="391" y="520"/>
-      <point x="416" y="484" type="curve"/>
-      <point x="464" y="534" type="line"/>
-      <point x="435" y="586"/>
-      <point x="385" y="612"/>
-      <point x="314" y="612" type="curve" smooth="yes"/>
-      <point x="163" y="612"/>
-      <point x="61" y="483"/>
-      <point x="61" y="293" type="curve" smooth="yes"/>
-      <point x="61" y="102"/>
-      <point x="169" y="-16"/>
+      <point x="323" y="-16" type="curve" smooth="yes"/>
+      <point x="383" y="-16"/>
+      <point x="440" y="0"/>
+      <point x="486" y="35" type="curve"/>
+      <point x="434" y="90" type="line"/>
+      <point x="405" y="71"/>
+      <point x="375" y="62"/>
+      <point x="338" y="62" type="curve" smooth="yes"/>
+      <point x="210" y="62"/>
+      <point x="136" y="142"/>
+      <point x="136" y="275" type="curve" smooth="yes"/>
+      <point x="136" y="377"/>
+      <point x="187" y="534"/>
+      <point x="322" y="534" type="curve" smooth="yes"/>
+      <point x="364" y="534"/>
+      <point x="387" y="522"/>
+      <point x="411" y="493" type="curve"/>
+      <point x="471" y="542" type="line"/>
+      <point x="433" y="591"/>
+      <point x="392" y="612"/>
+      <point x="332" y="612" type="curve" smooth="yes"/>
+      <point x="133" y="612"/>
+      <point x="56" y="415"/>
+      <point x="56" y="277" type="curve" smooth="yes"/>
+      <point x="56" y="104"/>
+      <point x="160" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ya-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ya-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1008"/>
   <outline>
     <component base="ya-malayalam"/>
-    <component base="halant-malayalam" xOffset="799"/>
+    <component base="halant-malayalam" xOffset="794"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/kerning.plist
@@ -47536,8 +47536,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -47647,7 +47645,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47703,7 +47701,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>80</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47756,7 +47754,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>180</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -47803,7 +47801,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -47838,7 +47836,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -47866,8 +47864,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47902,7 +47898,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47971,7 +47967,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48031,7 +48027,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48080,7 +48076,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48138,7 +48134,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48179,7 +48175,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48315,8 +48311,6 @@
       <integer>-30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48345,7 +48339,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48393,8 +48387,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>10</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>0</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>0</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48480,8 +48472,6 @@
       <integer>50</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48514,7 +48504,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48591,8 +48581,6 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48636,8 +48624,6 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48757,8 +48743,6 @@
       <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48866,7 +48850,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48913,7 +48897,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48959,41 +48943,39 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>50</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_braceright.loclMALM_R</key>
-      <integer>40</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
       <integer>20</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>40</integer>
-      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>70</integer>
-      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
+      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
+      <integer>60</integer>
+      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
-      <integer>110</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
-      <integer>100</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
       <integer>20</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
       <integer>-20</integer>
-      <key>public.kern2.MAL_rVocalic-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
-      <integer>90</integer>
-      <key>public.kern2.MAL_uMatra-malayalam_L</key>
       <integer>80</integer>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>60</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>220</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
       <integer>150</integer>
     </dict>
@@ -49020,7 +49002,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49069,7 +49051,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49102,8 +49084,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -49143,7 +49123,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49346,7 +49326,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49372,8 +49352,6 @@
       <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49400,7 +49378,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49456,7 +49434,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -49488,8 +49466,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49599,8 +49575,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_p_pa-malayalam_L</key>
@@ -49667,7 +49641,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
@@ -49712,7 +49686,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49753,7 +49727,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49843,7 +49817,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>150</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49984,8 +49958,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -50033,8 +50005,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50097,7 +50067,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50150,7 +50120,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>240</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>170</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -50235,7 +50205,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -50274,7 +50244,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>130</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50370,8 +50340,6 @@
       <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
-      <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
@@ -50476,7 +50444,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_ng_ka-malayalam_L</key>
@@ -50528,6 +50496,24 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-30</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>-20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>50</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.Man-georgian</key>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/d_da-malayalam.glif
@@ -1,73 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
-  <advance width="689"/>
-  <anchor x="362" y="596" name="top"/>
+  <advance width="679"/>
+  <anchor x="281" y="-269" name="bottom"/>
+  <anchor x="429" y="596" name="top"/>
   <outline>
     <contour>
-      <point x="378" y="-225" type="curve" smooth="yes"/>
-      <point x="514" y="-225"/>
-      <point x="579" y="-173"/>
-      <point x="579" y="-87" type="curve" smooth="yes"/>
-      <point x="579" y="-32"/>
-      <point x="549" y="6"/>
-      <point x="488" y="19" type="curve"/>
-      <point x="488" y="29" type="line"/>
-      <point x="555" y="40"/>
-      <point x="613" y="76"/>
-      <point x="613" y="165" type="curve" smooth="yes"/>
-      <point x="613" y="228"/>
-      <point x="577" y="271"/>
-      <point x="515" y="290" type="curve"/>
-      <point x="516" y="300" type="line"/>
-      <point x="600" y="313"/>
-      <point x="641" y="375"/>
-      <point x="641" y="437" type="curve" smooth="yes"/>
-      <point x="641" y="534"/>
-      <point x="571" y="612"/>
-      <point x="410" y="612" type="curve" smooth="yes"/>
-      <point x="185" y="612"/>
-      <point x="50" y="454"/>
-      <point x="50" y="229" type="curve" smooth="yes"/>
-      <point x="50" y="143"/>
-      <point x="70" y="57"/>
-      <point x="115" y="-16" type="curve"/>
-      <point x="188" y="30" type="line"/>
-      <point x="153" y="88"/>
-      <point x="132" y="156"/>
-      <point x="132" y="231" type="curve" smooth="yes"/>
-      <point x="132" y="407"/>
-      <point x="230" y="534"/>
-      <point x="405" y="534" type="curve" smooth="yes"/>
-      <point x="514" y="534"/>
-      <point x="557" y="490"/>
-      <point x="557" y="433" type="curve" smooth="yes"/>
-      <point x="557" y="373"/>
-      <point x="510" y="337"/>
-      <point x="441" y="337" type="curve" smooth="yes"/>
-      <point x="383" y="337" type="line"/>
-      <point x="370" y="263" type="line"/>
-      <point x="412" y="263" type="line" smooth="yes"/>
-      <point x="493" y="263"/>
-      <point x="531" y="230"/>
-      <point x="531" y="166" type="curve" smooth="yes"/>
-      <point x="531" y="97"/>
-      <point x="483" y="62"/>
-      <point x="409" y="62" type="curve" smooth="yes"/>
-      <point x="335" y="62" type="line"/>
-      <point x="322" y="-12" type="line"/>
-      <point x="385" y="-12" type="line" smooth="yes"/>
-      <point x="463" y="-12"/>
-      <point x="498" y="-30"/>
-      <point x="498" y="-74" type="curve" smooth="yes"/>
-      <point x="498" y="-123"/>
-      <point x="460" y="-147"/>
-      <point x="387" y="-147" type="curve" smooth="yes"/>
-      <point x="329" y="-147"/>
-      <point x="296" y="-139"/>
-      <point x="265" y="-129" type="curve"/>
-      <point x="225" y="-201" type="line"/>
-      <point x="258" y="-215"/>
-      <point x="320" y="-225"/>
+      <point x="325" y="-285" type="curve" smooth="yes"/>
+      <point x="459" y="-285"/>
+      <point x="557" y="-219"/>
+      <point x="557" y="-105" type="curve" smooth="yes"/>
+      <point x="557" y="-42"/>
+      <point x="532" y="-5"/>
+      <point x="482" y="17" type="curve"/>
+      <point x="484" y="27" type="line"/>
+      <point x="564" y="47"/>
+      <point x="607" y="102"/>
+      <point x="607" y="175" type="curve" smooth="yes"/>
+      <point x="607" y="235"/>
+      <point x="576" y="277"/>
+      <point x="509" y="293" type="curve"/>
+      <point x="511" y="303" type="line"/>
+      <point x="595" y="320"/>
+      <point x="637" y="373"/>
+      <point x="637" y="441" type="curve" smooth="yes"/>
+      <point x="637" y="539"/>
+      <point x="559" y="612"/>
+      <point x="415" y="612" type="curve" smooth="yes"/>
+      <point x="169" y="612"/>
+      <point x="51" y="429"/>
+      <point x="51" y="247" type="curve" smooth="yes"/>
+      <point x="51" y="154"/>
+      <point x="77" y="66"/>
+      <point x="124" y="-16" type="curve"/>
+      <point x="194" y="27" type="line"/>
+      <point x="155" y="97"/>
+      <point x="135" y="170"/>
+      <point x="135" y="247" type="curve" smooth="yes"/>
+      <point x="135" y="400"/>
+      <point x="226" y="534"/>
+      <point x="409" y="534" type="curve" smooth="yes"/>
+      <point x="512" y="534"/>
+      <point x="553" y="495"/>
+      <point x="553" y="434" type="curve" smooth="yes"/>
+      <point x="553" y="374"/>
+      <point x="508" y="337"/>
+      <point x="428" y="337" type="curve" smooth="yes"/>
+      <point x="373" y="337" type="line"/>
+      <point x="360" y="263" type="line"/>
+      <point x="406" y="263" type="line" smooth="yes"/>
+      <point x="486" y="263"/>
+      <point x="523" y="231"/>
+      <point x="523" y="170" type="curve" smooth="yes"/>
+      <point x="523" y="101"/>
+      <point x="475" y="62"/>
+      <point x="389" y="62" type="curve" smooth="yes"/>
+      <point x="304" y="62" type="line"/>
+      <point x="291" y="-12" type="line"/>
+      <point x="359" y="-12" type="line" smooth="yes"/>
+      <point x="441" y="-12"/>
+      <point x="473" y="-47"/>
+      <point x="473" y="-101" type="curve" smooth="yes"/>
+      <point x="473" y="-169"/>
+      <point x="421" y="-207"/>
+      <point x="331" y="-207" type="curve" smooth="yes"/>
+      <point x="271" y="-207"/>
+      <point x="223" y="-194"/>
+      <point x="171" y="-165" type="curve"/>
+      <point x="136" y="-233" type="line"/>
+      <point x="195" y="-268"/>
+      <point x="259" y="-285"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="987"/>
-  <anchor x="623" y="0" name="bottom"/>
-  <anchor x="551" y="596" name="top"/>
-  <anchor x="917" y="596" name="topright"/>
+  <advance width="980"/>
+  <anchor x="609" y="0" name="bottom"/>
+  <anchor x="546" y="596" name="top"/>
+  <anchor x="905" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="256" y="-16" type="curve" smooth="yes"/>
-      <point x="379" y="-16"/>
-      <point x="453" y="57"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="729" y="532" type="curve" smooth="yes"/>
-      <point x="825" y="532"/>
-      <point x="868" y="490"/>
-      <point x="868" y="433" type="curve" smooth="yes"/>
-      <point x="868" y="373"/>
-      <point x="821" y="337"/>
-      <point x="752" y="337" type="curve" smooth="yes"/>
-      <point x="684" y="337" type="line"/>
-      <point x="671" y="263" type="line"/>
-      <point x="723" y="263" type="line" smooth="yes"/>
-      <point x="804" y="263"/>
-      <point x="842" y="229"/>
-      <point x="842" y="166" type="curve" smooth="yes"/>
-      <point x="842" y="97"/>
-      <point x="804" y="62"/>
-      <point x="730" y="62" type="curve" smooth="yes"/>
-      <point x="683" y="62"/>
-      <point x="652" y="73"/>
-      <point x="623" y="89" type="curve"/>
-      <point x="579" y="24" type="line"/>
-      <point x="616" y="0"/>
-      <point x="672" y="-16"/>
-      <point x="728" y="-16" type="curve" smooth="yes"/>
-      <point x="847" y="-16"/>
-      <point x="924" y="47"/>
-      <point x="924" y="156" type="curve" smooth="yes"/>
-      <point x="924" y="226"/>
-      <point x="888" y="272"/>
-      <point x="826" y="291" type="curve"/>
-      <point x="827" y="301" type="line"/>
-      <point x="911" y="314"/>
-      <point x="952" y="375"/>
-      <point x="952" y="448" type="curve" smooth="yes"/>
-      <point x="952" y="544"/>
-      <point x="883" y="612"/>
-      <point x="730" y="612" type="curve" smooth="yes"/>
-      <point x="581" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="76"/>
-      <point x="127" y="-16"/>
+      <point x="263" y="-16" type="curve" smooth="yes"/>
+      <point x="400" y="-16"/>
+      <point x="477" y="78"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="464"/>
+      <point x="607" y="532"/>
+      <point x="717" y="532" type="curve" smooth="yes"/>
+      <point x="803" y="532"/>
+      <point x="848" y="499"/>
+      <point x="848" y="435" type="curve" smooth="yes"/>
+      <point x="848" y="373"/>
+      <point x="801" y="337"/>
+      <point x="732" y="337" type="curve" smooth="yes"/>
+      <point x="664" y="337" type="line"/>
+      <point x="651" y="263" type="line"/>
+      <point x="703" y="263" type="line" smooth="yes"/>
+      <point x="784" y="263"/>
+      <point x="822" y="229"/>
+      <point x="822" y="166" type="curve" smooth="yes"/>
+      <point x="822" y="97"/>
+      <point x="784" y="62"/>
+      <point x="710" y="62" type="curve" smooth="yes"/>
+      <point x="663" y="62"/>
+      <point x="632" y="73"/>
+      <point x="603" y="89" type="curve"/>
+      <point x="559" y="24" type="line"/>
+      <point x="596" y="0"/>
+      <point x="652" y="-16"/>
+      <point x="708" y="-16" type="curve" smooth="yes"/>
+      <point x="827" y="-16"/>
+      <point x="904" y="47"/>
+      <point x="904" y="156" type="curve" smooth="yes"/>
+      <point x="904" y="226"/>
+      <point x="868" y="272"/>
+      <point x="806" y="290" type="curve"/>
+      <point x="807" y="300" type="line"/>
+      <point x="891" y="312"/>
+      <point x="932" y="375"/>
+      <point x="932" y="441" type="curve" smooth="yes"/>
+      <point x="932" y="545"/>
+      <point x="848" y="612"/>
+      <point x="717" y="612" type="curve" smooth="yes"/>
+      <point x="561" y="612"/>
+      <point x="456" y="517"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="77"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/g_ga-malayalam.glif
@@ -1,92 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ga-malayalam" format="2">
   <advance width="934"/>
-  <anchor x="428" y="-357" name="bottom"/>
-  <anchor x="529" y="596" name="top"/>
-  <anchor x="823" y="596" name="topright"/>
+  <anchor x="447" y="-367" name="bottom"/>
+  <anchor x="522" y="596" name="top"/>
+  <anchor x="816" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="613" y="-381" type="line"/>
-      <point x="700" y="-301"/>
-      <point x="741" y="-214"/>
-      <point x="741" y="-112" type="curve" smooth="yes"/>
-      <point x="741" y="2"/>
-      <point x="669" y="48"/>
-      <point x="592" y="48" type="curve" smooth="yes"/>
-      <point x="483" y="48"/>
-      <point x="436" y="-11"/>
-      <point x="401" y="-152" type="curve" smooth="yes"/>
-      <point x="397" y="-168" type="line" smooth="yes"/>
-      <point x="370" y="-276"/>
-      <point x="344" y="-308"/>
-      <point x="286" y="-308" type="curve" smooth="yes"/>
-      <point x="238" y="-308"/>
-      <point x="203" y="-277"/>
-      <point x="203" y="-206" type="curve" smooth="yes"/>
-      <point x="203" y="-127"/>
-      <point x="240" y="-61"/>
-      <point x="299" y="-1" type="curve"/>
-      <point x="277" y="-15" type="line"/>
-      <point x="388" y="-7"/>
-      <point x="456" y="67"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="702" y="532" type="curve" smooth="yes"/>
-      <point x="779" y="532"/>
-      <point x="818" y="483"/>
-      <point x="818" y="387" type="curve" smooth="yes"/>
-      <point x="818" y="235"/>
-      <point x="749" y="113"/>
-      <point x="610" y="27" type="curve"/>
-      <point x="683" y="-16" type="line"/>
-      <point x="823" y="79"/>
-      <point x="900" y="222"/>
-      <point x="900" y="387" type="curve" smooth="yes"/>
-      <point x="900" y="534"/>
-      <point x="832" y="612"/>
-      <point x="704" y="612" type="curve" smooth="yes"/>
-      <point x="577" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="101"/>
-      <point x="104" y="16"/>
-      <point x="203" y="-9" type="curve"/>
-      <point x="203" y="-19" type="line"/>
-      <point x="153" y="-74"/>
-      <point x="128" y="-141"/>
-      <point x="128" y="-216" type="curve" smooth="yes"/>
-      <point x="128" y="-333"/>
-      <point x="202" y="-378"/>
-      <point x="280" y="-378" type="curve" smooth="yes"/>
-      <point x="386" y="-378"/>
-      <point x="435" y="-318"/>
-      <point x="469" y="-173" type="curve" smooth="yes"/>
-      <point x="473" y="-156" type="line" smooth="yes"/>
-      <point x="498" y="-51"/>
-      <point x="525" y="-22"/>
-      <point x="585" y="-22" type="curve" smooth="yes"/>
-      <point x="636" y="-22"/>
-      <point x="665" y="-56"/>
-      <point x="665" y="-121" type="curve" smooth="yes"/>
-      <point x="665" y="-210"/>
-      <point x="624" y="-275"/>
-      <point x="563" y="-339" type="curve"/>
+      <point x="263" y="-9" type="curve" smooth="yes"/>
+      <point x="400" y="-9"/>
+      <point x="476" y="83"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="458"/>
+      <point x="592" y="528"/>
+      <point x="683" y="528" type="curve" smooth="yes"/>
+      <point x="765" y="528"/>
+      <point x="804" y="481"/>
+      <point x="804" y="385" type="curve" smooth="yes"/>
+      <point x="804" y="247"/>
+      <point x="734" y="117"/>
+      <point x="609" y="37" type="curve"/>
+      <point x="677" y="-9" type="line"/>
+      <point x="815" y="87"/>
+      <point x="888" y="226"/>
+      <point x="888" y="389" type="curve" smooth="yes"/>
+      <point x="888" y="531"/>
+      <point x="809" y="612"/>
+      <point x="683" y="612" type="curve" smooth="yes"/>
+      <point x="546" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="81"/>
+      <point x="137" y="-9"/>
+    </contour>
+    <contour>
+      <point x="623" y="-380" type="line"/>
+      <point x="712" y="-311"/>
+      <point x="757" y="-234"/>
+      <point x="757" y="-127" type="curve" smooth="yes"/>
+      <point x="757" y="-21"/>
+      <point x="699" y="48"/>
+      <point x="597" y="48" type="curve" smooth="yes"/>
+      <point x="496" y="48"/>
+      <point x="433" y="-11"/>
+      <point x="417" y="-121" type="curve" smooth="yes"/>
+      <point x="414" y="-141"/>
+      <point x="412" y="-179"/>
+      <point x="409" y="-199" type="curve" smooth="yes"/>
+      <point x="398" y="-271"/>
+      <point x="366" y="-306"/>
+      <point x="312" y="-306" type="curve" smooth="yes"/>
+      <point x="254" y="-306"/>
+      <point x="222" y="-269"/>
+      <point x="222" y="-199" type="curve" smooth="yes"/>
+      <point x="222" y="-117"/>
+      <point x="255" y="-48"/>
+      <point x="315" y="15" type="curve"/>
+      <point x="231" y="15" type="line"/>
+      <point x="181" y="-38"/>
+      <point x="146" y="-121"/>
+      <point x="146" y="-201" type="curve" smooth="yes"/>
+      <point x="146" y="-309"/>
+      <point x="212" y="-378"/>
+      <point x="312" y="-378" type="curve" smooth="yes"/>
+      <point x="410" y="-378"/>
+      <point x="468" y="-320"/>
+      <point x="485" y="-211" type="curve" smooth="yes"/>
+      <point x="488" y="-191"/>
+      <point x="490" y="-153"/>
+      <point x="493" y="-133" type="curve" smooth="yes"/>
+      <point x="504" y="-59"/>
+      <point x="537" y="-24"/>
+      <point x="596" y="-24" type="curve" smooth="yes"/>
+      <point x="657" y="-24"/>
+      <point x="681" y="-61"/>
+      <point x="681" y="-129" type="curve" smooth="yes"/>
+      <point x="681" y="-206"/>
+      <point x="641" y="-273"/>
+      <point x="577" y="-322" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/g_la-malayalam.glif
@@ -1,116 +1,125 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_la-malayalam" format="2">
   <advance width="934"/>
-  <anchor x="399" y="-357" name="bottom"/>
-  <anchor x="529" y="596" name="top"/>
-  <anchor x="823" y="596" name="topright"/>
+  <anchor x="404" y="-362" name="bottom"/>
+  <anchor x="522" y="596" name="top"/>
+  <anchor x="816" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="195" y="-378" type="curve" smooth="yes"/>
-      <point x="282" y="-378"/>
-      <point x="332" y="-321"/>
-      <point x="332" y="-236" type="curve" smooth="yes"/>
-      <point x="332" y="-156"/>
-      <point x="287" y="-121"/>
-      <point x="221" y="-121" type="curve" smooth="yes"/>
-      <point x="188" y="-121"/>
-      <point x="153" y="-134"/>
-      <point x="129" y="-167" type="curve"/>
-      <point x="122" y="-166" type="line"/>
-      <point x="145" y="-72"/>
-      <point x="206" y="-22"/>
-      <point x="286" y="-22" type="curve" smooth="yes"/>
-      <point x="397" y="-22"/>
-      <point x="419" y="-91"/>
-      <point x="425" y="-180" type="curve" smooth="yes"/>
-      <point x="426" y="-196" type="line" smooth="yes"/>
-      <point x="433" y="-307"/>
-      <point x="477" y="-378"/>
-      <point x="594" y="-378" type="curve" smooth="yes"/>
-      <point x="728" y="-378"/>
-      <point x="778" y="-270"/>
-      <point x="778" y="-142" type="curve" smooth="yes"/>
-      <point x="778" y="-72"/>
-      <point x="758" y="-2"/>
-      <point x="734" y="39" type="curve"/>
-      <point x="729" y="19" type="line"/>
-      <point x="840" y="112"/>
-      <point x="900" y="241"/>
-      <point x="900" y="387" type="curve" smooth="yes"/>
-      <point x="900" y="534"/>
-      <point x="832" y="612"/>
-      <point x="704" y="612" type="curve" smooth="yes"/>
-      <point x="577" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="126"/>
-      <point x="84" y="49"/>
-      <point x="155" y="12" type="curve"/>
-      <point x="155" y="2" type="line"/>
-      <point x="85" y="-46"/>
-      <point x="49" y="-122"/>
-      <point x="49" y="-209" type="curve" smooth="yes"/>
-      <point x="49" y="-328"/>
-      <point x="114" y="-378"/>
+      <point x="190" y="-378" type="curve" smooth="yes"/>
+      <point x="289" y="-378"/>
+      <point x="332" y="-293"/>
+      <point x="332" y="-239" type="curve" smooth="yes"/>
+      <point x="332" y="-169"/>
+      <point x="296" y="-121"/>
+      <point x="227" y="-121" type="curve" smooth="yes"/>
+      <point x="176" y="-121"/>
+      <point x="119" y="-155"/>
+      <point x="106" y="-236" type="curve"/>
+      <point x="143" y="-171" type="line"/>
+      <point x="84" y="-171" type="line"/>
+      <point x="116" y="-188" type="line"/>
+      <point x="132" y="-89"/>
+      <point x="187" y="-22"/>
+      <point x="283" y="-22" type="curve" smooth="yes"/>
+      <point x="365" y="-22"/>
+      <point x="405" y="-61"/>
+      <point x="421" y="-160" type="curve" smooth="yes"/>
+      <point x="428" y="-203" type="line" smooth="yes"/>
+      <point x="448" y="-323"/>
+      <point x="500" y="-378"/>
+      <point x="591" y="-378" type="curve" smooth="yes"/>
+      <point x="731" y="-378"/>
+      <point x="775" y="-232"/>
+      <point x="775" y="-136" type="curve" smooth="yes"/>
+      <point x="775" y="-66"/>
+      <point x="758" y="-4"/>
+      <point x="724" y="46" type="curve"/>
+      <point x="713" y="12" type="line"/>
+      <point x="828" y="109"/>
+      <point x="888" y="238"/>
+      <point x="888" y="389" type="curve" smooth="yes"/>
+      <point x="888" y="531"/>
+      <point x="809" y="612"/>
+      <point x="683" y="612" type="curve" smooth="yes"/>
+      <point x="546" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="117"/>
+      <point x="89" y="43"/>
+      <point x="155" y="11" type="curve"/>
+      <point x="153" y="2" type="line"/>
+      <point x="88" y="-44"/>
+      <point x="48" y="-128"/>
+      <point x="48" y="-217" type="curve" smooth="yes"/>
+      <point x="48" y="-317"/>
+      <point x="107" y="-378"/>
     </contour>
     <contour>
-      <point x="194" y="-313" type="curve" smooth="yes"/>
-      <point x="140" y="-313"/>
-      <point x="117" y="-270"/>
-      <point x="117" y="-223" type="curve"/>
-      <point x="99" y="-200" type="line"/>
-      <point x="110" y="-256" type="line"/>
-      <point x="117" y="-216"/>
-      <point x="151" y="-181"/>
+      <point x="192" y="-313" type="curve" smooth="yes"/>
+      <point x="145" y="-313"/>
+      <point x="116" y="-275"/>
+      <point x="116" y="-227" type="curve" smooth="yes"/>
+      <point x="116" y="-219"/>
+      <point x="117" y="-211"/>
+      <point x="118" y="-203" type="curve"/>
+      <point x="98" y="-218" type="line"/>
+      <point x="104" y="-267" type="line"/>
+      <point x="112" y="-224"/>
+      <point x="148" y="-181"/>
       <point x="200" y="-181" type="curve" smooth="yes"/>
       <point x="242" y="-181"/>
-      <point x="261" y="-201"/>
-      <point x="261" y="-240" type="curve" smooth="yes"/>
-      <point x="261" y="-282"/>
-      <point x="238" y="-313"/>
+      <point x="261" y="-205"/>
+      <point x="261" y="-241" type="curve" smooth="yes"/>
+      <point x="261" y="-270"/>
+      <point x="244" y="-313"/>
     </contour>
     <contour>
-      <point x="595" y="-308" type="curve" smooth="yes"/>
-      <point x="534" y="-308"/>
-      <point x="510" y="-271"/>
-      <point x="501" y="-176" type="curve" smooth="yes"/>
-      <point x="499" y="-155" type="line" smooth="yes"/>
-      <point x="490" y="-61"/>
-      <point x="459" y="0"/>
-      <point x="393" y="29" type="curve"/>
-      <point x="393" y="39" type="line"/>
-      <point x="443" y="78"/>
-      <point x="475" y="136"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="702" y="532" type="curve" smooth="yes"/>
-      <point x="779" y="532"/>
-      <point x="818" y="483"/>
-      <point x="818" y="387" type="curve" smooth="yes"/>
-      <point x="818" y="245"/>
-      <point x="758" y="135"/>
-      <point x="645" y="52" type="curve"/>
-      <point x="677" y="-4"/>
-      <point x="702" y="-55"/>
-      <point x="702" y="-155" type="curve" smooth="yes"/>
-      <point x="702" y="-228"/>
-      <point x="674" y="-308"/>
+      <point x="596" y="-308" type="curve" smooth="yes"/>
+      <point x="541" y="-308"/>
+      <point x="516" y="-274"/>
+      <point x="502" y="-188" type="curve" smooth="yes"/>
+      <point x="495" y="-145" type="line" smooth="yes"/>
+      <point x="478" y="-42"/>
+      <point x="450" y="2"/>
+      <point x="383" y="28" type="curve"/>
+      <point x="385" y="37" type="line"/>
+      <point x="449" y="74"/>
+      <point x="487" y="139"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="507" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="458"/>
+      <point x="592" y="528"/>
+      <point x="683" y="528" type="curve" smooth="yes"/>
+      <point x="765" y="528"/>
+      <point x="804" y="481"/>
+      <point x="804" y="385" type="curve" smooth="yes"/>
+      <point x="804" y="253"/>
+      <point x="739" y="129"/>
+      <point x="629" y="51" type="curve"/>
+      <point x="678" y="-7"/>
+      <point x="701" y="-69"/>
+      <point x="701" y="-140" type="curve" smooth="yes"/>
+      <point x="701" y="-203"/>
+      <point x="680" y="-308"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/g_ma-malayalam.glif
@@ -1,99 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ma-malayalam" format="2">
   <advance width="1425"/>
-  <anchor x="1042" y="0" name="bottom"/>
-  <anchor x="761" y="596" name="top"/>
-  <anchor x="1371" y="596" name="topright"/>
+  <anchor x="1026" y="0" name="bottom"/>
+  <anchor x="755" y="596" name="top"/>
+  <anchor x="1365" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="256" y="-16" type="curve" smooth="yes"/>
-      <point x="379" y="-16"/>
-      <point x="453" y="57"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="702" y="532" type="curve" smooth="yes"/>
-      <point x="779" y="532"/>
-      <point x="816" y="483"/>
-      <point x="816" y="402" type="curve" smooth="yes"/>
-      <point x="816" y="379"/>
-      <point x="813" y="356"/>
-      <point x="809" y="331" type="curve" smooth="yes"/>
-      <point x="750" y="0" type="line"/>
-      <point x="1317" y="0" type="line"/>
-      <point x="1364" y="266" type="line" smooth="yes"/>
-      <point x="1371" y="307"/>
-      <point x="1376" y="348"/>
-      <point x="1376" y="382" type="curve" smooth="yes"/>
-      <point x="1376" y="533"/>
-      <point x="1287" y="612"/>
-      <point x="1125" y="612" type="curve" smooth="yes"/>
-      <point x="1008" y="612"/>
-      <point x="930" y="564"/>
-      <point x="885" y="490" type="curve"/>
-      <point x="875" y="490" type="line"/>
-      <point x="853" y="570"/>
-      <point x="798" y="612"/>
-      <point x="704" y="612" type="curve" smooth="yes"/>
-      <point x="577" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="76"/>
-      <point x="127" y="-16"/>
+      <point x="263" y="-16" type="curve" smooth="yes"/>
+      <point x="400" y="-16"/>
+      <point x="477" y="78"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="458"/>
+      <point x="596" y="528"/>
+      <point x="692" y="528" type="curve" smooth="yes"/>
+      <point x="768" y="528"/>
+      <point x="809" y="484"/>
+      <point x="809" y="402" type="curve" smooth="yes"/>
+      <point x="809" y="380"/>
+      <point x="806" y="357"/>
+      <point x="802" y="333" type="curve" smooth="yes"/>
+      <point x="743" y="0" type="line"/>
+      <point x="1309" y="0" type="line"/>
+      <point x="1356" y="266" type="line" smooth="yes"/>
+      <point x="1363" y="307"/>
+      <point x="1368" y="348"/>
+      <point x="1368" y="382" type="curve" smooth="yes"/>
+      <point x="1368" y="533"/>
+      <point x="1279" y="612"/>
+      <point x="1117" y="612" type="curve" smooth="yes"/>
+      <point x="1000" y="612"/>
+      <point x="922" y="564"/>
+      <point x="877" y="490" type="curve"/>
+      <point x="867" y="490" type="line"/>
+      <point x="843" y="565"/>
+      <point x="788" y="612"/>
+      <point x="690" y="612" type="curve" smooth="yes"/>
+      <point x="550" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="77"/>
+      <point x="137" y="-16"/>
     </contour>
     <contour>
-      <point x="809" y="45" type="line"/>
-      <point x="841" y="45" type="line"/>
-      <point x="893" y="341" type="line" smooth="yes"/>
-      <point x="911" y="441"/>
-      <point x="954" y="498"/>
-      <point x="1041" y="498" type="curve" smooth="yes"/>
-      <point x="1099" y="498"/>
-      <point x="1125" y="471"/>
-      <point x="1125" y="423" type="curve" smooth="yes"/>
-      <point x="1125" y="334"/>
-      <point x="1037" y="257"/>
-      <point x="940" y="167" type="curve" smooth="yes"/>
+      <point x="801" y="45" type="line"/>
+      <point x="833" y="45" type="line"/>
+      <point x="886" y="345" type="line" smooth="yes"/>
+      <point x="903" y="443"/>
+      <point x="947" y="498"/>
+      <point x="1033" y="498" type="curve" smooth="yes"/>
+      <point x="1091" y="498"/>
+      <point x="1117" y="471"/>
+      <point x="1117" y="423" type="curve" smooth="yes"/>
+      <point x="1117" y="356"/>
+      <point x="1078" y="303"/>
+      <point x="932" y="167" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="919" y="42" type="line"/>
-      <point x="1046" y="161" type="line" smooth="yes"/>
-      <point x="1131" y="241"/>
-      <point x="1203" y="321"/>
-      <point x="1203" y="415" type="curve" smooth="yes"/>
-      <point x="1203" y="485"/>
-      <point x="1157" y="531"/>
-      <point x="1070" y="531" type="curve"/>
-      <point x="1075" y="504" type="line"/>
-      <point x="1075" y="577" type="line"/>
-      <point x="1061" y="539" type="line"/>
-      <point x="1071" y="541"/>
-      <point x="1082" y="542"/>
-      <point x="1095" y="542" type="curve" smooth="yes"/>
-      <point x="1226" y="542"/>
-      <point x="1293" y="489"/>
-      <point x="1293" y="370" type="curve" smooth="yes"/>
-      <point x="1293" y="344"/>
-      <point x="1288" y="306"/>
-      <point x="1282" y="269" type="curve" smooth="yes"/>
-      <point x="1243" y="45" type="line"/>
-      <point x="1286" y="74" type="line"/>
-      <point x="913" y="74" type="line"/>
+      <point x="911" y="42" type="line"/>
+      <point x="1038" y="161" type="line" smooth="yes"/>
+      <point x="1150" y="266"/>
+      <point x="1195" y="339"/>
+      <point x="1195" y="415" type="curve" smooth="yes"/>
+      <point x="1195" y="485"/>
+      <point x="1149" y="531"/>
+      <point x="1062" y="531" type="curve"/>
+      <point x="1067" y="504" type="line"/>
+      <point x="1067" y="577" type="line"/>
+      <point x="1053" y="539" type="line"/>
+      <point x="1063" y="541"/>
+      <point x="1074" y="542"/>
+      <point x="1087" y="542" type="curve" smooth="yes"/>
+      <point x="1218" y="542"/>
+      <point x="1285" y="489"/>
+      <point x="1285" y="370" type="curve" smooth="yes"/>
+      <point x="1285" y="343"/>
+      <point x="1282" y="306"/>
+      <point x="1275" y="267" type="curve" smooth="yes"/>
+      <point x="1236" y="45" type="line"/>
+      <point x="1278" y="74" type="line"/>
+      <point x="905" y="74" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/g_na-malayalam.glif
@@ -1,70 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_na-malayalam" format="2">
   <advance width="1332"/>
-  <anchor x="864" y="0" name="bottom"/>
-  <anchor x="720" y="596" name="top"/>
-  <anchor x="1257" y="596" name="topright"/>
+  <anchor x="857" y="0" name="bottom"/>
+  <anchor x="715" y="596" name="top"/>
+  <anchor x="1252" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="256" y="-16" type="curve" smooth="yes"/>
-      <point x="379" y="-16"/>
-      <point x="453" y="57"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="537" y="366" type="line" smooth="yes"/>
-      <point x="571" y="490"/>
-      <point x="618" y="528"/>
-      <point x="697" y="528" type="curve" smooth="yes"/>
-      <point x="773" y="528"/>
-      <point x="815" y="485"/>
-      <point x="815" y="410" type="curve" smooth="yes"/>
-      <point x="815" y="382"/>
-      <point x="811" y="351"/>
-      <point x="804" y="309" type="curve" smooth="yes"/>
-      <point x="749" y="0" type="line"/>
-      <point x="833" y="0" type="line"/>
-      <point x="899" y="375" type="line" smooth="yes"/>
-      <point x="917" y="477"/>
-      <point x="978" y="534"/>
-      <point x="1071" y="534" type="curve" smooth="yes"/>
-      <point x="1162" y="534"/>
-      <point x="1212" y="475"/>
-      <point x="1212" y="369" type="curve" smooth="yes"/>
-      <point x="1212" y="249"/>
-      <point x="1155" y="143"/>
-      <point x="1035" y="45" type="curve"/>
-      <point x="1093" y="-16" type="line"/>
-      <point x="1228" y="96"/>
-      <point x="1296" y="225"/>
-      <point x="1296" y="369" type="curve" smooth="yes"/>
-      <point x="1296" y="526"/>
-      <point x="1218" y="612"/>
-      <point x="1078" y="612" type="curve" smooth="yes"/>
-      <point x="988" y="612"/>
-      <point x="917" y="570"/>
-      <point x="875" y="494" type="curve"/>
-      <point x="865" y="494" type="line"/>
-      <point x="836" y="571"/>
-      <point x="776" y="612"/>
+      <point x="263" y="-16" type="curve" smooth="yes"/>
+      <point x="400" y="-16"/>
+      <point x="477" y="78"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="461"/>
+      <point x="596" y="528"/>
+      <point x="688" y="528" type="curve" smooth="yes"/>
+      <point x="767" y="528"/>
+      <point x="810" y="486"/>
+      <point x="810" y="410" type="curve" smooth="yes"/>
+      <point x="810" y="383"/>
+      <point x="805" y="352"/>
+      <point x="798" y="311" type="curve" smooth="yes"/>
+      <point x="743" y="0" type="line"/>
+      <point x="827" y="0" type="line"/>
+      <point x="893" y="373" type="line" smooth="yes"/>
+      <point x="911" y="476"/>
+      <point x="969" y="534"/>
+      <point x="1059" y="534" type="curve" smooth="yes"/>
+      <point x="1150" y="534"/>
+      <point x="1200" y="475"/>
+      <point x="1200" y="369" type="curve" smooth="yes"/>
+      <point x="1200" y="249"/>
+      <point x="1143" y="143"/>
+      <point x="1023" y="45" type="curve"/>
+      <point x="1081" y="-16" type="line"/>
+      <point x="1216" y="96"/>
+      <point x="1284" y="225"/>
+      <point x="1284" y="369" type="curve" smooth="yes"/>
+      <point x="1284" y="526"/>
+      <point x="1207" y="612"/>
+      <point x="1068" y="612" type="curve" smooth="yes"/>
+      <point x="981" y="612"/>
+      <point x="909" y="571"/>
+      <point x="866" y="499" type="curve"/>
+      <point x="856" y="499" type="line"/>
+      <point x="829" y="574"/>
+      <point x="773" y="612"/>
       <point x="688" y="612" type="curve" smooth="yes"/>
-      <point x="575" y="612"/>
-      <point x="497" y="548"/>
-      <point x="458" y="403" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="76"/>
-      <point x="127" y="-16"/>
+      <point x="548" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="77"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ga-malayalam.glif
@@ -2,51 +2,55 @@
 <glyph name="ga-malayalam" format="2">
   <advance width="934"/>
   <unicode hex="0D17"/>
-  <anchor x="478" y="0" name="bottom"/>
-  <anchor x="529" y="596" name="top"/>
-  <anchor x="823" y="596" name="topright"/>
+  <anchor x="471" y="0" name="bottom"/>
+  <anchor x="522" y="596" name="top"/>
+  <anchor x="816" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="256" y="-16" type="curve" smooth="yes"/>
-      <point x="379" y="-16"/>
-      <point x="453" y="57"/>
-      <point x="498" y="222" type="curve" smooth="yes"/>
-      <point x="532" y="348" type="line" smooth="yes"/>
-      <point x="566" y="473"/>
-      <point x="620" y="532"/>
-      <point x="702" y="532" type="curve" smooth="yes"/>
-      <point x="779" y="532"/>
-      <point x="818" y="483"/>
-      <point x="818" y="387" type="curve" smooth="yes"/>
-      <point x="818" y="245"/>
-      <point x="758" y="135"/>
-      <point x="636" y="51" type="curve"/>
-      <point x="683" y="-16" type="line"/>
-      <point x="823" y="79"/>
-      <point x="900" y="222"/>
-      <point x="900" y="387" type="curve" smooth="yes"/>
-      <point x="900" y="534"/>
-      <point x="832" y="612"/>
-      <point x="704" y="612" type="curve" smooth="yes"/>
-      <point x="577" y="612"/>
-      <point x="494" y="534"/>
-      <point x="450" y="373" type="curve" smooth="yes"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="381" y="118"/>
-      <point x="334" y="64"/>
-      <point x="256" y="64" type="curve" smooth="yes"/>
-      <point x="174" y="64"/>
-      <point x="131" y="121"/>
-      <point x="131" y="228" type="curve" smooth="yes"/>
-      <point x="131" y="361"/>
-      <point x="197" y="471"/>
-      <point x="319" y="543" type="curve"/>
-      <point x="274" y="612" type="line"/>
-      <point x="131" y="525"/>
-      <point x="49" y="386"/>
-      <point x="49" y="228" type="curve" smooth="yes"/>
-      <point x="49" y="76"/>
-      <point x="127" y="-16"/>
+      <point x="263" y="-16" type="curve" smooth="yes"/>
+      <point x="400" y="-16"/>
+      <point x="477" y="78"/>
+      <point x="502" y="237" type="curve" smooth="yes"/>
+      <point x="508" y="272"/>
+      <point x="512" y="306"/>
+      <point x="517" y="341" type="curve" smooth="yes"/>
+      <point x="535" y="458"/>
+      <point x="592" y="528"/>
+      <point x="683" y="528" type="curve" smooth="yes"/>
+      <point x="765" y="528"/>
+      <point x="804" y="481"/>
+      <point x="804" y="385" type="curve" smooth="yes"/>
+      <point x="804" y="253"/>
+      <point x="739" y="129"/>
+      <point x="629" y="51" type="curve"/>
+      <point x="677" y="-16" type="line"/>
+      <point x="815" y="83"/>
+      <point x="888" y="223"/>
+      <point x="888" y="389" type="curve" smooth="yes"/>
+      <point x="888" y="531"/>
+      <point x="809" y="612"/>
+      <point x="683" y="612" type="curve" smooth="yes"/>
+      <point x="546" y="612"/>
+      <point x="456" y="520"/>
+      <point x="431" y="355" type="curve" smooth="yes"/>
+      <point x="426" y="320"/>
+      <point x="422" y="286"/>
+      <point x="417" y="251" type="curve" smooth="yes"/>
+      <point x="399" y="134"/>
+      <point x="347" y="68"/>
+      <point x="263" y="68" type="curve" smooth="yes"/>
+      <point x="178" y="68"/>
+      <point x="131" y="123"/>
+      <point x="131" y="223" type="curve" smooth="yes"/>
+      <point x="131" y="350"/>
+      <point x="194" y="463"/>
+      <point x="312" y="544" type="curve"/>
+      <point x="266" y="612" type="line"/>
+      <point x="126" y="518"/>
+      <point x="47" y="377"/>
+      <point x="47" y="219" type="curve" smooth="yes"/>
+      <point x="47" y="77"/>
+      <point x="137" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ga-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="934"/>
   <outline>
     <component base="ga-malayalam"/>
-    <component base="halant-malayalam" xOffset="743"/>
+    <component base="halant-malayalam" xOffset="736"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/j_ja-malayalam.glif
@@ -1,231 +1,230 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1626"/>
-  <anchor x="1181" y="0" name="bottom"/>
-  <anchor x="880" y="596" name="top"/>
-  <anchor x="1523" y="596" name="topright"/>
+  <advance width="1700"/>
+  <anchor x="1221" y="-6" name="bottom"/>
+  <anchor x="903" y="596" name="top"/>
+  <anchor x="1589" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="311" y="-16" type="curve" smooth="yes"/>
+      <point x="283" y="-16" type="curve" smooth="yes"/>
       <point x="585" y="-16"/>
-      <point x="747" y="77"/>
-      <point x="868" y="317" type="curve"/>
-      <point x="890" y="371" type="line"/>
-      <point x="898" y="371" type="line"/>
-      <point x="912" y="328"/>
-      <point x="954" y="307"/>
-      <point x="1011" y="307" type="curve" smooth="yes"/>
-      <point x="1097" y="307"/>
-      <point x="1151" y="357"/>
-      <point x="1151" y="436" type="curve" smooth="yes"/>
-      <point x="1151" y="496"/>
-      <point x="1118" y="530"/>
-      <point x="1057" y="530" type="curve" smooth="yes"/>
-      <point x="1035" y="530"/>
-      <point x="1011" y="526"/>
-      <point x="988" y="518" type="curve"/>
-      <point x="975" y="543" type="line"/>
-      <point x="975" y="521" type="line"/>
-      <point x="998" y="541"/>
-      <point x="1041" y="552"/>
-      <point x="1086" y="552" type="curve" smooth="yes"/>
-      <point x="1166" y="552"/>
-      <point x="1204" y="515"/>
-      <point x="1204" y="435" type="curve" smooth="yes"/>
-      <point x="1204" y="414"/>
-      <point x="1203" y="400"/>
-      <point x="1199" y="380" type="curve" smooth="yes"/>
-      <point x="1194" y="353" type="line"/>
-      <point x="1278" y="353" type="line"/>
-      <point x="1284" y="388" type="line" smooth="yes"/>
-      <point x="1300" y="480"/>
-      <point x="1351" y="534"/>
-      <point x="1422" y="534" type="curve" smooth="yes"/>
-      <point x="1483" y="534"/>
-      <point x="1514" y="503"/>
-      <point x="1514" y="442" type="curve" smooth="yes"/>
-      <point x="1514" y="348"/>
-      <point x="1453" y="294"/>
-      <point x="1347" y="294" type="curve" smooth="yes"/>
-      <point x="1055" y="294" type="line" smooth="yes"/>
-      <point x="919" y="294"/>
-      <point x="840" y="231"/>
-      <point x="840" y="125" type="curve" smooth="yes"/>
-      <point x="840" y="36"/>
-      <point x="890" y="-16"/>
-      <point x="980" y="-16" type="curve" smooth="yes"/>
-      <point x="1025" y="-16"/>
-      <point x="1066" y="-10"/>
-      <point x="1175" y="61" type="curve" smooth="yes"/>
-      <point x="1229" y="96" type="line"/>
-      <point x="1343" y="170" type="line"/>
-      <point x="1353" y="165" type="line"/>
-      <point x="1374" y="171"/>
-      <point x="1391" y="172"/>
-      <point x="1415" y="172" type="curve" smooth="yes"/>
-      <point x="1452" y="172"/>
-      <point x="1470" y="154"/>
-      <point x="1470" y="121" type="curve" smooth="yes"/>
-      <point x="1470" y="75"/>
-      <point x="1446" y="48"/>
-      <point x="1407" y="48" type="curve" smooth="yes"/>
-      <point x="1375" y="48"/>
-      <point x="1354" y="69"/>
-      <point x="1354" y="101" type="curve" smooth="yes"/>
-      <point x="1354" y="137"/>
-      <point x="1368" y="163"/>
-      <point x="1405" y="190" type="curve"/>
-      <point x="1285" y="166" type="line"/>
-      <point x="1323" y="118" type="line"/>
-      <point x="1333" y="164" type="line"/>
-      <point x="1308" y="146"/>
-      <point x="1296" y="119"/>
-      <point x="1296" y="82" type="curve" smooth="yes"/>
-      <point x="1296" y="24"/>
-      <point x="1340" y="-16"/>
-      <point x="1405" y="-16" type="curve" smooth="yes"/>
-      <point x="1489" y="-16"/>
-      <point x="1537" y="35"/>
-      <point x="1537" y="124" type="curve" smooth="yes"/>
-      <point x="1537" y="196"/>
-      <point x="1499" y="238"/>
-      <point x="1433" y="238" type="curve" smooth="yes"/>
-      <point x="1375" y="238"/>
-      <point x="1332" y="232"/>
-      <point x="1225" y="169" type="curve" smooth="yes"/>
-      <point x="1142" y="120" type="line" smooth="yes"/>
-      <point x="1064" y="74"/>
-      <point x="1026" y="61"/>
-      <point x="992" y="61" type="curve" smooth="yes"/>
-      <point x="941" y="61"/>
-      <point x="919" y="85"/>
-      <point x="919" y="131" type="curve" smooth="yes"/>
-      <point x="919" y="189"/>
-      <point x="964" y="222"/>
-      <point x="1045" y="222" type="curve" smooth="yes"/>
-      <point x="1335" y="222" type="line" smooth="yes"/>
-      <point x="1497" y="222"/>
-      <point x="1598" y="309"/>
-      <point x="1598" y="449" type="curve" smooth="yes"/>
-      <point x="1598" y="546"/>
-      <point x="1534" y="612"/>
-      <point x="1440" y="612" type="curve" smooth="yes"/>
-      <point x="1358" y="612"/>
-      <point x="1295" y="569"/>
-      <point x="1265" y="490" type="curve"/>
-      <point x="1257" y="490" type="line"/>
-      <point x="1241" y="571"/>
-      <point x="1183" y="612"/>
-      <point x="1094" y="612" type="curve" smooth="yes"/>
-      <point x="997" y="612"/>
-      <point x="931" y="579"/>
-      <point x="873" y="469" type="curve" smooth="yes"/>
-      <point x="819" y="366" type="line" smooth="yes"/>
-      <point x="693" y="126"/>
-      <point x="531" y="61"/>
-      <point x="325" y="61" type="curve" smooth="yes"/>
-      <point x="180" y="61"/>
-      <point x="111" y="81"/>
-      <point x="111" y="147" type="curve" smooth="yes"/>
-      <point x="111" y="194"/>
-      <point x="154" y="222"/>
-      <point x="235" y="222" type="curve" smooth="yes"/>
-      <point x="543" y="222" type="line" smooth="yes"/>
-      <point x="705" y="222"/>
-      <point x="806" y="309"/>
-      <point x="806" y="449" type="curve" smooth="yes"/>
-      <point x="806" y="546"/>
-      <point x="742" y="612"/>
-      <point x="648" y="612" type="curve" smooth="yes"/>
-      <point x="566" y="612"/>
-      <point x="500" y="569"/>
-      <point x="470" y="490" type="curve"/>
-      <point x="462" y="490" type="line"/>
-      <point x="446" y="571"/>
-      <point x="391" y="612"/>
-      <point x="294" y="612" type="curve" smooth="yes"/>
-      <point x="174" y="612"/>
-      <point x="81" y="535"/>
-      <point x="81" y="435" type="curve" smooth="yes"/>
-      <point x="81" y="355"/>
-      <point x="133" y="307"/>
-      <point x="219" y="307" type="curve" smooth="yes"/>
-      <point x="305" y="307"/>
-      <point x="359" y="357"/>
-      <point x="359" y="436" type="curve" smooth="yes"/>
-      <point x="359" y="496"/>
-      <point x="326" y="530"/>
-      <point x="269" y="530" type="curve" smooth="yes"/>
-      <point x="245" y="530"/>
-      <point x="220" y="526"/>
-      <point x="196" y="518" type="curve"/>
-      <point x="183" y="543" type="line"/>
-      <point x="183" y="521" type="line"/>
-      <point x="206" y="541"/>
-      <point x="249" y="552"/>
-      <point x="294" y="552" type="curve" smooth="yes"/>
-      <point x="374" y="552"/>
-      <point x="412" y="515"/>
-      <point x="412" y="435" type="curve" smooth="yes"/>
-      <point x="412" y="414"/>
-      <point x="411" y="400"/>
-      <point x="407" y="380" type="curve" smooth="yes"/>
-      <point x="402" y="353" type="line"/>
-      <point x="486" y="353" type="line"/>
-      <point x="492" y="388" type="line" smooth="yes"/>
-      <point x="508" y="480"/>
-      <point x="559" y="534"/>
-      <point x="630" y="534" type="curve" smooth="yes"/>
-      <point x="691" y="534"/>
-      <point x="722" y="503"/>
-      <point x="722" y="442" type="curve" smooth="yes"/>
-      <point x="722" y="348"/>
-      <point x="661" y="294"/>
-      <point x="555" y="294" type="curve" smooth="yes"/>
-      <point x="245" y="294" type="line" smooth="yes"/>
-      <point x="109" y="294"/>
-      <point x="30" y="236"/>
-      <point x="30" y="140" type="curve" smooth="yes"/>
-      <point x="30" y="40"/>
-      <point x="118" y="-16"/>
+      <point x="768" y="75"/>
+      <point x="896" y="294" type="curve"/>
+      <point x="912" y="354" type="line"/>
+      <point x="921" y="354" type="line"/>
+      <point x="932" y="307"/>
+      <point x="971" y="274"/>
+      <point x="1028" y="274" type="curve" smooth="yes"/>
+      <point x="1129" y="274"/>
+      <point x="1173" y="350"/>
+      <point x="1173" y="408" type="curve" smooth="yes"/>
+      <point x="1173" y="474"/>
+      <point x="1137" y="512"/>
+      <point x="1074" y="512" type="curve" smooth="yes"/>
+      <point x="1046" y="512"/>
+      <point x="1025" y="509"/>
+      <point x="1002" y="501" type="curve"/>
+      <point x="984" y="527" type="line"/>
+      <point x="990" y="499" type="line"/>
+      <point x="1019" y="531"/>
+      <point x="1068" y="552"/>
+      <point x="1126" y="552" type="curve" smooth="yes"/>
+      <point x="1211" y="552"/>
+      <point x="1248" y="504"/>
+      <point x="1248" y="436" type="curve" smooth="yes"/>
+      <point x="1248" y="422"/>
+      <point x="1247" y="407"/>
+      <point x="1244" y="390" type="curve" smooth="yes"/>
+      <point x="1234" y="333" type="line"/>
+      <point x="1318" y="333" type="line"/>
+      <point x="1328" y="390" type="line" smooth="yes"/>
+      <point x="1344" y="481"/>
+      <point x="1402" y="534"/>
+      <point x="1483" y="534" type="curve" smooth="yes"/>
+      <point x="1549" y="534"/>
+      <point x="1585" y="499"/>
+      <point x="1585" y="433" type="curve" smooth="yes"/>
+      <point x="1585" y="328"/>
+      <point x="1512" y="264"/>
+      <point x="1369" y="264" type="curve" smooth="yes"/>
+      <point x="1033" y="264" type="line" smooth="yes"/>
+      <point x="923" y="264"/>
+      <point x="845" y="207"/>
+      <point x="845" y="114" type="curve" smooth="yes"/>
+      <point x="845" y="34"/>
+      <point x="905" y="-16"/>
+      <point x="992" y="-16" type="curve" smooth="yes"/>
+      <point x="1041" y="-16"/>
+      <point x="1077" y="-6"/>
+      <point x="1148" y="27" type="curve" smooth="yes"/>
+      <point x="1304" y="99" type="line"/>
+      <point x="1377" y="148" type="line"/>
+      <point x="1405" y="154" type="line"/>
+      <point x="1436" y="172"/>
+      <point x="1458" y="178"/>
+      <point x="1486" y="178" type="curve" smooth="yes"/>
+      <point x="1524" y="178"/>
+      <point x="1541" y="157"/>
+      <point x="1541" y="124" type="curve" smooth="yes"/>
+      <point x="1541" y="92"/>
+      <point x="1521" y="56"/>
+      <point x="1470" y="56" type="curve" smooth="yes"/>
+      <point x="1434" y="56"/>
+      <point x="1413" y="77"/>
+      <point x="1413" y="109" type="curve" smooth="yes"/>
+      <point x="1413" y="140"/>
+      <point x="1427" y="161"/>
+      <point x="1454" y="188" type="curve"/>
+      <point x="1350" y="148" type="line"/>
+      <point x="1366" y="128" type="line"/>
+      <point x="1357" y="114"/>
+      <point x="1352" y="98"/>
+      <point x="1352" y="80" type="curve" smooth="yes"/>
+      <point x="1352" y="22"/>
+      <point x="1396" y="-16"/>
+      <point x="1463" y="-16" type="curve" smooth="yes"/>
+      <point x="1571" y="-16"/>
+      <point x="1612" y="69"/>
+      <point x="1612" y="126" type="curve" smooth="yes"/>
+      <point x="1612" y="189"/>
+      <point x="1573" y="232"/>
+      <point x="1502" y="232" type="curve" smooth="yes"/>
+      <point x="1456" y="232"/>
+      <point x="1417" y="224"/>
+      <point x="1335" y="186" type="curve" smooth="yes"/>
+      <point x="1126" y="89" type="line" smooth="yes"/>
+      <point x="1078" y="67"/>
+      <point x="1041" y="58"/>
+      <point x="996" y="58" type="curve" smooth="yes"/>
+      <point x="954" y="58"/>
+      <point x="927" y="82"/>
+      <point x="927" y="119" type="curve" smooth="yes"/>
+      <point x="927" y="164"/>
+      <point x="963" y="192"/>
+      <point x="1030" y="192" type="curve" smooth="yes"/>
+      <point x="1351" y="192" type="line" smooth="yes"/>
+      <point x="1533" y="192"/>
+      <point x="1667" y="286"/>
+      <point x="1667" y="438" type="curve" smooth="yes"/>
+      <point x="1667" y="546"/>
+      <point x="1605" y="612"/>
+      <point x="1500" y="612" type="curve" smooth="yes"/>
+      <point x="1412" y="612"/>
+      <point x="1347" y="570"/>
+      <point x="1313" y="491" type="curve"/>
+      <point x="1305" y="491" type="line"/>
+      <point x="1288" y="571"/>
+      <point x="1234" y="612"/>
+      <point x="1132" y="612" type="curve" smooth="yes"/>
+      <point x="1025" y="612"/>
+      <point x="945" y="560"/>
+      <point x="898" y="457" type="curve" smooth="yes"/>
+      <point x="856" y="365" type="line" smooth="yes"/>
+      <point x="760" y="154"/>
+      <point x="583" y="61"/>
+      <point x="291" y="61" type="curve" smooth="yes"/>
+      <point x="176" y="61"/>
+      <point x="111" y="74"/>
+      <point x="111" y="129" type="curve" smooth="yes"/>
+      <point x="111" y="163"/>
+      <point x="137" y="192"/>
+      <point x="203" y="192" type="curve" smooth="yes"/>
+      <point x="503" y="192" type="line" smooth="yes"/>
+      <point x="690" y="192"/>
+      <point x="827" y="289"/>
+      <point x="827" y="445" type="curve" smooth="yes"/>
+      <point x="827" y="549"/>
+      <point x="770" y="612"/>
+      <point x="673" y="612" type="curve" smooth="yes"/>
+      <point x="589" y="612"/>
+      <point x="527" y="570"/>
+      <point x="495" y="491" type="curve"/>
+      <point x="487" y="491" type="line"/>
+      <point x="470" y="571"/>
+      <point x="416" y="612"/>
+      <point x="314" y="612" type="curve" smooth="yes"/>
+      <point x="156" y="612"/>
+      <point x="77" y="502"/>
+      <point x="77" y="413" type="curve" smooth="yes"/>
+      <point x="77" y="329"/>
+      <point x="127" y="274"/>
+      <point x="210" y="274" type="curve" smooth="yes"/>
+      <point x="311" y="274"/>
+      <point x="355" y="350"/>
+      <point x="355" y="408" type="curve" smooth="yes"/>
+      <point x="355" y="474"/>
+      <point x="319" y="512"/>
+      <point x="256" y="512" type="curve" smooth="yes"/>
+      <point x="228" y="512"/>
+      <point x="207" y="509"/>
+      <point x="184" y="501" type="curve"/>
+      <point x="166" y="527" type="line"/>
+      <point x="171" y="497" type="line"/>
+      <point x="196" y="529"/>
+      <point x="248" y="552"/>
+      <point x="309" y="552" type="curve" smooth="yes"/>
+      <point x="393" y="552"/>
+      <point x="430" y="504"/>
+      <point x="430" y="436" type="curve" smooth="yes"/>
+      <point x="430" y="422"/>
+      <point x="429" y="407"/>
+      <point x="426" y="390" type="curve" smooth="yes"/>
+      <point x="416" y="333" type="line"/>
+      <point x="500" y="333" type="line"/>
+      <point x="510" y="390" type="line" smooth="yes"/>
+      <point x="526" y="481"/>
+      <point x="580" y="534"/>
+      <point x="656" y="534" type="curve" smooth="yes"/>
+      <point x="714" y="534"/>
+      <point x="745" y="501"/>
+      <point x="745" y="440" type="curve" smooth="yes"/>
+      <point x="745" y="332"/>
+      <point x="667" y="264"/>
+      <point x="515" y="264" type="curve" smooth="yes"/>
+      <point x="206" y="264" type="line" smooth="yes"/>
+      <point x="78" y="264"/>
+      <point x="29" y="189"/>
+      <point x="29" y="127" type="curve" smooth="yes"/>
+      <point x="29" y="34"/>
+      <point x="115" y="-16"/>
     </contour>
     <contour>
-      <point x="219" y="371" type="curve" smooth="yes"/>
-      <point x="178" y="371"/>
-      <point x="157" y="393"/>
-      <point x="157" y="437" type="curve" smooth="yes"/>
-      <point x="157" y="461"/>
-      <point x="165" y="485"/>
-      <point x="179" y="503" type="curve"/>
-      <point x="157" y="505" type="line"/>
-      <point x="128" y="463" type="line"/>
-      <point x="153" y="480"/>
-      <point x="190" y="490"/>
-      <point x="227" y="490" type="curve" smooth="yes"/>
-      <point x="270" y="490"/>
-      <point x="287" y="474"/>
-      <point x="287" y="434" type="curve" smooth="yes"/>
-      <point x="287" y="395"/>
-      <point x="261" y="371"/>
+      <point x="214" y="338" type="curve" smooth="yes"/>
+      <point x="171" y="338"/>
+      <point x="147" y="367"/>
+      <point x="147" y="411" type="curve" smooth="yes"/>
+      <point x="147" y="432"/>
+      <point x="152" y="451"/>
+      <point x="162" y="473" type="curve"/>
+      <point x="137" y="473" type="line"/>
+      <point x="124" y="443" type="line"/>
+      <point x="150" y="458"/>
+      <point x="181" y="468"/>
+      <point x="216" y="468" type="curve" smooth="yes"/>
+      <point x="260" y="468"/>
+      <point x="283" y="448"/>
+      <point x="283" y="408" type="curve" smooth="yes"/>
+      <point x="283" y="377"/>
+      <point x="265" y="338"/>
     </contour>
     <contour>
-      <point x="1011" y="371" type="curve" smooth="yes"/>
-      <point x="970" y="371"/>
-      <point x="949" y="393"/>
-      <point x="949" y="437" type="curve" smooth="yes"/>
-      <point x="949" y="461"/>
-      <point x="957" y="485"/>
-      <point x="971" y="503" type="curve"/>
-      <point x="949" y="505" type="line"/>
-      <point x="920" y="463" type="line"/>
-      <point x="945" y="480"/>
-      <point x="982" y="490"/>
-      <point x="1019" y="490" type="curve" smooth="yes"/>
-      <point x="1062" y="490"/>
-      <point x="1079" y="474"/>
-      <point x="1079" y="434" type="curve" smooth="yes"/>
-      <point x="1079" y="395"/>
-      <point x="1053" y="371"/>
+      <point x="1032" y="338" type="curve" smooth="yes"/>
+      <point x="989" y="338"/>
+      <point x="965" y="367"/>
+      <point x="965" y="411" type="curve" smooth="yes"/>
+      <point x="965" y="432"/>
+      <point x="971" y="451"/>
+      <point x="980" y="473" type="curve"/>
+      <point x="955" y="473" type="line"/>
+      <point x="942" y="443" type="line"/>
+      <point x="969" y="457"/>
+      <point x="999" y="468"/>
+      <point x="1034" y="468" type="curve" smooth="yes"/>
+      <point x="1078" y="468"/>
+      <point x="1101" y="448"/>
+      <point x="1101" y="408" type="curve" smooth="yes"/>
+      <point x="1101" y="377"/>
+      <point x="1083" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/j_nya-malayalam.glif
@@ -1,194 +1,194 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2219"/>
-  <anchor x="1756" y="0" name="bottom"/>
-  <anchor x="1154" y="596" name="top"/>
-  <anchor x="2120" y="596" name="topright"/>
+  <advance width="2252"/>
+  <anchor x="1789" y="0" name="bottom"/>
+  <anchor x="1179" y="596" name="top"/>
+  <anchor x="2155" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="311" y="-16" type="curve" smooth="yes"/>
-      <point x="527" y="-16"/>
-      <point x="678" y="42"/>
-      <point x="790" y="183" type="curve"/>
-      <point x="840" y="183" type="line"/>
-      <point x="800" y="250" type="line"/>
-      <point x="799" y="241"/>
-      <point x="799" y="231"/>
-      <point x="799" y="222" type="curve" smooth="yes"/>
-      <point x="799" y="79"/>
-      <point x="876" y="-16"/>
-      <point x="1002" y="-16" type="curve" smooth="yes"/>
-      <point x="1117" y="-16"/>
-      <point x="1187" y="60"/>
-      <point x="1187" y="185" type="curve" smooth="yes"/>
-      <point x="1187" y="293"/>
-      <point x="1131" y="356"/>
-      <point x="1035" y="356" type="curve" smooth="yes"/>
-      <point x="974" y="356"/>
-      <point x="923" y="330"/>
-      <point x="887" y="281" type="curve"/>
-      <point x="851" y="287" type="line"/>
-      <point x="862" y="153" type="line"/>
-      <point x="886" y="229"/>
-      <point x="948" y="282"/>
-      <point x="1013" y="282" type="curve" smooth="yes"/>
-      <point x="1075" y="282"/>
-      <point x="1105" y="250"/>
-      <point x="1105" y="184" type="curve" smooth="yes"/>
-      <point x="1105" y="106"/>
-      <point x="1067" y="62"/>
-      <point x="1000" y="62" type="curve" smooth="yes"/>
-      <point x="919" y="62"/>
-      <point x="872" y="120"/>
-      <point x="872" y="220" type="curve" smooth="yes"/>
-      <point x="872" y="406"/>
-      <point x="975" y="534"/>
-      <point x="1125" y="534" type="curve" smooth="yes"/>
-      <point x="1232" y="534"/>
-      <point x="1288" y="479"/>
-      <point x="1288" y="372" type="curve" smooth="yes"/>
-      <point x="1288" y="354"/>
-      <point x="1286" y="335"/>
-      <point x="1282" y="314" type="curve" smooth="yes"/>
-      <point x="1226" y="0" type="line"/>
-      <point x="1310" y="0" type="line"/>
-      <point x="1369" y="333" type="line" smooth="yes"/>
-      <point x="1393" y="470"/>
-      <point x="1462" y="534"/>
-      <point x="1585" y="534" type="curve" smooth="yes"/>
-      <point x="1732" y="534"/>
-      <point x="1818" y="439"/>
-      <point x="1818" y="275" type="curve" smooth="yes"/>
-      <point x="1818" y="152"/>
-      <point x="1762" y="62"/>
-      <point x="1684" y="62" type="curve" smooth="yes"/>
-      <point x="1612" y="62"/>
-      <point x="1576" y="109"/>
-      <point x="1576" y="202" type="curve" smooth="yes"/>
-      <point x="1576" y="381"/>
-      <point x="1718" y="534"/>
-      <point x="1884" y="534" type="curve" smooth="yes"/>
-      <point x="2013" y="534"/>
-      <point x="2090" y="467"/>
-      <point x="2090" y="354" type="curve" smooth="yes"/>
-      <point x="2090" y="246"/>
-      <point x="2038" y="143"/>
-      <point x="1933" y="43" type="curve"/>
-      <point x="1994" y="-14" type="line"/>
-      <point x="2118" y="107"/>
-      <point x="2172" y="218"/>
-      <point x="2172" y="354" type="curve" smooth="yes"/>
-      <point x="2172" y="512"/>
-      <point x="2064" y="612"/>
-      <point x="1895" y="612" type="curve" smooth="yes"/>
-      <point x="1681" y="612"/>
-      <point x="1494" y="418"/>
-      <point x="1494" y="197" type="curve" smooth="yes"/>
-      <point x="1494" y="62"/>
-      <point x="1564" y="-16"/>
-      <point x="1684" y="-16" type="curve" smooth="yes"/>
-      <point x="1817" y="-16"/>
-      <point x="1900" y="96"/>
-      <point x="1900" y="275" type="curve" smooth="yes"/>
-      <point x="1900" y="479"/>
-      <point x="1779" y="612"/>
-      <point x="1594" y="612" type="curve" smooth="yes"/>
-      <point x="1480" y="612"/>
-      <point x="1395" y="567"/>
-      <point x="1348" y="480" type="curve"/>
-      <point x="1338" y="480" type="line"/>
-      <point x="1303" y="567"/>
-      <point x="1231" y="612"/>
-      <point x="1125" y="612" type="curve" smooth="yes"/>
-      <point x="1002" y="612"/>
-      <point x="898" y="553"/>
-      <point x="812" y="353" type="curve" smooth="yes"/>
-      <point x="717" y="132"/>
-      <point x="543" y="61"/>
-      <point x="325" y="61" type="curve" smooth="yes"/>
-      <point x="187" y="61"/>
-      <point x="111" y="81"/>
-      <point x="111" y="147" type="curve" smooth="yes"/>
-      <point x="111" y="194"/>
-      <point x="154" y="222"/>
-      <point x="235" y="222" type="curve" smooth="yes"/>
-      <point x="535" y="222" type="line" smooth="yes"/>
-      <point x="697" y="222"/>
-      <point x="795" y="309"/>
-      <point x="795" y="449" type="curve" smooth="yes"/>
-      <point x="795" y="544"/>
-      <point x="742" y="612"/>
-      <point x="636" y="612" type="curve" smooth="yes"/>
-      <point x="562" y="612"/>
-      <point x="500" y="569"/>
-      <point x="470" y="490" type="curve"/>
-      <point x="462" y="490" type="line"/>
-      <point x="446" y="571"/>
-      <point x="391" y="612"/>
-      <point x="294" y="612" type="curve" smooth="yes"/>
-      <point x="174" y="612"/>
-      <point x="81" y="535"/>
-      <point x="81" y="435" type="curve" smooth="yes"/>
-      <point x="81" y="355"/>
-      <point x="133" y="307"/>
-      <point x="219" y="307" type="curve" smooth="yes"/>
-      <point x="305" y="307"/>
-      <point x="359" y="357"/>
-      <point x="359" y="436" type="curve" smooth="yes"/>
-      <point x="359" y="496"/>
-      <point x="326" y="530"/>
-      <point x="269" y="530" type="curve" smooth="yes"/>
-      <point x="245" y="530"/>
-      <point x="220" y="526"/>
-      <point x="196" y="518" type="curve"/>
-      <point x="183" y="543" type="line"/>
-      <point x="183" y="521" type="line"/>
-      <point x="206" y="541"/>
-      <point x="249" y="552"/>
-      <point x="294" y="552" type="curve" smooth="yes"/>
-      <point x="374" y="552"/>
-      <point x="412" y="515"/>
-      <point x="412" y="435" type="curve" smooth="yes"/>
-      <point x="412" y="414"/>
-      <point x="411" y="400"/>
-      <point x="407" y="380" type="curve" smooth="yes"/>
-      <point x="402" y="353" type="line"/>
-      <point x="486" y="353" type="line"/>
-      <point x="492" y="388" type="line" smooth="yes"/>
-      <point x="508" y="480"/>
-      <point x="555" y="534"/>
-      <point x="618" y="534" type="curve" smooth="yes"/>
-      <point x="679" y="534"/>
-      <point x="711" y="503"/>
-      <point x="711" y="442" type="curve" smooth="yes"/>
-      <point x="711" y="348"/>
-      <point x="653" y="294"/>
-      <point x="537" y="294" type="curve" smooth="yes"/>
-      <point x="245" y="294" type="line" smooth="yes"/>
-      <point x="109" y="294"/>
-      <point x="30" y="236"/>
-      <point x="30" y="140" type="curve" smooth="yes"/>
-      <point x="30" y="40"/>
-      <point x="118" y="-16"/>
+      <point x="283" y="-16" type="curve" smooth="yes"/>
+      <point x="537" y="-16"/>
+      <point x="705" y="42"/>
+      <point x="826" y="194" type="curve"/>
+      <point x="876" y="188" type="line"/>
+      <point x="835" y="250" type="line"/>
+      <point x="834" y="241"/>
+      <point x="834" y="231"/>
+      <point x="834" y="222" type="curve" smooth="yes"/>
+      <point x="834" y="79"/>
+      <point x="911" y="-16"/>
+      <point x="1037" y="-16" type="curve" smooth="yes"/>
+      <point x="1152" y="-16"/>
+      <point x="1222" y="60"/>
+      <point x="1222" y="185" type="curve" smooth="yes"/>
+      <point x="1222" y="293"/>
+      <point x="1166" y="356"/>
+      <point x="1070" y="356" type="curve" smooth="yes"/>
+      <point x="1009" y="356"/>
+      <point x="958" y="330"/>
+      <point x="922" y="281" type="curve"/>
+      <point x="886" y="287" type="line"/>
+      <point x="897" y="153" type="line"/>
+      <point x="921" y="229"/>
+      <point x="983" y="282"/>
+      <point x="1048" y="282" type="curve" smooth="yes"/>
+      <point x="1110" y="282"/>
+      <point x="1140" y="250"/>
+      <point x="1140" y="184" type="curve" smooth="yes"/>
+      <point x="1140" y="106"/>
+      <point x="1102" y="62"/>
+      <point x="1035" y="62" type="curve" smooth="yes"/>
+      <point x="954" y="62"/>
+      <point x="907" y="120"/>
+      <point x="907" y="220" type="curve" smooth="yes"/>
+      <point x="907" y="406"/>
+      <point x="1010" y="534"/>
+      <point x="1160" y="534" type="curve" smooth="yes"/>
+      <point x="1267" y="534"/>
+      <point x="1323" y="478"/>
+      <point x="1323" y="373" type="curve" smooth="yes"/>
+      <point x="1323" y="355"/>
+      <point x="1321" y="335"/>
+      <point x="1317" y="314" type="curve" smooth="yes"/>
+      <point x="1261" y="0" type="line"/>
+      <point x="1345" y="0" type="line"/>
+      <point x="1404" y="333" type="line" smooth="yes"/>
+      <point x="1428" y="470"/>
+      <point x="1494" y="534"/>
+      <point x="1614" y="534" type="curve" smooth="yes"/>
+      <point x="1761" y="534"/>
+      <point x="1847" y="439"/>
+      <point x="1847" y="275" type="curve" smooth="yes"/>
+      <point x="1847" y="152"/>
+      <point x="1791" y="62"/>
+      <point x="1713" y="62" type="curve" smooth="yes"/>
+      <point x="1641" y="62"/>
+      <point x="1605" y="109"/>
+      <point x="1605" y="202" type="curve" smooth="yes"/>
+      <point x="1605" y="381"/>
+      <point x="1747" y="534"/>
+      <point x="1913" y="534" type="curve" smooth="yes"/>
+      <point x="2042" y="534"/>
+      <point x="2119" y="467"/>
+      <point x="2119" y="354" type="curve" smooth="yes"/>
+      <point x="2119" y="246"/>
+      <point x="2067" y="143"/>
+      <point x="1962" y="43" type="curve"/>
+      <point x="2023" y="-14" type="line"/>
+      <point x="2147" y="107"/>
+      <point x="2201" y="218"/>
+      <point x="2201" y="354" type="curve" smooth="yes"/>
+      <point x="2201" y="512"/>
+      <point x="2093" y="612"/>
+      <point x="1924" y="612" type="curve" smooth="yes"/>
+      <point x="1710" y="612"/>
+      <point x="1523" y="418"/>
+      <point x="1523" y="197" type="curve" smooth="yes"/>
+      <point x="1523" y="62"/>
+      <point x="1593" y="-16"/>
+      <point x="1713" y="-16" type="curve" smooth="yes"/>
+      <point x="1846" y="-16"/>
+      <point x="1929" y="96"/>
+      <point x="1929" y="275" type="curve" smooth="yes"/>
+      <point x="1929" y="479"/>
+      <point x="1808" y="612"/>
+      <point x="1623" y="612" type="curve" smooth="yes"/>
+      <point x="1512" y="612"/>
+      <point x="1429" y="567"/>
+      <point x="1383" y="480" type="curve"/>
+      <point x="1373" y="480" type="line"/>
+      <point x="1338" y="567"/>
+      <point x="1266" y="612"/>
+      <point x="1160" y="612" type="curve" smooth="yes"/>
+      <point x="1037" y="612"/>
+      <point x="933" y="553"/>
+      <point x="847" y="353" type="curve" smooth="yes"/>
+      <point x="750" y="127"/>
+      <point x="578" y="61"/>
+      <point x="291" y="61" type="curve" smooth="yes"/>
+      <point x="176" y="61"/>
+      <point x="111" y="74"/>
+      <point x="111" y="129" type="curve" smooth="yes"/>
+      <point x="111" y="163"/>
+      <point x="137" y="192"/>
+      <point x="203" y="192" type="curve" smooth="yes"/>
+      <point x="490" y="192" type="line" smooth="yes"/>
+      <point x="728" y="192"/>
+      <point x="823" y="322"/>
+      <point x="823" y="445" type="curve" smooth="yes"/>
+      <point x="823" y="549"/>
+      <point x="766" y="612"/>
+      <point x="670" y="612" type="curve" smooth="yes"/>
+      <point x="589" y="612"/>
+      <point x="526" y="570"/>
+      <point x="495" y="491" type="curve"/>
+      <point x="487" y="491" type="line"/>
+      <point x="470" y="571"/>
+      <point x="416" y="612"/>
+      <point x="314" y="612" type="curve" smooth="yes"/>
+      <point x="156" y="612"/>
+      <point x="77" y="502"/>
+      <point x="77" y="413" type="curve" smooth="yes"/>
+      <point x="77" y="329"/>
+      <point x="127" y="274"/>
+      <point x="210" y="274" type="curve" smooth="yes"/>
+      <point x="311" y="274"/>
+      <point x="355" y="350"/>
+      <point x="355" y="408" type="curve" smooth="yes"/>
+      <point x="355" y="474"/>
+      <point x="319" y="512"/>
+      <point x="256" y="512" type="curve" smooth="yes"/>
+      <point x="228" y="512"/>
+      <point x="207" y="509"/>
+      <point x="184" y="501" type="curve"/>
+      <point x="166" y="527" type="line"/>
+      <point x="171" y="497" type="line"/>
+      <point x="196" y="529"/>
+      <point x="248" y="552"/>
+      <point x="309" y="552" type="curve" smooth="yes"/>
+      <point x="393" y="552"/>
+      <point x="430" y="504"/>
+      <point x="430" y="436" type="curve" smooth="yes"/>
+      <point x="430" y="422"/>
+      <point x="429" y="407"/>
+      <point x="426" y="390" type="curve" smooth="yes"/>
+      <point x="416" y="333" type="line"/>
+      <point x="500" y="333" type="line"/>
+      <point x="510" y="390" type="line" smooth="yes"/>
+      <point x="526" y="481"/>
+      <point x="577" y="534"/>
+      <point x="651" y="534" type="curve" smooth="yes"/>
+      <point x="709" y="534"/>
+      <point x="741" y="501"/>
+      <point x="741" y="440" type="curve" smooth="yes"/>
+      <point x="741" y="357"/>
+      <point x="680" y="264"/>
+      <point x="500" y="264" type="curve" smooth="yes"/>
+      <point x="206" y="264" type="line" smooth="yes"/>
+      <point x="78" y="264"/>
+      <point x="29" y="189"/>
+      <point x="29" y="127" type="curve" smooth="yes"/>
+      <point x="29" y="34"/>
+      <point x="115" y="-16"/>
     </contour>
     <contour>
-      <point x="219" y="371" type="curve" smooth="yes"/>
-      <point x="178" y="371"/>
-      <point x="157" y="393"/>
-      <point x="157" y="437" type="curve" smooth="yes"/>
-      <point x="157" y="461"/>
-      <point x="165" y="485"/>
-      <point x="179" y="503" type="curve"/>
-      <point x="157" y="505" type="line"/>
-      <point x="128" y="463" type="line"/>
-      <point x="153" y="480"/>
-      <point x="190" y="490"/>
-      <point x="227" y="490" type="curve" smooth="yes"/>
-      <point x="270" y="490"/>
-      <point x="287" y="474"/>
-      <point x="287" y="434" type="curve" smooth="yes"/>
-      <point x="287" y="395"/>
-      <point x="261" y="371"/>
+      <point x="214" y="338" type="curve" smooth="yes"/>
+      <point x="171" y="338"/>
+      <point x="147" y="367"/>
+      <point x="147" y="411" type="curve" smooth="yes"/>
+      <point x="147" y="432"/>
+      <point x="152" y="451"/>
+      <point x="162" y="473" type="curve"/>
+      <point x="137" y="473" type="line"/>
+      <point x="124" y="443" type="line"/>
+      <point x="150" y="458"/>
+      <point x="181" y="468"/>
+      <point x="216" y="468" type="curve" smooth="yes"/>
+      <point x="260" y="468"/>
+      <point x="283" y="448"/>
+      <point x="283" y="408" type="curve" smooth="yes"/>
+      <point x="283" y="377"/>
+      <point x="265" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ja-malayalam.glif
@@ -1,139 +1,138 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <unicode hex="0D1C"/>
-  <anchor x="393" y="0" name="bottom"/>
-  <anchor x="489" y="596" name="top"/>
-  <anchor x="735" y="596" name="topright"/>
+  <anchor x="403" y="-6" name="bottom"/>
+  <anchor x="494" y="596" name="top"/>
+  <anchor x="771" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="161" y="-16" type="curve" smooth="yes"/>
-      <point x="214" y="-16"/>
-      <point x="269" y="2"/>
-      <point x="368" y="57" type="curve" smooth="yes"/>
-      <point x="437" y="95" type="line"/>
-      <point x="559" y="171" type="line"/>
-      <point x="570" y="161" type="line"/>
-      <point x="592" y="170"/>
-      <point x="609" y="172"/>
-      <point x="625" y="172" type="curve" smooth="yes"/>
-      <point x="660" y="172"/>
-      <point x="678" y="154"/>
-      <point x="678" y="121" type="curve" smooth="yes"/>
-      <point x="678" y="75"/>
-      <point x="654" y="48"/>
-      <point x="615" y="48" type="curve" smooth="yes"/>
-      <point x="583" y="48"/>
-      <point x="562" y="69"/>
-      <point x="562" y="101" type="curve" smooth="yes"/>
-      <point x="562" y="137"/>
-      <point x="576" y="163"/>
-      <point x="613" y="190" type="curve"/>
-      <point x="489" y="166" type="line"/>
-      <point x="528" y="108" type="line"/>
-      <point x="548" y="162" type="line"/>
-      <point x="521" y="146"/>
-      <point x="501" y="119"/>
-      <point x="501" y="79" type="curve" smooth="yes"/>
-      <point x="501" y="24"/>
-      <point x="548" y="-16"/>
-      <point x="613" y="-16" type="curve" smooth="yes"/>
-      <point x="697" y="-16"/>
-      <point x="745" y="35"/>
-      <point x="745" y="124" type="curve" smooth="yes"/>
-      <point x="745" y="196"/>
-      <point x="707" y="238"/>
-      <point x="641" y="238" type="curve" smooth="yes"/>
-      <point x="583" y="238"/>
-      <point x="544" y="225"/>
-      <point x="433" y="169" type="curve" smooth="yes"/>
-      <point x="350" y="127" type="line" smooth="yes"/>
-      <point x="239" y="71"/>
-      <point x="214" y="61"/>
-      <point x="174" y="61" type="curve" smooth="yes"/>
-      <point x="132" y="61"/>
-      <point x="109" y="85"/>
-      <point x="109" y="129" type="curve" smooth="yes"/>
-      <point x="109" y="189"/>
-      <point x="154" y="222"/>
-      <point x="235" y="222" type="curve" smooth="yes"/>
-      <point x="543" y="222" type="line" smooth="yes"/>
-      <point x="705" y="222"/>
-      <point x="806" y="309"/>
-      <point x="806" y="449" type="curve" smooth="yes"/>
-      <point x="806" y="546"/>
-      <point x="742" y="612"/>
-      <point x="648" y="612" type="curve" smooth="yes"/>
-      <point x="566" y="612"/>
-      <point x="503" y="569"/>
-      <point x="474" y="490" type="curve"/>
-      <point x="464" y="490" type="line"/>
-      <point x="449" y="571"/>
-      <point x="391" y="612"/>
-      <point x="294" y="612" type="curve" smooth="yes"/>
-      <point x="174" y="612"/>
-      <point x="81" y="535"/>
-      <point x="81" y="435" type="curve" smooth="yes"/>
-      <point x="81" y="355"/>
-      <point x="133" y="307"/>
-      <point x="219" y="307" type="curve" smooth="yes"/>
-      <point x="305" y="307"/>
-      <point x="359" y="357"/>
-      <point x="359" y="436" type="curve" smooth="yes"/>
-      <point x="359" y="496"/>
-      <point x="326" y="530"/>
-      <point x="264" y="530" type="curve" smooth="yes"/>
-      <point x="240" y="530"/>
-      <point x="220" y="526"/>
-      <point x="195" y="518" type="curve"/>
-      <point x="183" y="543" type="line"/>
-      <point x="183" y="520" type="line"/>
-      <point x="206" y="540"/>
-      <point x="249" y="552"/>
-      <point x="294" y="552" type="curve" smooth="yes"/>
-      <point x="374" y="552"/>
-      <point x="412" y="515"/>
-      <point x="412" y="435" type="curve" smooth="yes"/>
-      <point x="412" y="414"/>
-      <point x="411" y="400"/>
-      <point x="407" y="380" type="curve" smooth="yes"/>
-      <point x="402" y="353" type="line"/>
-      <point x="486" y="353" type="line"/>
-      <point x="492" y="388" type="line" smooth="yes"/>
-      <point x="508" y="480"/>
-      <point x="559" y="534"/>
-      <point x="630" y="534" type="curve" smooth="yes"/>
-      <point x="691" y="534"/>
-      <point x="722" y="503"/>
-      <point x="722" y="442" type="curve" smooth="yes"/>
-      <point x="722" y="348"/>
-      <point x="661" y="294"/>
-      <point x="555" y="294" type="curve" smooth="yes"/>
-      <point x="245" y="294" type="line" smooth="yes"/>
-      <point x="109" y="294"/>
-      <point x="30" y="231"/>
-      <point x="30" y="121" type="curve" smooth="yes"/>
-      <point x="30" y="36"/>
-      <point x="80" y="-16"/>
+      <point x="174" y="-16" type="curve" smooth="yes"/>
+      <point x="223" y="-16"/>
+      <point x="259" y="-6"/>
+      <point x="330" y="27" type="curve" smooth="yes"/>
+      <point x="486" y="99" type="line"/>
+      <point x="559" y="148" type="line"/>
+      <point x="587" y="154" type="line"/>
+      <point x="618" y="172"/>
+      <point x="640" y="178"/>
+      <point x="668" y="178" type="curve" smooth="yes"/>
+      <point x="706" y="178"/>
+      <point x="723" y="157"/>
+      <point x="723" y="124" type="curve" smooth="yes"/>
+      <point x="723" y="92"/>
+      <point x="703" y="56"/>
+      <point x="652" y="56" type="curve" smooth="yes"/>
+      <point x="616" y="56"/>
+      <point x="595" y="77"/>
+      <point x="595" y="109" type="curve" smooth="yes"/>
+      <point x="595" y="140"/>
+      <point x="609" y="161"/>
+      <point x="636" y="188" type="curve"/>
+      <point x="532" y="148" type="line"/>
+      <point x="548" y="128" type="line"/>
+      <point x="539" y="114"/>
+      <point x="534" y="98"/>
+      <point x="534" y="80" type="curve" smooth="yes"/>
+      <point x="534" y="22"/>
+      <point x="578" y="-16"/>
+      <point x="645" y="-16" type="curve" smooth="yes"/>
+      <point x="753" y="-16"/>
+      <point x="794" y="69"/>
+      <point x="794" y="126" type="curve" smooth="yes"/>
+      <point x="794" y="189"/>
+      <point x="755" y="232"/>
+      <point x="684" y="232" type="curve" smooth="yes"/>
+      <point x="638" y="232"/>
+      <point x="599" y="224"/>
+      <point x="517" y="186" type="curve" smooth="yes"/>
+      <point x="308" y="89" type="line" smooth="yes"/>
+      <point x="260" y="67"/>
+      <point x="223" y="58"/>
+      <point x="178" y="58" type="curve" smooth="yes"/>
+      <point x="136" y="58"/>
+      <point x="109" y="82"/>
+      <point x="109" y="119" type="curve" smooth="yes"/>
+      <point x="109" y="164"/>
+      <point x="145" y="192"/>
+      <point x="212" y="192" type="curve" smooth="yes"/>
+      <point x="533" y="192" type="line" smooth="yes"/>
+      <point x="715" y="192"/>
+      <point x="849" y="286"/>
+      <point x="849" y="438" type="curve" smooth="yes"/>
+      <point x="849" y="546"/>
+      <point x="787" y="612"/>
+      <point x="682" y="612" type="curve" smooth="yes"/>
+      <point x="594" y="612"/>
+      <point x="529" y="570"/>
+      <point x="495" y="491" type="curve"/>
+      <point x="487" y="491" type="line"/>
+      <point x="470" y="571"/>
+      <point x="416" y="612"/>
+      <point x="314" y="612" type="curve" smooth="yes"/>
+      <point x="156" y="612"/>
+      <point x="77" y="502"/>
+      <point x="77" y="413" type="curve" smooth="yes"/>
+      <point x="77" y="329"/>
+      <point x="127" y="274"/>
+      <point x="210" y="274" type="curve" smooth="yes"/>
+      <point x="311" y="274"/>
+      <point x="355" y="350"/>
+      <point x="355" y="408" type="curve" smooth="yes"/>
+      <point x="355" y="474"/>
+      <point x="319" y="512"/>
+      <point x="256" y="512" type="curve" smooth="yes"/>
+      <point x="228" y="512"/>
+      <point x="207" y="509"/>
+      <point x="184" y="501" type="curve"/>
+      <point x="166" y="527" type="line"/>
+      <point x="171" y="497" type="line"/>
+      <point x="196" y="529"/>
+      <point x="248" y="552"/>
+      <point x="309" y="552" type="curve" smooth="yes"/>
+      <point x="393" y="552"/>
+      <point x="430" y="504"/>
+      <point x="430" y="436" type="curve" smooth="yes"/>
+      <point x="430" y="422"/>
+      <point x="429" y="407"/>
+      <point x="426" y="390" type="curve" smooth="yes"/>
+      <point x="416" y="333" type="line"/>
+      <point x="500" y="333" type="line"/>
+      <point x="510" y="390" type="line" smooth="yes"/>
+      <point x="526" y="481"/>
+      <point x="584" y="534"/>
+      <point x="665" y="534" type="curve" smooth="yes"/>
+      <point x="731" y="534"/>
+      <point x="767" y="499"/>
+      <point x="767" y="433" type="curve" smooth="yes"/>
+      <point x="767" y="328"/>
+      <point x="694" y="264"/>
+      <point x="551" y="264" type="curve" smooth="yes"/>
+      <point x="215" y="264" type="line" smooth="yes"/>
+      <point x="105" y="264"/>
+      <point x="27" y="207"/>
+      <point x="27" y="114" type="curve" smooth="yes"/>
+      <point x="27" y="34"/>
+      <point x="87" y="-16"/>
     </contour>
     <contour>
-      <point x="219" y="371" type="curve" smooth="yes"/>
-      <point x="178" y="371"/>
-      <point x="157" y="393"/>
-      <point x="157" y="437" type="curve" smooth="yes"/>
-      <point x="157" y="461"/>
-      <point x="165" y="485"/>
-      <point x="179" y="503" type="curve"/>
-      <point x="157" y="505" type="line"/>
-      <point x="128" y="463" type="line"/>
-      <point x="153" y="480"/>
-      <point x="190" y="490"/>
-      <point x="227" y="490" type="curve" smooth="yes"/>
-      <point x="270" y="490"/>
-      <point x="287" y="474"/>
-      <point x="287" y="434" type="curve" smooth="yes"/>
-      <point x="287" y="395"/>
-      <point x="261" y="371"/>
+      <point x="214" y="338" type="curve" smooth="yes"/>
+      <point x="171" y="338"/>
+      <point x="147" y="367"/>
+      <point x="147" y="411" type="curve" smooth="yes"/>
+      <point x="147" y="432"/>
+      <point x="152" y="451"/>
+      <point x="162" y="473" type="curve"/>
+      <point x="137" y="473" type="line"/>
+      <point x="124" y="443" type="line"/>
+      <point x="150" y="458"/>
+      <point x="181" y="468"/>
+      <point x="216" y="468" type="curve" smooth="yes"/>
+      <point x="260" y="468"/>
+      <point x="283" y="448"/>
+      <point x="283" y="408" type="curve" smooth="yes"/>
+      <point x="283" y="377"/>
+      <point x="265" y="338"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="655"/>
+    <component base="halant-malayalam" xOffset="691"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="440"/>
+    <component base="lVocalicMatra-malayalam" xOffset="450" yOffset="-6"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="832"/>
+  <advance width="882"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="441"/>
+    <component base="llVocalicMatra-malayalam" xOffset="451" yOffset="-6"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/kC_hillu-malayalam.glif
@@ -2,114 +2,112 @@
 <glyph name="kChillu-malayalam" format="2">
   <advance width="1066"/>
   <unicode hex="0D7F"/>
-  <guideline x="1046"/>
-  <anchor x="690" y="0" name="bottom"/>
-  <anchor x="375" y="596" name="top"/>
+  <anchor x="615" y="0" name="bottom"/>
+  <anchor x="406" y="596" name="top"/>
   <outline>
     <contour>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="321" y="26"/>
-      <point x="348" y="90" type="curve"/>
-      <point x="358" y="90" type="line"/>
-      <point x="385" y="23"/>
-      <point x="432" y="-16"/>
-      <point x="514" y="-16" type="curve" smooth="yes"/>
-      <point x="587" y="-16"/>
-      <point x="643" y="14"/>
-      <point x="680" y="84" type="curve"/>
-      <point x="690" y="84" type="line"/>
-      <point x="709" y="23"/>
-      <point x="755" y="-16"/>
-      <point x="836" y="-16" type="curve" smooth="yes"/>
-      <point x="944" y="-16"/>
-      <point x="1005" y="60"/>
-      <point x="1005" y="170" type="curve" smooth="yes"/>
-      <point x="1005" y="261"/>
-      <point x="944" y="333"/>
-      <point x="816" y="333" type="curve" smooth="yes"/>
-      <point x="776" y="333" type="line"/>
-      <point x="730" y="259" type="line"/>
-      <point x="797" y="259" type="line" smooth="yes"/>
-      <point x="893" y="259"/>
-      <point x="920" y="219"/>
-      <point x="920" y="171" type="curve" smooth="yes"/>
-      <point x="920" y="105"/>
-      <point x="889" y="62"/>
-      <point x="828" y="62" type="curve" smooth="yes"/>
-      <point x="769" y="62"/>
-      <point x="736" y="98"/>
-      <point x="736" y="162" type="curve" smooth="yes"/>
-      <point x="736" y="252"/>
-      <point x="808" y="330"/>
-      <point x="892" y="435" type="curve" smooth="yes"/>
-      <point x="957" y="516"/>
-      <point x="1005" y="580"/>
-      <point x="1005" y="679" type="curve" smooth="yes"/>
-      <point x="1005" y="758"/>
-      <point x="957" y="810"/>
-      <point x="857" y="810" type="curve" smooth="yes"/>
-      <point x="808" y="810"/>
-      <point x="759" y="800"/>
-      <point x="705" y="769" type="curve"/>
-      <point x="731" y="700" type="line"/>
-      <point x="774" y="723"/>
-      <point x="815" y="732"/>
-      <point x="846" y="732" type="curve" smooth="yes"/>
-      <point x="901" y="732"/>
-      <point x="922" y="706"/>
-      <point x="922" y="667" type="curve" smooth="yes"/>
-      <point x="922" y="601"/>
-      <point x="886" y="545"/>
-      <point x="823" y="464" type="curve" smooth="yes"/>
-      <point x="800" y="434"/>
-      <point x="781" y="409"/>
-      <point x="768" y="377" type="curve"/>
-      <point x="717" y="377" type="line"/>
-      <point x="757" y="340" type="line"/>
-      <point x="758" y="352"/>
-      <point x="758" y="364"/>
-      <point x="758" y="376" type="curve" smooth="yes"/>
-      <point x="758" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="726" y="259" type="line"/>
-      <point x="726" y="333" type="line"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="557" y="-16"/>
+      <point x="614" y="18"/>
+      <point x="655" y="83" type="curve"/>
+      <point x="666" y="83" type="line"/>
+      <point x="683" y="24"/>
+      <point x="734" y="-16"/>
+      <point x="809" y="-16" type="curve" smooth="yes"/>
+      <point x="920" y="-16"/>
+      <point x="1000" y="77"/>
+      <point x="1000" y="186" type="curve" smooth="yes"/>
+      <point x="1000" y="289"/>
+      <point x="931" y="353"/>
+      <point x="813" y="353" type="curve" smooth="yes"/>
+      <point x="788" y="353" type="line"/>
+      <point x="741" y="279" type="line"/>
+      <point x="810" y="279" type="line" smooth="yes"/>
+      <point x="885" y="279"/>
+      <point x="916" y="243"/>
+      <point x="916" y="181" type="curve" smooth="yes"/>
+      <point x="916" y="111"/>
+      <point x="873" y="62"/>
+      <point x="811" y="62" type="curve" smooth="yes"/>
+      <point x="755" y="62"/>
+      <point x="722" y="94"/>
+      <point x="722" y="149" type="curve" smooth="yes"/>
+      <point x="722" y="211"/>
+      <point x="764" y="287"/>
+      <point x="882" y="432" type="curve" smooth="yes"/>
+      <point x="968" y="538"/>
+      <point x="1001" y="604"/>
+      <point x="1001" y="675" type="curve" smooth="yes"/>
+      <point x="1001" y="752"/>
+      <point x="953" y="810"/>
+      <point x="860" y="810" type="curve" smooth="yes"/>
+      <point x="802" y="810"/>
+      <point x="753" y="796"/>
+      <point x="697" y="759" type="curve"/>
+      <point x="735" y="692" type="line"/>
+      <point x="776" y="719"/>
+      <point x="815" y="731"/>
+      <point x="853" y="731" type="curve" smooth="yes"/>
+      <point x="897" y="731"/>
+      <point x="918" y="710"/>
+      <point x="918" y="667" type="curve" smooth="yes"/>
+      <point x="918" y="619"/>
+      <point x="882" y="553"/>
+      <point x="814" y="467" type="curve" smooth="yes"/>
+      <point x="782" y="427"/>
+      <point x="764" y="393"/>
+      <point x="751" y="360" type="curve"/>
+      <point x="743" y="360" type="line"/>
+      <point x="746" y="383"/>
+      <point x="748" y="405"/>
+      <point x="748" y="425" type="curve" smooth="yes"/>
+      <point x="748" y="544"/>
+      <point x="694" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="707" y="279" type="line"/>
+      <point x="727" y="353" type="line"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="521" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="209"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="658" y="534"/>
+      <point x="685" y="484"/>
+      <point x="685" y="407" type="curve" smooth="yes"/>
+      <point x="685" y="316"/>
+      <point x="643" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/k_ka-malayalam.glif
@@ -1,99 +1,98 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ka-malayalam" format="2">
   <advance width="1454"/>
-  <guideline x="1405"/>
-  <anchor x="1049" y="0" name="bottom"/>
-  <anchor x="798" y="596" name="top"/>
-  <anchor x="1326" y="596" name="topright"/>
+  <anchor x="991" y="0" name="bottom"/>
+  <anchor x="846" y="596" name="top"/>
+  <anchor x="1374" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="316" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="380" y="23"/>
-      <point x="434" y="-16"/>
-      <point x="518" y="-16" type="curve" smooth="yes"/>
-      <point x="688" y="-16"/>
-      <point x="772" y="175"/>
-      <point x="772" y="385" type="curve" smooth="yes"/>
-      <point x="772" y="519"/>
-      <point x="713" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="258"/>
-      <point x="233" y="258" type="curve" smooth="yes"/>
-      <point x="918" y="258" type="line" smooth="yes"/>
-      <point x="1031" y="258"/>
-      <point x="1056" y="218"/>
-      <point x="1056" y="164" type="curve" smooth="yes"/>
-      <point x="1056" y="112"/>
-      <point x="1036" y="62"/>
-      <point x="985" y="62" type="curve" smooth="yes"/>
-      <point x="927" y="62"/>
-      <point x="901" y="110"/>
-      <point x="901" y="182" type="curve" smooth="yes"/>
-      <point x="901" y="381"/>
-      <point x="991" y="533"/>
-      <point x="1150" y="533" type="curve" smooth="yes"/>
-      <point x="1268" y="533"/>
-      <point x="1327" y="460"/>
-      <point x="1327" y="343" type="curve" smooth="yes"/>
-      <point x="1327" y="212"/>
-      <point x="1271" y="127"/>
-      <point x="1185" y="37" type="curve"/>
-      <point x="1246" y="-16" type="line"/>
-      <point x="1349" y="86"/>
-      <point x="1410" y="201"/>
-      <point x="1410" y="350" type="curve" smooth="yes"/>
-      <point x="1410" y="510"/>
-      <point x="1320" y="612"/>
-      <point x="1148" y="612" type="curve" smooth="yes"/>
-      <point x="944" y="612"/>
-      <point x="820" y="440"/>
-      <point x="820" y="187" type="curve" smooth="yes"/>
-      <point x="820" y="76"/>
-      <point x="869" y="-16"/>
-      <point x="988" y="-16" type="curve" smooth="yes"/>
-      <point x="1085" y="-16"/>
-      <point x="1139" y="65"/>
-      <point x="1139" y="163" type="curve" smooth="yes"/>
-      <point x="1139" y="258"/>
-      <point x="1091" y="332"/>
-      <point x="923" y="332" type="curve" smooth="yes"/>
-      <point x="242" y="332" type="line" smooth="yes"/>
-      <point x="106" y="332"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="956" y="279" type="line" smooth="yes"/>
+      <point x="1029" y="279"/>
+      <point x="1063" y="248"/>
+      <point x="1063" y="178" type="curve" smooth="yes"/>
+      <point x="1063" y="137"/>
+      <point x="1044" y="62"/>
+      <point x="975" y="62" type="curve" smooth="yes"/>
+      <point x="920" y="62"/>
+      <point x="892" y="100"/>
+      <point x="892" y="179" type="curve" smooth="yes"/>
+      <point x="892" y="319"/>
+      <point x="965" y="533"/>
+      <point x="1155" y="533" type="curve" smooth="yes"/>
+      <point x="1265" y="533"/>
+      <point x="1320" y="465"/>
+      <point x="1320" y="343" type="curve" smooth="yes"/>
+      <point x="1320" y="236"/>
+      <point x="1281" y="141"/>
+      <point x="1179" y="43" type="curve"/>
+      <point x="1238" y="-16" type="line"/>
+      <point x="1349" y="91"/>
+      <point x="1402" y="222"/>
+      <point x="1402" y="350" type="curve" smooth="yes"/>
+      <point x="1402" y="512"/>
+      <point x="1318" y="612"/>
+      <point x="1164" y="612" type="curve" smooth="yes"/>
+      <point x="930" y="612"/>
+      <point x="811" y="381"/>
+      <point x="811" y="181" type="curve" smooth="yes"/>
+      <point x="811" y="59"/>
+      <point x="871" y="-16"/>
+      <point x="969" y="-16" type="curve" smooth="yes"/>
+      <point x="1086" y="-16"/>
+      <point x="1145" y="85"/>
+      <point x="1145" y="184" type="curve" smooth="yes"/>
+      <point x="1145" y="293"/>
+      <point x="1081" y="353"/>
+      <point x="960" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="515" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="661" y="534"/>
-      <point x="690" y="478"/>
-      <point x="690" y="397" type="curve" smooth="yes"/>
-      <point x="690" y="229"/>
-      <point x="640" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/k_la-malayalam.glif
@@ -1,145 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_la-malayalam" format="2">
   <advance width="1061"/>
-  <anchor x="546" y="-357" name="bottom"/>
-  <anchor x="604" y="596" name="top"/>
-  <anchor x="942" y="556" name="topright"/>
+  <anchor x="551" y="-362" name="bottom"/>
+  <anchor x="599" y="596" name="top"/>
+  <anchor x="936" y="556" name="topright"/>
   <outline>
     <contour>
-      <point x="342" y="-378" type="curve" smooth="yes"/>
-      <point x="429" y="-378"/>
-      <point x="479" y="-321"/>
-      <point x="479" y="-236" type="curve" smooth="yes"/>
-      <point x="479" y="-156"/>
-      <point x="434" y="-121"/>
-      <point x="368" y="-121" type="curve" smooth="yes"/>
-      <point x="334" y="-121"/>
-      <point x="301" y="-134"/>
-      <point x="278" y="-167" type="curve"/>
-      <point x="230" y="-162" type="line"/>
-      <point x="265" y="-184" type="line"/>
-      <point x="284" y="-78"/>
-      <point x="348" y="-22"/>
-      <point x="433" y="-22" type="curve" smooth="yes"/>
-      <point x="544" y="-22"/>
-      <point x="566" y="-91"/>
-      <point x="572" y="-180" type="curve" smooth="yes"/>
-      <point x="573" y="-196" type="line" smooth="yes"/>
-      <point x="580" y="-307"/>
-      <point x="624" y="-378"/>
-      <point x="741" y="-378" type="curve" smooth="yes"/>
-      <point x="875" y="-378"/>
-      <point x="925" y="-270"/>
-      <point x="925" y="-132" type="curve" smooth="yes"/>
-      <point x="925" y="-57"/>
-      <point x="902" y="7"/>
-      <point x="875" y="48" type="curve"/>
-      <point x="812" y="10" type="line"/>
-      <point x="828" y="-20"/>
-      <point x="849" y="-69"/>
-      <point x="849" y="-145" type="curve" smooth="yes"/>
-      <point x="849" y="-228"/>
-      <point x="821" y="-308"/>
-      <point x="742" y="-308" type="curve" smooth="yes"/>
-      <point x="681" y="-308"/>
-      <point x="657" y="-271"/>
-      <point x="648" y="-176" type="curve" smooth="yes"/>
-      <point x="646" y="-155" type="line" smooth="yes"/>
-      <point x="640" y="-91"/>
-      <point x="625" y="-41"/>
-      <point x="591" y="-7" type="curve"/>
-      <point x="592" y="3" type="line"/>
-      <point x="714" y="49"/>
-      <point x="774" y="208"/>
-      <point x="774" y="375" type="curve" smooth="yes"/>
-      <point x="774" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="802" y="259" type="line" smooth="yes"/>
-      <point x="884" y="259"/>
-      <point x="919" y="227"/>
-      <point x="919" y="165" type="curve" smooth="yes"/>
-      <point x="919" y="112"/>
-      <point x="895" y="60"/>
-      <point x="822" y="60" type="curve" smooth="yes"/>
-      <point x="797" y="60"/>
-      <point x="776" y="66"/>
-      <point x="761" y="73" type="curve"/>
-      <point x="730" y="3" type="line"/>
-      <point x="753" y="-9"/>
-      <point x="787" y="-16"/>
-      <point x="824" y="-16" type="curve" smooth="yes"/>
-      <point x="940" y="-16"/>
-      <point x="1001" y="59"/>
-      <point x="1001" y="168" type="curve" smooth="yes"/>
-      <point x="1001" y="267"/>
-      <point x="942" y="333"/>
-      <point x="810" y="333" type="curve" smooth="yes"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="316" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="359" y="75"/>
-      <point x="373" y="56"/>
-      <point x="389" y="46" type="curve"/>
-      <point x="388" y="35" type="line"/>
-      <point x="265" y="11"/>
-      <point x="196" y="-89"/>
-      <point x="196" y="-209" type="curve" smooth="yes"/>
-      <point x="196" y="-328"/>
-      <point x="261" y="-378"/>
+      <point x="334" y="-378" type="curve" smooth="yes"/>
+      <point x="433" y="-378"/>
+      <point x="479" y="-300"/>
+      <point x="479" y="-234" type="curve" smooth="yes"/>
+      <point x="479" y="-166"/>
+      <point x="444" y="-121"/>
+      <point x="381" y="-121" type="curve" smooth="yes"/>
+      <point x="333" y="-121"/>
+      <point x="267" y="-155"/>
+      <point x="253" y="-236" type="curve"/>
+      <point x="288" y="-175" type="line"/>
+      <point x="229" y="-175" type="line"/>
+      <point x="263" y="-201" type="line"/>
+      <point x="280" y="-94"/>
+      <point x="362" y="-22"/>
+      <point x="446" y="-22" type="curve" smooth="yes"/>
+      <point x="524" y="-22"/>
+      <point x="553" y="-61"/>
+      <point x="569" y="-160" type="curve" smooth="yes"/>
+      <point x="576" y="-203" type="line" smooth="yes"/>
+      <point x="596" y="-323"/>
+      <point x="645" y="-378"/>
+      <point x="736" y="-378" type="curve" smooth="yes"/>
+      <point x="878" y="-378"/>
+      <point x="922" y="-231"/>
+      <point x="922" y="-135" type="curve" smooth="yes"/>
+      <point x="922" y="-59"/>
+      <point x="902" y="0"/>
+      <point x="872" y="46" type="curve"/>
+      <point x="810" y="10" type="line"/>
+      <point x="833" y="-30"/>
+      <point x="848" y="-77"/>
+      <point x="848" y="-139" type="curve" smooth="yes"/>
+      <point x="848" y="-202"/>
+      <point x="829" y="-308"/>
+      <point x="743" y="-308" type="curve" smooth="yes"/>
+      <point x="687" y="-308"/>
+      <point x="662" y="-274"/>
+      <point x="648" y="-188" type="curve" smooth="yes"/>
+      <point x="641" y="-145" type="line" smooth="yes"/>
+      <point x="629" y="-68"/>
+      <point x="612" y="-26"/>
+      <point x="576" y="-1" type="curve"/>
+      <point x="578" y="10" type="line"/>
+      <point x="730" y="75"/>
+      <point x="769" y="279"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="793" y="279" type="line" smooth="yes"/>
+      <point x="872" y="279"/>
+      <point x="912" y="245"/>
+      <point x="912" y="178" type="curve" smooth="yes"/>
+      <point x="912" y="105"/>
+      <point x="871" y="60"/>
+      <point x="807" y="60" type="curve" smooth="yes"/>
+      <point x="785" y="60"/>
+      <point x="766" y="63"/>
+      <point x="748" y="70" type="curve"/>
+      <point x="725" y="-2" type="line"/>
+      <point x="748" y="-12"/>
+      <point x="773" y="-16"/>
+      <point x="801" y="-16" type="curve" smooth="yes"/>
+      <point x="914" y="-16"/>
+      <point x="993" y="65"/>
+      <point x="993" y="180" type="curve" smooth="yes"/>
+      <point x="993" y="289"/>
+      <point x="920" y="353"/>
+      <point x="796" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="351" y="70"/>
+      <point x="363" y="51"/>
+      <point x="381" y="38" type="curve"/>
+      <point x="379" y="27" type="line"/>
+      <point x="270" y="-6"/>
+      <point x="196" y="-113"/>
+      <point x="196" y="-227" type="curve" smooth="yes"/>
+      <point x="196" y="-321"/>
+      <point x="256" y="-378"/>
     </contour>
     <contour>
-      <point x="341" y="-313" type="curve" smooth="yes"/>
-      <point x="287" y="-313"/>
-      <point x="264" y="-270"/>
-      <point x="264" y="-223" type="curve"/>
-      <point x="246" y="-200" type="line"/>
-      <point x="257" y="-256" type="line"/>
-      <point x="264" y="-216"/>
-      <point x="298" y="-181"/>
-      <point x="347" y="-181" type="curve" smooth="yes"/>
-      <point x="389" y="-181"/>
-      <point x="408" y="-201"/>
-      <point x="408" y="-240" type="curve" smooth="yes"/>
-      <point x="408" y="-282"/>
-      <point x="385" y="-313"/>
+      <point x="337" y="-313" type="curve" smooth="yes"/>
+      <point x="291" y="-313"/>
+      <point x="263" y="-276"/>
+      <point x="263" y="-227" type="curve" smooth="yes"/>
+      <point x="263" y="-219"/>
+      <point x="264" y="-211"/>
+      <point x="266" y="-203" type="curve"/>
+      <point x="246" y="-218" type="line"/>
+      <point x="255" y="-268" type="line"/>
+      <point x="263" y="-224"/>
+      <point x="304" y="-181"/>
+      <point x="357" y="-181" type="curve" smooth="yes"/>
+      <point x="393" y="-181"/>
+      <point x="409" y="-202"/>
+      <point x="409" y="-236" type="curve" smooth="yes"/>
+      <point x="409" y="-270"/>
+      <point x="390" y="-313"/>
     </contour>
     <contour>
-      <point x="523" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="229"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.glif
@@ -1,116 +1,115 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam" format="2">
   <advance width="1726"/>
-  <guideline x="1643"/>
-  <anchor x="1235" y="0" name="bottom"/>
-  <anchor x="937" y="596" name="top"/>
-  <anchor x="1662" y="596" name="topright"/>
+  <anchor x="1228" y="0" name="bottom"/>
+  <anchor x="932" y="596" name="top"/>
+  <anchor x="1657" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="183" y="-16" type="curve" smooth="yes"/>
-      <point x="261" y="-16"/>
-      <point x="317" y="26"/>
-      <point x="344" y="90" type="curve"/>
-      <point x="354" y="90" type="line"/>
-      <point x="381" y="23"/>
-      <point x="435" y="-16"/>
-      <point x="525" y="-16" type="curve" smooth="yes"/>
-      <point x="691" y="-16"/>
-      <point x="775" y="173"/>
-      <point x="775" y="372" type="curve" smooth="yes"/>
-      <point x="775" y="517"/>
-      <point x="714" y="612"/>
-      <point x="587" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="369" y="505"/>
-      <point x="339" y="325" type="curve" smooth="yes"/>
-      <point x="334" y="293"/>
-      <point x="329" y="248"/>
-      <point x="325" y="224" type="curve" smooth="yes"/>
-      <point x="307" y="112"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
       <point x="258" y="62"/>
-      <point x="193" y="62" type="curve" smooth="yes"/>
-      <point x="132" y="62"/>
-      <point x="102" y="95"/>
-      <point x="102" y="151" type="curve" smooth="yes"/>
-      <point x="102" y="218"/>
-      <point x="147" y="265"/>
-      <point x="235" y="265" type="curve" smooth="yes"/>
-      <point x="806" y="265" type="line" smooth="yes"/>
-      <point x="895" y="265"/>
-      <point x="923" y="233"/>
-      <point x="923" y="186" type="curve" smooth="yes"/>
-      <point x="923" y="123"/>
-      <point x="890" y="90"/>
-      <point x="836" y="57" type="curve"/>
-      <point x="846" y="0" type="line"/>
-      <point x="1590" y="0" type="line"/>
-      <point x="1695" y="596" type="line"/>
-      <point x="1643" y="596" type="line"/>
-      <point x="1554" y="414"/>
-      <point x="1442" y="320"/>
-      <point x="1293" y="320" type="curve" smooth="yes"/>
-      <point x="1194" y="320"/>
-      <point x="1142" y="365"/>
-      <point x="1142" y="437" type="curve" smooth="yes"/>
-      <point x="1142" y="495"/>
-      <point x="1172" y="534"/>
-      <point x="1227" y="534" type="curve" smooth="yes"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="801" y="279" type="line" smooth="yes"/>
+      <point x="878" y="279"/>
+      <point x="917" y="248"/>
+      <point x="917" y="185" type="curve" smooth="yes"/>
+      <point x="917" y="137"/>
+      <point x="893" y="102"/>
+      <point x="830" y="58" type="curve"/>
+      <point x="840" y="0" type="line"/>
+      <point x="1584" y="0" type="line"/>
+      <point x="1689" y="596" type="line"/>
+      <point x="1639" y="596" type="line"/>
+      <point x="1533" y="421"/>
+      <point x="1399" y="320"/>
+      <point x="1267" y="320" type="curve" smooth="yes"/>
+      <point x="1184" y="320"/>
+      <point x="1137" y="360"/>
+      <point x="1137" y="430" type="curve" smooth="yes"/>
+      <point x="1137" y="490"/>
+      <point x="1177" y="534"/>
+      <point x="1231" y="534" type="curve" smooth="yes"/>
       <point x="1271" y="534"/>
-      <point x="1293" y="510"/>
-      <point x="1293" y="465" type="curve" smooth="yes"/>
-      <point x="1293" y="445"/>
-      <point x="1291" y="428"/>
-      <point x="1288" y="411" type="curve" smooth="yes"/>
-      <point x="1226" y="61" type="line"/>
-      <point x="1308" y="61" type="line"/>
-      <point x="1371" y="407" type="line" smooth="yes"/>
-      <point x="1376" y="435"/>
-      <point x="1376" y="458"/>
-      <point x="1376" y="471" type="curve" smooth="yes"/>
-      <point x="1376" y="553"/>
-      <point x="1324" y="612"/>
-      <point x="1227" y="612" type="curve" smooth="yes"/>
-      <point x="1122" y="612"/>
-      <point x="1059" y="547"/>
-      <point x="1059" y="443" type="curve" smooth="yes"/>
-      <point x="1059" y="315"/>
-      <point x="1161" y="242"/>
-      <point x="1294" y="242" type="curve" smooth="yes"/>
-      <point x="1405" y="242"/>
-      <point x="1495" y="284"/>
-      <point x="1558" y="358" type="curve"/>
-      <point x="1568" y="354" type="line"/>
-      <point x="1513" y="40" type="line"/>
-      <point x="1559" y="74" type="line"/>
-      <point x="915" y="74" type="line"/>
-      <point x="917" y="43" type="line"/>
-      <point x="973" y="74"/>
-      <point x="1007" y="123"/>
-      <point x="1007" y="187" type="curve" smooth="yes"/>
-      <point x="1007" y="279"/>
-      <point x="953" y="339"/>
-      <point x="812" y="339" type="curve" smooth="yes"/>
-      <point x="242" y="339" type="line" smooth="yes"/>
-      <point x="106" y="339"/>
-      <point x="18" y="268"/>
-      <point x="18" y="150" type="curve" smooth="yes"/>
-      <point x="18" y="50"/>
-      <point x="74" y="-16"/>
+      <point x="1292" y="514"/>
+      <point x="1292" y="474" type="curve" smooth="yes"/>
+      <point x="1292" y="463"/>
+      <point x="1291" y="452"/>
+      <point x="1289" y="440" type="curve" smooth="yes"/>
+      <point x="1222" y="61" type="line"/>
+      <point x="1304" y="61" type="line"/>
+      <point x="1370" y="435" type="line" smooth="yes"/>
+      <point x="1373" y="452"/>
+      <point x="1375" y="469"/>
+      <point x="1375" y="483" type="curve" smooth="yes"/>
+      <point x="1375" y="563"/>
+      <point x="1326" y="612"/>
+      <point x="1244" y="612" type="curve" smooth="yes"/>
+      <point x="1135" y="612"/>
+      <point x="1056" y="534"/>
+      <point x="1056" y="425" type="curve" smooth="yes"/>
+      <point x="1056" y="316"/>
+      <point x="1137" y="244"/>
+      <point x="1261" y="244" type="curve" smooth="yes"/>
+      <point x="1370" y="244"/>
+      <point x="1474" y="293"/>
+      <point x="1562" y="390" type="curve"/>
+      <point x="1570" y="390" type="line"/>
+      <point x="1508" y="40" type="line"/>
+      <point x="1554" y="74" type="line"/>
+      <point x="946" y="74" type="line"/>
+      <point x="944" y="80" type="line"/>
+      <point x="977" y="109"/>
+      <point x="1000" y="154"/>
+      <point x="1000" y="200" type="curve" smooth="yes"/>
+      <point x="1000" y="294"/>
+      <point x="939" y="353"/>
+      <point x="809" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="521" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="408" y="117"/>
-      <point x="408" y="202" type="curve" smooth="yes"/>
-      <point x="408" y="352"/>
-      <point x="463" y="534"/>
-      <point x="589" y="534" type="curve" smooth="yes"/>
-      <point x="661" y="534"/>
-      <point x="688" y="480"/>
-      <point x="688" y="380" type="curve" smooth="yes"/>
-      <point x="688" y="231"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1726"/>
   <outline>
     <component base="k_ssa-malayalam"/>
-    <component base="halant-malayalam" xOffset="1582"/>
+    <component base="halant-malayalam" xOffset="1577"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/k_ta-malayalam.glif
@@ -1,114 +1,114 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ta-malayalam" format="2">
   <advance width="1820"/>
-  <anchor x="1367" y="0" name="bottom"/>
-  <anchor x="895" y="596" name="top"/>
-  <anchor x="1704" y="596" name="topright"/>
+  <anchor x="1357" y="0" name="bottom"/>
+  <anchor x="891" y="596" name="top"/>
+  <anchor x="1696" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="316" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="380" y="23"/>
-      <point x="434" y="-16"/>
-      <point x="524" y="-16" type="curve" smooth="yes"/>
-      <point x="689" y="-16"/>
-      <point x="774" y="175"/>
-      <point x="774" y="375" type="curve" smooth="yes"/>
-      <point x="774" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="903" y="259" type="line"/>
-      <point x="911" y="333" type="line"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
+      <point x="939" y="-16" type="curve"/>
+      <point x="1003" y="31" type="line"/>
+      <point x="959" y="92"/>
+      <point x="941" y="161"/>
+      <point x="941" y="236" type="curve" smooth="yes"/>
+      <point x="941" y="404"/>
+      <point x="1044" y="534"/>
+      <point x="1211" y="534" type="curve" smooth="yes"/>
+      <point x="1353" y="534"/>
+      <point x="1420" y="426"/>
+      <point x="1420" y="292" type="curve" smooth="yes"/>
+      <point x="1420" y="194"/>
+      <point x="1379" y="62"/>
+      <point x="1282" y="62" type="curve" smooth="yes"/>
+      <point x="1217" y="62"/>
+      <point x="1182" y="107"/>
+      <point x="1182" y="193" type="curve" smooth="yes"/>
+      <point x="1182" y="355"/>
+      <point x="1319" y="534"/>
+      <point x="1506" y="534" type="curve" smooth="yes"/>
+      <point x="1639" y="534"/>
+      <point x="1687" y="467"/>
+      <point x="1687" y="358" type="curve" smooth="yes"/>
+      <point x="1687" y="257"/>
+      <point x="1637" y="148"/>
+      <point x="1528" y="45" type="curve"/>
+      <point x="1591" y="-16" type="line"/>
+      <point x="1721" y="107"/>
+      <point x="1770" y="236"/>
+      <point x="1770" y="362" type="curve" smooth="yes"/>
+      <point x="1770" y="515"/>
+      <point x="1684" y="612"/>
+      <point x="1516" y="612" type="curve" smooth="yes"/>
+      <point x="1273" y="612"/>
+      <point x="1099" y="378"/>
+      <point x="1099" y="190" type="curve" smooth="yes"/>
+      <point x="1099" y="66"/>
+      <point x="1168" y="-16"/>
+      <point x="1275" y="-16" type="curve" smooth="yes"/>
+      <point x="1444" y="-16"/>
+      <point x="1506" y="162"/>
+      <point x="1506" y="290" type="curve" smooth="yes"/>
+      <point x="1506" y="462"/>
+      <point x="1404" y="612"/>
+      <point x="1220" y="612" type="curve" smooth="yes"/>
+      <point x="996" y="612"/>
+      <point x="859" y="429"/>
+      <point x="859" y="235" type="curve" smooth="yes"/>
+      <point x="859" y="143"/>
+      <point x="885" y="58"/>
     </contour>
     <contour>
-      <point x="523" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="229"/>
-      <point x="638" y="62"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="915" y="279" type="line"/>
+      <point x="915" y="353" type="line"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="956" y="-16" type="curve"/>
-      <point x="1022" y="32" type="line"/>
-      <point x="978" y="87"/>
-      <point x="953" y="165"/>
-      <point x="953" y="248" type="curve" smooth="yes"/>
-      <point x="953" y="421"/>
-      <point x="1056" y="534"/>
-      <point x="1214" y="534" type="curve" smooth="yes"/>
-      <point x="1356" y="534"/>
-      <point x="1434" y="443"/>
-      <point x="1434" y="275" type="curve" smooth="yes"/>
-      <point x="1434" y="136"/>
-      <point x="1389" y="62"/>
-      <point x="1303" y="62" type="curve" smooth="yes"/>
-      <point x="1232" y="62"/>
-      <point x="1196" y="109"/>
-      <point x="1196" y="199" type="curve" smooth="yes"/>
-      <point x="1196" y="387"/>
-      <point x="1329" y="534"/>
-      <point x="1500" y="534" type="curve" smooth="yes"/>
-      <point x="1622" y="534"/>
-      <point x="1686" y="466"/>
-      <point x="1686" y="336" type="curve" smooth="yes"/>
-      <point x="1686" y="218"/>
-      <point x="1637" y="128"/>
-      <point x="1528" y="48" type="curve"/>
-      <point x="1579" y="-16" type="line"/>
-      <point x="1707" y="79"/>
-      <point x="1768" y="193"/>
-      <point x="1768" y="336" type="curve" smooth="yes"/>
-      <point x="1768" y="513"/>
-      <point x="1672" y="612"/>
-      <point x="1502" y="612" type="curve" smooth="yes"/>
-      <point x="1296" y="612"/>
-      <point x="1114" y="418"/>
-      <point x="1114" y="199" type="curve" smooth="yes"/>
-      <point x="1114" y="62"/>
-      <point x="1183" y="-16"/>
-      <point x="1303" y="-16" type="curve" smooth="yes"/>
-      <point x="1433" y="-16"/>
-      <point x="1520" y="100"/>
-      <point x="1520" y="275" type="curve" smooth="yes"/>
-      <point x="1520" y="475"/>
-      <point x="1398" y="612"/>
-      <point x="1218" y="612" type="curve" smooth="yes"/>
-      <point x="1013" y="612"/>
-      <point x="871" y="463"/>
-      <point x="871" y="248" type="curve" smooth="yes"/>
-      <point x="871" y="143"/>
-      <point x="899" y="56"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/k_tta-malayalam.glif
@@ -1,128 +1,119 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_tta-malayalam" format="2">
   <advance width="1060"/>
-  <anchor x="683" y="-362" name="bottom"/>
-  <anchor x="604" y="596" name="top"/>
-  <anchor x="942" y="556" name="topright"/>
+  <anchor x="736" y="-362" name="bottom"/>
+  <anchor x="599" y="596" name="top"/>
+  <anchor x="936" y="556" name="topright"/>
   <outline>
     <contour>
-      <point x="719" y="-378" type="curve" smooth="yes"/>
-      <point x="840" y="-378"/>
-      <point x="898" y="-324"/>
-      <point x="898" y="-244" type="curve" smooth="yes"/>
-      <point x="898" y="-180"/>
-      <point x="866" y="-136"/>
-      <point x="745" y="-129" type="curve" smooth="yes"/>
-      <point x="712" y="-127" type="line" smooth="yes"/>
-      <point x="656" y="-124"/>
-      <point x="630" y="-108"/>
-      <point x="630" y="-75" type="curve" smooth="yes"/>
-      <point x="630" y="-42"/>
-      <point x="660" y="-17"/>
-      <point x="741" y="-17" type="curve" smooth="yes"/>
-      <point x="800" y="-17"/>
-      <point x="851" y="-26"/>
-      <point x="893" y="-42" type="curve"/>
-      <point x="922" y="16" type="line"/>
-      <point x="878" y="36"/>
-      <point x="817" y="48"/>
-      <point x="755" y="48" type="curve" smooth="yes"/>
-      <point x="721" y="48"/>
-      <point x="692" y="43"/>
-      <point x="664" y="34" type="curve"/>
-      <point x="659" y="41" type="line"/>
-      <point x="736" y="112"/>
-      <point x="774" y="241"/>
-      <point x="774" y="375" type="curve" smooth="yes"/>
-      <point x="774" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="802" y="259" type="line" smooth="yes"/>
-      <point x="884" y="259"/>
-      <point x="919" y="227"/>
-      <point x="919" y="165" type="curve" smooth="yes"/>
-      <point x="919" y="112"/>
-      <point x="895" y="60"/>
-      <point x="822" y="60" type="curve" smooth="yes"/>
-      <point x="797" y="60"/>
-      <point x="776" y="66"/>
-      <point x="761" y="73" type="curve"/>
-      <point x="730" y="3" type="line"/>
-      <point x="753" y="-9"/>
-      <point x="787" y="-16"/>
-      <point x="824" y="-16" type="curve" smooth="yes"/>
-      <point x="940" y="-16"/>
-      <point x="1001" y="59"/>
-      <point x="1001" y="168" type="curve" smooth="yes"/>
-      <point x="1001" y="267"/>
-      <point x="942" y="333"/>
-      <point x="810" y="333" type="curve" smooth="yes"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="316" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="380" y="23"/>
-      <point x="434" y="-16"/>
-      <point x="524" y="-16" type="curve" smooth="yes"/>
-      <point x="540" y="-16"/>
-      <point x="559" y="-13"/>
-      <point x="576" y="-7" type="curve"/>
-      <point x="581" y="-14" type="line"/>
-      <point x="564" y="-36"/>
-      <point x="554" y="-58"/>
-      <point x="554" y="-87" type="curve" smooth="yes"/>
-      <point x="554" y="-151"/>
-      <point x="602" y="-192"/>
-      <point x="693" y="-197" type="curve" smooth="yes"/>
-      <point x="729" y="-199" type="line" smooth="yes"/>
-      <point x="814" y="-204"/>
-      <point x="822" y="-228"/>
-      <point x="822" y="-252" type="curve" smooth="yes"/>
-      <point x="822" y="-286"/>
-      <point x="794" y="-313"/>
-      <point x="719" y="-313" type="curve" smooth="yes"/>
-      <point x="636" y="-313"/>
-      <point x="583" y="-295"/>
-      <point x="542" y="-271" type="curve"/>
-      <point x="505" y="-328" type="line"/>
-      <point x="555" y="-360"/>
-      <point x="629" y="-378"/>
+      <point x="725" y="-378" type="curve" smooth="yes"/>
+      <point x="862" y="-378"/>
+      <point x="930" y="-318"/>
+      <point x="930" y="-242" type="curve" smooth="yes"/>
+      <point x="930" y="-180"/>
+      <point x="896" y="-139"/>
+      <point x="796" y="-130" type="curve" smooth="yes"/>
+      <point x="727" y="-124" type="line" smooth="yes"/>
+      <point x="687" y="-121"/>
+      <point x="668" y="-107"/>
+      <point x="668" y="-81" type="curve" smooth="yes"/>
+      <point x="668" y="-45"/>
+      <point x="704" y="-16"/>
+      <point x="788" y="-16" type="curve" smooth="yes"/>
+      <point x="846" y="-16"/>
+      <point x="888" y="-25"/>
+      <point x="929" y="-44" type="curve"/>
+      <point x="953" y="13" type="line"/>
+      <point x="939" y="20"/>
+      <point x="922" y="26"/>
+      <point x="905" y="30" type="curve"/>
+      <point x="907" y="39" type="line"/>
+      <point x="960" y="68"/>
+      <point x="994" y="119"/>
+      <point x="994" y="189" type="curve" smooth="yes"/>
+      <point x="994" y="288"/>
+      <point x="925" y="353"/>
+      <point x="796" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="793" y="279" type="line" smooth="yes"/>
+      <point x="876" y="279"/>
+      <point x="913" y="244"/>
+      <point x="913" y="175" type="curve" smooth="yes"/>
+      <point x="913" y="110"/>
+      <point x="870" y="60"/>
+      <point x="807" y="60" type="curve" smooth="yes"/>
+      <point x="786" y="60"/>
+      <point x="768" y="63"/>
+      <point x="753" y="69" type="curve"/>
+      <point x="737" y="29" type="line"/>
+      <point x="767" y="47" type="line"/>
+      <point x="669" y="41"/>
+      <point x="593" y="-11"/>
+      <point x="593" y="-89" type="curve" smooth="yes"/>
+      <point x="593" y="-149"/>
+      <point x="636" y="-189"/>
+      <point x="714" y="-196" type="curve" smooth="yes"/>
+      <point x="783" y="-202" type="line" smooth="yes"/>
+      <point x="842" y="-207"/>
+      <point x="855" y="-224"/>
+      <point x="855" y="-250" type="curve" smooth="yes"/>
+      <point x="855" y="-284"/>
+      <point x="822" y="-313"/>
+      <point x="731" y="-313" type="curve" smooth="yes"/>
+      <point x="670" y="-313"/>
+      <point x="618" y="-300"/>
+      <point x="574" y="-272" type="curve"/>
+      <point x="543" y="-332" type="line"/>
+      <point x="591" y="-362"/>
+      <point x="653" y="-378"/>
     </contour>
     <contour>
-      <point x="523" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="229"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ka-malayalam.glif
@@ -2,80 +2,80 @@
 <glyph name="ka-malayalam" format="2">
   <advance width="1061"/>
   <unicode hex="0D15"/>
-  <anchor x="616" y="0" name="bottom"/>
-  <anchor x="604" y="596" name="top"/>
-  <anchor x="942" y="556" name="topright"/>
+  <anchor x="609" y="0" name="bottom"/>
+  <anchor x="599" y="596" name="top"/>
+  <anchor x="936" y="556" name="topright"/>
   <outline>
     <contour>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="317" y="26"/>
-      <point x="343" y="90" type="curve"/>
-      <point x="353" y="90" type="line"/>
-      <point x="379" y="23"/>
-      <point x="434" y="-16"/>
-      <point x="524" y="-16" type="curve" smooth="yes"/>
-      <point x="689" y="-16"/>
-      <point x="774" y="175"/>
-      <point x="774" y="375" type="curve" smooth="yes"/>
-      <point x="774" y="519"/>
-      <point x="714" y="612"/>
-      <point x="589" y="612" type="curve" smooth="yes"/>
-      <point x="460" y="612"/>
-      <point x="368" y="503"/>
-      <point x="338" y="322" type="curve" smooth="yes"/>
-      <point x="333" y="291"/>
-      <point x="328" y="246"/>
-      <point x="324" y="221" type="curve" smooth="yes"/>
-      <point x="306" y="109"/>
-      <point x="257" y="62"/>
-      <point x="192" y="62" type="curve" smooth="yes"/>
-      <point x="131" y="62"/>
-      <point x="101" y="95"/>
-      <point x="101" y="151" type="curve" smooth="yes"/>
-      <point x="101" y="214"/>
-      <point x="145" y="259"/>
-      <point x="233" y="259" type="curve" smooth="yes"/>
-      <point x="802" y="259" type="line" smooth="yes"/>
-      <point x="884" y="259"/>
-      <point x="919" y="227"/>
-      <point x="919" y="165" type="curve" smooth="yes"/>
-      <point x="919" y="112"/>
-      <point x="895" y="60"/>
-      <point x="822" y="60" type="curve" smooth="yes"/>
-      <point x="797" y="60"/>
-      <point x="776" y="66"/>
-      <point x="761" y="73" type="curve"/>
-      <point x="730" y="3" type="line"/>
-      <point x="753" y="-9"/>
-      <point x="787" y="-16"/>
-      <point x="824" y="-16" type="curve" smooth="yes"/>
-      <point x="940" y="-16"/>
-      <point x="1001" y="59"/>
-      <point x="1001" y="168" type="curve" smooth="yes"/>
-      <point x="1001" y="267"/>
-      <point x="942" y="333"/>
-      <point x="810" y="333" type="curve" smooth="yes"/>
-      <point x="242" y="333" type="line" smooth="yes"/>
-      <point x="106" y="333"/>
-      <point x="17" y="260"/>
-      <point x="17" y="144" type="curve" smooth="yes"/>
-      <point x="17" y="50"/>
-      <point x="73" y="-16"/>
+      <point x="175" y="-16" type="curve" smooth="yes"/>
+      <point x="243" y="-16"/>
+      <point x="299" y="22"/>
+      <point x="333" y="91" type="curve"/>
+      <point x="344" y="91" type="line"/>
+      <point x="365" y="23"/>
+      <point x="418" y="-16"/>
+      <point x="495" y="-16" type="curve" smooth="yes"/>
+      <point x="706" y="-16"/>
+      <point x="769" y="265"/>
+      <point x="769" y="396" type="curve" smooth="yes"/>
+      <point x="769" y="529"/>
+      <point x="706" y="612"/>
+      <point x="598" y="612" type="curve" smooth="yes"/>
+      <point x="463" y="612"/>
+      <point x="365" y="501"/>
+      <point x="332" y="314" type="curve" smooth="yes"/>
+      <point x="327" y="287"/>
+      <point x="323" y="242"/>
+      <point x="318" y="214" type="curve" smooth="yes"/>
+      <point x="302" y="115"/>
+      <point x="258" y="62"/>
+      <point x="190" y="62" type="curve" smooth="yes"/>
+      <point x="135" y="62"/>
+      <point x="101" y="98"/>
+      <point x="101" y="154" type="curve" smooth="yes"/>
+      <point x="101" y="230"/>
+      <point x="160" y="279"/>
+      <point x="252" y="279" type="curve" smooth="yes"/>
+      <point x="793" y="279" type="line" smooth="yes"/>
+      <point x="873" y="279"/>
+      <point x="913" y="245"/>
+      <point x="913" y="178" type="curve" smooth="yes"/>
+      <point x="913" y="105"/>
+      <point x="872" y="60"/>
+      <point x="807" y="60" type="curve" smooth="yes"/>
+      <point x="786" y="60"/>
+      <point x="767" y="63"/>
+      <point x="750" y="69" type="curve"/>
+      <point x="727" y="-3" type="line"/>
+      <point x="749" y="-12"/>
+      <point x="774" y="-16"/>
+      <point x="801" y="-16" type="curve" smooth="yes"/>
+      <point x="915" y="-16"/>
+      <point x="994" y="65"/>
+      <point x="994" y="180" type="curve" smooth="yes"/>
+      <point x="994" y="289"/>
+      <point x="921" y="353"/>
+      <point x="796" y="353" type="curve" smooth="yes"/>
+      <point x="256" y="353" type="line" smooth="yes"/>
+      <point x="113" y="353"/>
+      <point x="18" y="270"/>
+      <point x="18" y="147" type="curve" smooth="yes"/>
+      <point x="18" y="52"/>
+      <point x="84" y="-16"/>
     </contour>
     <contour>
-      <point x="523" y="62" type="curve" smooth="yes"/>
-      <point x="439" y="62"/>
-      <point x="407" y="119"/>
-      <point x="407" y="205" type="curve" smooth="yes"/>
-      <point x="407" y="354"/>
-      <point x="461" y="534"/>
-      <point x="585" y="534" type="curve" smooth="yes"/>
-      <point x="659" y="534"/>
-      <point x="687" y="478"/>
-      <point x="687" y="377" type="curve" smooth="yes"/>
-      <point x="687" y="229"/>
-      <point x="638" y="62"/>
+      <point x="500" y="62" type="curve" smooth="yes"/>
+      <point x="434" y="62"/>
+      <point x="401" y="107"/>
+      <point x="401" y="195" type="curve" smooth="yes"/>
+      <point x="401" y="303"/>
+      <point x="441" y="534"/>
+      <point x="590" y="534" type="curve" smooth="yes"/>
+      <point x="652" y="534"/>
+      <point x="684" y="488"/>
+      <point x="684" y="402" type="curve" smooth="yes"/>
+      <point x="684" y="286"/>
+      <point x="637" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/m_la-malayalam.glif
@@ -1,53 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="m_la-malayalam" format="2">
   <advance width="692"/>
-  <anchor x="230" y="-357" name="bottom"/>
-  <anchor x="407" y="596" name="top"/>
-  <anchor x="635" y="596" name="topright"/>
+  <anchor x="230" y="-362" name="bottom"/>
+  <anchor x="402" y="596" name="top"/>
+  <anchor x="630" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="26" y="-378" type="curve" smooth="yes"/>
-      <point x="113" y="-378"/>
-      <point x="163" y="-321"/>
-      <point x="163" y="-236" type="curve" smooth="yes"/>
-      <point x="163" y="-156"/>
-      <point x="118" y="-121"/>
-      <point x="52" y="-121" type="curve" smooth="yes"/>
-      <point x="19" y="-121"/>
-      <point x="-14" y="-134"/>
-      <point x="-37" y="-167" type="curve"/>
-      <point x="-47" y="-166" type="line"/>
-      <point x="-24" y="-72"/>
-      <point x="37" y="-22"/>
-      <point x="117" y="-22" type="curve" smooth="yes"/>
-      <point x="228" y="-22"/>
-      <point x="250" y="-91"/>
-      <point x="256" y="-180" type="curve" smooth="yes"/>
-      <point x="257" y="-196" type="line" smooth="yes"/>
-      <point x="264" y="-307"/>
-      <point x="308" y="-378"/>
-      <point x="425" y="-378" type="curve" smooth="yes"/>
-      <point x="559" y="-378"/>
-      <point x="609" y="-270"/>
-      <point x="609" y="-132" type="curve" smooth="yes"/>
-      <point x="609" y="-57"/>
-      <point x="586" y="7"/>
-      <point x="559" y="48" type="curve"/>
-      <point x="496" y="10" type="line"/>
-      <point x="512" y="-20"/>
-      <point x="533" y="-69"/>
-      <point x="533" y="-145" type="curve" smooth="yes"/>
-      <point x="533" y="-228"/>
-      <point x="505" y="-308"/>
-      <point x="426" y="-308" type="curve" smooth="yes"/>
-      <point x="365" y="-308"/>
-      <point x="341" y="-271"/>
-      <point x="332" y="-176" type="curve" smooth="yes"/>
-      <point x="330" y="-155" type="line" smooth="yes"/>
-      <point x="324" y="-89"/>
-      <point x="307" y="-38"/>
-      <point x="269" y="-10" type="curve"/>
-      <point x="270" y="0" type="line"/>
+      <point x="10" y="0" type="line"/>
       <point x="576" y="0" type="line"/>
       <point x="623" y="266" type="line" smooth="yes"/>
       <point x="631" y="313"/>
@@ -59,30 +18,75 @@
       <point x="218" y="612"/>
       <point x="102" y="520"/>
       <point x="74" y="360" type="curve" smooth="yes"/>
-      <point x="10" y="0" type="line"/>
-      <point x="42" y="0" type="line"/>
-      <point x="42" y="35" type="line"/>
-      <point x="-59" y="1"/>
-      <point x="-120" y="-95"/>
-      <point x="-120" y="-209" type="curve" smooth="yes"/>
-      <point x="-120" y="-328"/>
-      <point x="-55" y="-378"/>
     </contour>
     <contour>
-      <point x="25" y="-313" type="curve" smooth="yes"/>
-      <point x="-29" y="-313"/>
-      <point x="-52" y="-270"/>
-      <point x="-52" y="-223" type="curve"/>
-      <point x="-70" y="-200" type="line"/>
-      <point x="-59" y="-256" type="line"/>
-      <point x="-52" y="-216"/>
-      <point x="-18" y="-181"/>
-      <point x="31" y="-181" type="curve" smooth="yes"/>
-      <point x="73" y="-181"/>
-      <point x="92" y="-201"/>
-      <point x="92" y="-240" type="curve" smooth="yes"/>
-      <point x="92" y="-282"/>
-      <point x="69" y="-313"/>
+      <point x="95" y="-378" type="curve" smooth="yes"/>
+      <point x="199" y="-378"/>
+      <point x="237" y="-293"/>
+      <point x="237" y="-219" type="curve" smooth="yes"/>
+      <point x="237" y="-147"/>
+      <point x="208" y="-104"/>
+      <point x="144" y="-104" type="curve" smooth="yes"/>
+      <point x="88" y="-104"/>
+      <point x="41" y="-142"/>
+      <point x="28" y="-196" type="curve"/>
+      <point x="70" y="-157" type="line"/>
+      <point x="20" y="-141" type="line"/>
+      <point x="31" y="-201" type="line"/>
+      <point x="46" y="-88"/>
+      <point x="106" y="-18"/>
+      <point x="191" y="-18" type="curve" smooth="yes"/>
+      <point x="258" y="-18"/>
+      <point x="289" y="-56"/>
+      <point x="289" y="-153" type="curve" smooth="yes"/>
+      <point x="289" y="-236" type="line" smooth="yes"/>
+      <point x="289" y="-325"/>
+      <point x="330" y="-378"/>
+      <point x="408" y="-378" type="curve" smooth="yes"/>
+      <point x="528" y="-378"/>
+      <point x="561" y="-254"/>
+      <point x="561" y="-172" type="curve" smooth="yes"/>
+      <point x="561" y="-96"/>
+      <point x="541" y="-23"/>
+      <point x="501" y="45" type="curve"/>
+      <point x="438" y="8" type="line"/>
+      <point x="472" y="-50"/>
+      <point x="488" y="-106"/>
+      <point x="488" y="-170" type="curve" smooth="yes"/>
+      <point x="488" y="-224"/>
+      <point x="473" y="-308"/>
+      <point x="412" y="-308" type="curve" smooth="yes"/>
+      <point x="377" y="-308"/>
+      <point x="361" y="-285"/>
+      <point x="361" y="-224" type="curve" smooth="yes"/>
+      <point x="361" y="-141" type="line" smooth="yes"/>
+      <point x="361" y="-27"/>
+      <point x="314" y="32"/>
+      <point x="198" y="32" type="curve" smooth="yes"/>
+      <point x="36" y="32"/>
+      <point x="-35" y="-102"/>
+      <point x="-35" y="-231" type="curve" smooth="yes"/>
+      <point x="-35" y="-318"/>
+      <point x="9" y="-378"/>
+    </contour>
+    <contour>
+      <point x="97" y="-312" type="curve" smooth="yes"/>
+      <point x="54" y="-312"/>
+      <point x="31" y="-285"/>
+      <point x="31" y="-241" type="curve" smooth="yes"/>
+      <point x="31" y="-228"/>
+      <point x="32" y="-217"/>
+      <point x="35" y="-205" type="curve"/>
+      <point x="10" y="-221" type="line"/>
+      <point x="22" y="-250" type="line"/>
+      <point x="34" y="-198"/>
+      <point x="70" y="-164"/>
+      <point x="112" y="-164" type="curve" smooth="yes"/>
+      <point x="151" y="-164"/>
+      <point x="166" y="-185"/>
+      <point x="166" y="-223" type="curve" smooth="yes"/>
+      <point x="166" y="-275"/>
+      <point x="140" y="-312"/>
     </contour>
     <contour>
       <point x="68" y="45" type="line"/>
@@ -105,8 +109,8 @@
       <point x="462" y="339"/>
       <point x="462" y="415" type="curve" smooth="yes"/>
       <point x="462" y="493"/>
-      <point x="417" y="538"/>
-      <point x="336" y="541" type="curve"/>
+      <point x="417" y="539"/>
+      <point x="336" y="542" type="curve"/>
       <point x="336" y="577" type="line"/>
       <point x="322" y="550" type="line"/>
       <point x="337" y="552"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ng_ka-malayalam.glif
@@ -1,103 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng_ka-malayalam" format="2">
   <advance width="1066"/>
-  <anchor x="619" y="0" name="bottom"/>
-  <anchor x="607" y="596" name="top"/>
-  <anchor x="928" y="596" name="topright"/>
+  <anchor x="614" y="0" name="bottom"/>
+  <anchor x="604" y="596" name="top"/>
+  <anchor x="925" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="186" y="-16" type="curve" smooth="yes"/>
-      <point x="264" y="-16"/>
-      <point x="321" y="26"/>
-      <point x="348" y="90" type="curve"/>
-      <point x="358" y="90" type="line"/>
-      <point x="385" y="23"/>
-      <point x="438" y="-16"/>
-      <point x="527" y="-16" type="curve" smooth="yes"/>
-      <point x="693" y="-16"/>
-      <point x="778" y="175"/>
-      <point x="778" y="375" type="curve" smooth="yes"/>
-      <point x="778" y="519"/>
-      <point x="718" y="612"/>
-      <point x="595" y="612" type="curve" smooth="yes"/>
-      <point x="518" y="612"/>
-      <point x="456" y="572"/>
-      <point x="418" y="500" type="curve"/>
-      <point x="407" y="500" type="line"/>
-      <point x="393" y="564"/>
-      <point x="346" y="612"/>
-      <point x="254" y="612" type="curve" smooth="yes"/>
+      <point x="177" y="-16" type="curve" smooth="yes"/>
+      <point x="248" y="-16"/>
+      <point x="301" y="19"/>
+      <point x="337" y="91" type="curve"/>
+      <point x="348" y="91" type="line"/>
+      <point x="368" y="26"/>
+      <point x="420" y="-16"/>
+      <point x="500" y="-16" type="curve" smooth="yes"/>
+      <point x="711" y="-16"/>
+      <point x="774" y="265"/>
+      <point x="774" y="396" type="curve" smooth="yes"/>
+      <point x="774" y="529"/>
+      <point x="713" y="612"/>
+      <point x="604" y="612" type="curve" smooth="yes"/>
+      <point x="524" y="612"/>
+      <point x="458" y="572"/>
+      <point x="418" y="495" type="curve"/>
+      <point x="408" y="495" type="line"/>
+      <point x="397" y="562"/>
+      <point x="352" y="612"/>
+      <point x="265" y="612" type="curve" smooth="yes"/>
       <point x="157" y="612"/>
-      <point x="81" y="544"/>
-      <point x="81" y="443" type="curve" smooth="yes"/>
-      <point x="81" y="386"/>
-      <point x="108" y="337"/>
-      <point x="157" y="312" type="curve"/>
-      <point x="156" y="302" type="line"/>
-      <point x="78" y="286"/>
-      <point x="21" y="227"/>
-      <point x="21" y="141" type="curve" smooth="yes"/>
-      <point x="21" y="50"/>
-      <point x="77" y="-16"/>
+      <point x="79" y="542"/>
+      <point x="79" y="443" type="curve" smooth="yes"/>
+      <point x="79" y="393"/>
+      <point x="104" y="351"/>
+      <point x="146" y="325" type="curve"/>
+      <point x="145" y="315" type="line"/>
+      <point x="68" y="283"/>
+      <point x="20" y="215"/>
+      <point x="20" y="136" type="curve" smooth="yes"/>
+      <point x="20" y="46"/>
+      <point x="85" y="-16"/>
     </contour>
     <contour>
-      <point x="527" y="62" type="curve" smooth="yes"/>
-      <point x="443" y="62"/>
-      <point x="411" y="119"/>
-      <point x="411" y="205" type="curve" smooth="yes"/>
-      <point x="411" y="354"/>
-      <point x="465" y="534"/>
-      <point x="589" y="534" type="curve" smooth="yes"/>
-      <point x="663" y="534"/>
-      <point x="691" y="478"/>
-      <point x="691" y="377" type="curve" smooth="yes"/>
-      <point x="691" y="229"/>
-      <point x="642" y="62"/>
-    </contour>
-    <contour>
-      <point x="828" y="-16" type="curve" smooth="yes"/>
-      <point x="944" y="-16"/>
-      <point x="1005" y="59"/>
-      <point x="1005" y="168" type="curve" smooth="yes"/>
-      <point x="1005" y="267"/>
-      <point x="946" y="333"/>
-      <point x="814" y="333" type="curve" smooth="yes"/>
-      <point x="287" y="333" type="line" smooth="yes"/>
-      <point x="198" y="333"/>
-      <point x="163" y="379"/>
-      <point x="163" y="435" type="curve" smooth="yes"/>
-      <point x="163" y="495"/>
+      <point x="806" y="-16" type="curve" smooth="yes"/>
+      <point x="920" y="-16"/>
+      <point x="999" y="65"/>
+      <point x="999" y="180" type="curve" smooth="yes"/>
+      <point x="999" y="289"/>
+      <point x="926" y="353"/>
+      <point x="801" y="353" type="curve" smooth="yes"/>
+      <point x="274" y="353" type="line" smooth="yes"/>
+      <point x="202" y="353"/>
+      <point x="159" y="385"/>
+      <point x="159" y="440" type="curve" smooth="yes"/>
+      <point x="159" y="495"/>
       <point x="202" y="534"/>
-      <point x="265" y="534" type="curve" smooth="yes"/>
-      <point x="331" y="534"/>
-      <point x="361" y="492"/>
-      <point x="361" y="430" type="curve" smooth="yes"/>
-      <point x="361" y="410"/>
-      <point x="358" y="384"/>
-      <point x="352" y="353" type="curve" smooth="yes"/>
-      <point x="328" y="221" type="line" smooth="yes"/>
-      <point x="308" y="109"/>
-      <point x="261" y="62"/>
-      <point x="196" y="62" type="curve" smooth="yes"/>
-      <point x="135" y="62"/>
-      <point x="105" y="95"/>
-      <point x="105" y="148" type="curve" smooth="yes"/>
-      <point x="105" y="214"/>
-      <point x="149" y="259"/>
-      <point x="237" y="259" type="curve" smooth="yes"/>
-      <point x="806" y="259" type="line" smooth="yes"/>
-      <point x="888" y="259"/>
-      <point x="923" y="227"/>
-      <point x="923" y="165" type="curve" smooth="yes"/>
-      <point x="923" y="112"/>
-      <point x="899" y="60"/>
-      <point x="826" y="60" type="curve" smooth="yes"/>
-      <point x="801" y="60"/>
-      <point x="780" y="66"/>
-      <point x="765" y="73" type="curve"/>
-      <point x="734" y="3" type="line"/>
-      <point x="757" y="-9"/>
-      <point x="791" y="-16"/>
+      <point x="264" y="534" type="curve" smooth="yes"/>
+      <point x="332" y="534"/>
+      <point x="358" y="497"/>
+      <point x="358" y="438" type="curve" smooth="yes"/>
+      <point x="358" y="420"/>
+      <point x="356" y="400"/>
+      <point x="352" y="378" type="curve" smooth="yes"/>
+      <point x="323" y="212" type="line" smooth="yes"/>
+      <point x="306" y="114"/>
+      <point x="260" y="62"/>
+      <point x="192" y="62" type="curve" smooth="yes"/>
+      <point x="138" y="62"/>
+      <point x="105" y="94"/>
+      <point x="105" y="146" type="curve" smooth="yes"/>
+      <point x="105" y="228"/>
+      <point x="165" y="279"/>
+      <point x="261" y="279" type="curve" smooth="yes"/>
+      <point x="798" y="279" type="line" smooth="yes"/>
+      <point x="878" y="279"/>
+      <point x="918" y="245"/>
+      <point x="918" y="178" type="curve" smooth="yes"/>
+      <point x="918" y="105"/>
+      <point x="877" y="60"/>
+      <point x="812" y="60" type="curve" smooth="yes"/>
+      <point x="791" y="60"/>
+      <point x="772" y="63"/>
+      <point x="755" y="69" type="curve"/>
+      <point x="732" y="-3" type="line"/>
+      <point x="754" y="-12"/>
+      <point x="779" y="-16"/>
+    </contour>
+    <contour>
+      <point x="505" y="62" type="curve" smooth="yes"/>
+      <point x="439" y="62"/>
+      <point x="406" y="107"/>
+      <point x="406" y="195" type="curve" smooth="yes"/>
+      <point x="406" y="303"/>
+      <point x="446" y="534"/>
+      <point x="595" y="534" type="curve" smooth="yes"/>
+      <point x="657" y="534"/>
+      <point x="689" y="488"/>
+      <point x="689" y="402" type="curve" smooth="yes"/>
+      <point x="689" y="286"/>
+      <point x="642" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,192 +1,193 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1542"/>
-  <anchor x="1098" y="16" name="bottom"/>
-  <anchor x="859" y="596" name="top"/>
-  <anchor x="1467" y="596" name="topright"/>
+  <advance width="1592"/>
+  <anchor x="1113" y="-6" name="bottom"/>
+  <anchor x="849" y="596" name="top"/>
+  <anchor x="1481" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="260" y="-16" type="curve" smooth="yes"/>
-      <point x="375" y="-16"/>
-      <point x="445" y="60"/>
-      <point x="445" y="185" type="curve" smooth="yes"/>
-      <point x="445" y="293"/>
-      <point x="389" y="356"/>
-      <point x="293" y="356" type="curve" smooth="yes"/>
-      <point x="232" y="356"/>
-      <point x="181" y="330"/>
-      <point x="145" y="281" type="curve"/>
-      <point x="109" y="287" type="line"/>
-      <point x="120" y="153" type="line"/>
-      <point x="144" y="229"/>
-      <point x="206" y="282"/>
-      <point x="271" y="282" type="curve" smooth="yes"/>
-      <point x="333" y="282"/>
-      <point x="363" y="250"/>
-      <point x="363" y="184" type="curve" smooth="yes"/>
-      <point x="363" y="106"/>
-      <point x="325" y="62"/>
-      <point x="258" y="62" type="curve" smooth="yes"/>
-      <point x="177" y="62"/>
-      <point x="130" y="120"/>
-      <point x="130" y="220" type="curve" smooth="yes"/>
-      <point x="130" y="406"/>
-      <point x="233" y="534"/>
+      <point x="245" y="-16" type="curve" smooth="yes"/>
+      <point x="378" y="-16"/>
+      <point x="440" y="94"/>
+      <point x="440" y="191" type="curve" smooth="yes"/>
+      <point x="440" y="293"/>
+      <point x="386" y="356"/>
+      <point x="288" y="356" type="curve" smooth="yes"/>
+      <point x="230" y="356"/>
+      <point x="179" y="331"/>
+      <point x="145" y="289" type="curve"/>
+      <point x="110" y="296" type="line"/>
+      <point x="114" y="153" type="line"/>
+      <point x="139" y="229"/>
+      <point x="205" y="282"/>
+      <point x="272" y="282" type="curve" smooth="yes"/>
+      <point x="331" y="282"/>
+      <point x="358" y="249"/>
+      <point x="358" y="189" type="curve" smooth="yes"/>
+      <point x="358" y="128"/>
+      <point x="327" y="62"/>
+      <point x="247" y="62" type="curve" smooth="yes"/>
+      <point x="173" y="62"/>
+      <point x="129" y="124"/>
+      <point x="129" y="231" type="curve" smooth="yes"/>
+      <point x="129" y="376"/>
+      <point x="207" y="534"/>
       <point x="383" y="534" type="curve" smooth="yes"/>
-      <point x="490" y="534"/>
-      <point x="546" y="479"/>
-      <point x="546" y="372" type="curve" smooth="yes"/>
-      <point x="546" y="354"/>
-      <point x="544" y="335"/>
-      <point x="540" y="314" type="curve" smooth="yes"/>
-      <point x="484" y="0" type="line"/>
-      <point x="568" y="0" type="line"/>
-      <point x="627" y="333" type="line" smooth="yes"/>
-      <point x="651" y="470"/>
-      <point x="720" y="545"/>
-      <point x="843" y="545" type="curve" smooth="yes"/>
-      <point x="861" y="545"/>
-      <point x="881" y="544"/>
-      <point x="894" y="543" type="curve"/>
-      <point x="858" y="586" type="line"/>
-      <point x="858" y="534" type="line"/>
-      <point x="818" y="517"/>
-      <point x="792" y="484"/>
-      <point x="792" y="431" type="curve" smooth="yes"/>
-      <point x="792" y="360"/>
-      <point x="843" y="310"/>
-      <point x="930" y="310" type="curve" smooth="yes"/>
-      <point x="1021" y="310"/>
-      <point x="1073" y="367"/>
-      <point x="1073" y="447" type="curve" smooth="yes"/>
-      <point x="1073" y="486"/>
-      <point x="1056" y="525"/>
-      <point x="1009" y="546" type="curve"/>
-      <point x="1017" y="604" type="line"/>
-      <point x="950" y="553" type="line"/>
-      <point x="963" y="555"/>
-      <point x="979" y="556"/>
-      <point x="1001" y="556" type="curve" smooth="yes"/>
-      <point x="1088" y="556"/>
-      <point x="1130" y="515"/>
-      <point x="1130" y="435" type="curve" smooth="yes"/>
-      <point x="1130" y="414"/>
-      <point x="1129" y="400"/>
-      <point x="1125" y="380" type="curve" smooth="yes"/>
-      <point x="1120" y="353" type="line"/>
-      <point x="1204" y="353" type="line"/>
-      <point x="1210" y="388" type="line" smooth="yes"/>
-      <point x="1226" y="480"/>
-      <point x="1277" y="534"/>
-      <point x="1344" y="534" type="curve" smooth="yes"/>
-      <point x="1405" y="534"/>
-      <point x="1436" y="503"/>
-      <point x="1436" y="442" type="curve" smooth="yes"/>
-      <point x="1436" y="348"/>
-      <point x="1375" y="294"/>
-      <point x="1269" y="294" type="curve" smooth="yes"/>
-      <point x="959" y="294" type="line" smooth="yes"/>
-      <point x="823" y="294"/>
-      <point x="744" y="231"/>
-      <point x="744" y="121" type="curve" smooth="yes"/>
-      <point x="744" y="36"/>
-      <point x="794" y="-16"/>
-      <point x="875" y="-16" type="curve" smooth="yes"/>
-      <point x="928" y="-16"/>
-      <point x="983" y="3"/>
-      <point x="1082" y="58" type="curve" smooth="yes"/>
-      <point x="1151" y="96" type="line"/>
-      <point x="1268" y="159" type="line"/>
-      <point x="1278" y="161" type="line"/>
-      <point x="1300" y="170"/>
-      <point x="1317" y="172"/>
-      <point x="1339" y="172" type="curve" smooth="yes"/>
-      <point x="1374" y="172"/>
-      <point x="1392" y="154"/>
-      <point x="1392" y="121" type="curve" smooth="yes"/>
-      <point x="1392" y="75"/>
-      <point x="1368" y="48"/>
-      <point x="1329" y="48" type="curve" smooth="yes"/>
-      <point x="1297" y="48"/>
-      <point x="1276" y="69"/>
-      <point x="1276" y="101" type="curve" smooth="yes"/>
-      <point x="1276" y="137"/>
-      <point x="1290" y="163"/>
-      <point x="1327" y="190" type="curve"/>
-      <point x="1202" y="166" type="line"/>
-      <point x="1245" y="108" type="line"/>
-      <point x="1261" y="160" type="line"/>
-      <point x="1235" y="142"/>
-      <point x="1219" y="115"/>
-      <point x="1219" y="80" type="curve" smooth="yes"/>
-      <point x="1219" y="24"/>
-      <point x="1262" y="-16"/>
-      <point x="1327" y="-16" type="curve" smooth="yes"/>
-      <point x="1411" y="-16"/>
-      <point x="1459" y="35"/>
-      <point x="1459" y="124" type="curve" smooth="yes"/>
-      <point x="1459" y="196"/>
-      <point x="1421" y="238"/>
-      <point x="1355" y="238" type="curve" smooth="yes"/>
-      <point x="1297" y="238"/>
-      <point x="1258" y="225"/>
-      <point x="1147" y="169" type="curve" smooth="yes"/>
-      <point x="1064" y="127" type="line" smooth="yes"/>
-      <point x="953" y="71"/>
-      <point x="928" y="61"/>
-      <point x="888" y="61" type="curve" smooth="yes"/>
-      <point x="846" y="61"/>
-      <point x="823" y="85"/>
-      <point x="823" y="129" type="curve" smooth="yes"/>
-      <point x="823" y="189"/>
-      <point x="868" y="222"/>
-      <point x="949" y="222" type="curve" smooth="yes"/>
-      <point x="1257" y="222" type="line" smooth="yes"/>
-      <point x="1419" y="222"/>
-      <point x="1520" y="309"/>
-      <point x="1520" y="449" type="curve" smooth="yes"/>
-      <point x="1520" y="546"/>
-      <point x="1456" y="612"/>
-      <point x="1362" y="612" type="curve" smooth="yes"/>
-      <point x="1284" y="612"/>
-      <point x="1220" y="569"/>
-      <point x="1191" y="490" type="curve"/>
-      <point x="1181" y="490" type="line"/>
-      <point x="1166" y="571"/>
-      <point x="1107" y="612"/>
-      <point x="1015" y="612" type="curve" smooth="yes"/>
-      <point x="971" y="612"/>
-      <point x="939" y="604"/>
-      <point x="914" y="592" type="curve"/>
-      <point x="930" y="544" type="line"/>
-      <point x="982" y="524"/>
-      <point x="998" y="495"/>
-      <point x="998" y="456" type="curve" smooth="yes"/>
-      <point x="998" y="415"/>
-      <point x="977" y="380"/>
-      <point x="932" y="380" type="curve" smooth="yes"/>
-      <point x="891" y="380"/>
-      <point x="866" y="407"/>
-      <point x="866" y="449" type="curve" smooth="yes"/>
-      <point x="866" y="500"/>
-      <point x="901" y="550"/>
-      <point x="992" y="550" type="curve"/>
-      <point x="1000" y="575" type="line"/>
-      <point x="976" y="594"/>
-      <point x="934" y="612"/>
+      <point x="489" y="534"/>
+      <point x="541" y="474"/>
+      <point x="541" y="380" type="curve" smooth="yes"/>
+      <point x="541" y="359"/>
+      <point x="539" y="339"/>
+      <point x="535" y="316" type="curve" smooth="yes"/>
+      <point x="479" y="0" type="line"/>
+      <point x="563" y="0" type="line"/>
+      <point x="622" y="333" type="line" smooth="yes"/>
+      <point x="647" y="475"/>
+      <point x="725" y="548"/>
+      <point x="857" y="548" type="curve" smooth="yes"/>
+      <point x="868" y="548"/>
+      <point x="880" y="547"/>
+      <point x="891" y="546" type="curve"/>
+      <point x="847" y="565" type="line"/>
+      <point x="847" y="538" type="line"/>
+      <point x="809" y="512"/>
+      <point x="784" y="465"/>
+      <point x="784" y="415" type="curve" smooth="yes"/>
+      <point x="784" y="341"/>
+      <point x="837" y="286"/>
+      <point x="918" y="286" type="curve" smooth="yes"/>
+      <point x="1035" y="286"/>
+      <point x="1075" y="375"/>
+      <point x="1075" y="440" type="curve" smooth="yes"/>
+      <point x="1075" y="485"/>
+      <point x="1057" y="522"/>
+      <point x="1027" y="545" type="curve"/>
+      <point x="1045" y="582" type="line"/>
+      <point x="994" y="551" type="line"/>
+      <point x="1003" y="553"/>
+      <point x="1014" y="554"/>
+      <point x="1026" y="554" type="curve" smooth="yes"/>
+      <point x="1105" y="554"/>
+      <point x="1140" y="505"/>
+      <point x="1140" y="436" type="curve" smooth="yes"/>
+      <point x="1140" y="422"/>
+      <point x="1139" y="407"/>
+      <point x="1136" y="390" type="curve" smooth="yes"/>
+      <point x="1126" y="333" type="line"/>
+      <point x="1210" y="333" type="line"/>
+      <point x="1220" y="390" type="line" smooth="yes"/>
+      <point x="1236" y="481"/>
+      <point x="1294" y="534"/>
+      <point x="1375" y="534" type="curve" smooth="yes"/>
+      <point x="1441" y="534"/>
+      <point x="1477" y="499"/>
+      <point x="1477" y="433" type="curve" smooth="yes"/>
+      <point x="1477" y="328"/>
+      <point x="1404" y="264"/>
+      <point x="1261" y="264" type="curve" smooth="yes"/>
+      <point x="925" y="264" type="line" smooth="yes"/>
+      <point x="815" y="264"/>
+      <point x="737" y="207"/>
+      <point x="737" y="114" type="curve" smooth="yes"/>
+      <point x="737" y="34"/>
+      <point x="797" y="-16"/>
+      <point x="884" y="-16" type="curve" smooth="yes"/>
+      <point x="933" y="-16"/>
+      <point x="969" y="-6"/>
+      <point x="1040" y="27" type="curve" smooth="yes"/>
+      <point x="1196" y="99" type="line"/>
+      <point x="1269" y="148" type="line"/>
+      <point x="1297" y="154" type="line"/>
+      <point x="1328" y="172"/>
+      <point x="1350" y="178"/>
+      <point x="1378" y="178" type="curve" smooth="yes"/>
+      <point x="1416" y="178"/>
+      <point x="1433" y="157"/>
+      <point x="1433" y="124" type="curve" smooth="yes"/>
+      <point x="1433" y="92"/>
+      <point x="1413" y="56"/>
+      <point x="1362" y="56" type="curve" smooth="yes"/>
+      <point x="1326" y="56"/>
+      <point x="1305" y="77"/>
+      <point x="1305" y="109" type="curve" smooth="yes"/>
+      <point x="1305" y="140"/>
+      <point x="1319" y="161"/>
+      <point x="1346" y="188" type="curve"/>
+      <point x="1242" y="148" type="line"/>
+      <point x="1258" y="128" type="line"/>
+      <point x="1249" y="114"/>
+      <point x="1244" y="98"/>
+      <point x="1244" y="80" type="curve" smooth="yes"/>
+      <point x="1244" y="22"/>
+      <point x="1288" y="-16"/>
+      <point x="1355" y="-16" type="curve" smooth="yes"/>
+      <point x="1463" y="-16"/>
+      <point x="1504" y="69"/>
+      <point x="1504" y="126" type="curve" smooth="yes"/>
+      <point x="1504" y="189"/>
+      <point x="1465" y="232"/>
+      <point x="1394" y="232" type="curve" smooth="yes"/>
+      <point x="1348" y="232"/>
+      <point x="1309" y="224"/>
+      <point x="1227" y="186" type="curve" smooth="yes"/>
+      <point x="1018" y="89" type="line" smooth="yes"/>
+      <point x="970" y="67"/>
+      <point x="933" y="58"/>
+      <point x="888" y="58" type="curve" smooth="yes"/>
+      <point x="846" y="58"/>
+      <point x="819" y="82"/>
+      <point x="819" y="119" type="curve" smooth="yes"/>
+      <point x="819" y="164"/>
+      <point x="855" y="192"/>
+      <point x="922" y="192" type="curve" smooth="yes"/>
+      <point x="1243" y="192" type="line" smooth="yes"/>
+      <point x="1425" y="192"/>
+      <point x="1559" y="286"/>
+      <point x="1559" y="438" type="curve" smooth="yes"/>
+      <point x="1559" y="546"/>
+      <point x="1497" y="612"/>
+      <point x="1392" y="612" type="curve" smooth="yes"/>
+      <point x="1304" y="612"/>
+      <point x="1239" y="570"/>
+      <point x="1205" y="491" type="curve"/>
+      <point x="1197" y="491" type="line"/>
+      <point x="1180" y="571"/>
+      <point x="1128" y="612"/>
+      <point x="1028" y="612" type="curve" smooth="yes"/>
+      <point x="994" y="612"/>
+      <point x="961" y="607"/>
+      <point x="931" y="596" type="curve"/>
+      <point x="954" y="594" type="line"/>
+      <point x="927" y="604"/>
+      <point x="893" y="612"/>
       <point x="854" y="612" type="curve" smooth="yes"/>
-      <point x="738" y="612"/>
-      <point x="652" y="567"/>
-      <point x="605" y="480" type="curve"/>
-      <point x="595" y="480" type="line"/>
-      <point x="562" y="567"/>
+      <point x="741" y="612"/>
+      <point x="655" y="565"/>
+      <point x="606" y="477" type="curve"/>
+      <point x="596" y="477" type="line"/>
+      <point x="563" y="566"/>
       <point x="489" y="612"/>
       <point x="385" y="612" type="curve" smooth="yes"/>
-      <point x="189" y="612"/>
-      <point x="50" y="449"/>
-      <point x="50" y="229" type="curve" smooth="yes"/>
-      <point x="50" y="79"/>
-      <point x="135" y="-16"/>
+      <point x="147" y="612"/>
+      <point x="49" y="401"/>
+      <point x="49" y="229" type="curve" smooth="yes"/>
+      <point x="49" y="79"/>
+      <point x="128" y="-16"/>
+    </contour>
+    <contour>
+      <point x="924" y="356" type="curve" smooth="yes"/>
+      <point x="884" y="356"/>
+      <point x="861" y="383"/>
+      <point x="861" y="424" type="curve" smooth="yes"/>
+      <point x="861" y="484"/>
+      <point x="903" y="533"/>
+      <point x="986" y="553" type="curve"/>
+      <point x="921" y="553" type="line"/>
+      <point x="979" y="532"/>
+      <point x="1002" y="497"/>
+      <point x="1002" y="446" type="curve" smooth="yes"/>
+      <point x="1002" y="406"/>
+      <point x="977" y="356"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/rr_rra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/rr_rra-malayalam.glif
@@ -1,38 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="rr_rra-malayalam" format="2">
-  <advance width="730"/>
+  <advance width="720"/>
   <anchor x="271" y="-327" name="bottom"/>
   <anchor x="412" y="596" name="top"/>
   <anchor x="623" y="596" name="topright"/>
   <outline>
-    <contour>
-      <point x="154" y="-343" type="curve"/>
-      <point x="209" y="-297" type="line"/>
-      <point x="189" y="-270"/>
-      <point x="166" y="-230"/>
-      <point x="166" y="-160" type="curve" smooth="yes"/>
-      <point x="166" y="-71"/>
-      <point x="210" y="13"/>
-      <point x="319" y="13" type="curve" smooth="yes"/>
-      <point x="387" y="13"/>
-      <point x="438" y="-24"/>
-      <point x="438" y="-109" type="curve" smooth="yes"/>
-      <point x="438" y="-188"/>
-      <point x="395" y="-242"/>
-      <point x="333" y="-292" type="curve"/>
-      <point x="378" y="-343" type="line"/>
-      <point x="463" y="-281"/>
-      <point x="513" y="-208"/>
-      <point x="513" y="-106" type="curve" smooth="yes"/>
-      <point x="513" y="21"/>
-      <point x="434" y="83"/>
-      <point x="318" y="83" type="curve" smooth="yes"/>
-      <point x="165" y="83"/>
-      <point x="91" y="-33"/>
-      <point x="91" y="-161" type="curve" smooth="yes"/>
-      <point x="91" y="-241"/>
-      <point x="114" y="-300"/>
-    </contour>
     <contour>
       <point x="170" y="-16" type="curve"/>
       <point x="228" y="45" type="line"/>
@@ -60,6 +32,34 @@
       <point x="53" y="256" type="curve" smooth="yes"/>
       <point x="53" y="144"/>
       <point x="94" y="48"/>
+    </contour>
+    <contour>
+      <point x="154" y="-343" type="curve"/>
+      <point x="209" y="-297" type="line"/>
+      <point x="189" y="-270"/>
+      <point x="166" y="-230"/>
+      <point x="166" y="-160" type="curve" smooth="yes"/>
+      <point x="166" y="-71"/>
+      <point x="210" y="13"/>
+      <point x="319" y="13" type="curve" smooth="yes"/>
+      <point x="387" y="13"/>
+      <point x="438" y="-24"/>
+      <point x="438" y="-109" type="curve" smooth="yes"/>
+      <point x="438" y="-188"/>
+      <point x="395" y="-242"/>
+      <point x="333" y="-292" type="curve"/>
+      <point x="378" y="-343" type="line"/>
+      <point x="463" y="-281"/>
+      <point x="513" y="-208"/>
+      <point x="513" y="-106" type="curve" smooth="yes"/>
+      <point x="513" y="21"/>
+      <point x="434" y="83"/>
+      <point x="318" y="83" type="curve" smooth="yes"/>
+      <point x="165" y="83"/>
+      <point x="91" y="-33"/>
+      <point x="91" y="-161" type="curve" smooth="yes"/>
+      <point x="91" y="-241"/>
+      <point x="114" y="-300"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/t_la-malayalam.glif
@@ -1,136 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_la-malayalam" format="2">
   <advance width="1005"/>
-  <anchor x="481" y="-357" name="bottom"/>
-  <anchor x="558" y="596" name="top"/>
-  <anchor x="885" y="596" name="topright"/>
+  <anchor x="494" y="-362" name="bottom"/>
+  <anchor x="554" y="596" name="top"/>
+  <anchor x="881" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="277" y="-378" type="curve" smooth="yes"/>
-      <point x="364" y="-378"/>
-      <point x="414" y="-321"/>
-      <point x="414" y="-236" type="curve" smooth="yes"/>
-      <point x="414" y="-156"/>
-      <point x="369" y="-121"/>
-      <point x="303" y="-121" type="curve" smooth="yes"/>
-      <point x="270" y="-121"/>
-      <point x="238" y="-134"/>
-      <point x="214" y="-167" type="curve"/>
-      <point x="204" y="-166" type="line"/>
-      <point x="227" y="-72"/>
-      <point x="288" y="-22"/>
-      <point x="368" y="-22" type="curve" smooth="yes"/>
-      <point x="479" y="-22"/>
-      <point x="501" y="-91"/>
-      <point x="507" y="-180" type="curve" smooth="yes"/>
-      <point x="508" y="-196" type="line" smooth="yes"/>
-      <point x="515" y="-307"/>
-      <point x="559" y="-378"/>
-      <point x="676" y="-378" type="curve" smooth="yes"/>
-      <point x="810" y="-378"/>
-      <point x="860" y="-270"/>
-      <point x="860" y="-132" type="curve" smooth="yes"/>
-      <point x="860" y="-59"/>
-      <point x="838" y="3"/>
-      <point x="812" y="44" type="curve"/>
-      <point x="802" y="18" type="line"/>
-      <point x="901" y="106"/>
-      <point x="949" y="210"/>
-      <point x="949" y="336" type="curve" smooth="yes"/>
-      <point x="949" y="513"/>
-      <point x="853" y="612"/>
-      <point x="683" y="612" type="curve" smooth="yes"/>
-      <point x="477" y="612"/>
-      <point x="295" y="418"/>
-      <point x="295" y="199" type="curve" smooth="yes"/>
-      <point x="295" y="139"/>
-      <point x="310" y="88"/>
-      <point x="348" y="50" type="curve"/>
-      <point x="345" y="40" type="line"/>
-      <point x="210" y="21"/>
-      <point x="131" y="-82"/>
-      <point x="131" y="-209" type="curve" smooth="yes"/>
-      <point x="131" y="-328"/>
-      <point x="196" y="-378"/>
+      <point x="276" y="-378" type="curve" smooth="yes"/>
+      <point x="375" y="-378"/>
+      <point x="421" y="-300"/>
+      <point x="421" y="-234" type="curve" smooth="yes"/>
+      <point x="421" y="-166"/>
+      <point x="386" y="-121"/>
+      <point x="323" y="-121" type="curve" smooth="yes"/>
+      <point x="275" y="-121"/>
+      <point x="209" y="-155"/>
+      <point x="195" y="-236" type="curve"/>
+      <point x="230" y="-175" type="line"/>
+      <point x="171" y="-175" type="line"/>
+      <point x="205" y="-201" type="line"/>
+      <point x="222" y="-94"/>
+      <point x="304" y="-22"/>
+      <point x="388" y="-22" type="curve" smooth="yes"/>
+      <point x="466" y="-22"/>
+      <point x="495" y="-61"/>
+      <point x="511" y="-160" type="curve" smooth="yes"/>
+      <point x="518" y="-203" type="line" smooth="yes"/>
+      <point x="538" y="-323"/>
+      <point x="587" y="-378"/>
+      <point x="678" y="-378" type="curve" smooth="yes"/>
+      <point x="820" y="-378"/>
+      <point x="864" y="-231"/>
+      <point x="864" y="-135" type="curve" smooth="yes"/>
+      <point x="864" y="-59"/>
+      <point x="844" y="0"/>
+      <point x="814" y="46" type="curve"/>
+      <point x="813" y="21" type="line"/>
+      <point x="914" y="132"/>
+      <point x="955" y="249"/>
+      <point x="955" y="362" type="curve" smooth="yes"/>
+      <point x="955" y="515"/>
+      <point x="870" y="612"/>
+      <point x="704" y="612" type="curve" smooth="yes"/>
+      <point x="638" y="612"/>
+      <point x="578" y="595"/>
+      <point x="524" y="567" type="curve"/>
+      <point x="566" y="564" type="line"/>
+      <point x="524" y="594"/>
+      <point x="471" y="612"/>
+      <point x="408" y="612" type="curve" smooth="yes"/>
+      <point x="185" y="612"/>
+      <point x="49" y="429"/>
+      <point x="49" y="235" type="curve" smooth="yes"/>
+      <point x="49" y="143"/>
+      <point x="75" y="58"/>
+      <point x="129" y="-16" type="curve"/>
+      <point x="193" y="31" type="line"/>
+      <point x="149" y="92"/>
+      <point x="131" y="161"/>
+      <point x="131" y="236" type="curve" smooth="yes"/>
+      <point x="131" y="404"/>
+      <point x="233" y="534"/>
+      <point x="399" y="534" type="curve" smooth="yes"/>
+      <point x="431" y="534"/>
+      <point x="459" y="528"/>
+      <point x="484" y="518" type="curve"/>
+      <point x="483" y="542" type="line"/>
+      <point x="361" y="458"/>
+      <point x="285" y="314"/>
+      <point x="285" y="190" type="curve" smooth="yes"/>
+      <point x="285" y="129"/>
+      <point x="306" y="79"/>
+      <point x="338" y="43" type="curve"/>
+      <point x="336" y="32" type="line"/>
+      <point x="214" y="7"/>
+      <point x="138" y="-111"/>
+      <point x="138" y="-227" type="curve" smooth="yes"/>
+      <point x="138" y="-321"/>
+      <point x="198" y="-378"/>
     </contour>
     <contour>
-      <point x="677" y="-308" type="curve" smooth="yes"/>
-      <point x="616" y="-308"/>
-      <point x="592" y="-271"/>
-      <point x="583" y="-176" type="curve" smooth="yes"/>
-      <point x="581" y="-155" type="line" smooth="yes"/>
-      <point x="575" y="-96"/>
-      <point x="562" y="-52"/>
-      <point x="526" y="-17" type="curve"/>
-      <point x="528" y="-7" type="line"/>
-      <point x="638" y="18"/>
-      <point x="701" y="127"/>
-      <point x="701" y="275" type="curve" smooth="yes"/>
-      <point x="701" y="392"/>
-      <point x="660" y="487"/>
-      <point x="589" y="546" type="curve"/>
-      <point x="518" y="503" type="line"/>
-      <point x="581" y="463"/>
-      <point x="615" y="385"/>
-      <point x="615" y="275" type="curve" smooth="yes"/>
-      <point x="615" y="136"/>
-      <point x="570" y="62"/>
-      <point x="484" y="62" type="curve" smooth="yes"/>
-      <point x="413" y="62"/>
-      <point x="377" y="109"/>
-      <point x="377" y="199" type="curve" smooth="yes"/>
-      <point x="377" y="387"/>
-      <point x="510" y="534"/>
-      <point x="681" y="534" type="curve" smooth="yes"/>
-      <point x="803" y="534"/>
-      <point x="867" y="466"/>
-      <point x="867" y="336" type="curve" smooth="yes"/>
-      <point x="867" y="218"/>
-      <point x="818" y="128"/>
-      <point x="722" y="43" type="curve"/>
-      <point x="746" y="11"/>
-      <point x="784" y="-52"/>
-      <point x="784" y="-145" type="curve" smooth="yes"/>
-      <point x="784" y="-228"/>
-      <point x="756" y="-308"/>
+      <point x="279" y="-313" type="curve" smooth="yes"/>
+      <point x="233" y="-313"/>
+      <point x="205" y="-276"/>
+      <point x="205" y="-227" type="curve" smooth="yes"/>
+      <point x="205" y="-219"/>
+      <point x="206" y="-211"/>
+      <point x="208" y="-203" type="curve"/>
+      <point x="188" y="-218" type="line"/>
+      <point x="197" y="-268" type="line"/>
+      <point x="205" y="-224"/>
+      <point x="246" y="-181"/>
+      <point x="299" y="-181" type="curve" smooth="yes"/>
+      <point x="335" y="-181"/>
+      <point x="351" y="-202"/>
+      <point x="351" y="-236" type="curve" smooth="yes"/>
+      <point x="351" y="-270"/>
+      <point x="332" y="-313"/>
     </contour>
     <contour>
-      <point x="276" y="-313" type="curve" smooth="yes"/>
-      <point x="222" y="-313"/>
-      <point x="199" y="-270"/>
-      <point x="199" y="-223" type="curve"/>
-      <point x="181" y="-200" type="line"/>
-      <point x="192" y="-256" type="line"/>
-      <point x="199" y="-216"/>
-      <point x="233" y="-181"/>
-      <point x="282" y="-181" type="curve" smooth="yes"/>
-      <point x="324" y="-181"/>
-      <point x="343" y="-201"/>
-      <point x="343" y="-240" type="curve" smooth="yes"/>
-      <point x="343" y="-282"/>
-      <point x="320" y="-313"/>
+      <point x="468" y="62" type="curve" smooth="yes"/>
+      <point x="403" y="62"/>
+      <point x="368" y="107"/>
+      <point x="368" y="193" type="curve" smooth="yes"/>
+      <point x="368" y="308"/>
+      <point x="437" y="431"/>
+      <point x="544" y="493" type="curve"/>
+      <point x="521" y="497" type="line"/>
+      <point x="578" y="454"/>
+      <point x="606" y="379"/>
+      <point x="606" y="292" type="curve" smooth="yes"/>
+      <point x="606" y="194"/>
+      <point x="565" y="62"/>
     </contour>
     <contour>
-      <point x="137" y="-16" type="curve"/>
-      <point x="203" y="32" type="line"/>
-      <point x="159" y="87"/>
-      <point x="134" y="165"/>
-      <point x="134" y="248" type="curve" smooth="yes"/>
-      <point x="134" y="421"/>
-      <point x="237" y="534"/>
-      <point x="395" y="534" type="curve" smooth="yes"/>
-      <point x="444" y="534"/>
-      <point x="485" y="523"/>
-      <point x="518" y="503" type="curve"/>
-      <point x="589" y="546" type="line"/>
-      <point x="539" y="588"/>
-      <point x="474" y="612"/>
-      <point x="399" y="612" type="curve" smooth="yes"/>
-      <point x="194" y="612"/>
-      <point x="52" y="463"/>
-      <point x="52" y="248" type="curve" smooth="yes"/>
-      <point x="52" y="143"/>
-      <point x="80" y="56"/>
+      <point x="685" y="-308" type="curve" smooth="yes"/>
+      <point x="629" y="-308"/>
+      <point x="604" y="-274"/>
+      <point x="590" y="-188" type="curve" smooth="yes"/>
+      <point x="583" y="-145" type="line" smooth="yes"/>
+      <point x="571" y="-69"/>
+      <point x="561" y="-28"/>
+      <point x="533" y="-3" type="curve"/>
+      <point x="535" y="8" type="line"/>
+      <point x="653" y="48"/>
+      <point x="692" y="187"/>
+      <point x="692" y="290" type="curve" smooth="yes"/>
+      <point x="692" y="394"/>
+      <point x="655" y="489"/>
+      <point x="586" y="549" type="curve"/>
+      <point x="597" y="518" type="line"/>
+      <point x="627" y="528"/>
+      <point x="660" y="534"/>
+      <point x="694" y="534" type="curve" smooth="yes"/>
+      <point x="825" y="534"/>
+      <point x="872" y="467"/>
+      <point x="872" y="358" type="curve" smooth="yes"/>
+      <point x="872" y="257"/>
+      <point x="822" y="148"/>
+      <point x="713" y="45" type="curve"/>
+      <point x="766" y="-8"/>
+      <point x="790" y="-65"/>
+      <point x="790" y="-139" type="curve" smooth="yes"/>
+      <point x="790" y="-202"/>
+      <point x="771" y="-308"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ta-malayalam.glif
@@ -2,61 +2,61 @@
 <glyph name="ta-malayalam" format="2">
   <advance width="1005"/>
   <unicode hex="0D24"/>
-  <anchor x="548" y="0" name="bottom"/>
-  <anchor x="558" y="596" name="top"/>
-  <anchor x="885" y="596" name="topright"/>
+  <anchor x="542" y="0" name="bottom"/>
+  <anchor x="554" y="596" name="top"/>
+  <anchor x="881" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="137" y="-16" type="curve"/>
-      <point x="203" y="32" type="line"/>
-      <point x="159" y="87"/>
-      <point x="134" y="165"/>
-      <point x="134" y="248" type="curve" smooth="yes"/>
-      <point x="134" y="421"/>
-      <point x="237" y="534"/>
-      <point x="395" y="534" type="curve" smooth="yes"/>
-      <point x="537" y="534"/>
-      <point x="615" y="443"/>
-      <point x="615" y="275" type="curve" smooth="yes"/>
-      <point x="615" y="136"/>
-      <point x="570" y="62"/>
-      <point x="484" y="62" type="curve" smooth="yes"/>
-      <point x="413" y="62"/>
-      <point x="377" y="109"/>
-      <point x="377" y="199" type="curve" smooth="yes"/>
-      <point x="377" y="387"/>
-      <point x="510" y="534"/>
-      <point x="681" y="534" type="curve" smooth="yes"/>
-      <point x="803" y="534"/>
-      <point x="867" y="466"/>
-      <point x="867" y="336" type="curve" smooth="yes"/>
-      <point x="867" y="218"/>
-      <point x="818" y="128"/>
-      <point x="709" y="48" type="curve"/>
-      <point x="760" y="-16" type="line"/>
-      <point x="888" y="79"/>
-      <point x="949" y="193"/>
-      <point x="949" y="336" type="curve" smooth="yes"/>
-      <point x="949" y="513"/>
-      <point x="853" y="612"/>
-      <point x="683" y="612" type="curve" smooth="yes"/>
-      <point x="477" y="612"/>
-      <point x="295" y="418"/>
-      <point x="295" y="199" type="curve" smooth="yes"/>
-      <point x="295" y="62"/>
-      <point x="364" y="-16"/>
-      <point x="484" y="-16" type="curve" smooth="yes"/>
-      <point x="614" y="-16"/>
-      <point x="701" y="100"/>
-      <point x="701" y="275" type="curve" smooth="yes"/>
-      <point x="701" y="475"/>
-      <point x="579" y="612"/>
-      <point x="399" y="612" type="curve" smooth="yes"/>
-      <point x="194" y="612"/>
-      <point x="52" y="463"/>
-      <point x="52" y="248" type="curve" smooth="yes"/>
-      <point x="52" y="143"/>
-      <point x="80" y="56"/>
+      <point x="129" y="-16" type="curve"/>
+      <point x="193" y="31" type="line"/>
+      <point x="149" y="92"/>
+      <point x="131" y="161"/>
+      <point x="131" y="236" type="curve" smooth="yes"/>
+      <point x="131" y="404"/>
+      <point x="233" y="534"/>
+      <point x="399" y="534" type="curve" smooth="yes"/>
+      <point x="540" y="534"/>
+      <point x="606" y="426"/>
+      <point x="606" y="292" type="curve" smooth="yes"/>
+      <point x="606" y="194"/>
+      <point x="565" y="62"/>
+      <point x="468" y="62" type="curve" smooth="yes"/>
+      <point x="403" y="62"/>
+      <point x="368" y="107"/>
+      <point x="368" y="193" type="curve" smooth="yes"/>
+      <point x="368" y="355"/>
+      <point x="506" y="534"/>
+      <point x="694" y="534" type="curve" smooth="yes"/>
+      <point x="823" y="534"/>
+      <point x="870" y="467"/>
+      <point x="870" y="358" type="curve" smooth="yes"/>
+      <point x="870" y="257"/>
+      <point x="820" y="148"/>
+      <point x="711" y="45" type="curve"/>
+      <point x="774" y="-16" type="line"/>
+      <point x="902" y="105"/>
+      <point x="953" y="236"/>
+      <point x="953" y="362" type="curve" smooth="yes"/>
+      <point x="953" y="515"/>
+      <point x="869" y="612"/>
+      <point x="704" y="612" type="curve" smooth="yes"/>
+      <point x="460" y="612"/>
+      <point x="285" y="378"/>
+      <point x="285" y="190" type="curve" smooth="yes"/>
+      <point x="285" y="66"/>
+      <point x="354" y="-16"/>
+      <point x="461" y="-16" type="curve" smooth="yes"/>
+      <point x="630" y="-16"/>
+      <point x="692" y="162"/>
+      <point x="692" y="290" type="curve" smooth="yes"/>
+      <point x="692" y="462"/>
+      <point x="591" y="612"/>
+      <point x="408" y="612" type="curve" smooth="yes"/>
+      <point x="185" y="612"/>
+      <point x="49" y="429"/>
+      <point x="49" y="235" type="curve" smooth="yes"/>
+      <point x="49" y="143"/>
+      <point x="75" y="58"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1005"/>
   <outline>
     <component base="ta-malayalam"/>
-    <component base="halant-malayalam" xOffset="805"/>
+    <component base="halant-malayalam" xOffset="801"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="597"/>
-  <anchor x="300" y="0" name="bottom"/>
-  <anchor x="282" y="596" name="top"/>
-  <anchor x="421" y="596" name="topright"/>
+  <anchor x="229" y="-271" name="bottom"/>
+  <anchor x="349" y="596" name="top"/>
+  <anchor x="488" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="234" y="-225" type="curve" smooth="yes"/>
-      <point x="400" y="-225"/>
-      <point x="493" y="-177"/>
-      <point x="493" y="-78" type="curve" smooth="yes"/>
-      <point x="493" y="-21"/>
-      <point x="462" y="12"/>
-      <point x="402" y="28" type="curve"/>
-      <point x="403" y="38" type="line"/>
-      <point x="488" y="58"/>
-      <point x="530" y="123"/>
-      <point x="530" y="198" type="curve" smooth="yes"/>
-      <point x="530" y="289"/>
-      <point x="484" y="348"/>
-      <point x="354" y="355" type="curve" smooth="yes"/>
-      <point x="258" y="360" type="line" smooth="yes"/>
-      <point x="185" y="364"/>
-      <point x="152" y="392"/>
-      <point x="152" y="438" type="curve" smooth="yes"/>
-      <point x="152" y="496"/>
-      <point x="205" y="532"/>
-      <point x="304" y="532" type="curve" smooth="yes"/>
-      <point x="396" y="532"/>
-      <point x="454" y="511"/>
-      <point x="513" y="479" type="curve"/>
-      <point x="556" y="550" type="line"/>
-      <point x="490" y="587"/>
-      <point x="414" y="612"/>
-      <point x="314" y="612" type="curve" smooth="yes"/>
-      <point x="163" y="612"/>
-      <point x="64" y="549"/>
-      <point x="64" y="428" type="curve" smooth="yes"/>
-      <point x="64" y="339"/>
-      <point x="122" y="288"/>
-      <point x="223" y="273" type="curve"/>
-      <point x="344" y="266" type="line" smooth="yes"/>
-      <point x="420" y="262"/>
-      <point x="444" y="231"/>
-      <point x="444" y="183" type="curve" smooth="yes"/>
-      <point x="444" y="113"/>
-      <point x="388" y="80"/>
-      <point x="304" y="80" type="curve" smooth="yes"/>
-      <point x="48" y="80" type="line"/>
-      <point x="35" y="6" type="line"/>
-      <point x="238" y="6" type="line" smooth="yes"/>
-      <point x="362" y="6"/>
-      <point x="411" y="-27"/>
-      <point x="411" y="-71" type="curve" smooth="yes"/>
-      <point x="411" y="-127"/>
-      <point x="354" y="-147"/>
-      <point x="247" y="-147" type="curve" smooth="yes"/>
-      <point x="144" y="-147"/>
-      <point x="72" y="-125"/>
-      <point x="17" y="-98" type="curve"/>
-      <point x="-28" y="-165" type="line"/>
-      <point x="27" y="-197"/>
-      <point x="125" y="-225"/>
+      <point x="213" y="-277" type="curve" smooth="yes"/>
+      <point x="394" y="-277"/>
+      <point x="481" y="-183"/>
+      <point x="481" y="-84" type="curve" smooth="yes"/>
+      <point x="481" y="-23"/>
+      <point x="455" y="17"/>
+      <point x="398" y="39" type="curve"/>
+      <point x="399" y="49" type="line"/>
+      <point x="478" y="69"/>
+      <point x="524" y="121"/>
+      <point x="524" y="192" type="curve" smooth="yes"/>
+      <point x="524" y="285"/>
+      <point x="471" y="341"/>
+      <point x="347" y="353" type="curve" smooth="yes"/>
+      <point x="241" y="363" type="line" smooth="yes"/>
+      <point x="177" y="369"/>
+      <point x="150" y="394"/>
+      <point x="150" y="439" type="curve" smooth="yes"/>
+      <point x="150" y="491"/>
+      <point x="196" y="534"/>
+      <point x="310" y="534" type="curve" smooth="yes"/>
+      <point x="395" y="534"/>
+      <point x="459" y="518"/>
+      <point x="525" y="484" type="curve"/>
+      <point x="561" y="553" type="line"/>
+      <point x="482" y="594"/>
+      <point x="408" y="612"/>
+      <point x="317" y="612" type="curve" smooth="yes"/>
+      <point x="136" y="612"/>
+      <point x="64" y="522"/>
+      <point x="64" y="430" type="curve" smooth="yes"/>
+      <point x="64" y="342"/>
+      <point x="124" y="284"/>
+      <point x="221" y="275" type="curve" smooth="yes"/>
+      <point x="327" y="265" type="line" smooth="yes"/>
+      <point x="410" y="257"/>
+      <point x="438" y="231"/>
+      <point x="438" y="181" type="curve" smooth="yes"/>
+      <point x="438" y="117"/>
+      <point x="380" y="80"/>
+      <point x="278" y="80" type="curve" smooth="yes"/>
+      <point x="44" y="80" type="line"/>
+      <point x="31" y="6" type="line"/>
+      <point x="278" y="6" type="line" smooth="yes"/>
+      <point x="367" y="6"/>
+      <point x="400" y="-28"/>
+      <point x="400" y="-84" type="curve" smooth="yes"/>
+      <point x="400" y="-140"/>
+      <point x="354" y="-199"/>
+      <point x="220" y="-199" type="curve" smooth="yes"/>
+      <point x="137" y="-199"/>
+      <point x="62" y="-176"/>
+      <point x="7" y="-132" type="curve"/>
+      <point x="-40" y="-192" type="line"/>
+      <point x="30" y="-247"/>
+      <point x="118" y="-277"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/tta-malayalam.glif
@@ -2,51 +2,51 @@
 <glyph name="tta-malayalam" format="2">
   <advance width="599"/>
   <unicode hex="0D1F"/>
-  <anchor x="254" y="0" name="bottom"/>
-  <anchor x="340" y="596" name="top"/>
-  <anchor x="479" y="596" name="topright"/>
+  <anchor x="260" y="0" name="bottom"/>
+  <anchor x="348" y="596" name="top"/>
+  <anchor x="487" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="280" y="-16" type="curve" smooth="yes"/>
-      <point x="418" y="-16"/>
-      <point x="524" y="41"/>
-      <point x="524" y="178" type="curve" smooth="yes"/>
-      <point x="524" y="279"/>
-      <point x="467" y="337"/>
-      <point x="341" y="343" type="curve" smooth="yes"/>
-      <point x="255" y="347" type="line" smooth="yes"/>
-      <point x="177" y="351"/>
-      <point x="148" y="385"/>
-      <point x="148" y="429" type="curve" smooth="yes"/>
-      <point x="148" y="492"/>
-      <point x="201" y="532"/>
-      <point x="301" y="532" type="curve" smooth="yes"/>
-      <point x="393" y="532"/>
-      <point x="451" y="511"/>
-      <point x="510" y="479" type="curve"/>
-      <point x="553" y="550" type="line"/>
-      <point x="487" y="587"/>
-      <point x="411" y="612"/>
-      <point x="311" y="612" type="curve" smooth="yes"/>
-      <point x="167" y="612"/>
-      <point x="62" y="549"/>
-      <point x="62" y="416" type="curve" smooth="yes"/>
-      <point x="62" y="328"/>
-      <point x="114" y="264"/>
-      <point x="239" y="258" type="curve" smooth="yes"/>
-      <point x="320" y="254" type="line" smooth="yes"/>
-      <point x="407" y="250"/>
-      <point x="438" y="223"/>
-      <point x="438" y="168" type="curve" smooth="yes"/>
-      <point x="438" y="97"/>
-      <point x="375" y="65"/>
-      <point x="289" y="65" type="curve" smooth="yes"/>
-      <point x="191" y="65"/>
-      <point x="126" y="99"/>
-      <point x="59" y="151" type="curve"/>
-      <point x="3" y="80" type="line"/>
-      <point x="77" y="20"/>
-      <point x="168" y="-16"/>
+      <point x="276" y="-16" type="curve" smooth="yes"/>
+      <point x="453" y="-16"/>
+      <point x="528" y="75"/>
+      <point x="528" y="172" type="curve" smooth="yes"/>
+      <point x="528" y="270"/>
+      <point x="471" y="329"/>
+      <point x="363" y="339" type="curve" smooth="yes"/>
+      <point x="252" y="349" type="line" smooth="yes"/>
+      <point x="186" y="355"/>
+      <point x="155" y="378"/>
+      <point x="155" y="429" type="curve" smooth="yes"/>
+      <point x="155" y="484"/>
+      <point x="207" y="532"/>
+      <point x="329" y="532" type="curve" smooth="yes"/>
+      <point x="403" y="532"/>
+      <point x="468" y="517"/>
+      <point x="527" y="485" type="curve"/>
+      <point x="563" y="556" type="line"/>
+      <point x="490" y="595"/>
+      <point x="422" y="612"/>
+      <point x="337" y="612" type="curve" smooth="yes"/>
+      <point x="136" y="612"/>
+      <point x="69" y="509"/>
+      <point x="69" y="421" type="curve" smooth="yes"/>
+      <point x="69" y="332"/>
+      <point x="127" y="271"/>
+      <point x="234" y="261" type="curve" smooth="yes"/>
+      <point x="345" y="251" type="line" smooth="yes"/>
+      <point x="413" y="245"/>
+      <point x="442" y="215"/>
+      <point x="442" y="164" type="curve" smooth="yes"/>
+      <point x="442" y="115"/>
+      <point x="398" y="64"/>
+      <point x="284" y="64" type="curve" smooth="yes"/>
+      <point x="193" y="64"/>
+      <point x="114" y="96"/>
+      <point x="51" y="144" type="curve"/>
+      <point x="-1" y="76" type="line"/>
+      <point x="78" y="17"/>
+      <point x="172" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/tta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/tta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="599"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="halant-malayalam" xOffset="399"/>
+    <component base="halant-malayalam" xOffset="407"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="599"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="301"/>
+    <component base="lVocalicMatra-malayalam" xOffset="307"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="599"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="302"/>
+    <component base="llVocalicMatra-malayalam" xOffset="308"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/uuM_atra-malayalam.glif
@@ -4,65 +4,71 @@
   <unicode hex="0D42"/>
   <outline>
     <contour>
-      <point x="42" y="31" type="curve"/>
-      <point x="126" y="31" type="line"/>
-      <point x="208" y="171"/>
-      <point x="254" y="309"/>
-      <point x="254" y="411" type="curve" smooth="yes"/>
-      <point x="254" y="532"/>
-      <point x="193" y="600"/>
-      <point x="76" y="610" type="curve" smooth="yes"/>
-      <point x="52" y="612" type="line"/>
-      <point x="38" y="534" type="line"/>
-      <point x="131" y="527"/>
-      <point x="172" y="489"/>
-      <point x="172" y="408" type="curve" smooth="yes"/>
-      <point x="172" y="307"/>
-      <point x="120" y="157"/>
+      <point x="52" y="34" type="curve"/>
+      <point x="134" y="34" type="line"/>
+      <point x="211" y="160"/>
+      <point x="263" y="312"/>
+      <point x="263" y="411" type="curve" smooth="yes"/>
+      <point x="263" y="541"/>
+      <point x="200" y="612"/>
+      <point x="80" y="612" type="curve" smooth="yes"/>
+      <point x="60" y="612" type="line"/>
+      <point x="46" y="535" type="line"/>
+      <point x="140" y="535"/>
+      <point x="181" y="499"/>
+      <point x="181" y="409" type="curve" smooth="yes"/>
+      <point x="181" y="311"/>
+      <point x="128" y="158"/>
     </contour>
     <contour>
-      <point x="73" y="-259" type="curve" smooth="yes"/>
-      <point x="179" y="-259"/>
-      <point x="259" y="-183"/>
-      <point x="259" y="-82" type="curve" smooth="yes"/>
-      <point x="259" y="12"/>
-      <point x="186" y="82"/>
-      <point x="88" y="82" type="curve" smooth="yes"/>
-      <point x="-15" y="82"/>
+      <point x="72" y="-185" type="curve" smooth="yes"/>
+      <point x="11" y="-185"/>
+      <point x="-31" y="-150"/>
+      <point x="-31" y="-99" type="curve" smooth="yes"/>
+      <point x="-31" y="-84"/>
+      <point x="-29" y="-74"/>
+      <point x="-24" y="-63" type="curve"/>
+      <point x="-18" y="-63" type="line"/>
+      <point x="-4" y="-101"/>
+      <point x="30" y="-127"/>
+      <point x="78" y="-127" type="curve" smooth="yes"/>
+      <point x="125" y="-127"/>
+      <point x="160" y="-103"/>
+      <point x="182" y="-63" type="curve"/>
+      <point x="187" y="-63" type="line"/>
+      <point x="188" y="-69"/>
+      <point x="188" y="-77"/>
+      <point x="188" y="-82" type="curve" smooth="yes"/>
+      <point x="188" y="-127"/>
+      <point x="161" y="-185"/>
+    </contour>
+    <contour>
+      <point x="70" y="-259" type="curve" smooth="yes"/>
+      <point x="174" y="-259"/>
+      <point x="253" y="-183"/>
+      <point x="253" y="-82" type="curve" smooth="yes"/>
+      <point x="253" y="12"/>
+      <point x="181" y="82"/>
+      <point x="85" y="82" type="curve" smooth="yes"/>
+      <point x="-16" y="82"/>
       <point x="-99" y="2"/>
       <point x="-99" y="-97" type="curve" smooth="yes"/>
       <point x="-99" y="-193"/>
-      <point x="-28" y="-259"/>
+      <point x="-29" y="-259"/>
     </contour>
     <contour>
-      <point x="75" y="-185" type="curve" smooth="yes"/>
-      <point x="11" y="-185"/>
-      <point x="-27" y="-149"/>
-      <point x="-27" y="-91" type="curve" smooth="yes"/>
-      <point x="-27" y="-28"/>
-      <point x="19" y="17"/>
-      <point x="86" y="17" type="curve" smooth="yes"/>
-      <point x="147" y="17"/>
-      <point x="187" y="-21"/>
-      <point x="187" y="-78" type="curve" smooth="yes"/>
-      <point x="187" y="-140"/>
-      <point x="141" y="-185"/>
-    </contour>
-    <contour>
-      <point x="104" y="-113" type="curve" smooth="yes"/>
-      <point x="144" y="-113"/>
-      <point x="180" y="-106"/>
-      <point x="215" y="-87" type="curve"/>
-      <point x="198" y="-49" type="line"/>
-      <point x="182" y="-52"/>
-      <point x="164" y="-53"/>
-      <point x="144" y="-53" type="curve" smooth="yes"/>
-      <point x="99" y="-53"/>
-      <point x="17" y="-45"/>
-      <point x="-21" y="-30" type="curve"/>
-      <point x="-49" y="-62" type="line"/>
-      <point x="-9" y="-96"/>
-      <point x="45" y="-113"/>
+      <point x="77" y="-57" type="curve" smooth="yes"/>
+      <point x="38" y="-57"/>
+      <point x="9" y="-38"/>
+      <point x="9" y="-13" type="curve" smooth="yes"/>
+      <point x="9" y="8"/>
+      <point x="36" y="24"/>
+      <point x="94" y="24" type="curve" smooth="yes"/>
+      <point x="146" y="24"/>
+      <point x="163" y="12"/>
+      <point x="163" y="-7" type="curve" smooth="yes"/>
+      <point x="163" y="-33"/>
+      <point x="129" y="-57"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/y_ya-malayalam.glif
@@ -1,96 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="1008"/>
-  <anchor x="495" y="-322" name="bottom"/>
-  <anchor x="573" y="596" name="top"/>
-  <anchor x="879" y="596" name="topright"/>
+  <anchor x="507" y="-306" name="bottom"/>
+  <anchor x="568" y="596" name="top"/>
+  <anchor x="874" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="207" y="-322" type="line"/>
-      <point x="779" y="-322" type="line"/>
-      <point x="846" y="72" type="line"/>
-      <point x="828" y="37" type="line"/>
-      <point x="916" y="99"/>
-      <point x="969" y="211"/>
-      <point x="969" y="351" type="curve" smooth="yes"/>
-      <point x="969" y="455"/>
-      <point x="944" y="542"/>
-      <point x="894" y="612" type="curve"/>
-      <point x="825" y="569" type="line"/>
-      <point x="866" y="513"/>
-      <point x="887" y="439"/>
-      <point x="887" y="351" type="curve" smooth="yes"/>
-      <point x="887" y="178"/>
-      <point x="792" y="62"/>
-      <point x="651" y="62" type="curve" smooth="yes"/>
-      <point x="514" y="62"/>
-      <point x="432" y="158"/>
-      <point x="432" y="319" type="curve" smooth="yes"/>
-      <point x="432" y="447"/>
-      <point x="484" y="534"/>
-      <point x="560" y="534" type="curve" smooth="yes"/>
-      <point x="616" y="534"/>
-      <point x="643" y="494"/>
-      <point x="643" y="412" type="curve" smooth="yes"/>
-      <point x="643" y="281"/>
-      <point x="580" y="162"/>
-      <point x="476" y="96" type="curve"/>
-      <point x="524" y="37" type="line"/>
-      <point x="658" y="124"/>
-      <point x="725" y="248"/>
-      <point x="725" y="412" type="curve" smooth="yes"/>
-      <point x="725" y="544"/>
-      <point x="674" y="612"/>
-      <point x="576" y="612" type="curve" smooth="yes"/>
-      <point x="445" y="612"/>
-      <point x="352" y="490"/>
-      <point x="352" y="317" type="curve" smooth="yes"/>
-      <point x="352" y="125"/>
-      <point x="480" y="-16"/>
-      <point x="651" y="-16" type="curve" smooth="yes"/>
-      <point x="659" y="-16"/>
-      <point x="666" y="-16"/>
-      <point x="674" y="-15" type="curve"/>
-      <point x="611" y="29" type="line"/>
-      <point x="622" y="-25" type="line"/>
-      <point x="536" y="-72" type="line"/>
-      <point x="217" y="-264" type="line"/>
+      <point x="202" y="-306" type="line"/>
+      <point x="772" y="-306" type="line"/>
+      <point x="845" y="105" type="line"/>
+      <point x="824" y="67" type="line"/>
+      <point x="913" y="142"/>
+      <point x="959" y="256"/>
+      <point x="959" y="357" type="curve" smooth="yes"/>
+      <point x="959" y="449"/>
+      <point x="930" y="539"/>
+      <point x="877" y="612" type="curve"/>
+      <point x="810" y="566" type="line"/>
+      <point x="856" y="502"/>
+      <point x="879" y="434"/>
+      <point x="879" y="358" type="curve" smooth="yes"/>
+      <point x="879" y="225"/>
+      <point x="794" y="62"/>
+      <point x="623" y="62" type="curve" smooth="yes"/>
+      <point x="474" y="62"/>
+      <point x="389" y="157"/>
+      <point x="389" y="308" type="curve" smooth="yes"/>
+      <point x="389" y="399"/>
+      <point x="435" y="534"/>
+      <point x="557" y="534" type="curve" smooth="yes"/>
+      <point x="618" y="534"/>
+      <point x="650" y="488"/>
+      <point x="650" y="405" type="curve" smooth="yes"/>
+      <point x="650" y="301"/>
+      <point x="576" y="164"/>
+      <point x="459" y="102" type="curve"/>
+      <point x="512" y="53" type="line"/>
+      <point x="652" y="128"/>
+      <point x="732" y="293"/>
+      <point x="732" y="412" type="curve" smooth="yes"/>
+      <point x="732" y="536"/>
+      <point x="672" y="612"/>
+      <point x="564" y="612" type="curve" smooth="yes"/>
+      <point x="402" y="612"/>
+      <point x="308" y="448"/>
+      <point x="308" y="314" type="curve" smooth="yes"/>
+      <point x="308" y="132"/>
+      <point x="434" y="-12"/>
+      <point x="615" y="-12" type="curve" smooth="yes"/>
+      <point x="642" y="-12"/>
+      <point x="667" y="-9"/>
+      <point x="690" y="-4" type="curve"/>
+      <point x="598" y="29" type="line"/>
+      <point x="594" y="-23" type="line"/>
+      <point x="522" y="-57" type="line"/>
+      <point x="213" y="-248" type="line"/>
     </contour>
     <contour>
-      <point x="295" y="-295" type="line"/>
-      <point x="774" y="-5" type="line"/>
-      <point x="751" y="-5" type="line"/>
-      <point x="704" y="-270" type="line"/>
-      <point x="741" y="-257" type="line"/>
-      <point x="302" y="-257" type="line"/>
+      <point x="296" y="-277" type="line"/>
+      <point x="770" y="15" type="line"/>
+      <point x="747" y="15" type="line"/>
+      <point x="700" y="-254" type="line"/>
+      <point x="737" y="-241" type="line"/>
+      <point x="302" y="-241" type="line"/>
     </contour>
     <contour>
-      <point x="342" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="455" y="-2"/>
-      <point x="507" y="31" type="curve"/>
-      <point x="453" y="85" type="line"/>
-      <point x="420" y="69"/>
-      <point x="389" y="62"/>
-      <point x="346" y="62" type="curve" smooth="yes"/>
-      <point x="216" y="62"/>
-      <point x="141" y="148"/>
-      <point x="141" y="295" type="curve" smooth="yes"/>
-      <point x="141" y="441"/>
-      <point x="209" y="535"/>
-      <point x="314" y="535" type="curve" smooth="yes"/>
-      <point x="361" y="535"/>
-      <point x="391" y="520"/>
-      <point x="416" y="484" type="curve"/>
-      <point x="464" y="534" type="line"/>
-      <point x="435" y="586"/>
-      <point x="385" y="612"/>
-      <point x="314" y="612" type="curve" smooth="yes"/>
-      <point x="163" y="612"/>
-      <point x="61" y="483"/>
-      <point x="61" y="293" type="curve" smooth="yes"/>
-      <point x="61" y="102"/>
-      <point x="169" y="-16"/>
+      <point x="323" y="-16" type="curve" smooth="yes"/>
+      <point x="383" y="-16"/>
+      <point x="440" y="0"/>
+      <point x="486" y="35" type="curve"/>
+      <point x="434" y="90" type="line"/>
+      <point x="405" y="71"/>
+      <point x="375" y="62"/>
+      <point x="338" y="62" type="curve" smooth="yes"/>
+      <point x="210" y="62"/>
+      <point x="136" y="142"/>
+      <point x="136" y="275" type="curve" smooth="yes"/>
+      <point x="136" y="377"/>
+      <point x="187" y="534"/>
+      <point x="322" y="534" type="curve" smooth="yes"/>
+      <point x="364" y="534"/>
+      <point x="387" y="522"/>
+      <point x="411" y="493" type="curve"/>
+      <point x="471" y="542" type="line"/>
+      <point x="433" y="591"/>
+      <point x="392" y="612"/>
+      <point x="332" y="612" type="curve" smooth="yes"/>
+      <point x="133" y="612"/>
+      <point x="56" y="415"/>
+      <point x="56" y="277" type="curve" smooth="yes"/>
+      <point x="56" y="104"/>
+      <point x="160" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ya-malayalam.glif
@@ -2,78 +2,78 @@
 <glyph name="ya-malayalam" format="2">
   <advance width="1008"/>
   <unicode hex="0D2F"/>
-  <anchor x="553" y="0" name="bottom"/>
-  <anchor x="810" y="-16" name="bottomright"/>
-  <anchor x="573" y="596" name="top"/>
-  <anchor x="879" y="596" name="topright"/>
+  <anchor x="546" y="0" name="bottom"/>
+  <anchor x="804" y="-16" name="bottomright"/>
+  <anchor x="568" y="596" name="top"/>
+  <anchor x="874" y="596" name="topright"/>
   <outline>
     <contour>
-      <point x="653" y="-16" type="curve" smooth="yes"/>
+      <point x="615" y="-16" type="curve" smooth="yes"/>
       <point x="841" y="-16"/>
-      <point x="969" y="133"/>
-      <point x="969" y="351" type="curve" smooth="yes"/>
-      <point x="969" y="455"/>
-      <point x="944" y="542"/>
-      <point x="894" y="612" type="curve"/>
-      <point x="825" y="569" type="line"/>
-      <point x="866" y="513"/>
-      <point x="887" y="439"/>
-      <point x="887" y="351" type="curve" smooth="yes"/>
-      <point x="887" y="178"/>
-      <point x="792" y="62"/>
-      <point x="651" y="62" type="curve" smooth="yes"/>
-      <point x="514" y="62"/>
-      <point x="432" y="158"/>
-      <point x="432" y="319" type="curve" smooth="yes"/>
-      <point x="432" y="447"/>
-      <point x="484" y="534"/>
-      <point x="560" y="534" type="curve" smooth="yes"/>
-      <point x="616" y="534"/>
-      <point x="643" y="494"/>
-      <point x="643" y="412" type="curve" smooth="yes"/>
-      <point x="643" y="281"/>
-      <point x="580" y="162"/>
-      <point x="476" y="96" type="curve"/>
-      <point x="524" y="37" type="line"/>
-      <point x="658" y="124"/>
-      <point x="725" y="248"/>
-      <point x="725" y="412" type="curve" smooth="yes"/>
-      <point x="725" y="544"/>
-      <point x="674" y="612"/>
-      <point x="576" y="612" type="curve" smooth="yes"/>
-      <point x="445" y="612"/>
-      <point x="352" y="490"/>
-      <point x="352" y="317" type="curve" smooth="yes"/>
-      <point x="352" y="126"/>
-      <point x="480" y="-16"/>
+      <point x="959" y="188"/>
+      <point x="959" y="357" type="curve" smooth="yes"/>
+      <point x="959" y="449"/>
+      <point x="930" y="539"/>
+      <point x="877" y="612" type="curve"/>
+      <point x="810" y="566" type="line"/>
+      <point x="856" y="502"/>
+      <point x="879" y="434"/>
+      <point x="879" y="358" type="curve" smooth="yes"/>
+      <point x="879" y="225"/>
+      <point x="794" y="62"/>
+      <point x="623" y="62" type="curve" smooth="yes"/>
+      <point x="474" y="62"/>
+      <point x="389" y="157"/>
+      <point x="389" y="308" type="curve" smooth="yes"/>
+      <point x="389" y="399"/>
+      <point x="435" y="534"/>
+      <point x="557" y="534" type="curve" smooth="yes"/>
+      <point x="618" y="534"/>
+      <point x="650" y="488"/>
+      <point x="650" y="405" type="curve" smooth="yes"/>
+      <point x="650" y="301"/>
+      <point x="576" y="164"/>
+      <point x="459" y="102" type="curve"/>
+      <point x="512" y="53" type="line"/>
+      <point x="652" y="128"/>
+      <point x="732" y="293"/>
+      <point x="732" y="412" type="curve" smooth="yes"/>
+      <point x="732" y="536"/>
+      <point x="672" y="612"/>
+      <point x="564" y="612" type="curve" smooth="yes"/>
+      <point x="402" y="612"/>
+      <point x="308" y="448"/>
+      <point x="308" y="314" type="curve" smooth="yes"/>
+      <point x="308" y="130"/>
+      <point x="434" y="-16"/>
     </contour>
     <contour>
-      <point x="342" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="455" y="-2"/>
-      <point x="507" y="31" type="curve"/>
-      <point x="453" y="85" type="line"/>
-      <point x="420" y="69"/>
-      <point x="389" y="62"/>
-      <point x="346" y="62" type="curve" smooth="yes"/>
-      <point x="216" y="62"/>
-      <point x="141" y="148"/>
-      <point x="141" y="295" type="curve" smooth="yes"/>
-      <point x="141" y="441"/>
-      <point x="209" y="535"/>
-      <point x="314" y="535" type="curve" smooth="yes"/>
-      <point x="361" y="535"/>
-      <point x="391" y="520"/>
-      <point x="416" y="484" type="curve"/>
-      <point x="464" y="534" type="line"/>
-      <point x="435" y="586"/>
-      <point x="385" y="612"/>
-      <point x="314" y="612" type="curve" smooth="yes"/>
-      <point x="163" y="612"/>
-      <point x="61" y="483"/>
-      <point x="61" y="293" type="curve" smooth="yes"/>
-      <point x="61" y="102"/>
-      <point x="169" y="-16"/>
+      <point x="323" y="-16" type="curve" smooth="yes"/>
+      <point x="383" y="-16"/>
+      <point x="440" y="0"/>
+      <point x="486" y="35" type="curve"/>
+      <point x="434" y="90" type="line"/>
+      <point x="405" y="71"/>
+      <point x="375" y="62"/>
+      <point x="338" y="62" type="curve" smooth="yes"/>
+      <point x="210" y="62"/>
+      <point x="136" y="142"/>
+      <point x="136" y="275" type="curve" smooth="yes"/>
+      <point x="136" y="377"/>
+      <point x="187" y="534"/>
+      <point x="322" y="534" type="curve" smooth="yes"/>
+      <point x="364" y="534"/>
+      <point x="387" y="522"/>
+      <point x="411" y="493" type="curve"/>
+      <point x="471" y="542" type="line"/>
+      <point x="433" y="591"/>
+      <point x="392" y="612"/>
+      <point x="332" y="612" type="curve" smooth="yes"/>
+      <point x="133" y="612"/>
+      <point x="56" y="415"/>
+      <point x="56" y="277" type="curve" smooth="yes"/>
+      <point x="56" y="104"/>
+      <point x="160" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ya-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ya-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1008"/>
   <outline>
     <component base="ya-malayalam"/>
-    <component base="halant-malayalam" xOffset="799"/>
+    <component base="halant-malayalam" xOffset="794"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/kerning.plist
@@ -47536,8 +47536,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -47647,7 +47645,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47703,7 +47701,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>80</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47756,7 +47754,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>180</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -47803,7 +47801,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -47838,7 +47836,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -47866,8 +47864,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47902,7 +47898,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47971,7 +47967,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48031,7 +48027,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48080,7 +48076,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48138,7 +48134,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48179,7 +48175,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48315,8 +48311,6 @@
       <integer>-30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48345,7 +48339,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48393,8 +48387,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>10</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>0</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>0</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48480,8 +48472,6 @@
       <integer>50</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48514,7 +48504,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48591,8 +48581,6 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48636,8 +48624,6 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48757,8 +48743,6 @@
       <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48866,7 +48850,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48913,7 +48897,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48959,41 +48943,39 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>50</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_braceright.loclMALM_R</key>
-      <integer>40</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
       <integer>20</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>40</integer>
-      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>70</integer>
-      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
+      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
+      <integer>60</integer>
+      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
-      <integer>110</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
-      <integer>100</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
       <integer>20</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
       <integer>-20</integer>
-      <key>public.kern2.MAL_rVocalic-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
-      <integer>90</integer>
-      <key>public.kern2.MAL_uMatra-malayalam_L</key>
       <integer>80</integer>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>60</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>220</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
       <integer>150</integer>
     </dict>
@@ -49020,7 +49002,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49069,7 +49051,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49102,8 +49084,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -49143,7 +49123,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49346,7 +49326,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49372,8 +49352,6 @@
       <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49400,7 +49378,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49456,7 +49434,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -49488,8 +49466,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49599,8 +49575,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_p_pa-malayalam_L</key>
@@ -49667,7 +49641,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
@@ -49712,7 +49686,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49753,7 +49727,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49843,7 +49817,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>150</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49984,8 +49958,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -50033,8 +50005,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50097,7 +50067,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50150,7 +50120,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>240</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>170</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -50235,7 +50205,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -50274,7 +50244,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>130</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50370,8 +50340,6 @@
       <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
-      <integer>40</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
@@ -50476,7 +50444,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_ng_ka-malayalam_L</key>
@@ -50528,6 +50496,24 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-30</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>-20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>50</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.Man-georgian</key>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/archaicii-malayalam.part.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/archaicii-malayalam.part.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="archaicii-malayalam.part" format="2">
-  <advance width="373"/>
+  <advance width="380"/>
   <outline>
     <contour>
-      <point x="176" y="174" type="curve" smooth="yes"/>
-      <point x="280" y="174"/>
-      <point x="348" y="242"/>
-      <point x="348" y="335" type="curve" smooth="yes"/>
-      <point x="348" y="411"/>
-      <point x="297" y="461"/>
-      <point x="218" y="461" type="curve" smooth="yes"/>
-      <point x="114" y="461"/>
-      <point x="45" y="394"/>
-      <point x="45" y="302" type="curve" smooth="yes"/>
-      <point x="45" y="231"/>
-      <point x="96" y="174"/>
+      <point x="183" y="174" type="curve" smooth="yes"/>
+      <point x="273" y="174"/>
+      <point x="345" y="242"/>
+      <point x="345" y="327" type="curve" smooth="yes"/>
+      <point x="345" y="405"/>
+      <point x="285" y="461"/>
+      <point x="201" y="461" type="curve" smooth="yes"/>
+      <point x="108" y="461"/>
+      <point x="39" y="396"/>
+      <point x="39" y="308" type="curve" smooth="yes"/>
+      <point x="39" y="230"/>
+      <point x="100" y="174"/>
     </contour>
     <contour>
       <point x="188" y="260" type="curve" smooth="yes"/>
-      <point x="157" y="260"/>
-      <point x="136" y="282"/>
-      <point x="136" y="308" type="curve" smooth="yes"/>
-      <point x="136" y="349"/>
-      <point x="165" y="375"/>
-      <point x="206" y="375" type="curve" smooth="yes"/>
-      <point x="238" y="375"/>
-      <point x="257" y="353"/>
-      <point x="257" y="326" type="curve" smooth="yes"/>
-      <point x="257" y="286"/>
-      <point x="226" y="260"/>
+      <point x="152" y="260"/>
+      <point x="131" y="280"/>
+      <point x="131" y="314" type="curve" smooth="yes"/>
+      <point x="131" y="351"/>
+      <point x="156" y="375"/>
+      <point x="196" y="375" type="curve" smooth="yes"/>
+      <point x="231" y="375"/>
+      <point x="253" y="355"/>
+      <point x="253" y="321" type="curve" smooth="yes"/>
+      <point x="253" y="284"/>
+      <point x="227" y="260"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/d_da-malayalam.glif
@@ -1,73 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
-  <advance width="728"/>
-  <anchor x="379" y="613" name="top"/>
+  <advance width="718"/>
+  <anchor x="312" y="-255" name="bottom"/>
+  <anchor x="447" y="613" name="top"/>
   <outline>
     <contour>
-      <point x="400" y="-229" type="curve" smooth="yes"/>
-      <point x="545" y="-229"/>
-      <point x="623" y="-174"/>
-      <point x="623" y="-73" type="curve" smooth="yes"/>
-      <point x="623" y="-13"/>
-      <point x="587" y="26"/>
-      <point x="517" y="41" type="curve"/>
-      <point x="518" y="54" type="line"/>
-      <point x="596" y="61"/>
-      <point x="656" y="97"/>
-      <point x="655" y="184" type="curve" smooth="yes"/>
-      <point x="654" y="240"/>
-      <point x="621" y="285"/>
-      <point x="542" y="300" type="curve"/>
-      <point x="543" y="313" type="line"/>
-      <point x="633" y="324"/>
-      <point x="684" y="377"/>
-      <point x="684" y="447" type="curve" smooth="yes"/>
-      <point x="684" y="550"/>
-      <point x="598" y="629"/>
-      <point x="425" y="629" type="curve" smooth="yes"/>
-      <point x="188" y="629"/>
-      <point x="47" y="470"/>
-      <point x="47" y="232" type="curve" smooth="yes"/>
-      <point x="47" y="144"/>
-      <point x="68" y="58"/>
-      <point x="110" y="-16" type="curve"/>
-      <point x="216" y="44" type="line"/>
-      <point x="188" y="95"/>
-      <point x="168" y="159"/>
-      <point x="168" y="239" type="curve" smooth="yes"/>
-      <point x="168" y="403"/>
-      <point x="252" y="518"/>
-      <point x="421" y="518" type="curve" smooth="yes"/>
-      <point x="517" y="518"/>
-      <point x="559" y="486"/>
-      <point x="559" y="436" type="curve" smooth="yes"/>
-      <point x="559" y="391"/>
-      <point x="520" y="362"/>
-      <point x="463" y="362" type="curve" smooth="yes"/>
-      <point x="397" y="362" type="line"/>
-      <point x="379" y="256" type="line"/>
-      <point x="428" y="256" type="line" smooth="yes"/>
-      <point x="494" y="256"/>
-      <point x="534" y="235"/>
-      <point x="534" y="184" type="curve" smooth="yes"/>
-      <point x="534" y="125"/>
-      <point x="492" y="101"/>
-      <point x="430" y="101" type="curve" smooth="yes"/>
-      <point x="351" y="101" type="line"/>
-      <point x="332" y="-4" type="line"/>
-      <point x="402" y="-4" type="line" smooth="yes"/>
-      <point x="477" y="-4"/>
-      <point x="504" y="-23"/>
-      <point x="504" y="-58" type="curve" smooth="yes"/>
-      <point x="504" y="-99"/>
-      <point x="468" y="-116"/>
-      <point x="401" y="-116" type="curve" smooth="yes"/>
-      <point x="344" y="-116"/>
-      <point x="311" y="-108"/>
-      <point x="279" y="-97" type="curve"/>
-      <point x="222" y="-200" type="line"/>
-      <point x="263" y="-217"/>
-      <point x="327" y="-229"/>
+      <point x="347" y="-271" type="curve" smooth="yes"/>
+      <point x="514" y="-271"/>
+      <point x="602" y="-180"/>
+      <point x="602" y="-80" type="curve" smooth="yes"/>
+      <point x="602" y="-17"/>
+      <point x="573" y="23"/>
+      <point x="514" y="44" type="curve"/>
+      <point x="516" y="56" type="line"/>
+      <point x="598" y="70"/>
+      <point x="650" y="114"/>
+      <point x="650" y="193" type="curve" smooth="yes"/>
+      <point x="650" y="255"/>
+      <point x="617" y="296"/>
+      <point x="539" y="305" type="curve"/>
+      <point x="541" y="317" type="line"/>
+      <point x="629" y="333"/>
+      <point x="682" y="381"/>
+      <point x="682" y="459" type="curve" smooth="yes"/>
+      <point x="682" y="561"/>
+      <point x="590" y="629"/>
+      <point x="439" y="629" type="curve" smooth="yes"/>
+      <point x="176" y="629"/>
+      <point x="47" y="441"/>
+      <point x="47" y="238" type="curve" smooth="yes"/>
+      <point x="47" y="146"/>
+      <point x="69" y="61"/>
+      <point x="112" y="-16" type="curve"/>
+      <point x="218" y="44" type="line"/>
+      <point x="184" y="108"/>
+      <point x="168" y="171"/>
+      <point x="168" y="238" type="curve" smooth="yes"/>
+      <point x="168" y="395"/>
+      <point x="256" y="518"/>
+      <point x="431" y="518" type="curve" smooth="yes"/>
+      <point x="516" y="518"/>
+      <point x="559" y="493"/>
+      <point x="559" y="440" type="curve" smooth="yes"/>
+      <point x="559" y="388"/>
+      <point x="512" y="362"/>
+      <point x="451" y="362" type="curve" smooth="yes"/>
+      <point x="392" y="362" type="line"/>
+      <point x="374" y="256" type="line"/>
+      <point x="437" y="256" type="line" smooth="yes"/>
+      <point x="497" y="256"/>
+      <point x="527" y="236"/>
+      <point x="527" y="189" type="curve" smooth="yes"/>
+      <point x="527" y="132"/>
+      <point x="480" y="101"/>
+      <point x="407" y="101" type="curve" smooth="yes"/>
+      <point x="319" y="101" type="line"/>
+      <point x="301" y="-4" type="line"/>
+      <point x="394" y="-4" type="line" smooth="yes"/>
+      <point x="453" y="-4"/>
+      <point x="479" y="-28"/>
+      <point x="479" y="-73" type="curve" smooth="yes"/>
+      <point x="479" y="-120"/>
+      <point x="444" y="-160"/>
+      <point x="355" y="-160" type="curve" smooth="yes"/>
+      <point x="297" y="-160"/>
+      <point x="250" y="-147"/>
+      <point x="201" y="-117" type="curve"/>
+      <point x="145" y="-213" type="line"/>
+      <point x="208" y="-251"/>
+      <point x="277" y="-271"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="1026"/>
-  <anchor x="647" y="0" name="bottom"/>
-  <anchor x="576" y="613" name="top"/>
-  <anchor x="931" y="613" name="topright"/>
+  <advance width="1020"/>
+  <anchor x="633" y="0" name="bottom"/>
+  <anchor x="559" y="613" name="top"/>
+  <anchor x="919" y="603" name="topright"/>
   <outline>
     <contour>
-      <point x="274" y="-16" type="curve" smooth="yes"/>
-      <point x="410" y="-16"/>
-      <point x="495" y="63"/>
-      <point x="539" y="232" type="curve" smooth="yes"/>
-      <point x="567" y="343" type="line" smooth="yes"/>
-      <point x="599" y="463"/>
-      <point x="647" y="518"/>
-      <point x="747" y="518" type="curve" smooth="yes"/>
-      <point x="828" y="518"/>
-      <point x="871" y="486"/>
-      <point x="871" y="432" type="curve" smooth="yes"/>
-      <point x="871" y="384"/>
-      <point x="834" y="355"/>
-      <point x="776" y="355" type="curve" smooth="yes"/>
-      <point x="704" y="355" type="line"/>
-      <point x="686" y="250" type="line"/>
-      <point x="740" y="250" type="line" smooth="yes"/>
-      <point x="813" y="250"/>
-      <point x="845" y="225"/>
-      <point x="845" y="175" type="curve" smooth="yes"/>
-      <point x="845" y="124"/>
-      <point x="813" y="97"/>
-      <point x="755" y="97" type="curve" smooth="yes"/>
-      <point x="713" y="97"/>
-      <point x="679" y="106"/>
-      <point x="651" y="124" type="curve"/>
-      <point x="586" y="24" type="line"/>
-      <point x="626" y="-1"/>
-      <point x="690" y="-16"/>
-      <point x="754" y="-16" type="curve" smooth="yes"/>
-      <point x="882" y="-16"/>
-      <point x="967" y="51"/>
-      <point x="967" y="157" type="curve" smooth="yes"/>
-      <point x="967" y="230"/>
-      <point x="927" y="277"/>
-      <point x="853" y="294" type="curve"/>
-      <point x="854" y="307" type="line"/>
-      <point x="946" y="321"/>
-      <point x="993" y="376"/>
-      <point x="993" y="458" type="curve" smooth="yes"/>
-      <point x="993" y="560"/>
-      <point x="909" y="629"/>
-      <point x="756" y="629" type="curve" smooth="yes"/>
-      <point x="585" y="629"/>
-      <point x="491" y="543"/>
-      <point x="446" y="368" type="curve" smooth="yes"/>
-      <point x="417" y="258" type="line" smooth="yes"/>
-      <point x="388" y="146"/>
-      <point x="344" y="95"/>
-      <point x="274" y="95" type="curve" smooth="yes"/>
-      <point x="204" y="95"/>
-      <point x="166" y="145"/>
-      <point x="166" y="235" type="curve" smooth="yes"/>
-      <point x="166" y="349"/>
-      <point x="228" y="451"/>
-      <point x="347" y="531" type="curve"/>
-      <point x="275" y="629" type="line"/>
-      <point x="127" y="529"/>
-      <point x="45" y="388"/>
-      <point x="45" y="231" type="curve" smooth="yes"/>
-      <point x="45" y="79"/>
-      <point x="133" y="-16"/>
+      <point x="291" y="-16" type="curve" smooth="yes"/>
+      <point x="421" y="-16"/>
+      <point x="515" y="74"/>
+      <point x="538" y="216" type="curve" smooth="yes"/>
+      <point x="546" y="265"/>
+      <point x="544" y="314"/>
+      <point x="552" y="362" type="curve" smooth="yes"/>
+      <point x="568" y="462"/>
+      <point x="635" y="518"/>
+      <point x="736" y="518" type="curve" smooth="yes"/>
+      <point x="815" y="518"/>
+      <point x="851" y="487"/>
+      <point x="851" y="435" type="curve" smooth="yes"/>
+      <point x="851" y="385"/>
+      <point x="814" y="355"/>
+      <point x="756" y="355" type="curve" smooth="yes"/>
+      <point x="684" y="355" type="line"/>
+      <point x="666" y="250" type="line"/>
+      <point x="720" y="250" type="line" smooth="yes"/>
+      <point x="792" y="250"/>
+      <point x="825" y="225"/>
+      <point x="825" y="175" type="curve" smooth="yes"/>
+      <point x="825" y="124"/>
+      <point x="793" y="97"/>
+      <point x="735" y="97" type="curve" smooth="yes"/>
+      <point x="693" y="97"/>
+      <point x="659" y="106"/>
+      <point x="631" y="124" type="curve"/>
+      <point x="566" y="24" type="line"/>
+      <point x="606" y="-1"/>
+      <point x="670" y="-16"/>
+      <point x="734" y="-16" type="curve" smooth="yes"/>
+      <point x="862" y="-16"/>
+      <point x="946" y="51"/>
+      <point x="946" y="157" type="curve" smooth="yes"/>
+      <point x="946" y="230"/>
+      <point x="907" y="277"/>
+      <point x="832" y="294" type="curve"/>
+      <point x="834" y="307" type="line"/>
+      <point x="925" y="320"/>
+      <point x="973" y="378"/>
+      <point x="973" y="453" type="curve" smooth="yes"/>
+      <point x="973" y="556"/>
+      <point x="891" y="629"/>
+      <point x="740" y="629" type="curve" smooth="yes"/>
+      <point x="576" y="629"/>
+      <point x="457" y="532"/>
+      <point x="433" y="381" type="curve" smooth="yes"/>
+      <point x="426" y="335"/>
+      <point x="427" y="288"/>
+      <point x="420" y="241" type="curve" smooth="yes"/>
+      <point x="405" y="147"/>
+      <point x="363" y="98"/>
+      <point x="291" y="98" type="curve" smooth="yes"/>
+      <point x="209" y="98"/>
+      <point x="167" y="147"/>
+      <point x="167" y="242" type="curve" smooth="yes"/>
+      <point x="167" y="350"/>
+      <point x="241" y="461"/>
+      <point x="348" y="533" type="curve"/>
+      <point x="276" y="629" type="line"/>
+      <point x="130" y="528"/>
+      <point x="45" y="382"/>
+      <point x="45" y="240" type="curve" smooth="yes"/>
+      <point x="45" y="85"/>
+      <point x="144" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/g_ga-malayalam.glif
@@ -1,92 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ga-malayalam" format="2">
-  <advance width="973"/>
-  <anchor x="446" y="-360" name="bottom"/>
-  <anchor x="551" y="613" name="top"/>
-  <anchor x="836" y="613" name="topright"/>
+  <advance width="974"/>
+  <anchor x="470" y="-368" name="bottom"/>
+  <anchor x="545" y="613" name="top"/>
+  <anchor x="830" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="655" y="-384" type="line"/>
-      <point x="735" y="-305"/>
-      <point x="782" y="-216"/>
-      <point x="782" y="-117" type="curve" smooth="yes"/>
-      <point x="782" y="-3"/>
-      <point x="713" y="55"/>
-      <point x="611" y="55" type="curve" smooth="yes"/>
-      <point x="505" y="55"/>
-      <point x="445" y="-1"/>
-      <point x="410" y="-140" type="curve" smooth="yes"/>
-      <point x="402" y="-172" type="line" smooth="yes"/>
-      <point x="380" y="-263"/>
-      <point x="352" y="-292"/>
-      <point x="301" y="-292" type="curve" smooth="yes"/>
-      <point x="254" y="-292"/>
-      <point x="224" y="-261"/>
-      <point x="224" y="-199" type="curve" smooth="yes"/>
-      <point x="224" y="-128"/>
-      <point x="264" y="-59"/>
-      <point x="318" y="-5" type="curve"/>
-      <point x="301" y="-15" type="line"/>
-      <point x="422" y="-5"/>
-      <point x="498" y="74"/>
-      <point x="539" y="232" type="curve" smooth="yes"/>
-      <point x="567" y="343" type="line" smooth="yes"/>
-      <point x="599" y="463"/>
-      <point x="647" y="518"/>
-      <point x="720" y="518" type="curve" smooth="yes"/>
-      <point x="786" y="518"/>
-      <point x="819" y="475"/>
-      <point x="819" y="390" type="curve" smooth="yes"/>
-      <point x="819" y="255"/>
-      <point x="752" y="132"/>
-      <point x="613" y="39" type="curve"/>
-      <point x="723" y="-16" type="line"/>
-      <point x="865" y="91"/>
-      <point x="940" y="232"/>
-      <point x="940" y="390" type="curve" smooth="yes"/>
-      <point x="940" y="543"/>
-      <point x="865" y="629"/>
-      <point x="723" y="629" type="curve" smooth="yes"/>
-      <point x="584" y="629"/>
-      <point x="491" y="543"/>
-      <point x="446" y="368" type="curve" smooth="yes"/>
-      <point x="417" y="258" type="line" smooth="yes"/>
-      <point x="388" y="146"/>
-      <point x="344" y="95"/>
-      <point x="274" y="95" type="curve" smooth="yes"/>
-      <point x="204" y="95"/>
-      <point x="166" y="145"/>
-      <point x="166" y="235" type="curve" smooth="yes"/>
-      <point x="166" y="349"/>
-      <point x="228" y="451"/>
-      <point x="347" y="531" type="curve"/>
-      <point x="275" y="629" type="line"/>
-      <point x="127" y="529"/>
-      <point x="45" y="388"/>
-      <point x="45" y="231" type="curve" smooth="yes"/>
-      <point x="45" y="110"/>
-      <point x="100" y="25"/>
-      <point x="199" y="-6" type="curve"/>
-      <point x="199" y="-18" type="line"/>
-      <point x="150" y="-67"/>
-      <point x="124" y="-133"/>
-      <point x="124" y="-207" type="curve" smooth="yes"/>
-      <point x="124" y="-317"/>
-      <point x="192" y="-382"/>
-      <point x="296" y="-382" type="curve" smooth="yes"/>
-      <point x="402" y="-382"/>
-      <point x="462" y="-325"/>
-      <point x="495" y="-189" type="curve" smooth="yes"/>
-      <point x="505" y="-149" type="line" smooth="yes"/>
-      <point x="526" y="-62"/>
-      <point x="554" y="-35"/>
-      <point x="606" y="-35" type="curve" smooth="yes"/>
-      <point x="653" y="-35"/>
-      <point x="683" y="-66"/>
-      <point x="683" y="-122" type="curve" smooth="yes"/>
-      <point x="683" y="-198"/>
-      <point x="642" y="-270"/>
-      <point x="586" y="-327" type="curve"/>
+      <point x="291" y="-8" type="curve" smooth="yes"/>
+      <point x="421" y="-8"/>
+      <point x="516" y="79"/>
+      <point x="538" y="216" type="curve" smooth="yes"/>
+      <point x="546" y="265"/>
+      <point x="544" y="314"/>
+      <point x="552" y="362" type="curve" smooth="yes"/>
+      <point x="568" y="461"/>
+      <point x="620" y="515"/>
+      <point x="700" y="515" type="curve" smooth="yes"/>
+      <point x="771" y="515"/>
+      <point x="809" y="469"/>
+      <point x="809" y="380" type="curve" smooth="yes"/>
+      <point x="809" y="258"/>
+      <point x="745" y="141"/>
+      <point x="591" y="40" type="curve"/>
+      <point x="712" y="-8" type="line"/>
+      <point x="845" y="82"/>
+      <point x="931" y="244"/>
+      <point x="931" y="382" type="curve" smooth="yes"/>
+      <point x="931" y="534"/>
+      <point x="842" y="629"/>
+      <point x="700" y="629" type="curve" smooth="yes"/>
+      <point x="560" y="629"/>
+      <point x="457" y="532"/>
+      <point x="433" y="381" type="curve" smooth="yes"/>
+      <point x="426" y="335"/>
+      <point x="427" y="288"/>
+      <point x="420" y="241" type="curve" smooth="yes"/>
+      <point x="405" y="147"/>
+      <point x="363" y="98"/>
+      <point x="291" y="98" type="curve" smooth="yes"/>
+      <point x="209" y="98"/>
+      <point x="167" y="147"/>
+      <point x="167" y="242" type="curve" smooth="yes"/>
+      <point x="167" y="350"/>
+      <point x="241" y="461"/>
+      <point x="348" y="533" type="curve"/>
+      <point x="276" y="629" type="line"/>
+      <point x="130" y="528"/>
+      <point x="45" y="382"/>
+      <point x="45" y="240" type="curve" smooth="yes"/>
+      <point x="45" y="90"/>
+      <point x="144" y="-8"/>
+    </contour>
+    <contour>
+      <point x="675" y="-385" type="line"/>
+      <point x="756" y="-309"/>
+      <point x="799" y="-218"/>
+      <point x="799" y="-122" type="curve" smooth="yes"/>
+      <point x="799" y="-19"/>
+      <point x="734" y="55"/>
+      <point x="623" y="55" type="curve" smooth="yes"/>
+      <point x="514" y="55"/>
+      <point x="441" y="-11"/>
+      <point x="424" y="-118" type="curve" smooth="yes"/>
+      <point x="420" y="-143"/>
+      <point x="421" y="-168"/>
+      <point x="417" y="-193" type="curve" smooth="yes"/>
+      <point x="407" y="-256"/>
+      <point x="376" y="-290"/>
+      <point x="329" y="-290" type="curve" smooth="yes"/>
+      <point x="276" y="-290"/>
+      <point x="243" y="-255"/>
+      <point x="243" y="-194" type="curve" smooth="yes"/>
+      <point x="243" y="-123"/>
+      <point x="279" y="-40"/>
+      <point x="335" y="17" type="curve"/>
+      <point x="224" y="17" type="line"/>
+      <point x="175" y="-33"/>
+      <point x="143" y="-123"/>
+      <point x="143" y="-196" type="curve" smooth="yes"/>
+      <point x="143" y="-310"/>
+      <point x="211" y="-382"/>
+      <point x="327" y="-382" type="curve" smooth="yes"/>
+      <point x="431" y="-382"/>
+      <point x="499" y="-315"/>
+      <point x="516" y="-208" type="curve" smooth="yes"/>
+      <point x="520" y="-183"/>
+      <point x="519" y="-158"/>
+      <point x="523" y="-133" type="curve" smooth="yes"/>
+      <point x="533" y="-71"/>
+      <point x="569" y="-35"/>
+      <point x="621" y="-35" type="curve" smooth="yes"/>
+      <point x="673" y="-35"/>
+      <point x="699" y="-63"/>
+      <point x="699" y="-124" type="curve" smooth="yes"/>
+      <point x="699" y="-191"/>
+      <point x="666" y="-260"/>
+      <point x="608" y="-314" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/g_la-malayalam.glif
@@ -1,116 +1,125 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_la-malayalam" format="2">
-  <advance width="973"/>
-  <anchor x="425" y="-364" name="bottom"/>
-  <anchor x="551" y="613" name="top"/>
-  <anchor x="836" y="613" name="topright"/>
+  <advance width="974"/>
+  <anchor x="437" y="-366" name="bottom"/>
+  <anchor x="545" y="613" name="top"/>
+  <anchor x="830" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="207" y="-382" type="curve" smooth="yes"/>
-      <point x="302" y="-382"/>
-      <point x="358" y="-323"/>
-      <point x="358" y="-233" type="curve" smooth="yes"/>
-      <point x="358" y="-153"/>
-      <point x="314" y="-118"/>
-      <point x="248" y="-118" type="curve" smooth="yes"/>
-      <point x="214" y="-118"/>
-      <point x="182" y="-130"/>
-      <point x="160" y="-159" type="curve"/>
-      <point x="148" y="-158" type="line"/>
-      <point x="164" y="-92"/>
-      <point x="215" y="-33"/>
-      <point x="303" y="-33" type="curve" smooth="yes"/>
-      <point x="402" y="-33"/>
-      <point x="428" y="-84"/>
-      <point x="435" y="-177" type="curve" smooth="yes"/>
-      <point x="436" y="-189" type="line" smooth="yes"/>
-      <point x="447" y="-315"/>
-      <point x="497" y="-382"/>
+      <point x="208" y="-382" type="curve" smooth="yes"/>
+      <point x="315" y="-382"/>
+      <point x="358" y="-302"/>
+      <point x="358" y="-231" type="curve" smooth="yes"/>
+      <point x="358" y="-160"/>
+      <point x="319" y="-118"/>
+      <point x="253" y="-118" type="curve" smooth="yes"/>
+      <point x="198" y="-118"/>
+      <point x="152" y="-145"/>
+      <point x="133" y="-211" type="curve"/>
+      <point x="177" y="-164" type="line"/>
+      <point x="124" y="-164" type="line"/>
+      <point x="144" y="-176" type="line"/>
+      <point x="159" y="-86"/>
+      <point x="220" y="-33"/>
+      <point x="307" y="-33" type="curve" smooth="yes"/>
+      <point x="384" y="-33"/>
+      <point x="420" y="-69"/>
+      <point x="435" y="-161" type="curve" smooth="yes"/>
+      <point x="441" y="-199" type="line" smooth="yes"/>
+      <point x="461" y="-325"/>
+      <point x="524" y="-382"/>
       <point x="625" y="-382" type="curve" smooth="yes"/>
-      <point x="768" y="-382"/>
-      <point x="824" y="-278"/>
-      <point x="824" y="-138" type="curve" smooth="yes"/>
-      <point x="824" y="-63"/>
-      <point x="802" y="5"/>
-      <point x="780" y="47" type="curve"/>
-      <point x="764" y="18" type="line"/>
-      <point x="879" y="120"/>
-      <point x="940" y="248"/>
-      <point x="940" y="390" type="curve" smooth="yes"/>
-      <point x="940" y="543"/>
-      <point x="862" y="629"/>
-      <point x="724" y="629" type="curve" smooth="yes"/>
-      <point x="584" y="629"/>
-      <point x="491" y="543"/>
-      <point x="446" y="368" type="curve" smooth="yes"/>
-      <point x="417" y="258" type="line" smooth="yes"/>
-      <point x="388" y="146"/>
-      <point x="344" y="95"/>
-      <point x="274" y="95" type="curve" smooth="yes"/>
-      <point x="204" y="95"/>
-      <point x="166" y="145"/>
-      <point x="166" y="235" type="curve" smooth="yes"/>
-      <point x="166" y="349"/>
-      <point x="228" y="451"/>
-      <point x="347" y="531" type="curve"/>
-      <point x="275" y="629" type="line"/>
-      <point x="127" y="529"/>
-      <point x="45" y="388"/>
-      <point x="45" y="231" type="curve" smooth="yes"/>
-      <point x="45" y="131"/>
-      <point x="83" y="58"/>
-      <point x="158" y="19" type="curve"/>
-      <point x="158" y="6" type="line"/>
-      <point x="86" y="-40"/>
-      <point x="51" y="-118"/>
-      <point x="51" y="-206" type="curve" smooth="yes"/>
-      <point x="51" y="-327"/>
-      <point x="116" y="-382"/>
+      <point x="763" y="-382"/>
+      <point x="823" y="-259"/>
+      <point x="823" y="-139" type="curve" smooth="yes"/>
+      <point x="823" y="-69"/>
+      <point x="804" y="-3"/>
+      <point x="767" y="52" type="curve"/>
+      <point x="758" y="22" type="line"/>
+      <point x="862" y="118"/>
+      <point x="931" y="258"/>
+      <point x="931" y="382" type="curve" smooth="yes"/>
+      <point x="931" y="534"/>
+      <point x="842" y="629"/>
+      <point x="700" y="629" type="curve" smooth="yes"/>
+      <point x="560" y="629"/>
+      <point x="457" y="532"/>
+      <point x="433" y="381" type="curve" smooth="yes"/>
+      <point x="426" y="335"/>
+      <point x="427" y="288"/>
+      <point x="420" y="241" type="curve" smooth="yes"/>
+      <point x="405" y="147"/>
+      <point x="363" y="98"/>
+      <point x="291" y="98" type="curve" smooth="yes"/>
+      <point x="209" y="98"/>
+      <point x="167" y="147"/>
+      <point x="167" y="242" type="curve" smooth="yes"/>
+      <point x="167" y="350"/>
+      <point x="241" y="461"/>
+      <point x="348" y="533" type="curve"/>
+      <point x="276" y="629" type="line"/>
+      <point x="130" y="528"/>
+      <point x="45" y="382"/>
+      <point x="45" y="240" type="curve" smooth="yes"/>
+      <point x="45" y="135"/>
+      <point x="92" y="62"/>
+      <point x="165" y="25" type="curve"/>
+      <point x="163" y="13" type="line"/>
+      <point x="87" y="-34"/>
+      <point x="51" y="-116"/>
+      <point x="51" y="-197" type="curve" smooth="yes"/>
+      <point x="51" y="-315"/>
+      <point x="120" y="-382"/>
     </contour>
     <contour>
       <point x="210" y="-302" type="curve" smooth="yes"/>
-      <point x="166" y="-302"/>
-      <point x="144" y="-269"/>
-      <point x="144" y="-226" type="curve"/>
-      <point x="129" y="-214" type="line"/>
-      <point x="137" y="-251" type="line"/>
-      <point x="149" y="-213"/>
-      <point x="178" y="-191"/>
-      <point x="214" y="-191" type="curve" smooth="yes"/>
+      <point x="168" y="-302"/>
+      <point x="144" y="-273"/>
+      <point x="144" y="-239" type="curve" smooth="yes"/>
+      <point x="144" y="-232"/>
+      <point x="145" y="-225"/>
+      <point x="146" y="-219" type="curve"/>
+      <point x="130" y="-220" type="line"/>
+      <point x="136" y="-262" type="line"/>
+      <point x="143" y="-219"/>
+      <point x="180" y="-191"/>
+      <point x="217" y="-191" type="curve" smooth="yes"/>
       <point x="251" y="-191"/>
       <point x="268" y="-207"/>
-      <point x="268" y="-241" type="curve" smooth="yes"/>
-      <point x="268" y="-277"/>
-      <point x="248" y="-302"/>
+      <point x="268" y="-239" type="curve" smooth="yes"/>
+      <point x="268" y="-270"/>
+      <point x="247" y="-302"/>
     </contour>
     <contour>
-      <point x="625" y="-292" type="curve" smooth="yes"/>
-      <point x="567" y="-292"/>
-      <point x="543" y="-255"/>
-      <point x="536" y="-177" type="curve" smooth="yes"/>
-      <point x="533" y="-151" type="line" smooth="yes"/>
-      <point x="524" y="-62"/>
-      <point x="494" y="1"/>
-      <point x="426" y="31" type="curve"/>
-      <point x="426" y="44" type="line"/>
-      <point x="482" y="84"/>
-      <point x="516" y="144"/>
-      <point x="539" y="232" type="curve" smooth="yes"/>
-      <point x="567" y="343" type="line" smooth="yes"/>
-      <point x="599" y="463"/>
-      <point x="647" y="518"/>
-      <point x="720" y="518" type="curve" smooth="yes"/>
-      <point x="786" y="518"/>
-      <point x="819" y="475"/>
-      <point x="819" y="390" type="curve" smooth="yes"/>
-      <point x="819" y="267"/>
-      <point x="761" y="162"/>
-      <point x="652" y="67" type="curve"/>
-      <point x="689" y="15"/>
-      <point x="723" y="-50"/>
-      <point x="723" y="-150" type="curve" smooth="yes"/>
-      <point x="723" y="-231"/>
-      <point x="697" y="-292"/>
+      <point x="629" y="-292" type="curve" smooth="yes"/>
+      <point x="576" y="-292"/>
+      <point x="550" y="-258"/>
+      <point x="538" y="-182" type="curve" smooth="yes"/>
+      <point x="532" y="-144" type="line" smooth="yes"/>
+      <point x="517" y="-50"/>
+      <point x="487" y="-4"/>
+      <point x="424" y="26" type="curve"/>
+      <point x="426" y="38" type="line"/>
+      <point x="486" y="76"/>
+      <point x="525" y="138"/>
+      <point x="538" y="216" type="curve" smooth="yes"/>
+      <point x="546" y="265"/>
+      <point x="544" y="314"/>
+      <point x="552" y="362" type="curve" smooth="yes"/>
+      <point x="568" y="461"/>
+      <point x="620" y="515"/>
+      <point x="700" y="515" type="curve" smooth="yes"/>
+      <point x="771" y="515"/>
+      <point x="809" y="469"/>
+      <point x="809" y="380" type="curve" smooth="yes"/>
+      <point x="809" y="259"/>
+      <point x="744" y="154"/>
+      <point x="634" y="76" type="curve"/>
+      <point x="694" y="11"/>
+      <point x="725" y="-64"/>
+      <point x="725" y="-145" type="curve" smooth="yes"/>
+      <point x="725" y="-198"/>
+      <point x="708" y="-292"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/g_ma-malayalam.glif
@@ -1,99 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ma-malayalam" format="2">
   <advance width="1464"/>
-  <anchor x="1055" y="0" name="bottom"/>
-  <anchor x="796" y="613" name="top"/>
-  <anchor x="1391" y="613" name="topright"/>
+  <anchor x="1048" y="0" name="bottom"/>
+  <anchor x="791" y="613" name="top"/>
+  <anchor x="1386" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="272" y="-16" type="curve" smooth="yes"/>
-      <point x="406" y="-16"/>
-      <point x="490" y="63"/>
-      <point x="534" y="232" type="curve" smooth="yes"/>
-      <point x="563" y="343" type="line" smooth="yes"/>
-      <point x="594" y="463"/>
-      <point x="642" y="518"/>
-      <point x="716" y="518" type="curve" smooth="yes"/>
-      <point x="784" y="518"/>
-      <point x="817" y="475"/>
-      <point x="817" y="406" type="curve" smooth="yes"/>
-      <point x="817" y="386"/>
-      <point x="814" y="364"/>
-      <point x="810" y="340" type="curve" smooth="yes"/>
-      <point x="750" y="0" type="line"/>
-      <point x="1360" y="0" type="line"/>
-      <point x="1410" y="285" type="line" smooth="yes"/>
-      <point x="1416" y="322"/>
-      <point x="1420" y="360"/>
-      <point x="1420" y="387" type="curve" smooth="yes"/>
-      <point x="1420" y="544"/>
-      <point x="1329" y="629"/>
+      <point x="291" y="-16" type="curve" smooth="yes"/>
+      <point x="421" y="-16"/>
+      <point x="515" y="74"/>
+      <point x="538" y="216" type="curve" smooth="yes"/>
+      <point x="546" y="265"/>
+      <point x="544" y="314"/>
+      <point x="552" y="362" type="curve" smooth="yes"/>
+      <point x="568" y="461"/>
+      <point x="619" y="515"/>
+      <point x="698" y="515" type="curve" smooth="yes"/>
+      <point x="768" y="515"/>
+      <point x="811" y="473"/>
+      <point x="811" y="406" type="curve" smooth="yes"/>
+      <point x="811" y="386"/>
+      <point x="809" y="364"/>
+      <point x="805" y="340" type="curve" smooth="yes"/>
+      <point x="745" y="0" type="line"/>
+      <point x="1350" y="0" type="line"/>
+      <point x="1400" y="285" type="line" smooth="yes"/>
+      <point x="1406" y="322"/>
+      <point x="1410" y="360"/>
+      <point x="1410" y="387" type="curve" smooth="yes"/>
+      <point x="1410" y="545"/>
+      <point x="1323" y="629"/>
       <point x="1152" y="629" type="curve" smooth="yes"/>
-      <point x="1048" y="629"/>
-      <point x="964" y="593"/>
-      <point x="909" y="519" type="curve"/>
-      <point x="896" y="519" type="line"/>
-      <point x="864" y="598"/>
-      <point x="803" y="629"/>
-      <point x="718" y="629" type="curve" smooth="yes"/>
-      <point x="584" y="629"/>
-      <point x="486" y="543"/>
-      <point x="442" y="368" type="curve" smooth="yes"/>
-      <point x="414" y="258" type="line" smooth="yes"/>
-      <point x="386" y="146"/>
-      <point x="339" y="95"/>
-      <point x="272" y="95" type="curve" smooth="yes"/>
-      <point x="204" y="95"/>
-      <point x="166" y="145"/>
-      <point x="166" y="235" type="curve" smooth="yes"/>
-      <point x="166" y="349"/>
-      <point x="228" y="451"/>
-      <point x="347" y="531" type="curve"/>
-      <point x="275" y="629" type="line"/>
-      <point x="127" y="529"/>
-      <point x="45" y="388"/>
-      <point x="45" y="231" type="curve" smooth="yes"/>
-      <point x="45" y="79"/>
-      <point x="133" y="-16"/>
+      <point x="1046" y="629"/>
+      <point x="955" y="589"/>
+      <point x="899" y="519" type="curve"/>
+      <point x="886" y="519" type="line"/>
+      <point x="857" y="588"/>
+      <point x="797" y="629"/>
+      <point x="701" y="629" type="curve" smooth="yes"/>
+      <point x="560" y="629"/>
+      <point x="457" y="531"/>
+      <point x="433" y="381" type="curve" smooth="yes"/>
+      <point x="426" y="335"/>
+      <point x="427" y="288"/>
+      <point x="420" y="241" type="curve" smooth="yes"/>
+      <point x="405" y="147"/>
+      <point x="363" y="98"/>
+      <point x="291" y="98" type="curve" smooth="yes"/>
+      <point x="209" y="98"/>
+      <point x="167" y="147"/>
+      <point x="167" y="242" type="curve" smooth="yes"/>
+      <point x="167" y="350"/>
+      <point x="241" y="461"/>
+      <point x="348" y="533" type="curve"/>
+      <point x="276" y="629" type="line"/>
+      <point x="130" y="528"/>
+      <point x="45" y="382"/>
+      <point x="45" y="240" type="curve" smooth="yes"/>
+      <point x="45" y="85"/>
+      <point x="144" y="-16"/>
     </contour>
     <contour>
-      <point x="827" y="48" type="line"/>
-      <point x="879" y="48" type="line"/>
-      <point x="931" y="342" type="line" smooth="yes"/>
-      <point x="946" y="428"/>
-      <point x="980" y="472"/>
-      <point x="1046" y="472" type="curve" smooth="yes"/>
-      <point x="1092" y="472"/>
-      <point x="1117" y="451"/>
-      <point x="1117" y="407" type="curve" smooth="yes"/>
-      <point x="1117" y="326"/>
-      <point x="1049" y="262"/>
-      <point x="969" y="185" type="curve" smooth="yes"/>
+      <point x="817" y="48" type="line"/>
+      <point x="873" y="48" type="line"/>
+      <point x="925" y="342" type="line" smooth="yes"/>
+      <point x="941" y="431"/>
+      <point x="976" y="473"/>
+      <point x="1037" y="473" type="curve" smooth="yes"/>
+      <point x="1083" y="473"/>
+      <point x="1107" y="447"/>
+      <point x="1107" y="405" type="curve" smooth="yes"/>
+      <point x="1107" y="344"/>
+      <point x="1071" y="294"/>
+      <point x="959" y="185" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="988" y="45" type="line"/>
-      <point x="1103" y="160" type="line" smooth="yes"/>
-      <point x="1173" y="230"/>
-      <point x="1230" y="309"/>
-      <point x="1230" y="394" type="curve" smooth="yes"/>
-      <point x="1230" y="471"/>
-      <point x="1181" y="523"/>
-      <point x="1073" y="523" type="curve"/>
-      <point x="1078" y="489" type="line"/>
-      <point x="1078" y="582" type="line"/>
-      <point x="1045" y="528" type="line"/>
-      <point x="1064" y="534"/>
-      <point x="1091" y="537"/>
-      <point x="1115" y="537" type="curve" smooth="yes"/>
-      <point x="1233" y="537"/>
-      <point x="1299" y="496"/>
-      <point x="1299" y="383" type="curve" smooth="yes"/>
-      <point x="1299" y="360"/>
-      <point x="1296" y="331"/>
-      <point x="1290" y="295" type="curve" smooth="yes"/>
-      <point x="1248" y="50" type="line"/>
-      <point x="1326" y="104" type="line"/>
-      <point x="930" y="104" type="line"/>
+      <point x="978" y="45" type="line"/>
+      <point x="1093" y="160" type="line" smooth="yes"/>
+      <point x="1178" y="245"/>
+      <point x="1220" y="322"/>
+      <point x="1220" y="394" type="curve" smooth="yes"/>
+      <point x="1220" y="481"/>
+      <point x="1166" y="529"/>
+      <point x="1069" y="529" type="curve"/>
+      <point x="1082" y="495" type="line"/>
+      <point x="1086" y="588" type="line"/>
+      <point x="1041" y="534" type="line"/>
+      <point x="1062" y="540"/>
+      <point x="1092" y="543"/>
+      <point x="1119" y="543" type="curve" smooth="yes"/>
+      <point x="1237" y="543"/>
+      <point x="1290" y="493"/>
+      <point x="1290" y="383" type="curve" smooth="yes"/>
+      <point x="1290" y="358"/>
+      <point x="1287" y="328"/>
+      <point x="1280" y="289" type="curve" smooth="yes"/>
+      <point x="1238" y="50" type="line"/>
+      <point x="1316" y="104" type="line"/>
+      <point x="920" y="104" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/g_na-malayalam.glif
@@ -1,70 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_na-malayalam" format="2">
   <advance width="1371"/>
-  <anchor x="886" y="0" name="bottom"/>
-  <anchor x="737" y="613" name="top"/>
-  <anchor x="1283" y="603" name="topright"/>
+  <anchor x="880" y="0" name="bottom"/>
+  <anchor x="732" y="613" name="top"/>
+  <anchor x="1277" y="603" name="topright"/>
   <outline>
     <contour>
-      <point x="274" y="-16" type="curve" smooth="yes"/>
-      <point x="410" y="-16"/>
-      <point x="494" y="63"/>
-      <point x="539" y="232" type="curve" smooth="yes"/>
-      <point x="572" y="362" type="line" smooth="yes"/>
-      <point x="601" y="472"/>
-      <point x="642" y="516"/>
-      <point x="715" y="516" type="curve" smooth="yes"/>
-      <point x="783" y="516"/>
-      <point x="816" y="481"/>
-      <point x="816" y="411" type="curve" smooth="yes"/>
-      <point x="816" y="379"/>
-      <point x="812" y="348"/>
-      <point x="805" y="312" type="curve" smooth="yes"/>
-      <point x="750" y="0" type="line"/>
-      <point x="872" y="0" type="line"/>
-      <point x="935" y="351" type="line" smooth="yes"/>
-      <point x="955" y="465"/>
-      <point x="1004" y="518"/>
-      <point x="1091" y="518" type="curve" smooth="yes"/>
-      <point x="1173" y="518"/>
-      <point x="1215" y="468"/>
-      <point x="1215" y="372" type="curve" smooth="yes"/>
-      <point x="1215" y="264"/>
-      <point x="1160" y="170"/>
-      <point x="1041" y="76" type="curve"/>
-      <point x="1121" y="-16" type="line"/>
-      <point x="1261" y="94"/>
-      <point x="1337" y="232"/>
-      <point x="1337" y="372" type="curve" smooth="yes"/>
-      <point x="1337" y="536"/>
-      <point x="1253" y="629"/>
-      <point x="1104" y="629" type="curve" smooth="yes"/>
-      <point x="1013" y="629"/>
-      <point x="944" y="586"/>
-      <point x="899" y="509" type="curve"/>
-      <point x="887" y="509" type="line"/>
-      <point x="854" y="588"/>
-      <point x="792" y="629"/>
-      <point x="702" y="629" type="curve" smooth="yes"/>
-      <point x="577" y="629"/>
-      <point x="496" y="559"/>
-      <point x="452" y="391" type="curve" smooth="yes"/>
-      <point x="417" y="258" type="line" smooth="yes"/>
-      <point x="388" y="146"/>
-      <point x="344" y="95"/>
-      <point x="274" y="95" type="curve" smooth="yes"/>
-      <point x="204" y="95"/>
-      <point x="166" y="145"/>
-      <point x="166" y="235" type="curve" smooth="yes"/>
-      <point x="166" y="349"/>
-      <point x="228" y="451"/>
-      <point x="347" y="531" type="curve"/>
-      <point x="275" y="629" type="line"/>
-      <point x="127" y="529"/>
-      <point x="45" y="388"/>
-      <point x="45" y="231" type="curve" smooth="yes"/>
-      <point x="45" y="79"/>
-      <point x="133" y="-16"/>
+      <point x="291" y="-16" type="curve" smooth="yes"/>
+      <point x="421" y="-16"/>
+      <point x="515" y="74"/>
+      <point x="538" y="216" type="curve" smooth="yes"/>
+      <point x="546" y="265"/>
+      <point x="544" y="314"/>
+      <point x="552" y="362" type="curve" smooth="yes"/>
+      <point x="568" y="462"/>
+      <point x="620" y="515"/>
+      <point x="700" y="515" type="curve" smooth="yes"/>
+      <point x="768" y="515"/>
+      <point x="809" y="475"/>
+      <point x="809" y="407" type="curve" smooth="yes"/>
+      <point x="809" y="380"/>
+      <point x="807" y="352"/>
+      <point x="800" y="312" type="curve" smooth="yes"/>
+      <point x="745" y="0" type="line"/>
+      <point x="867" y="0" type="line"/>
+      <point x="929" y="350" type="line" smooth="yes"/>
+      <point x="949" y="465"/>
+      <point x="996" y="518"/>
+      <point x="1080" y="518" type="curve" smooth="yes"/>
+      <point x="1162" y="518"/>
+      <point x="1204" y="468"/>
+      <point x="1204" y="372" type="curve" smooth="yes"/>
+      <point x="1204" y="264"/>
+      <point x="1149" y="170"/>
+      <point x="1030" y="76" type="curve"/>
+      <point x="1110" y="-16" type="line"/>
+      <point x="1250" y="94"/>
+      <point x="1326" y="232"/>
+      <point x="1326" y="372" type="curve" smooth="yes"/>
+      <point x="1326" y="536"/>
+      <point x="1242" y="629"/>
+      <point x="1093" y="629" type="curve" smooth="yes"/>
+      <point x="1000" y="629"/>
+      <point x="931" y="587"/>
+      <point x="888" y="515" type="curve"/>
+      <point x="876" y="515" type="line"/>
+      <point x="847" y="591"/>
+      <point x="788" y="629"/>
+      <point x="700" y="629" type="curve" smooth="yes"/>
+      <point x="560" y="629"/>
+      <point x="457" y="534"/>
+      <point x="433" y="381" type="curve" smooth="yes"/>
+      <point x="426" y="335"/>
+      <point x="427" y="288"/>
+      <point x="420" y="241" type="curve" smooth="yes"/>
+      <point x="405" y="147"/>
+      <point x="363" y="98"/>
+      <point x="291" y="98" type="curve" smooth="yes"/>
+      <point x="209" y="98"/>
+      <point x="167" y="147"/>
+      <point x="167" y="242" type="curve" smooth="yes"/>
+      <point x="167" y="350"/>
+      <point x="241" y="461"/>
+      <point x="348" y="533" type="curve"/>
+      <point x="276" y="629" type="line"/>
+      <point x="130" y="528"/>
+      <point x="45" y="382"/>
+      <point x="45" y="240" type="curve" smooth="yes"/>
+      <point x="45" y="85"/>
+      <point x="144" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ga-malayalam.glif
@@ -1,52 +1,56 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ga-malayalam" format="2">
-  <advance width="973"/>
+  <advance width="974"/>
   <unicode hex="0D17"/>
-  <anchor x="496" y="0" name="bottom"/>
-  <anchor x="551" y="613" name="top"/>
-  <anchor x="836" y="613" name="topright"/>
+  <anchor x="491" y="0" name="bottom"/>
+  <anchor x="545" y="613" name="top"/>
+  <anchor x="830" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="274" y="-16" type="curve" smooth="yes"/>
-      <point x="410" y="-16"/>
-      <point x="495" y="63"/>
-      <point x="539" y="232" type="curve" smooth="yes"/>
-      <point x="567" y="343" type="line" smooth="yes"/>
-      <point x="599" y="463"/>
-      <point x="647" y="518"/>
-      <point x="720" y="518" type="curve" smooth="yes"/>
-      <point x="786" y="518"/>
-      <point x="819" y="475"/>
-      <point x="819" y="390" type="curve" smooth="yes"/>
-      <point x="819" y="267"/>
-      <point x="761" y="162"/>
-      <point x="645" y="76" type="curve"/>
-      <point x="723" y="-16" type="line"/>
-      <point x="865" y="91"/>
-      <point x="940" y="232"/>
-      <point x="940" y="390" type="curve" smooth="yes"/>
-      <point x="940" y="543"/>
-      <point x="862" y="629"/>
-      <point x="724" y="629" type="curve" smooth="yes"/>
-      <point x="584" y="629"/>
-      <point x="491" y="543"/>
-      <point x="446" y="368" type="curve" smooth="yes"/>
-      <point x="417" y="258" type="line" smooth="yes"/>
-      <point x="388" y="146"/>
-      <point x="344" y="95"/>
-      <point x="274" y="95" type="curve" smooth="yes"/>
-      <point x="204" y="95"/>
-      <point x="166" y="145"/>
-      <point x="166" y="235" type="curve" smooth="yes"/>
-      <point x="166" y="349"/>
-      <point x="228" y="451"/>
-      <point x="347" y="531" type="curve"/>
-      <point x="275" y="629" type="line"/>
-      <point x="127" y="529"/>
-      <point x="45" y="388"/>
-      <point x="45" y="231" type="curve" smooth="yes"/>
-      <point x="45" y="79"/>
-      <point x="133" y="-16"/>
+      <point x="291" y="-16" type="curve" smooth="yes"/>
+      <point x="421" y="-16"/>
+      <point x="515" y="74"/>
+      <point x="538" y="216" type="curve" smooth="yes"/>
+      <point x="546" y="265"/>
+      <point x="544" y="314"/>
+      <point x="552" y="362" type="curve" smooth="yes"/>
+      <point x="568" y="461"/>
+      <point x="620" y="515"/>
+      <point x="700" y="515" type="curve" smooth="yes"/>
+      <point x="771" y="515"/>
+      <point x="809" y="469"/>
+      <point x="809" y="380" type="curve" smooth="yes"/>
+      <point x="809" y="261"/>
+      <point x="747" y="157"/>
+      <point x="641" y="81" type="curve"/>
+      <point x="712" y="-16" type="line"/>
+      <point x="841" y="78"/>
+      <point x="931" y="241"/>
+      <point x="931" y="382" type="curve" smooth="yes"/>
+      <point x="931" y="534"/>
+      <point x="842" y="629"/>
+      <point x="700" y="629" type="curve" smooth="yes"/>
+      <point x="560" y="629"/>
+      <point x="457" y="532"/>
+      <point x="433" y="381" type="curve" smooth="yes"/>
+      <point x="426" y="335"/>
+      <point x="427" y="288"/>
+      <point x="420" y="241" type="curve" smooth="yes"/>
+      <point x="405" y="147"/>
+      <point x="363" y="98"/>
+      <point x="291" y="98" type="curve" smooth="yes"/>
+      <point x="209" y="98"/>
+      <point x="167" y="147"/>
+      <point x="167" y="242" type="curve" smooth="yes"/>
+      <point x="167" y="350"/>
+      <point x="241" y="461"/>
+      <point x="348" y="533" type="curve"/>
+      <point x="276" y="629" type="line"/>
+      <point x="130" y="528"/>
+      <point x="45" y="382"/>
+      <point x="45" y="240" type="curve" smooth="yes"/>
+      <point x="45" y="85"/>
+      <point x="144" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ga-malayalam.half.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ga-malayalam.half" format="2">
-  <advance width="973"/>
+  <advance width="974"/>
   <outline>
     <component base="ga-malayalam"/>
-    <component base="halant-malayalam" xOffset="753"/>
+    <component base="halant-malayalam" xOffset="747"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/j_ja-malayalam.glif
@@ -1,231 +1,230 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1665"/>
-  <anchor x="1199" y="0" name="bottom"/>
-  <anchor x="879" y="613" name="top"/>
-  <anchor x="1571" y="613" name="topright"/>
+  <advance width="1740"/>
+  <anchor x="1249" y="-1" name="bottom"/>
+  <anchor x="924" y="613" name="top"/>
+  <anchor x="1616" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="365" y="-16" type="curve" smooth="yes"/>
-      <point x="658" y="-16"/>
-      <point x="792" y="78"/>
-      <point x="900" y="314" type="curve"/>
-      <point x="915" y="364" type="line"/>
-      <point x="922" y="364" type="line"/>
-      <point x="939" y="338"/>
-      <point x="972" y="320"/>
-      <point x="1027" y="320" type="curve" smooth="yes"/>
-      <point x="1113" y="320"/>
-      <point x="1165" y="368"/>
-      <point x="1165" y="443" type="curve" smooth="yes"/>
-      <point x="1165" y="502"/>
-      <point x="1132" y="534"/>
-      <point x="1071" y="534" type="curve" smooth="yes"/>
-      <point x="1047" y="534"/>
-      <point x="1021" y="529"/>
-      <point x="999" y="519" type="curve"/>
-      <point x="985" y="542" type="line"/>
-      <point x="983" y="524" type="line"/>
-      <point x="1011" y="546"/>
-      <point x="1051" y="557"/>
-      <point x="1096" y="557" type="curve" smooth="yes"/>
-      <point x="1177" y="557"/>
-      <point x="1213" y="518"/>
-      <point x="1213" y="442" type="curve" smooth="yes"/>
-      <point x="1213" y="428"/>
-      <point x="1211" y="412"/>
-      <point x="1208" y="397" type="curve" smooth="yes"/>
-      <point x="1201" y="354" type="line"/>
-      <point x="1319" y="354" type="line"/>
-      <point x="1328" y="407" type="line" smooth="yes"/>
-      <point x="1341" y="484"/>
-      <point x="1381" y="526"/>
-      <point x="1442" y="526" type="curve" smooth="yes"/>
-      <point x="1494" y="526"/>
-      <point x="1522" y="500"/>
-      <point x="1522" y="445" type="curve" smooth="yes"/>
-      <point x="1522" y="355"/>
-      <point x="1473" y="307"/>
-      <point x="1382" y="307" type="curve" smooth="yes"/>
-      <point x="1092" y="307" type="line" smooth="yes"/>
-      <point x="952" y="307"/>
-      <point x="871" y="242"/>
-      <point x="871" y="134" type="curve" smooth="yes"/>
-      <point x="871" y="41"/>
-      <point x="932" y="-16"/>
-      <point x="1030" y="-16" type="curve" smooth="yes"/>
-      <point x="1085" y="-16"/>
-      <point x="1131" y="-5"/>
-      <point x="1219" y="57" type="curve" smooth="yes"/>
-      <point x="1268" y="91" type="line"/>
-      <point x="1369" y="167" type="line"/>
-      <point x="1382" y="163" type="line"/>
-      <point x="1405" y="173"/>
-      <point x="1424" y="176"/>
-      <point x="1444" y="176" type="curve" smooth="yes"/>
-      <point x="1476" y="176"/>
-      <point x="1492" y="161"/>
-      <point x="1492" y="132" type="curve" smooth="yes"/>
-      <point x="1492" y="95"/>
-      <point x="1472" y="73"/>
-      <point x="1438" y="73" type="curve" smooth="yes"/>
-      <point x="1410" y="73"/>
-      <point x="1393" y="91"/>
-      <point x="1393" y="119" type="curve" smooth="yes"/>
-      <point x="1393" y="144"/>
-      <point x="1403" y="164"/>
-      <point x="1426" y="183" type="curve"/>
-      <point x="1278" y="155" type="line"/>
-      <point x="1337" y="102" type="line"/>
-      <point x="1359" y="171" type="line"/>
-      <point x="1332" y="153"/>
-      <point x="1317" y="124"/>
-      <point x="1317" y="89" type="curve" smooth="yes"/>
-      <point x="1317" y="25"/>
-      <point x="1361" y="-16"/>
-      <point x="1435" y="-16" type="curve" smooth="yes"/>
-      <point x="1526" y="-16"/>
-      <point x="1581" y="42"/>
-      <point x="1581" y="136" type="curve" smooth="yes"/>
-      <point x="1581" y="216"/>
-      <point x="1540" y="260"/>
-      <point x="1462" y="260" type="curve" smooth="yes"/>
-      <point x="1410" y="260"/>
-      <point x="1365" y="253"/>
-      <point x="1273" y="193" type="curve" smooth="yes"/>
-      <point x="1196" y="143" type="line" smooth="yes"/>
-      <point x="1118" y="92"/>
-      <point x="1076" y="87"/>
-      <point x="1054" y="87" type="curve" smooth="yes"/>
-      <point x="1011" y="87"/>
-      <point x="988" y="107"/>
-      <point x="988" y="143" type="curve" smooth="yes"/>
-      <point x="988" y="184"/>
-      <point x="1018" y="208"/>
-      <point x="1081" y="208" type="curve" smooth="yes"/>
-      <point x="1395" y="208" type="line" smooth="yes"/>
-      <point x="1548" y="208"/>
-      <point x="1641" y="300"/>
-      <point x="1641" y="452" type="curve" smooth="yes"/>
-      <point x="1641" y="564"/>
-      <point x="1575" y="629"/>
-      <point x="1466" y="629" type="curve" smooth="yes"/>
-      <point x="1382" y="629"/>
-      <point x="1321" y="589"/>
-      <point x="1291" y="516" type="curve"/>
-      <point x="1279" y="516" type="line"/>
-      <point x="1257" y="591"/>
-      <point x="1198" y="629"/>
-      <point x="1101" y="629" type="curve" smooth="yes"/>
-      <point x="985" y="629"/>
-      <point x="913" y="578"/>
-      <point x="865" y="458" type="curve" smooth="yes"/>
-      <point x="824" y="361" type="line" smooth="yes"/>
-      <point x="736" y="150"/>
-      <point x="607" y="87"/>
-      <point x="352" y="87" type="curve" smooth="yes"/>
-      <point x="193" y="87"/>
-      <point x="147" y="112"/>
-      <point x="147" y="156" type="curve" smooth="yes"/>
-      <point x="147" y="186"/>
-      <point x="172" y="208"/>
-      <point x="237" y="208" type="curve" smooth="yes"/>
-      <point x="534" y="208" type="line" smooth="yes"/>
-      <point x="717" y="208"/>
-      <point x="812" y="306"/>
-      <point x="812" y="458" type="curve" smooth="yes"/>
-      <point x="812" y="557"/>
-      <point x="753" y="629"/>
-      <point x="652" y="629" type="curve" smooth="yes"/>
-      <point x="577" y="629"/>
-      <point x="517" y="589"/>
-      <point x="486" y="516" type="curve"/>
-      <point x="474" y="516" type="line"/>
-      <point x="453" y="591"/>
-      <point x="396" y="629"/>
-      <point x="301" y="629" type="curve" smooth="yes"/>
-      <point x="168" y="629"/>
-      <point x="79" y="554"/>
-      <point x="79" y="448" type="curve" smooth="yes"/>
-      <point x="79" y="372"/>
-      <point x="132" y="320"/>
-      <point x="224" y="320" type="curve" smooth="yes"/>
-      <point x="310" y="320"/>
-      <point x="368" y="368"/>
-      <point x="368" y="444" type="curve" smooth="yes"/>
-      <point x="368" y="503"/>
-      <point x="335" y="534"/>
-      <point x="276" y="534" type="curve" smooth="yes"/>
-      <point x="251" y="534"/>
-      <point x="229" y="529"/>
-      <point x="208" y="520" type="curve"/>
-      <point x="194" y="542" type="line"/>
-      <point x="192" y="524" type="line"/>
-      <point x="215" y="545"/>
-      <point x="253" y="557"/>
-      <point x="298" y="557" type="curve" smooth="yes"/>
-      <point x="379" y="557"/>
-      <point x="412" y="518"/>
-      <point x="412" y="442" type="curve" smooth="yes"/>
-      <point x="412" y="428"/>
-      <point x="410" y="412"/>
-      <point x="408" y="397" type="curve" smooth="yes"/>
-      <point x="400" y="354" type="line"/>
-      <point x="518" y="354" type="line"/>
-      <point x="527" y="407" type="line" smooth="yes"/>
-      <point x="541" y="484"/>
-      <point x="577" y="526"/>
-      <point x="629" y="526" type="curve" smooth="yes"/>
-      <point x="674" y="526"/>
-      <point x="698" y="500"/>
-      <point x="698" y="451" type="curve" smooth="yes"/>
-      <point x="698" y="355"/>
-      <point x="656" y="307"/>
-      <point x="546" y="307" type="curve" smooth="yes"/>
-      <point x="244" y="307" type="line" smooth="yes"/>
-      <point x="94" y="307"/>
-      <point x="29" y="244"/>
-      <point x="29" y="154" type="curve" smooth="yes"/>
-      <point x="29" y="60"/>
-      <point x="100" y="-16"/>
+      <point x="311" y="-16" type="curve" smooth="yes"/>
+      <point x="624" y="-16"/>
+      <point x="802" y="69"/>
+      <point x="910" y="274" type="curve"/>
+      <point x="928" y="343" type="line"/>
+      <point x="938" y="343" type="line"/>
+      <point x="945" y="310"/>
+      <point x="983" y="281"/>
+      <point x="1040" y="281" type="curve" smooth="yes"/>
+      <point x="1136" y="281"/>
+      <point x="1207" y="338"/>
+      <point x="1207" y="425" type="curve" smooth="yes"/>
+      <point x="1207" y="487"/>
+      <point x="1174" y="527"/>
+      <point x="1109" y="527" type="curve" smooth="yes"/>
+      <point x="1080" y="527"/>
+      <point x="1047" y="518"/>
+      <point x="1020" y="503" type="curve"/>
+      <point x="1003" y="525" type="line"/>
+      <point x="996" y="491" type="line"/>
+      <point x="1028" y="532"/>
+      <point x="1075" y="555"/>
+      <point x="1147" y="555" type="curve" smooth="yes"/>
+      <point x="1224" y="555"/>
+      <point x="1260" y="518"/>
+      <point x="1260" y="457" type="curve" smooth="yes"/>
+      <point x="1260" y="434"/>
+      <point x="1257" y="410"/>
+      <point x="1253" y="387" type="curve" smooth="yes"/>
+      <point x="1243" y="330" type="line"/>
+      <point x="1357" y="330" type="line"/>
+      <point x="1369" y="398" type="line" smooth="yes"/>
+      <point x="1383" y="479"/>
+      <point x="1426" y="523"/>
+      <point x="1498" y="523" type="curve" smooth="yes"/>
+      <point x="1559" y="523"/>
+      <point x="1592" y="491"/>
+      <point x="1592" y="430" type="curve" smooth="yes"/>
+      <point x="1592" y="333"/>
+      <point x="1522" y="273"/>
+      <point x="1391" y="273" type="curve" smooth="yes"/>
+      <point x="1068" y="273" type="line" smooth="yes"/>
+      <point x="950" y="273"/>
+      <point x="880" y="201"/>
+      <point x="880" y="119" type="curve" smooth="yes"/>
+      <point x="880" y="39"/>
+      <point x="938" y="-16"/>
+      <point x="1040" y="-16" type="curve" smooth="yes"/>
+      <point x="1082" y="-16"/>
+      <point x="1121" y="-4"/>
+      <point x="1188" y="26" type="curve" smooth="yes"/>
+      <point x="1321" y="85" type="line"/>
+      <point x="1386" y="142" type="line"/>
+      <point x="1428" y="159" type="line"/>
+      <point x="1462" y="180"/>
+      <point x="1480" y="186"/>
+      <point x="1508" y="186" type="curve" smooth="yes"/>
+      <point x="1549" y="186"/>
+      <point x="1567" y="167"/>
+      <point x="1567" y="134" type="curve" smooth="yes"/>
+      <point x="1567" y="106"/>
+      <point x="1548" y="73"/>
+      <point x="1499" y="73" type="curve" smooth="yes"/>
+      <point x="1462" y="73"/>
+      <point x="1440" y="94"/>
+      <point x="1440" y="125" type="curve" smooth="yes"/>
+      <point x="1440" y="145"/>
+      <point x="1446" y="163"/>
+      <point x="1460" y="183" type="curve"/>
+      <point x="1359" y="142" type="line"/>
+      <point x="1380" y="123" type="line"/>
+      <point x="1374" y="110"/>
+      <point x="1372" y="97"/>
+      <point x="1372" y="81" type="curve" smooth="yes"/>
+      <point x="1372" y="26"/>
+      <point x="1418" y="-16"/>
+      <point x="1492" y="-16" type="curve" smooth="yes"/>
+      <point x="1610" y="-16"/>
+      <point x="1656" y="71"/>
+      <point x="1656" y="136" type="curve" smooth="yes"/>
+      <point x="1656" y="203"/>
+      <point x="1615" y="248"/>
+      <point x="1535" y="248" type="curve" smooth="yes"/>
+      <point x="1476" y="248"/>
+      <point x="1422" y="229"/>
+      <point x="1333" y="190" type="curve" smooth="yes"/>
+      <point x="1159" y="113" type="line" smooth="yes"/>
+      <point x="1116" y="94"/>
+      <point x="1084" y="84"/>
+      <point x="1052" y="84" type="curve" smooth="yes"/>
+      <point x="1014" y="84"/>
+      <point x="994" y="99"/>
+      <point x="994" y="127" type="curve" smooth="yes"/>
+      <point x="994" y="157"/>
+      <point x="1017" y="178"/>
+      <point x="1065" y="178" type="curve" smooth="yes"/>
+      <point x="1375" y="178" type="line" smooth="yes"/>
+      <point x="1545" y="178"/>
+      <point x="1710" y="269"/>
+      <point x="1710" y="448" type="curve" smooth="yes"/>
+      <point x="1710" y="563"/>
+      <point x="1646" y="629"/>
+      <point x="1534" y="629" type="curve" smooth="yes"/>
+      <point x="1446" y="629"/>
+      <point x="1380" y="585"/>
+      <point x="1346" y="514" type="curve"/>
+      <point x="1334" y="514" type="line"/>
+      <point x="1312" y="588"/>
+      <point x="1262" y="629"/>
+      <point x="1155" y="629" type="curve" smooth="yes"/>
+      <point x="1036" y="629"/>
+      <point x="933" y="566"/>
+      <point x="891" y="446" type="curve" smooth="yes"/>
+      <point x="865" y="371" type="line" smooth="yes"/>
+      <point x="797" y="178"/>
+      <point x="626" y="87"/>
+      <point x="324" y="87" type="curve" smooth="yes"/>
+      <point x="187" y="87"/>
+      <point x="142" y="95"/>
+      <point x="142" y="135" type="curve" smooth="yes"/>
+      <point x="142" y="160"/>
+      <point x="165" y="178"/>
+      <point x="213" y="178" type="curve" smooth="yes"/>
+      <point x="487" y="178" type="line" smooth="yes"/>
+      <point x="685" y="178"/>
+      <point x="838" y="296"/>
+      <point x="838" y="460" type="curve" smooth="yes"/>
+      <point x="838" y="565"/>
+      <point x="781" y="629"/>
+      <point x="689" y="629" type="curve" smooth="yes"/>
+      <point x="611" y="629"/>
+      <point x="552" y="585"/>
+      <point x="522" y="514" type="curve"/>
+      <point x="510" y="514" type="line"/>
+      <point x="490" y="588"/>
+      <point x="438" y="629"/>
+      <point x="331" y="629" type="curve" smooth="yes"/>
+      <point x="156" y="629"/>
+      <point x="73" y="511"/>
+      <point x="73" y="418" type="curve" smooth="yes"/>
+      <point x="73" y="336"/>
+      <point x="132" y="281"/>
+      <point x="218" y="281" type="curve" smooth="yes"/>
+      <point x="314" y="281"/>
+      <point x="385" y="338"/>
+      <point x="385" y="425" type="curve" smooth="yes"/>
+      <point x="385" y="487"/>
+      <point x="352" y="527"/>
+      <point x="287" y="527" type="curve" smooth="yes"/>
+      <point x="258" y="527"/>
+      <point x="225" y="518"/>
+      <point x="198" y="503" type="curve"/>
+      <point x="181" y="525" type="line"/>
+      <point x="174" y="491" type="line"/>
+      <point x="206" y="532"/>
+      <point x="255" y="555"/>
+      <point x="325" y="555" type="curve" smooth="yes"/>
+      <point x="402" y="555"/>
+      <point x="438" y="518"/>
+      <point x="438" y="457" type="curve" smooth="yes"/>
+      <point x="438" y="434"/>
+      <point x="435" y="410"/>
+      <point x="431" y="387" type="curve" smooth="yes"/>
+      <point x="421" y="330" type="line"/>
+      <point x="535" y="330" type="line"/>
+      <point x="547" y="398" type="line" smooth="yes"/>
+      <point x="561" y="479"/>
+      <point x="597" y="523"/>
+      <point x="660" y="523" type="curve" smooth="yes"/>
+      <point x="706" y="523"/>
+      <point x="729" y="498"/>
+      <point x="729" y="448" type="curve" smooth="yes"/>
+      <point x="729" y="333"/>
+      <point x="632" y="273"/>
+      <point x="495" y="273" type="curve" smooth="yes"/>
+      <point x="216" y="273" type="line" smooth="yes"/>
+      <point x="87" y="273"/>
+      <point x="24" y="205"/>
+      <point x="24" y="127" type="curve" smooth="yes"/>
+      <point x="24" y="39"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
-      <point x="230" y="400" type="curve" smooth="yes"/>
-      <point x="197" y="400"/>
-      <point x="177" y="419"/>
-      <point x="177" y="452" type="curve" smooth="yes"/>
-      <point x="177" y="472"/>
-      <point x="185" y="490"/>
-      <point x="198" y="506" type="curve"/>
-      <point x="167" y="506" type="line"/>
-      <point x="155" y="475" type="line"/>
-      <point x="183" y="485"/>
-      <point x="206" y="491"/>
-      <point x="230" y="491" type="curve" smooth="yes"/>
-      <point x="267" y="491"/>
-      <point x="284" y="478"/>
-      <point x="284" y="448" type="curve" smooth="yes"/>
-      <point x="284" y="417"/>
-      <point x="263" y="400"/>
+      <point x="226" y="368" type="curve" smooth="yes"/>
+      <point x="189" y="368"/>
+      <point x="165" y="388"/>
+      <point x="165" y="425" type="curve" smooth="yes"/>
+      <point x="165" y="441"/>
+      <point x="167" y="454"/>
+      <point x="174" y="470" type="curve"/>
+      <point x="157" y="470" type="line"/>
+      <point x="145" y="441" type="line"/>
+      <point x="174" y="456"/>
+      <point x="202" y="463"/>
+      <point x="234" y="463" type="curve" smooth="yes"/>
+      <point x="271" y="463"/>
+      <point x="289" y="448"/>
+      <point x="289" y="421" type="curve" smooth="yes"/>
+      <point x="289" y="391"/>
+      <point x="266" y="368"/>
     </contour>
     <contour>
-      <point x="1025" y="400" type="curve" smooth="yes"/>
-      <point x="989" y="400"/>
-      <point x="969" y="419"/>
-      <point x="969" y="452" type="curve" smooth="yes"/>
-      <point x="969" y="472"/>
-      <point x="976" y="490"/>
-      <point x="989" y="506" type="curve"/>
-      <point x="958" y="506" type="line"/>
-      <point x="946" y="475" type="line"/>
-      <point x="974" y="485"/>
-      <point x="998" y="491"/>
-      <point x="1025" y="491" type="curve" smooth="yes"/>
-      <point x="1065" y="491"/>
-      <point x="1081" y="478"/>
-      <point x="1081" y="447" type="curve" smooth="yes"/>
-      <point x="1081" y="417"/>
-      <point x="1060" y="400"/>
+      <point x="1048" y="368" type="curve" smooth="yes"/>
+      <point x="1011" y="368"/>
+      <point x="987" y="388"/>
+      <point x="987" y="425" type="curve" smooth="yes"/>
+      <point x="987" y="441"/>
+      <point x="989" y="454"/>
+      <point x="996" y="470" type="curve"/>
+      <point x="979" y="470" type="line"/>
+      <point x="967" y="441" type="line"/>
+      <point x="996" y="456"/>
+      <point x="1024" y="463"/>
+      <point x="1056" y="463" type="curve" smooth="yes"/>
+      <point x="1093" y="463"/>
+      <point x="1111" y="448"/>
+      <point x="1111" y="421" type="curve" smooth="yes"/>
+      <point x="1111" y="391"/>
+      <point x="1088" y="368"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/j_nya-malayalam.glif
@@ -1,194 +1,194 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2279"/>
-  <anchor x="1833" y="0" name="bottom"/>
-  <anchor x="1151" y="613" name="top"/>
-  <anchor x="2134" y="613" name="topright"/>
+  <advance width="2312"/>
+  <anchor x="1830" y="0" name="bottom"/>
+  <anchor x="1210" y="613" name="top"/>
+  <anchor x="2203" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="358" y="-16" type="curve" smooth="yes"/>
-      <point x="551" y="-16"/>
-      <point x="711" y="35"/>
-      <point x="821" y="155" type="curve"/>
-      <point x="888" y="155" type="line"/>
-      <point x="820" y="281" type="line"/>
-      <point x="819" y="270"/>
-      <point x="819" y="258"/>
-      <point x="819" y="247" type="curve" smooth="yes"/>
-      <point x="819" y="91"/>
-      <point x="898" y="-16"/>
-      <point x="1037" y="-16" type="curve" smooth="yes"/>
-      <point x="1159" y="-16"/>
-      <point x="1236" y="66"/>
-      <point x="1236" y="195" type="curve" smooth="yes"/>
-      <point x="1236" y="303"/>
-      <point x="1181" y="367"/>
-      <point x="1085" y="367" type="curve" smooth="yes"/>
-      <point x="1032" y="367"/>
-      <point x="986" y="346"/>
-      <point x="950" y="307" type="curve"/>
-      <point x="897" y="322" type="line"/>
-      <point x="906" y="141" type="line"/>
-      <point x="929" y="221"/>
-      <point x="981" y="273"/>
-      <point x="1040" y="273" type="curve" smooth="yes"/>
-      <point x="1091" y="273"/>
-      <point x="1116" y="245"/>
-      <point x="1116" y="189" type="curve" smooth="yes"/>
-      <point x="1116" y="130"/>
-      <point x="1086" y="95"/>
-      <point x="1035" y="95" type="curve" smooth="yes"/>
-      <point x="968" y="95"/>
-      <point x="930" y="144"/>
-      <point x="930" y="232" type="curve" smooth="yes"/>
-      <point x="930" y="401"/>
-      <point x="1025" y="518"/>
-      <point x="1164" y="518" type="curve" smooth="yes"/>
-      <point x="1263" y="518"/>
-      <point x="1317" y="464"/>
-      <point x="1317" y="363" type="curve" smooth="yes"/>
-      <point x="1317" y="345"/>
-      <point x="1314" y="319"/>
-      <point x="1309" y="292" type="curve" smooth="yes"/>
-      <point x="1258" y="0" type="line"/>
-      <point x="1380" y="0" type="line"/>
-      <point x="1438" y="331" type="line" smooth="yes"/>
-      <point x="1461" y="461"/>
-      <point x="1520" y="518"/>
-      <point x="1633" y="518" type="curve" smooth="yes"/>
-      <point x="1770" y="518"/>
-      <point x="1840" y="436"/>
-      <point x="1840" y="276" type="curve" smooth="yes"/>
-      <point x="1840" y="166"/>
-      <point x="1796" y="95"/>
-      <point x="1727" y="95" type="curve" smooth="yes"/>
-      <point x="1670" y="95"/>
-      <point x="1641" y="136"/>
-      <point x="1641" y="214" type="curve" smooth="yes"/>
-      <point x="1641" y="389"/>
-      <point x="1764" y="518"/>
-      <point x="1931" y="518" type="curve" smooth="yes"/>
-      <point x="2050" y="518"/>
-      <point x="2117" y="455"/>
-      <point x="2117" y="344" type="curve" smooth="yes"/>
-      <point x="2117" y="246"/>
-      <point x="2071" y="156"/>
-      <point x="1971" y="60" type="curve"/>
-      <point x="2058" y="-15" type="line"/>
-      <point x="2181" y="100"/>
-      <point x="2236" y="213"/>
-      <point x="2236" y="348" type="curve" smooth="yes"/>
-      <point x="2236" y="523"/>
-      <point x="2125" y="629"/>
-      <point x="1941" y="629" type="curve" smooth="yes"/>
-      <point x="1724" y="629"/>
-      <point x="1528" y="430"/>
-      <point x="1528" y="207" type="curve" smooth="yes"/>
-      <point x="1528" y="64"/>
-      <point x="1600" y="-16"/>
-      <point x="1728" y="-16" type="curve" smooth="yes"/>
-      <point x="1869" y="-16"/>
-      <point x="1958" y="95"/>
-      <point x="1958" y="274" type="curve" smooth="yes"/>
-      <point x="1958" y="484"/>
-      <point x="1828" y="629"/>
-      <point x="1641" y="629" type="curve" smooth="yes"/>
-      <point x="1528" y="629"/>
-      <point x="1443" y="579"/>
-      <point x="1394" y="490" type="curve"/>
-      <point x="1382" y="490" type="line"/>
-      <point x="1347" y="579"/>
-      <point x="1272" y="629"/>
-      <point x="1159" y="629" type="curve" smooth="yes"/>
-      <point x="1019" y="629"/>
-      <point x="916" y="560"/>
-      <point x="840" y="375" type="curve" smooth="yes"/>
-      <point x="749" y="153"/>
-      <point x="610" y="87"/>
-      <point x="352" y="87" type="curve" smooth="yes"/>
-      <point x="196" y="87"/>
-      <point x="147" y="112"/>
-      <point x="147" y="156" type="curve" smooth="yes"/>
-      <point x="147" y="186"/>
-      <point x="172" y="208"/>
-      <point x="237" y="208" type="curve" smooth="yes"/>
-      <point x="533" y="208" type="line" smooth="yes"/>
-      <point x="716" y="208"/>
-      <point x="816" y="306"/>
-      <point x="816" y="458" type="curve" smooth="yes"/>
-      <point x="816" y="556"/>
-      <point x="765" y="629"/>
-      <point x="652" y="629" type="curve" smooth="yes"/>
-      <point x="578" y="629"/>
-      <point x="520" y="589"/>
-      <point x="489" y="516" type="curve"/>
-      <point x="477" y="516" type="line"/>
-      <point x="456" y="591"/>
-      <point x="398" y="629"/>
-      <point x="301" y="629" type="curve" smooth="yes"/>
-      <point x="168" y="629"/>
-      <point x="79" y="554"/>
-      <point x="79" y="448" type="curve" smooth="yes"/>
-      <point x="79" y="372"/>
-      <point x="132" y="320"/>
-      <point x="224" y="320" type="curve" smooth="yes"/>
-      <point x="310" y="320"/>
-      <point x="368" y="368"/>
-      <point x="368" y="444" type="curve" smooth="yes"/>
-      <point x="368" y="503"/>
-      <point x="335" y="534"/>
-      <point x="276" y="534" type="curve" smooth="yes"/>
-      <point x="251" y="534"/>
-      <point x="229" y="529"/>
-      <point x="208" y="520" type="curve"/>
-      <point x="194" y="542" type="line"/>
-      <point x="192" y="524" type="line"/>
-      <point x="215" y="545"/>
-      <point x="253" y="557"/>
-      <point x="298" y="557" type="curve" smooth="yes"/>
-      <point x="381" y="557"/>
-      <point x="414" y="518"/>
-      <point x="414" y="442" type="curve" smooth="yes"/>
-      <point x="414" y="428"/>
-      <point x="412" y="412"/>
-      <point x="410" y="397" type="curve" smooth="yes"/>
-      <point x="402" y="354" type="line"/>
-      <point x="520" y="354" type="line"/>
-      <point x="529" y="407" type="line" smooth="yes"/>
-      <point x="543" y="484"/>
-      <point x="577" y="526"/>
-      <point x="630" y="526" type="curve" smooth="yes"/>
-      <point x="679" y="526"/>
-      <point x="703" y="499"/>
-      <point x="703" y="450" type="curve" smooth="yes"/>
-      <point x="703" y="362"/>
-      <point x="662" y="307"/>
-      <point x="542" y="307" type="curve" smooth="yes"/>
-      <point x="244" y="307" type="line" smooth="yes"/>
-      <point x="94" y="307"/>
-      <point x="29" y="244"/>
-      <point x="29" y="154" type="curve" smooth="yes"/>
-      <point x="29" y="60"/>
-      <point x="100" y="-16"/>
+      <point x="311" y="-16" type="curve" smooth="yes"/>
+      <point x="574" y="-16"/>
+      <point x="736" y="41"/>
+      <point x="848" y="173" type="curve"/>
+      <point x="915" y="173" type="line"/>
+      <point x="853" y="281" type="line"/>
+      <point x="852" y="270"/>
+      <point x="852" y="258"/>
+      <point x="852" y="247" type="curve" smooth="yes"/>
+      <point x="852" y="91"/>
+      <point x="927" y="-16"/>
+      <point x="1070" y="-16" type="curve" smooth="yes"/>
+      <point x="1192" y="-16"/>
+      <point x="1269" y="67"/>
+      <point x="1269" y="197" type="curve" smooth="yes"/>
+      <point x="1269" y="307"/>
+      <point x="1215" y="372"/>
+      <point x="1119" y="372" type="curve" smooth="yes"/>
+      <point x="1063" y="372"/>
+      <point x="1015" y="348"/>
+      <point x="979" y="307" type="curve"/>
+      <point x="926" y="322" type="line"/>
+      <point x="926" y="149" type="line"/>
+      <point x="963" y="228"/>
+      <point x="1015" y="270"/>
+      <point x="1076" y="270" type="curve" smooth="yes"/>
+      <point x="1125" y="270"/>
+      <point x="1149" y="244"/>
+      <point x="1149" y="193" type="curve" smooth="yes"/>
+      <point x="1149" y="130"/>
+      <point x="1107" y="92"/>
+      <point x="1060" y="92" type="curve" smooth="yes"/>
+      <point x="998" y="92"/>
+      <point x="956" y="145"/>
+      <point x="956" y="239" type="curve" smooth="yes"/>
+      <point x="956" y="356"/>
+      <point x="1037" y="518"/>
+      <point x="1197" y="518" type="curve" smooth="yes"/>
+      <point x="1299" y="518"/>
+      <point x="1350" y="464"/>
+      <point x="1350" y="369" type="curve" smooth="yes"/>
+      <point x="1350" y="349"/>
+      <point x="1347" y="319"/>
+      <point x="1342" y="290" type="curve" smooth="yes"/>
+      <point x="1291" y="0" type="line"/>
+      <point x="1413" y="0" type="line"/>
+      <point x="1471" y="329" type="line" smooth="yes"/>
+      <point x="1494" y="458"/>
+      <point x="1557" y="518"/>
+      <point x="1676" y="518" type="curve" smooth="yes"/>
+      <point x="1809" y="518"/>
+      <point x="1872" y="432"/>
+      <point x="1872" y="276" type="curve" smooth="yes"/>
+      <point x="1872" y="166"/>
+      <point x="1826" y="95"/>
+      <point x="1759" y="95" type="curve" smooth="yes"/>
+      <point x="1702" y="95"/>
+      <point x="1673" y="134"/>
+      <point x="1673" y="207" type="curve" smooth="yes"/>
+      <point x="1673" y="366"/>
+      <point x="1803" y="518"/>
+      <point x="1976" y="518" type="curve" smooth="yes"/>
+      <point x="2091" y="518"/>
+      <point x="2141" y="455"/>
+      <point x="2141" y="344" type="curve" smooth="yes"/>
+      <point x="2141" y="244"/>
+      <point x="2099" y="153"/>
+      <point x="2011" y="62" type="curve"/>
+      <point x="2097" y="-16" type="line"/>
+      <point x="2210" y="100"/>
+      <point x="2261" y="214"/>
+      <point x="2261" y="348" type="curve" smooth="yes"/>
+      <point x="2261" y="523"/>
+      <point x="2162" y="629"/>
+      <point x="1988" y="629" type="curve" smooth="yes"/>
+      <point x="1752" y="629"/>
+      <point x="1560" y="407"/>
+      <point x="1560" y="201" type="curve" smooth="yes"/>
+      <point x="1560" y="62"/>
+      <point x="1638" y="-16"/>
+      <point x="1752" y="-16" type="curve" smooth="yes"/>
+      <point x="1888" y="-16"/>
+      <point x="1990" y="98"/>
+      <point x="1990" y="274" type="curve" smooth="yes"/>
+      <point x="1990" y="482"/>
+      <point x="1862" y="629"/>
+      <point x="1680" y="629" type="curve" smooth="yes"/>
+      <point x="1569" y="629"/>
+      <point x="1484" y="577"/>
+      <point x="1435" y="491" type="curve"/>
+      <point x="1423" y="491" type="line"/>
+      <point x="1387" y="578"/>
+      <point x="1324" y="629"/>
+      <point x="1205" y="629" type="curve" smooth="yes"/>
+      <point x="1069" y="629"/>
+      <point x="947" y="561"/>
+      <point x="873" y="375" type="curve" smooth="yes"/>
+      <point x="789" y="164"/>
+      <point x="638" y="87"/>
+      <point x="324" y="87" type="curve" smooth="yes"/>
+      <point x="187" y="87"/>
+      <point x="142" y="95"/>
+      <point x="142" y="135" type="curve" smooth="yes"/>
+      <point x="142" y="160"/>
+      <point x="165" y="178"/>
+      <point x="213" y="178" type="curve" smooth="yes"/>
+      <point x="487" y="178" type="line" smooth="yes"/>
+      <point x="685" y="178"/>
+      <point x="838" y="296"/>
+      <point x="838" y="460" type="curve" smooth="yes"/>
+      <point x="838" y="565"/>
+      <point x="781" y="629"/>
+      <point x="689" y="629" type="curve" smooth="yes"/>
+      <point x="611" y="629"/>
+      <point x="552" y="585"/>
+      <point x="522" y="514" type="curve"/>
+      <point x="510" y="514" type="line"/>
+      <point x="490" y="588"/>
+      <point x="438" y="629"/>
+      <point x="331" y="629" type="curve" smooth="yes"/>
+      <point x="156" y="629"/>
+      <point x="73" y="511"/>
+      <point x="73" y="418" type="curve" smooth="yes"/>
+      <point x="73" y="336"/>
+      <point x="132" y="281"/>
+      <point x="218" y="281" type="curve" smooth="yes"/>
+      <point x="314" y="281"/>
+      <point x="385" y="338"/>
+      <point x="385" y="425" type="curve" smooth="yes"/>
+      <point x="385" y="487"/>
+      <point x="352" y="527"/>
+      <point x="287" y="527" type="curve" smooth="yes"/>
+      <point x="258" y="527"/>
+      <point x="225" y="518"/>
+      <point x="198" y="503" type="curve"/>
+      <point x="181" y="525" type="line"/>
+      <point x="174" y="491" type="line"/>
+      <point x="206" y="532"/>
+      <point x="255" y="555"/>
+      <point x="325" y="555" type="curve" smooth="yes"/>
+      <point x="402" y="555"/>
+      <point x="438" y="518"/>
+      <point x="438" y="457" type="curve" smooth="yes"/>
+      <point x="438" y="434"/>
+      <point x="435" y="410"/>
+      <point x="431" y="387" type="curve" smooth="yes"/>
+      <point x="421" y="330" type="line"/>
+      <point x="535" y="330" type="line"/>
+      <point x="547" y="398" type="line" smooth="yes"/>
+      <point x="561" y="479"/>
+      <point x="597" y="523"/>
+      <point x="660" y="523" type="curve" smooth="yes"/>
+      <point x="706" y="523"/>
+      <point x="729" y="498"/>
+      <point x="729" y="448" type="curve" smooth="yes"/>
+      <point x="729" y="333"/>
+      <point x="632" y="273"/>
+      <point x="495" y="273" type="curve" smooth="yes"/>
+      <point x="216" y="273" type="line" smooth="yes"/>
+      <point x="87" y="273"/>
+      <point x="24" y="205"/>
+      <point x="24" y="127" type="curve" smooth="yes"/>
+      <point x="24" y="39"/>
+      <point x="99" y="-16"/>
     </contour>
     <contour>
-      <point x="230" y="400" type="curve" smooth="yes"/>
-      <point x="197" y="400"/>
-      <point x="177" y="419"/>
-      <point x="177" y="452" type="curve" smooth="yes"/>
-      <point x="177" y="472"/>
-      <point x="185" y="490"/>
-      <point x="198" y="506" type="curve"/>
-      <point x="167" y="506" type="line"/>
-      <point x="155" y="475" type="line"/>
-      <point x="183" y="485"/>
-      <point x="206" y="491"/>
-      <point x="230" y="491" type="curve" smooth="yes"/>
-      <point x="267" y="491"/>
-      <point x="284" y="478"/>
-      <point x="284" y="448" type="curve" smooth="yes"/>
-      <point x="284" y="417"/>
-      <point x="263" y="400"/>
+      <point x="226" y="368" type="curve" smooth="yes"/>
+      <point x="189" y="368"/>
+      <point x="165" y="388"/>
+      <point x="165" y="425" type="curve" smooth="yes"/>
+      <point x="165" y="441"/>
+      <point x="167" y="454"/>
+      <point x="174" y="470" type="curve"/>
+      <point x="157" y="470" type="line"/>
+      <point x="145" y="441" type="line"/>
+      <point x="174" y="456"/>
+      <point x="202" y="463"/>
+      <point x="234" y="463" type="curve" smooth="yes"/>
+      <point x="271" y="463"/>
+      <point x="289" y="448"/>
+      <point x="289" y="421" type="curve" smooth="yes"/>
+      <point x="289" y="391"/>
+      <point x="266" y="368"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ja-malayalam.glif
@@ -1,139 +1,138 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="871"/>
+  <advance width="921"/>
   <unicode hex="0D1C"/>
-  <anchor x="411" y="0" name="bottom"/>
-  <anchor x="516" y="613" name="top"/>
-  <anchor x="783" y="613" name="topright"/>
+  <anchor x="430" y="-1" name="bottom"/>
+  <anchor x="515" y="613" name="top"/>
+  <anchor x="797" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="190" y="-16" type="curve" smooth="yes"/>
-      <point x="257" y="-16"/>
-      <point x="323" y="8"/>
-      <point x="414" y="62" type="curve" smooth="yes"/>
-      <point x="473" y="96" type="line"/>
-      <point x="575" y="166" type="line"/>
-      <point x="586" y="158" type="line"/>
-      <point x="617" y="172"/>
-      <point x="636" y="176"/>
-      <point x="654" y="176" type="curve" smooth="yes"/>
-      <point x="685" y="176"/>
-      <point x="700" y="161"/>
-      <point x="700" y="132" type="curve" smooth="yes"/>
-      <point x="700" y="95"/>
-      <point x="680" y="73"/>
-      <point x="647" y="73" type="curve" smooth="yes"/>
-      <point x="619" y="73"/>
-      <point x="601" y="91"/>
-      <point x="601" y="119" type="curve" smooth="yes"/>
-      <point x="601" y="144"/>
-      <point x="611" y="164"/>
-      <point x="635" y="183" type="curve"/>
-      <point x="482" y="163" type="line"/>
-      <point x="543" y="101" type="line"/>
-      <point x="569" y="170" type="line"/>
-      <point x="541" y="153"/>
-      <point x="521" y="123"/>
-      <point x="521" y="84" type="curve" smooth="yes"/>
-      <point x="521" y="24"/>
-      <point x="570" y="-16"/>
-      <point x="644" y="-16" type="curve" smooth="yes"/>
-      <point x="734" y="-16"/>
-      <point x="790" y="42"/>
-      <point x="790" y="136" type="curve" smooth="yes"/>
-      <point x="790" y="216"/>
-      <point x="748" y="260"/>
-      <point x="670" y="260" type="curve" smooth="yes"/>
-      <point x="619" y="260"/>
-      <point x="572" y="243"/>
-      <point x="475" y="193" type="curve" smooth="yes"/>
-      <point x="396" y="151" type="line" smooth="yes"/>
-      <point x="304" y="102"/>
-      <point x="257" y="87"/>
-      <point x="211" y="87" type="curve" smooth="yes"/>
-      <point x="170" y="87"/>
-      <point x="147" y="107"/>
-      <point x="147" y="143" type="curve" smooth="yes"/>
-      <point x="147" y="184"/>
-      <point x="180" y="208"/>
-      <point x="237" y="208" type="curve" smooth="yes"/>
-      <point x="604" y="208" type="line" smooth="yes"/>
-      <point x="757" y="208"/>
-      <point x="849" y="300"/>
-      <point x="849" y="452" type="curve" smooth="yes"/>
-      <point x="849" y="564"/>
-      <point x="785" y="629"/>
-      <point x="675" y="629" type="curve" smooth="yes"/>
-      <point x="591" y="629"/>
-      <point x="528" y="589"/>
-      <point x="498" y="516" type="curve"/>
-      <point x="485" y="516" type="line"/>
-      <point x="464" y="591"/>
-      <point x="407" y="629"/>
-      <point x="306" y="629" type="curve" smooth="yes"/>
-      <point x="175" y="629"/>
-      <point x="79" y="554"/>
-      <point x="79" y="448" type="curve" smooth="yes"/>
-      <point x="79" y="372"/>
-      <point x="133" y="320"/>
-      <point x="228" y="320" type="curve" smooth="yes"/>
-      <point x="316" y="320"/>
-      <point x="373" y="368"/>
-      <point x="373" y="443" type="curve" smooth="yes"/>
-      <point x="373" y="502"/>
-      <point x="341" y="534"/>
-      <point x="280" y="534" type="curve" smooth="yes"/>
-      <point x="255" y="534"/>
-      <point x="232" y="530"/>
-      <point x="207" y="519" type="curve"/>
-      <point x="194" y="542" type="line"/>
-      <point x="192" y="524" type="line"/>
-      <point x="220" y="546"/>
-      <point x="259" y="557"/>
-      <point x="304" y="557" type="curve" smooth="yes"/>
-      <point x="386" y="557"/>
-      <point x="421" y="518"/>
-      <point x="421" y="442" type="curve" smooth="yes"/>
-      <point x="421" y="428"/>
-      <point x="420" y="412"/>
-      <point x="417" y="397" type="curve" smooth="yes"/>
-      <point x="409" y="354" type="line"/>
-      <point x="527" y="354" type="line"/>
-      <point x="536" y="407" type="line" smooth="yes"/>
-      <point x="550" y="484"/>
-      <point x="590" y="526"/>
-      <point x="651" y="526" type="curve" smooth="yes"/>
-      <point x="705" y="526"/>
-      <point x="731" y="500"/>
-      <point x="731" y="445" type="curve" smooth="yes"/>
-      <point x="731" y="355"/>
-      <point x="681" y="307"/>
-      <point x="590" y="307" type="curve" smooth="yes"/>
-      <point x="237" y="307" type="line" smooth="yes"/>
-      <point x="108" y="307"/>
-      <point x="29" y="242"/>
-      <point x="29" y="135" type="curve" smooth="yes"/>
-      <point x="29" y="41"/>
-      <point x="89" y="-16"/>
+      <point x="191" y="-16" type="curve" smooth="yes"/>
+      <point x="244" y="-16"/>
+      <point x="297" y="-3"/>
+      <point x="366" y="28" type="curve" smooth="yes"/>
+      <point x="499" y="87" type="line"/>
+      <point x="564" y="142" type="line"/>
+      <point x="606" y="159" type="line"/>
+      <point x="640" y="180"/>
+      <point x="658" y="186"/>
+      <point x="686" y="186" type="curve" smooth="yes"/>
+      <point x="727" y="186"/>
+      <point x="745" y="167"/>
+      <point x="745" y="134" type="curve" smooth="yes"/>
+      <point x="745" y="106"/>
+      <point x="726" y="73"/>
+      <point x="677" y="73" type="curve" smooth="yes"/>
+      <point x="640" y="73"/>
+      <point x="618" y="94"/>
+      <point x="618" y="125" type="curve" smooth="yes"/>
+      <point x="618" y="145"/>
+      <point x="624" y="163"/>
+      <point x="638" y="183" type="curve"/>
+      <point x="537" y="142" type="line"/>
+      <point x="558" y="123" type="line"/>
+      <point x="552" y="110"/>
+      <point x="550" y="97"/>
+      <point x="550" y="81" type="curve" smooth="yes"/>
+      <point x="550" y="26"/>
+      <point x="596" y="-16"/>
+      <point x="670" y="-16" type="curve" smooth="yes"/>
+      <point x="788" y="-16"/>
+      <point x="834" y="71"/>
+      <point x="834" y="136" type="curve" smooth="yes"/>
+      <point x="834" y="203"/>
+      <point x="793" y="248"/>
+      <point x="713" y="248" type="curve" smooth="yes"/>
+      <point x="654" y="248"/>
+      <point x="599" y="231"/>
+      <point x="511" y="192" type="curve" smooth="yes"/>
+      <point x="337" y="115" type="line" smooth="yes"/>
+      <point x="288" y="93"/>
+      <point x="247" y="84"/>
+      <point x="201" y="84" type="curve" smooth="yes"/>
+      <point x="162" y="84"/>
+      <point x="142" y="100"/>
+      <point x="142" y="129" type="curve" smooth="yes"/>
+      <point x="142" y="158"/>
+      <point x="165" y="178"/>
+      <point x="213" y="178" type="curve" smooth="yes"/>
+      <point x="555" y="178" type="line" smooth="yes"/>
+      <point x="731" y="178"/>
+      <point x="890" y="266"/>
+      <point x="890" y="446" type="curve" smooth="yes"/>
+      <point x="890" y="556"/>
+      <point x="834" y="629"/>
+      <point x="714" y="629" type="curve" smooth="yes"/>
+      <point x="625" y="629"/>
+      <point x="558" y="585"/>
+      <point x="524" y="514" type="curve"/>
+      <point x="512" y="514" type="line"/>
+      <point x="492" y="588"/>
+      <point x="439" y="629"/>
+      <point x="331" y="629" type="curve" smooth="yes"/>
+      <point x="156" y="629"/>
+      <point x="73" y="511"/>
+      <point x="73" y="418" type="curve" smooth="yes"/>
+      <point x="73" y="336"/>
+      <point x="132" y="281"/>
+      <point x="218" y="281" type="curve" smooth="yes"/>
+      <point x="314" y="281"/>
+      <point x="385" y="338"/>
+      <point x="385" y="425" type="curve" smooth="yes"/>
+      <point x="385" y="487"/>
+      <point x="352" y="527"/>
+      <point x="287" y="527" type="curve" smooth="yes"/>
+      <point x="258" y="527"/>
+      <point x="225" y="518"/>
+      <point x="198" y="503" type="curve"/>
+      <point x="181" y="525" type="line"/>
+      <point x="174" y="491" type="line"/>
+      <point x="206" y="532"/>
+      <point x="255" y="555"/>
+      <point x="325" y="555" type="curve" smooth="yes"/>
+      <point x="402" y="555"/>
+      <point x="438" y="518"/>
+      <point x="438" y="457" type="curve" smooth="yes"/>
+      <point x="438" y="434"/>
+      <point x="435" y="410"/>
+      <point x="431" y="387" type="curve" smooth="yes"/>
+      <point x="421" y="330" type="line"/>
+      <point x="535" y="330" type="line"/>
+      <point x="547" y="398" type="line" smooth="yes"/>
+      <point x="561" y="479"/>
+      <point x="605" y="523"/>
+      <point x="678" y="523" type="curve" smooth="yes"/>
+      <point x="742" y="523"/>
+      <point x="772" y="488"/>
+      <point x="772" y="430" type="curve" smooth="yes"/>
+      <point x="772" y="331"/>
+      <point x="702" y="273"/>
+      <point x="571" y="273" type="curve" smooth="yes"/>
+      <point x="216" y="273" type="line" smooth="yes"/>
+      <point x="87" y="273"/>
+      <point x="24" y="202"/>
+      <point x="24" y="121" type="curve" smooth="yes"/>
+      <point x="24" y="40"/>
+      <point x="85" y="-16"/>
     </contour>
     <contour>
-      <point x="233" y="400" type="curve" smooth="yes"/>
-      <point x="198" y="400"/>
-      <point x="177" y="419"/>
-      <point x="177" y="452" type="curve" smooth="yes"/>
-      <point x="177" y="472"/>
-      <point x="185" y="490"/>
-      <point x="198" y="506" type="curve"/>
-      <point x="167" y="506" type="line"/>
-      <point x="155" y="475" type="line"/>
-      <point x="183" y="485"/>
-      <point x="207" y="491"/>
-      <point x="234" y="491" type="curve" smooth="yes"/>
-      <point x="273" y="491"/>
-      <point x="290" y="478"/>
-      <point x="290" y="447" type="curve" smooth="yes"/>
-      <point x="290" y="417"/>
-      <point x="269" y="400"/>
+      <point x="226" y="368" type="curve" smooth="yes"/>
+      <point x="189" y="368"/>
+      <point x="165" y="388"/>
+      <point x="165" y="425" type="curve" smooth="yes"/>
+      <point x="165" y="441"/>
+      <point x="167" y="454"/>
+      <point x="174" y="470" type="curve"/>
+      <point x="157" y="470" type="line"/>
+      <point x="145" y="441" type="line"/>
+      <point x="174" y="456"/>
+      <point x="202" y="463"/>
+      <point x="234" y="463" type="curve" smooth="yes"/>
+      <point x="271" y="463"/>
+      <point x="289" y="448"/>
+      <point x="289" y="421" type="curve" smooth="yes"/>
+      <point x="289" y="391"/>
+      <point x="266" y="368"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="871"/>
+  <advance width="921"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="700"/>
+    <component base="halant-malayalam" xOffset="714"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="871"/>
+  <advance width="921"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="461"/>
+    <component base="lVocalicMatra-malayalam" xOffset="480" yOffset="-1"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="871"/>
+  <advance width="921"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="461"/>
+    <component base="llVocalicMatra-malayalam" xOffset="480" yOffset="-1"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
@@ -2,113 +2,112 @@
 <glyph name="kChillu-malayalam" format="2">
   <advance width="1103"/>
   <unicode hex="0D7F"/>
-  <anchor x="712" y="0" name="bottom"/>
-  <anchor x="383" y="613" name="top"/>
+  <anchor x="635" y="0" name="bottom"/>
+  <anchor x="414" y="613" name="top"/>
   <outline>
     <contour>
-      <point x="184" y="-16" type="curve" smooth="yes"/>
-      <point x="272" y="-16"/>
-      <point x="327" y="31"/>
-      <point x="354" y="91" type="curve"/>
-      <point x="366" y="91" type="line"/>
-      <point x="390" y="26"/>
-      <point x="443" y="-16"/>
-      <point x="534" y="-16" type="curve" smooth="yes"/>
-      <point x="613" y="-16"/>
-      <point x="671" y="24"/>
-      <point x="697" y="89" type="curve"/>
-      <point x="709" y="89" type="line"/>
-      <point x="728" y="24"/>
-      <point x="778" y="-16"/>
-      <point x="865" y="-16" type="curve" smooth="yes"/>
-      <point x="980" y="-16"/>
-      <point x="1047" y="61"/>
-      <point x="1047" y="180" type="curve" smooth="yes"/>
-      <point x="1047" y="279"/>
-      <point x="982" y="353"/>
-      <point x="850" y="353" type="curve" smooth="yes"/>
-      <point x="820" y="353" type="line"/>
-      <point x="768" y="253" type="line"/>
-      <point x="820" y="253" type="line" smooth="yes"/>
-      <point x="901" y="253"/>
-      <point x="927" y="222"/>
-      <point x="927" y="180" type="curve" smooth="yes"/>
-      <point x="927" y="131"/>
-      <point x="901" y="95"/>
-      <point x="851" y="95" type="curve" smooth="yes"/>
-      <point x="799" y="95"/>
-      <point x="771" y="125"/>
-      <point x="771" y="179" type="curve" smooth="yes"/>
-      <point x="771" y="263"/>
-      <point x="838" y="342"/>
-      <point x="924" y="434" type="curve" smooth="yes"/>
-      <point x="1000" y="515"/>
-      <point x="1055" y="584"/>
-      <point x="1055" y="681" type="curve" smooth="yes"/>
-      <point x="1055" y="774"/>
-      <point x="1003" y="831"/>
-      <point x="876" y="831" type="curve" smooth="yes"/>
-      <point x="827" y="831"/>
-      <point x="774" y="821"/>
-      <point x="730" y="800" type="curve"/>
-      <point x="755" y="701" type="line"/>
-      <point x="791" y="716"/>
-      <point x="827" y="722"/>
-      <point x="859" y="722" type="curve" smooth="yes"/>
-      <point x="916" y="722"/>
-      <point x="941" y="700"/>
-      <point x="941" y="663" type="curve" smooth="yes"/>
-      <point x="941" y="608"/>
-      <point x="909" y="569"/>
-      <point x="851" y="507" type="curve" smooth="yes"/>
-      <point x="828" y="482"/>
-      <point x="813" y="463"/>
-      <point x="805" y="442" type="curve"/>
-      <point x="735" y="442" type="line"/>
-      <point x="795" y="327" type="line"/>
-      <point x="797" y="348"/>
-      <point x="798" y="369"/>
-      <point x="798" y="388" type="curve" smooth="yes"/>
-      <point x="798" y="530"/>
-      <point x="747" y="629"/>
-      <point x="606" y="629" type="curve" smooth="yes"/>
-      <point x="467" y="629"/>
-      <point x="368" y="522"/>
-      <point x="340" y="336" type="curve" smooth="yes"/>
-      <point x="333" y="295"/>
-      <point x="330" y="256"/>
-      <point x="326" y="227" type="curve" smooth="yes"/>
-      <point x="314" y="138"/>
-      <point x="270" y="95"/>
-      <point x="211" y="95" type="curve" smooth="yes"/>
-      <point x="160" y="95"/>
-      <point x="133" y="123"/>
-      <point x="133" y="169" type="curve" smooth="yes"/>
-      <point x="133" y="215"/>
-      <point x="166" y="253"/>
-      <point x="237" y="253" type="curve" smooth="yes"/>
-      <point x="744" y="253" type="line"/>
-      <point x="744" y="353" type="line"/>
-      <point x="250" y="353" type="line" smooth="yes"/>
-      <point x="100" y="353"/>
-      <point x="14" y="273"/>
-      <point x="14" y="152" type="curve" smooth="yes"/>
-      <point x="14" y="53"/>
-      <point x="75" y="-16"/>
+      <point x="181" y="-16" type="curve" smooth="yes"/>
+      <point x="258" y="-16"/>
+      <point x="315" y="34"/>
+      <point x="345" y="100" type="curve"/>
+      <point x="360" y="100" type="line"/>
+      <point x="381" y="29"/>
+      <point x="436" y="-16"/>
+      <point x="519" y="-16" type="curve" smooth="yes"/>
+      <point x="583" y="-16"/>
+      <point x="635" y="19"/>
+      <point x="669" y="82" type="curve"/>
+      <point x="683" y="82" type="line"/>
+      <point x="703" y="24"/>
+      <point x="756" y="-16"/>
+      <point x="834" y="-16" type="curve" smooth="yes"/>
+      <point x="953" y="-16"/>
+      <point x="1041" y="75"/>
+      <point x="1041" y="198" type="curve" smooth="yes"/>
+      <point x="1041" y="304"/>
+      <point x="965" y="373"/>
+      <point x="848" y="373" type="curve" smooth="yes"/>
+      <point x="817" y="373" type="line"/>
+      <point x="752" y="273" type="line"/>
+      <point x="829" y="273" type="line" smooth="yes"/>
+      <point x="892" y="273"/>
+      <point x="926" y="245"/>
+      <point x="926" y="194" type="curve" smooth="yes"/>
+      <point x="926" y="136"/>
+      <point x="891" y="94"/>
+      <point x="838" y="94" type="curve" smooth="yes"/>
+      <point x="791" y="94"/>
+      <point x="762" y="125"/>
+      <point x="762" y="174" type="curve" smooth="yes"/>
+      <point x="762" y="243"/>
+      <point x="815" y="325"/>
+      <point x="917" y="433" type="curve" smooth="yes"/>
+      <point x="1010" y="531"/>
+      <point x="1053" y="609"/>
+      <point x="1053" y="678" type="curve" smooth="yes"/>
+      <point x="1053" y="783"/>
+      <point x="989" y="845"/>
+      <point x="878" y="845" type="curve" smooth="yes"/>
+      <point x="819" y="845"/>
+      <point x="765" y="830"/>
+      <point x="708" y="798" type="curve"/>
+      <point x="753" y="700" type="line"/>
+      <point x="791" y="723"/>
+      <point x="829" y="736"/>
+      <point x="865" y="736" type="curve" smooth="yes"/>
+      <point x="913" y="736"/>
+      <point x="935" y="717"/>
+      <point x="935" y="676" type="curve" smooth="yes"/>
+      <point x="935" y="631"/>
+      <point x="906" y="586"/>
+      <point x="856" y="528" type="curve" smooth="yes"/>
+      <point x="820" y="486"/>
+      <point x="805" y="453"/>
+      <point x="792" y="397" type="curve"/>
+      <point x="781" y="397" type="line"/>
+      <point x="781" y="409"/>
+      <point x="781" y="421"/>
+      <point x="781" y="433" type="curve" smooth="yes"/>
+      <point x="781" y="560"/>
+      <point x="723" y="629"/>
+      <point x="618" y="629" type="curve" smooth="yes"/>
+      <point x="478" y="629"/>
+      <point x="367" y="509"/>
+      <point x="336" y="329" type="curve" smooth="yes"/>
+      <point x="330" y="296"/>
+      <point x="328" y="261"/>
+      <point x="323" y="229" type="curve" smooth="yes"/>
+      <point x="310" y="144"/>
+      <point x="267" y="95"/>
+      <point x="206" y="95" type="curve" smooth="yes"/>
+      <point x="162" y="95"/>
+      <point x="131" y="123"/>
+      <point x="131" y="169" type="curve" smooth="yes"/>
+      <point x="131" y="230"/>
+      <point x="177" y="273"/>
+      <point x="256" y="273" type="curve" smooth="yes"/>
+      <point x="734" y="273" type="line"/>
+      <point x="755" y="373" type="line"/>
+      <point x="278" y="373" type="line" smooth="yes"/>
+      <point x="118" y="373"/>
+      <point x="14" y="285"/>
+      <point x="14" y="151" type="curve" smooth="yes"/>
+      <point x="14" y="55"/>
+      <point x="82" y="-16"/>
     </contour>
     <contour>
-      <point x="537" y="95" type="curve" smooth="yes"/>
-      <point x="466" y="95"/>
-      <point x="437" y="143"/>
-      <point x="437" y="229" type="curve" smooth="yes"/>
-      <point x="437" y="356"/>
-      <point x="484" y="518"/>
-      <point x="598" y="518" type="curve" smooth="yes"/>
-      <point x="662" y="518"/>
-      <point x="691" y="472"/>
-      <point x="691" y="384" type="curve" smooth="yes"/>
-      <point x="691" y="246"/>
-      <point x="649" y="95"/>
+      <point x="524" y="95" type="curve" smooth="yes"/>
+      <point x="463" y="95"/>
+      <point x="432" y="135"/>
+      <point x="432" y="212" type="curve" smooth="yes"/>
+      <point x="432" y="298"/>
+      <point x="473" y="518"/>
+      <point x="606" y="518" type="curve" smooth="yes"/>
+      <point x="660" y="518"/>
+      <point x="688" y="480"/>
+      <point x="688" y="405" type="curve" smooth="yes"/>
+      <point x="688" y="319"/>
+      <point x="650" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/k_ka-malayalam.glif
@@ -1,98 +1,98 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ka-malayalam" format="2">
-  <advance width="1498"/>
-  <anchor x="1076" y="0" name="bottom"/>
-  <anchor x="832" y="613" name="top"/>
-  <anchor x="1344" y="613" name="topright"/>
+  <advance width="1497"/>
+  <anchor x="1016" y="0" name="bottom"/>
+  <anchor x="880" y="613" name="top"/>
+  <anchor x="1392" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="185" y="-16" type="curve" smooth="yes"/>
-      <point x="272" y="-16"/>
-      <point x="326" y="31"/>
-      <point x="353" y="91" type="curve"/>
-      <point x="365" y="91" type="line"/>
-      <point x="393" y="26"/>
-      <point x="444" y="-16"/>
-      <point x="534" y="-16" type="curve" smooth="yes"/>
-      <point x="726" y="-16"/>
-      <point x="810" y="191"/>
-      <point x="810" y="389" type="curve" smooth="yes"/>
-      <point x="810" y="530"/>
-      <point x="747" y="629"/>
-      <point x="606" y="629" type="curve" smooth="yes"/>
-      <point x="467" y="629"/>
-      <point x="368" y="522"/>
-      <point x="340" y="336" type="curve" smooth="yes"/>
-      <point x="334" y="295"/>
-      <point x="331" y="256"/>
-      <point x="327" y="227" type="curve" smooth="yes"/>
-      <point x="314" y="138"/>
-      <point x="271" y="95"/>
-      <point x="211" y="95" type="curve" smooth="yes"/>
-      <point x="160" y="95"/>
-      <point x="134" y="123"/>
-      <point x="134" y="169" type="curve" smooth="yes"/>
-      <point x="134" y="215"/>
-      <point x="166" y="253"/>
-      <point x="237" y="253" type="curve" smooth="yes"/>
-      <point x="958" y="253" type="line" smooth="yes"/>
-      <point x="1050" y="253"/>
-      <point x="1074" y="227"/>
-      <point x="1074" y="174" type="curve" smooth="yes"/>
-      <point x="1074" y="131"/>
-      <point x="1057" y="92"/>
-      <point x="1014" y="92" type="curve" smooth="yes"/>
-      <point x="973" y="92"/>
-      <point x="950" y="123"/>
-      <point x="950" y="194" type="curve" smooth="yes"/>
-      <point x="950" y="354"/>
-      <point x="1030" y="517"/>
-      <point x="1184" y="517" type="curve" smooth="yes"/>
-      <point x="1288" y="517"/>
-      <point x="1335" y="454"/>
-      <point x="1335" y="352" type="curve" smooth="yes"/>
-      <point x="1335" y="232"/>
-      <point x="1284" y="139"/>
-      <point x="1208" y="50" type="curve"/>
-      <point x="1302" y="-16" type="line"/>
-      <point x="1403" y="95"/>
-      <point x="1458" y="218"/>
-      <point x="1458" y="366" type="curve" smooth="yes"/>
-      <point x="1458" y="532"/>
-      <point x="1365" y="629"/>
-      <point x="1188" y="629" type="curve" smooth="yes"/>
-      <point x="965" y="629"/>
-      <point x="835" y="435"/>
-      <point x="835" y="197" type="curve" smooth="yes"/>
-      <point x="835" y="71"/>
-      <point x="890" y="-16"/>
-      <point x="1018" y="-16" type="curve" smooth="yes"/>
-      <point x="1122" y="-16"/>
-      <point x="1191" y="61"/>
-      <point x="1191" y="175" type="curve" smooth="yes"/>
-      <point x="1191" y="295"/>
-      <point x="1114" y="354"/>
-      <point x="965" y="354" type="curve" smooth="yes"/>
-      <point x="250" y="354" type="line" smooth="yes"/>
-      <point x="101" y="354"/>
-      <point x="14" y="273"/>
+      <point x="181" y="-16" type="curve" smooth="yes"/>
+      <point x="258" y="-16"/>
+      <point x="315" y="34"/>
+      <point x="345" y="100" type="curve"/>
+      <point x="360" y="100" type="line"/>
+      <point x="381" y="29"/>
+      <point x="436" y="-16"/>
+      <point x="519" y="-16" type="curve" smooth="yes"/>
+      <point x="730" y="-16"/>
+      <point x="805" y="244"/>
+      <point x="805" y="397" type="curve" smooth="yes"/>
+      <point x="805" y="533"/>
+      <point x="738" y="629"/>
+      <point x="616" y="629" type="curve" smooth="yes"/>
+      <point x="476" y="629"/>
+      <point x="367" y="509"/>
+      <point x="336" y="329" type="curve" smooth="yes"/>
+      <point x="330" y="296"/>
+      <point x="328" y="261"/>
+      <point x="323" y="229" type="curve" smooth="yes"/>
+      <point x="310" y="144"/>
+      <point x="267" y="95"/>
+      <point x="206" y="95" type="curve" smooth="yes"/>
+      <point x="162" y="95"/>
+      <point x="131" y="123"/>
+      <point x="131" y="169" type="curve" smooth="yes"/>
+      <point x="131" y="230"/>
+      <point x="177" y="273"/>
+      <point x="256" y="273" type="curve" smooth="yes"/>
+      <point x="980" y="273" type="line" smooth="yes"/>
+      <point x="1043" y="273"/>
+      <point x="1070" y="250"/>
+      <point x="1070" y="188" type="curve" smooth="yes"/>
+      <point x="1070" y="152"/>
+      <point x="1055" y="92"/>
+      <point x="1003" y="92" type="curve" smooth="yes"/>
+      <point x="964" y="92"/>
+      <point x="945" y="121"/>
+      <point x="945" y="180" type="curve" smooth="yes"/>
+      <point x="945" y="310"/>
+      <point x="1012" y="517"/>
+      <point x="1192" y="517" type="curve" smooth="yes"/>
+      <point x="1281" y="517"/>
+      <point x="1328" y="465"/>
+      <point x="1328" y="361" type="curve" smooth="yes"/>
+      <point x="1328" y="255"/>
+      <point x="1285" y="146"/>
+      <point x="1208" y="58" type="curve"/>
+      <point x="1301" y="-16" type="line"/>
+      <point x="1391" y="84"/>
+      <point x="1449" y="233"/>
+      <point x="1449" y="362" type="curve" smooth="yes"/>
+      <point x="1449" y="531"/>
+      <point x="1358" y="629"/>
+      <point x="1202" y="629" type="curve" smooth="yes"/>
+      <point x="943" y="629"/>
+      <point x="829" y="353"/>
+      <point x="829" y="177" type="curve" smooth="yes"/>
+      <point x="829" y="56"/>
+      <point x="891" y="-16"/>
+      <point x="997" y="-16" type="curve" smooth="yes"/>
+      <point x="1121" y="-16"/>
+      <point x="1186" y="100"/>
+      <point x="1186" y="192" type="curve" smooth="yes"/>
+      <point x="1186" y="302"/>
+      <point x="1120" y="373"/>
+      <point x="996" y="373" type="curve" smooth="yes"/>
+      <point x="278" y="373" type="line" smooth="yes"/>
+      <point x="118" y="373"/>
+      <point x="14" y="285"/>
       <point x="14" y="151" type="curve" smooth="yes"/>
-      <point x="14" y="53"/>
-      <point x="76" y="-16"/>
+      <point x="14" y="55"/>
+      <point x="82" y="-16"/>
     </contour>
     <contour>
-      <point x="535" y="95" type="curve" smooth="yes"/>
-      <point x="466" y="95"/>
-      <point x="437" y="143"/>
-      <point x="437" y="229" type="curve" smooth="yes"/>
-      <point x="437" y="356"/>
-      <point x="484" y="518"/>
-      <point x="598" y="518" type="curve" smooth="yes"/>
-      <point x="663" y="518"/>
-      <point x="692" y="472"/>
-      <point x="692" y="391" type="curve" smooth="yes"/>
-      <point x="692" y="253"/>
-      <point x="650" y="95"/>
+      <point x="524" y="95" type="curve" smooth="yes"/>
+      <point x="463" y="95"/>
+      <point x="432" y="135"/>
+      <point x="432" y="212" type="curve" smooth="yes"/>
+      <point x="432" y="298"/>
+      <point x="473" y="518"/>
+      <point x="606" y="518" type="curve" smooth="yes"/>
+      <point x="661" y="518"/>
+      <point x="688" y="476"/>
+      <point x="688" y="405" type="curve" smooth="yes"/>
+      <point x="688" y="322"/>
+      <point x="654" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/k_la-malayalam.glif
@@ -1,145 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_la-malayalam" format="2">
   <advance width="1099"/>
-  <anchor x="573" y="-371" name="bottom"/>
-  <anchor x="624" y="613" name="top"/>
-  <anchor x="979" y="573" name="topright"/>
+  <anchor x="578" y="-366" name="bottom"/>
+  <anchor x="618" y="613" name="top"/>
+  <anchor x="973" y="573" name="topright"/>
   <outline>
     <contour>
-      <point x="355" y="-388" type="curve" smooth="yes"/>
-      <point x="450" y="-388"/>
-      <point x="506" y="-330"/>
-      <point x="506" y="-240" type="curve" smooth="yes"/>
-      <point x="506" y="-160"/>
-      <point x="463" y="-125"/>
-      <point x="397" y="-125" type="curve" smooth="yes"/>
-      <point x="362" y="-125"/>
-      <point x="330" y="-137"/>
-      <point x="307" y="-165" type="curve"/>
-      <point x="272" y="-162" type="line"/>
-      <point x="294" y="-175" type="line"/>
-      <point x="307" y="-104"/>
-      <point x="358" y="-40"/>
-      <point x="451" y="-40" type="curve" smooth="yes"/>
-      <point x="550" y="-40"/>
-      <point x="576" y="-91"/>
-      <point x="584" y="-184" type="curve" smooth="yes"/>
-      <point x="585" y="-196" type="line" smooth="yes"/>
-      <point x="596" y="-321"/>
-      <point x="646" y="-388"/>
-      <point x="773" y="-388" type="curve" smooth="yes"/>
-      <point x="916" y="-388"/>
-      <point x="972" y="-284"/>
-      <point x="972" y="-141" type="curve" smooth="yes"/>
-      <point x="972" y="-61"/>
-      <point x="948" y="6"/>
-      <point x="923" y="48" type="curve"/>
-      <point x="837" y="-2" type="line"/>
-      <point x="854" y="-33"/>
-      <point x="871" y="-87"/>
-      <point x="871" y="-154" type="curve" smooth="yes"/>
-      <point x="871" y="-237"/>
-      <point x="845" y="-299"/>
-      <point x="773" y="-299" type="curve" smooth="yes"/>
-      <point x="716" y="-299"/>
-      <point x="692" y="-262"/>
-      <point x="684" y="-184" type="curve" smooth="yes"/>
-      <point x="681" y="-158" type="line" smooth="yes"/>
-      <point x="675" y="-93"/>
-      <point x="656" y="-40"/>
-      <point x="616" y="-5" type="curve"/>
-      <point x="618" y="8" type="line"/>
-      <point x="752" y="61"/>
-      <point x="811" y="225"/>
-      <point x="811" y="385" type="curve" smooth="yes"/>
-      <point x="811" y="530"/>
-      <point x="747" y="629"/>
-      <point x="606" y="629" type="curve" smooth="yes"/>
-      <point x="467" y="629"/>
-      <point x="368" y="522"/>
-      <point x="340" y="336" type="curve" smooth="yes"/>
-      <point x="334" y="295"/>
-      <point x="331" y="256"/>
-      <point x="327" y="227" type="curve" smooth="yes"/>
-      <point x="314" y="138"/>
-      <point x="271" y="95"/>
-      <point x="211" y="95" type="curve" smooth="yes"/>
-      <point x="160" y="95"/>
-      <point x="134" y="123"/>
-      <point x="134" y="169" type="curve" smooth="yes"/>
-      <point x="134" y="215"/>
-      <point x="166" y="253"/>
-      <point x="237" y="253" type="curve" smooth="yes"/>
-      <point x="834" y="253" type="line" smooth="yes"/>
-      <point x="901" y="253"/>
-      <point x="927" y="226"/>
-      <point x="927" y="181" type="curve" smooth="yes"/>
-      <point x="927" y="138"/>
-      <point x="907" y="94"/>
-      <point x="844" y="94" type="curve" smooth="yes"/>
-      <point x="823" y="94"/>
-      <point x="806" y="98"/>
-      <point x="788" y="105" type="curve"/>
-      <point x="744" y="6" type="line"/>
-      <point x="769" y="-7"/>
-      <point x="812" y="-16"/>
-      <point x="850" y="-16" type="curve" smooth="yes"/>
-      <point x="972" y="-16"/>
-      <point x="1044" y="64"/>
-      <point x="1044" y="184" type="curve" smooth="yes"/>
-      <point x="1044" y="285"/>
-      <point x="983" y="353"/>
-      <point x="840" y="353" type="curve" smooth="yes"/>
-      <point x="250" y="353" type="line" smooth="yes"/>
-      <point x="101" y="353"/>
-      <point x="14" y="273"/>
+      <point x="347" y="-382" type="curve" smooth="yes"/>
+      <point x="442" y="-382"/>
+      <point x="499" y="-317"/>
+      <point x="499" y="-231" type="curve" smooth="yes"/>
+      <point x="499" y="-161"/>
+      <point x="461" y="-118"/>
+      <point x="396" y="-118" type="curve" smooth="yes"/>
+      <point x="343" y="-118"/>
+      <point x="294" y="-149"/>
+      <point x="275" y="-225" type="curve"/>
+      <point x="317" y="-164" type="line"/>
+      <point x="264" y="-164" type="line"/>
+      <point x="287" y="-186" type="line"/>
+      <point x="303" y="-98"/>
+      <point x="374" y="-33"/>
+      <point x="459" y="-33" type="curve" smooth="yes"/>
+      <point x="534" y="-33"/>
+      <point x="563" y="-70"/>
+      <point x="579" y="-163" type="curve" smooth="yes"/>
+      <point x="585" y="-199" type="line" smooth="yes"/>
+      <point x="606" y="-327"/>
+      <point x="657" y="-382"/>
+      <point x="754" y="-382" type="curve" smooth="yes"/>
+      <point x="899" y="-382"/>
+      <point x="963" y="-256"/>
+      <point x="963" y="-134" type="curve" smooth="yes"/>
+      <point x="963" y="-61"/>
+      <point x="944" y="2"/>
+      <point x="914" y="52" type="curve"/>
+      <point x="828" y="5" type="line"/>
+      <point x="848" y="-31"/>
+      <point x="865" y="-80"/>
+      <point x="865" y="-145" type="curve" smooth="yes"/>
+      <point x="865" y="-197"/>
+      <point x="847" y="-292"/>
+      <point x="766" y="-292" type="curve" smooth="yes"/>
+      <point x="715" y="-292"/>
+      <point x="691" y="-263"/>
+      <point x="679" y="-182" type="curve" smooth="yes"/>
+      <point x="673" y="-144" type="line" smooth="yes"/>
+      <point x="660" y="-64"/>
+      <point x="643" y="-23"/>
+      <point x="606" y="2" type="curve"/>
+      <point x="609" y="15" type="line"/>
+      <point x="772" y="84"/>
+      <point x="806" y="298"/>
+      <point x="806" y="400" type="curve" smooth="yes"/>
+      <point x="806" y="534"/>
+      <point x="739" y="629"/>
+      <point x="616" y="629" type="curve" smooth="yes"/>
+      <point x="476" y="629"/>
+      <point x="367" y="509"/>
+      <point x="336" y="329" type="curve" smooth="yes"/>
+      <point x="330" y="296"/>
+      <point x="328" y="261"/>
+      <point x="323" y="229" type="curve" smooth="yes"/>
+      <point x="310" y="144"/>
+      <point x="267" y="95"/>
+      <point x="206" y="95" type="curve" smooth="yes"/>
+      <point x="162" y="95"/>
+      <point x="131" y="123"/>
+      <point x="131" y="169" type="curve" smooth="yes"/>
+      <point x="131" y="230"/>
+      <point x="177" y="273"/>
+      <point x="256" y="273" type="curve" smooth="yes"/>
+      <point x="818" y="273" type="line" smooth="yes"/>
+      <point x="887" y="273"/>
+      <point x="920" y="239"/>
+      <point x="920" y="188" type="curve" smooth="yes"/>
+      <point x="920" y="134"/>
+      <point x="884" y="94"/>
+      <point x="828" y="94" type="curve" smooth="yes"/>
+      <point x="807" y="94"/>
+      <point x="792" y="97"/>
+      <point x="777" y="102" type="curve"/>
+      <point x="747" y="-4" type="line"/>
+      <point x="773" y="-12"/>
+      <point x="799" y="-16"/>
+      <point x="831" y="-16" type="curve" smooth="yes"/>
+      <point x="957" y="-16"/>
+      <point x="1036" y="80"/>
+      <point x="1036" y="190" type="curve" smooth="yes"/>
+      <point x="1036" y="308"/>
+      <point x="955" y="373"/>
+      <point x="828" y="373" type="curve" smooth="yes"/>
+      <point x="278" y="373" type="line" smooth="yes"/>
+      <point x="118" y="373"/>
+      <point x="14" y="285"/>
       <point x="14" y="151" type="curve" smooth="yes"/>
-      <point x="14" y="53"/>
-      <point x="76" y="-16"/>
-      <point x="185" y="-16" type="curve" smooth="yes"/>
-      <point x="272" y="-16"/>
-      <point x="326" y="31"/>
-      <point x="353" y="91" type="curve"/>
-      <point x="365" y="91" type="line"/>
-      <point x="373" y="75"/>
-      <point x="383" y="59"/>
-      <point x="402" y="46" type="curve"/>
-      <point x="400" y="33" type="line"/>
-      <point x="269" y="10"/>
-      <point x="199" y="-89"/>
-      <point x="199" y="-212" type="curve" smooth="yes"/>
-      <point x="199" y="-333"/>
-      <point x="264" y="-388"/>
+      <point x="14" y="55"/>
+      <point x="82" y="-16"/>
+      <point x="181" y="-16" type="curve" smooth="yes"/>
+      <point x="258" y="-16"/>
+      <point x="315" y="34"/>
+      <point x="345" y="100" type="curve"/>
+      <point x="360" y="100" type="line"/>
+      <point x="365" y="81"/>
+      <point x="375" y="64"/>
+      <point x="390" y="50" type="curve"/>
+      <point x="387" y="36" type="line"/>
+      <point x="270" y="-2"/>
+      <point x="192" y="-106"/>
+      <point x="192" y="-213" type="curve" smooth="yes"/>
+      <point x="192" y="-321"/>
+      <point x="261" y="-382"/>
     </contour>
     <contour>
-      <point x="359" y="-308" type="curve" smooth="yes"/>
-      <point x="314" y="-308"/>
-      <point x="293" y="-275"/>
-      <point x="293" y="-233" type="curve"/>
-      <point x="277" y="-220" type="line"/>
-      <point x="285" y="-258" type="line"/>
-      <point x="297" y="-219"/>
-      <point x="326" y="-197"/>
-      <point x="363" y="-197" type="curve" smooth="yes"/>
-      <point x="399" y="-197"/>
-      <point x="417" y="-213"/>
-      <point x="417" y="-247" type="curve" smooth="yes"/>
-      <point x="417" y="-283"/>
-      <point x="398" y="-308"/>
+      <point x="347" y="-302" type="curve" smooth="yes"/>
+      <point x="307" y="-302"/>
+      <point x="284" y="-273"/>
+      <point x="284" y="-239" type="curve" smooth="yes"/>
+      <point x="284" y="-232"/>
+      <point x="285" y="-225"/>
+      <point x="286" y="-219" type="curve"/>
+      <point x="270" y="-220" type="line"/>
+      <point x="277" y="-267" type="line"/>
+      <point x="289" y="-221"/>
+      <point x="323" y="-191"/>
+      <point x="362" y="-191" type="curve" smooth="yes"/>
+      <point x="393" y="-191"/>
+      <point x="409" y="-207"/>
+      <point x="409" y="-239" type="curve" smooth="yes"/>
+      <point x="409" y="-277"/>
+      <point x="384" y="-302"/>
     </contour>
     <contour>
-      <point x="538" y="95" type="curve" smooth="yes"/>
-      <point x="466" y="95"/>
-      <point x="437" y="143"/>
-      <point x="437" y="229" type="curve" smooth="yes"/>
-      <point x="437" y="356"/>
-      <point x="484" y="518"/>
-      <point x="598" y="518" type="curve" smooth="yes"/>
-      <point x="662" y="518"/>
-      <point x="691" y="472"/>
-      <point x="691" y="384" type="curve" smooth="yes"/>
-      <point x="691" y="253"/>
-      <point x="649" y="95"/>
+      <point x="524" y="95" type="curve" smooth="yes"/>
+      <point x="463" y="95"/>
+      <point x="432" y="135"/>
+      <point x="432" y="212" type="curve" smooth="yes"/>
+      <point x="432" y="298"/>
+      <point x="473" y="518"/>
+      <point x="606" y="518" type="curve" smooth="yes"/>
+      <point x="661" y="518"/>
+      <point x="688" y="476"/>
+      <point x="688" y="405" type="curve" smooth="yes"/>
+      <point x="688" y="322"/>
+      <point x="654" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
@@ -1,115 +1,115 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam" format="2">
   <advance width="1765"/>
-  <anchor x="1255" y="0" name="bottom"/>
-  <anchor x="958" y="613" name="top"/>
-  <anchor x="1684" y="613" name="topright"/>
+  <anchor x="1249" y="0" name="bottom"/>
+  <anchor x="953" y="613" name="top"/>
+  <anchor x="1678" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="185" y="-16" type="curve" smooth="yes"/>
-      <point x="273" y="-16"/>
-      <point x="327" y="31"/>
-      <point x="353" y="91" type="curve"/>
-      <point x="366" y="91" type="line"/>
-      <point x="393" y="26"/>
-      <point x="445" y="-16"/>
-      <point x="537" y="-16" type="curve" smooth="yes"/>
-      <point x="728" y="-16"/>
-      <point x="812" y="191"/>
-      <point x="812" y="384" type="curve" smooth="yes"/>
-      <point x="812" y="529"/>
-      <point x="748" y="629"/>
-      <point x="606" y="629" type="curve" smooth="yes"/>
-      <point x="468" y="629"/>
-      <point x="369" y="523"/>
-      <point x="341" y="337" type="curve" smooth="yes"/>
-      <point x="335" y="296"/>
-      <point x="332" y="257"/>
-      <point x="328" y="228" type="curve" smooth="yes"/>
-      <point x="315" y="139"/>
-      <point x="272" y="95"/>
-      <point x="212" y="95" type="curve" smooth="yes"/>
-      <point x="161" y="95"/>
-      <point x="135" y="123"/>
-      <point x="135" y="170" type="curve" smooth="yes"/>
-      <point x="135" y="220"/>
-      <point x="167" y="259"/>
-      <point x="238" y="259" type="curve" smooth="yes"/>
-      <point x="824" y="259" type="line" smooth="yes"/>
-      <point x="894" y="259"/>
-      <point x="917" y="235"/>
-      <point x="917" y="190" type="curve" smooth="yes"/>
-      <point x="917" y="141"/>
-      <point x="891" y="110"/>
-      <point x="843" y="77" type="curve"/>
-      <point x="858" y="0" type="line"/>
-      <point x="1631" y="0" type="line"/>
-      <point x="1739" y="613" type="line"/>
-      <point x="1665" y="613" type="line"/>
-      <point x="1574" y="443"/>
-      <point x="1479" y="342"/>
-      <point x="1318" y="342" type="curve" smooth="yes"/>
-      <point x="1223" y="342"/>
-      <point x="1186" y="386"/>
-      <point x="1186" y="443" type="curve" smooth="yes"/>
-      <point x="1186" y="489"/>
-      <point x="1209" y="522"/>
-      <point x="1252" y="522" type="curve" smooth="yes"/>
-      <point x="1285" y="522"/>
-      <point x="1302" y="503"/>
-      <point x="1302" y="467" type="curve" smooth="yes"/>
-      <point x="1302" y="454"/>
-      <point x="1300" y="440"/>
-      <point x="1297" y="419" type="curve" smooth="yes"/>
-      <point x="1233" y="54" type="line"/>
-      <point x="1351" y="54" type="line"/>
-      <point x="1414" y="404" type="line" smooth="yes"/>
-      <point x="1418" y="430"/>
-      <point x="1420" y="455"/>
-      <point x="1420" y="473" type="curve" smooth="yes"/>
-      <point x="1420" y="569"/>
-      <point x="1367" y="628"/>
-      <point x="1258" y="628" type="curve" smooth="yes"/>
-      <point x="1146" y="628"/>
-      <point x="1072" y="554"/>
-      <point x="1072" y="439" type="curve" smooth="yes"/>
-      <point x="1072" y="310"/>
-      <point x="1175" y="236"/>
-      <point x="1312" y="236" type="curve" smooth="yes"/>
-      <point x="1417" y="236"/>
-      <point x="1500" y="274"/>
-      <point x="1555" y="339" type="curve"/>
-      <point x="1568" y="334" type="line"/>
-      <point x="1516" y="42" type="line"/>
-      <point x="1597" y="105" type="line"/>
-      <point x="938" y="105" type="line"/>
-      <point x="945" y="53" type="line"/>
-      <point x="1007" y="86"/>
-      <point x="1039" y="141"/>
-      <point x="1039" y="203" type="curve" smooth="yes"/>
-      <point x="1039" y="298"/>
-      <point x="984" y="359"/>
-      <point x="835" y="359" type="curve" smooth="yes"/>
-      <point x="251" y="359" type="line" smooth="yes"/>
-      <point x="101" y="359"/>
-      <point x="15" y="280"/>
-      <point x="15" y="154" type="curve" smooth="yes"/>
-      <point x="15" y="53"/>
-      <point x="77" y="-16"/>
+      <point x="181" y="-16" type="curve" smooth="yes"/>
+      <point x="258" y="-16"/>
+      <point x="315" y="34"/>
+      <point x="345" y="100" type="curve"/>
+      <point x="360" y="100" type="line"/>
+      <point x="381" y="29"/>
+      <point x="436" y="-16"/>
+      <point x="519" y="-16" type="curve" smooth="yes"/>
+      <point x="730" y="-16"/>
+      <point x="805" y="244"/>
+      <point x="805" y="397" type="curve" smooth="yes"/>
+      <point x="805" y="533"/>
+      <point x="738" y="629"/>
+      <point x="616" y="629" type="curve" smooth="yes"/>
+      <point x="476" y="629"/>
+      <point x="367" y="509"/>
+      <point x="336" y="329" type="curve" smooth="yes"/>
+      <point x="330" y="296"/>
+      <point x="328" y="261"/>
+      <point x="323" y="229" type="curve" smooth="yes"/>
+      <point x="310" y="144"/>
+      <point x="267" y="95"/>
+      <point x="206" y="95" type="curve" smooth="yes"/>
+      <point x="162" y="95"/>
+      <point x="131" y="123"/>
+      <point x="131" y="169" type="curve" smooth="yes"/>
+      <point x="131" y="230"/>
+      <point x="177" y="273"/>
+      <point x="256" y="273" type="curve" smooth="yes"/>
+      <point x="820" y="273" type="line" smooth="yes"/>
+      <point x="880" y="273"/>
+      <point x="912" y="247"/>
+      <point x="912" y="196" type="curve" smooth="yes"/>
+      <point x="912" y="151"/>
+      <point x="882" y="107"/>
+      <point x="841" y="79" type="curve"/>
+      <point x="859" y="0" type="line"/>
+      <point x="1625" y="0" type="line"/>
+      <point x="1733" y="613" type="line"/>
+      <point x="1657" y="613" type="line"/>
+      <point x="1533" y="424"/>
+      <point x="1423" y="340"/>
+      <point x="1294" y="340" type="curve" smooth="yes"/>
+      <point x="1216" y="340"/>
+      <point x="1180" y="382"/>
+      <point x="1180" y="435" type="curve" smooth="yes"/>
+      <point x="1180" y="490"/>
+      <point x="1215" y="522"/>
+      <point x="1253" y="522" type="curve" smooth="yes"/>
+      <point x="1283" y="522"/>
+      <point x="1298" y="505"/>
+      <point x="1298" y="477" type="curve" smooth="yes"/>
+      <point x="1298" y="464"/>
+      <point x="1296" y="448"/>
+      <point x="1293" y="430" type="curve" smooth="yes"/>
+      <point x="1227" y="54" type="line"/>
+      <point x="1345" y="54" type="line"/>
+      <point x="1410" y="421" type="line" smooth="yes"/>
+      <point x="1414" y="444"/>
+      <point x="1417" y="464"/>
+      <point x="1417" y="484" type="curve" smooth="yes"/>
+      <point x="1417" y="568"/>
+      <point x="1369" y="629"/>
+      <point x="1268" y="629" type="curve" smooth="yes"/>
+      <point x="1151" y="629"/>
+      <point x="1066" y="543"/>
+      <point x="1066" y="429" type="curve" smooth="yes"/>
+      <point x="1066" y="320"/>
+      <point x="1146" y="237"/>
+      <point x="1288" y="237" type="curve" smooth="yes"/>
+      <point x="1387" y="237"/>
+      <point x="1481" y="279"/>
+      <point x="1556" y="364" type="curve"/>
+      <point x="1567" y="364" type="line"/>
+      <point x="1510" y="42" type="line"/>
+      <point x="1591" y="105" type="line"/>
+      <point x="996" y="105" type="line"/>
+      <point x="993" y="114" type="line"/>
+      <point x="1021" y="147"/>
+      <point x="1033" y="178"/>
+      <point x="1033" y="222" type="curve" smooth="yes"/>
+      <point x="1033" y="320"/>
+      <point x="965" y="373"/>
+      <point x="837" y="373" type="curve" smooth="yes"/>
+      <point x="278" y="373" type="line" smooth="yes"/>
+      <point x="118" y="373"/>
+      <point x="14" y="285"/>
+      <point x="14" y="151" type="curve" smooth="yes"/>
+      <point x="14" y="55"/>
+      <point x="82" y="-16"/>
     </contour>
     <contour>
-      <point x="538" y="95" type="curve" smooth="yes"/>
-      <point x="467" y="95"/>
-      <point x="438" y="143"/>
-      <point x="438" y="228" type="curve" smooth="yes"/>
-      <point x="438" y="355"/>
-      <point x="485" y="518"/>
-      <point x="600" y="518" type="curve" smooth="yes"/>
-      <point x="664" y="518"/>
-      <point x="692" y="473"/>
-      <point x="692" y="385" type="curve" smooth="yes"/>
-      <point x="692" y="254"/>
-      <point x="650" y="95"/>
+      <point x="524" y="95" type="curve" smooth="yes"/>
+      <point x="463" y="95"/>
+      <point x="432" y="135"/>
+      <point x="432" y="212" type="curve" smooth="yes"/>
+      <point x="432" y="298"/>
+      <point x="473" y="518"/>
+      <point x="606" y="518" type="curve" smooth="yes"/>
+      <point x="661" y="518"/>
+      <point x="688" y="476"/>
+      <point x="688" y="405" type="curve" smooth="yes"/>
+      <point x="688" y="322"/>
+      <point x="654" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1765"/>
   <outline>
     <component base="k_ssa-malayalam"/>
-    <component base="halant-malayalam" xOffset="1601"/>
+    <component base="halant-malayalam" xOffset="1595"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/k_ta-malayalam.glif
@@ -1,114 +1,114 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ta-malayalam" format="2">
   <advance width="1859"/>
-  <anchor x="1389" y="0" name="bottom"/>
-  <anchor x="908" y="613" name="top"/>
-  <anchor x="1740" y="613" name="topright"/>
+  <anchor x="1377" y="0" name="bottom"/>
+  <anchor x="904" y="613" name="top"/>
+  <anchor x="1730" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="185" y="-16" type="curve" smooth="yes"/>
-      <point x="272" y="-16"/>
-      <point x="326" y="31"/>
-      <point x="353" y="91" type="curve"/>
-      <point x="365" y="91" type="line"/>
-      <point x="393" y="26"/>
-      <point x="444" y="-16"/>
-      <point x="536" y="-16" type="curve" smooth="yes"/>
-      <point x="726" y="-16"/>
-      <point x="811" y="191"/>
-      <point x="811" y="385" type="curve" smooth="yes"/>
-      <point x="811" y="530"/>
-      <point x="747" y="629"/>
-      <point x="606" y="629" type="curve" smooth="yes"/>
-      <point x="467" y="629"/>
-      <point x="368" y="522"/>
-      <point x="340" y="336" type="curve" smooth="yes"/>
-      <point x="334" y="295"/>
-      <point x="331" y="256"/>
-      <point x="327" y="227" type="curve" smooth="yes"/>
-      <point x="314" y="138"/>
-      <point x="271" y="95"/>
-      <point x="211" y="95" type="curve" smooth="yes"/>
-      <point x="160" y="95"/>
-      <point x="134" y="123"/>
-      <point x="134" y="169" type="curve" smooth="yes"/>
-      <point x="134" y="215"/>
-      <point x="166" y="253"/>
-      <point x="237" y="253" type="curve" smooth="yes"/>
-      <point x="886" y="253" type="line"/>
-      <point x="892" y="353" type="line"/>
-      <point x="250" y="353" type="line" smooth="yes"/>
-      <point x="101" y="353"/>
-      <point x="14" y="273"/>
+      <point x="942" y="-16" type="curve"/>
+      <point x="1032" y="47" type="line"/>
+      <point x="994" y="101"/>
+      <point x="974" y="165"/>
+      <point x="974" y="236" type="curve" smooth="yes"/>
+      <point x="974" y="385"/>
+      <point x="1065" y="522"/>
+      <point x="1231" y="522" type="curve" smooth="yes"/>
+      <point x="1356" y="522"/>
+      <point x="1423" y="428"/>
+      <point x="1423" y="295" type="curve" smooth="yes"/>
+      <point x="1423" y="229"/>
+      <point x="1394" y="95"/>
+      <point x="1297" y="95" type="curve" smooth="yes"/>
+      <point x="1248" y="95"/>
+      <point x="1217" y="132"/>
+      <point x="1217" y="208" type="curve" smooth="yes"/>
+      <point x="1217" y="372"/>
+      <point x="1336" y="522"/>
+      <point x="1520" y="522" type="curve" smooth="yes"/>
+      <point x="1635" y="522"/>
+      <point x="1688" y="458"/>
+      <point x="1688" y="346" type="curve" smooth="yes"/>
+      <point x="1688" y="251"/>
+      <point x="1645" y="157"/>
+      <point x="1551" y="67" type="curve"/>
+      <point x="1636" y="-16" type="line"/>
+      <point x="1750" y="94"/>
+      <point x="1810" y="222"/>
+      <point x="1810" y="354" type="curve" smooth="yes"/>
+      <point x="1810" y="519"/>
+      <point x="1712" y="629"/>
+      <point x="1533" y="629" type="curve" smooth="yes"/>
+      <point x="1307" y="629"/>
+      <point x="1100" y="421"/>
+      <point x="1100" y="202" type="curve" smooth="yes"/>
+      <point x="1100" y="72"/>
+      <point x="1169" y="-16"/>
+      <point x="1289" y="-16" type="curve" smooth="yes"/>
+      <point x="1453" y="-16"/>
+      <point x="1545" y="137"/>
+      <point x="1545" y="292" type="curve" smooth="yes"/>
+      <point x="1545" y="477"/>
+      <point x="1440" y="629"/>
+      <point x="1244" y="629" type="curve" smooth="yes"/>
+      <point x="1007" y="629"/>
+      <point x="857" y="446"/>
+      <point x="857" y="238" type="curve" smooth="yes"/>
+      <point x="857" y="146"/>
+      <point x="886" y="61"/>
+    </contour>
+    <contour>
+      <point x="181" y="-16" type="curve" smooth="yes"/>
+      <point x="258" y="-16"/>
+      <point x="315" y="34"/>
+      <point x="345" y="100" type="curve"/>
+      <point x="360" y="100" type="line"/>
+      <point x="381" y="29"/>
+      <point x="436" y="-16"/>
+      <point x="519" y="-16" type="curve" smooth="yes"/>
+      <point x="730" y="-16"/>
+      <point x="805" y="244"/>
+      <point x="805" y="397" type="curve" smooth="yes"/>
+      <point x="805" y="533"/>
+      <point x="738" y="629"/>
+      <point x="616" y="629" type="curve" smooth="yes"/>
+      <point x="476" y="629"/>
+      <point x="367" y="509"/>
+      <point x="336" y="329" type="curve" smooth="yes"/>
+      <point x="330" y="296"/>
+      <point x="328" y="261"/>
+      <point x="323" y="229" type="curve" smooth="yes"/>
+      <point x="310" y="144"/>
+      <point x="267" y="95"/>
+      <point x="206" y="95" type="curve" smooth="yes"/>
+      <point x="162" y="95"/>
+      <point x="131" y="123"/>
+      <point x="131" y="169" type="curve" smooth="yes"/>
+      <point x="131" y="230"/>
+      <point x="177" y="273"/>
+      <point x="256" y="273" type="curve" smooth="yes"/>
+      <point x="931" y="273" type="line"/>
+      <point x="931" y="373" type="line"/>
+      <point x="278" y="373" type="line" smooth="yes"/>
+      <point x="118" y="373"/>
+      <point x="14" y="285"/>
       <point x="14" y="151" type="curve" smooth="yes"/>
-      <point x="14" y="53"/>
-      <point x="76" y="-16"/>
+      <point x="14" y="55"/>
+      <point x="82" y="-16"/>
     </contour>
     <contour>
-      <point x="538" y="95" type="curve" smooth="yes"/>
-      <point x="466" y="95"/>
-      <point x="437" y="143"/>
-      <point x="437" y="229" type="curve" smooth="yes"/>
-      <point x="437" y="356"/>
-      <point x="484" y="518"/>
-      <point x="598" y="518" type="curve" smooth="yes"/>
-      <point x="662" y="518"/>
-      <point x="691" y="472"/>
-      <point x="691" y="384" type="curve" smooth="yes"/>
-      <point x="691" y="253"/>
-      <point x="649" y="95"/>
-    </contour>
-    <contour>
-      <point x="953" y="-16" type="curve"/>
-      <point x="1048" y="51" type="line"/>
-      <point x="1009" y="101"/>
-      <point x="987" y="169"/>
-      <point x="987" y="247" type="curve" smooth="yes"/>
-      <point x="987" y="399"/>
-      <point x="1072" y="522"/>
-      <point x="1226" y="522" type="curve" smooth="yes"/>
-      <point x="1348" y="522"/>
-      <point x="1420" y="433"/>
-      <point x="1420" y="281" type="curve" smooth="yes"/>
-      <point x="1420" y="160"/>
-      <point x="1386" y="95"/>
-      <point x="1312" y="95" type="curve" smooth="yes"/>
-      <point x="1256" y="95"/>
-      <point x="1221" y="133"/>
-      <point x="1221" y="213" type="curve" smooth="yes"/>
-      <point x="1221" y="388"/>
-      <point x="1338" y="522"/>
-      <point x="1514" y="522" type="curve" smooth="yes"/>
-      <point x="1631" y="522"/>
-      <point x="1691" y="452"/>
-      <point x="1691" y="335" type="curve" smooth="yes"/>
-      <point x="1691" y="231"/>
-      <point x="1644" y="150"/>
-      <point x="1545" y="75" type="curve"/>
-      <point x="1622" y="-16" type="line"/>
-      <point x="1744" y="76"/>
-      <point x="1812" y="193"/>
-      <point x="1812" y="335" type="curve" smooth="yes"/>
-      <point x="1812" y="526"/>
-      <point x="1698" y="629"/>
-      <point x="1522" y="629" type="curve" smooth="yes"/>
-      <point x="1310" y="629"/>
-      <point x="1104" y="442"/>
-      <point x="1104" y="213" type="curve" smooth="yes"/>
-      <point x="1104" y="71"/>
-      <point x="1180" y="-16"/>
-      <point x="1310" y="-16" type="curve" smooth="yes"/>
-      <point x="1458" y="-16"/>
-      <point x="1542" y="114"/>
-      <point x="1542" y="281" type="curve" smooth="yes"/>
-      <point x="1542" y="482"/>
-      <point x="1418" y="629"/>
-      <point x="1231" y="629" type="curve" smooth="yes"/>
-      <point x="999" y="629"/>
-      <point x="868" y="464"/>
-      <point x="868" y="247" type="curve" smooth="yes"/>
-      <point x="868" y="144"/>
-      <point x="898" y="51"/>
+      <point x="524" y="95" type="curve" smooth="yes"/>
+      <point x="463" y="95"/>
+      <point x="432" y="135"/>
+      <point x="432" y="212" type="curve" smooth="yes"/>
+      <point x="432" y="298"/>
+      <point x="473" y="518"/>
+      <point x="606" y="518" type="curve" smooth="yes"/>
+      <point x="661" y="518"/>
+      <point x="688" y="476"/>
+      <point x="688" y="405" type="curve" smooth="yes"/>
+      <point x="688" y="322"/>
+      <point x="654" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/k_tta-malayalam.glif
@@ -1,128 +1,119 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_tta-malayalam" format="2">
   <advance width="1099"/>
-  <anchor x="704" y="-366" name="bottom"/>
-  <anchor x="624" y="613" name="top"/>
-  <anchor x="979" y="573" name="topright"/>
+  <anchor x="751" y="-366" name="bottom"/>
+  <anchor x="618" y="613" name="top"/>
+  <anchor x="973" y="573" name="topright"/>
   <outline>
     <contour>
-      <point x="739" y="-382" type="curve" smooth="yes"/>
-      <point x="868" y="-382"/>
-      <point x="939" y="-331"/>
-      <point x="939" y="-239" type="curve" smooth="yes"/>
-      <point x="939" y="-167"/>
-      <point x="895" y="-126"/>
-      <point x="778" y="-119" type="curve" smooth="yes"/>
-      <point x="732" y="-117" type="line" smooth="yes"/>
-      <point x="676" y="-114"/>
-      <point x="649" y="-100"/>
-      <point x="649" y="-75" type="curve" smooth="yes"/>
-      <point x="649" y="-50"/>
-      <point x="674" y="-31"/>
-      <point x="760" y="-31" type="curve" smooth="yes"/>
-      <point x="825" y="-31"/>
-      <point x="884" y="-44"/>
-      <point x="928" y="-60" type="curve"/>
-      <point x="962" y="20" type="line"/>
-      <point x="915" y="39"/>
-      <point x="842" y="55"/>
-      <point x="765" y="55" type="curve" smooth="yes"/>
-      <point x="743" y="55"/>
-      <point x="717" y="51"/>
-      <point x="697" y="45" type="curve"/>
-      <point x="692" y="55" type="line"/>
-      <point x="776" y="130"/>
-      <point x="811" y="260"/>
-      <point x="811" y="385" type="curve" smooth="yes"/>
-      <point x="811" y="530"/>
-      <point x="747" y="629"/>
-      <point x="606" y="629" type="curve" smooth="yes"/>
-      <point x="467" y="629"/>
-      <point x="368" y="522"/>
-      <point x="340" y="336" type="curve" smooth="yes"/>
-      <point x="334" y="295"/>
-      <point x="331" y="256"/>
-      <point x="327" y="227" type="curve" smooth="yes"/>
-      <point x="314" y="138"/>
-      <point x="271" y="95"/>
-      <point x="211" y="95" type="curve" smooth="yes"/>
-      <point x="160" y="95"/>
-      <point x="134" y="123"/>
-      <point x="134" y="169" type="curve" smooth="yes"/>
-      <point x="134" y="215"/>
-      <point x="166" y="253"/>
-      <point x="237" y="253" type="curve" smooth="yes"/>
-      <point x="834" y="253" type="line" smooth="yes"/>
-      <point x="901" y="253"/>
-      <point x="927" y="226"/>
-      <point x="927" y="181" type="curve" smooth="yes"/>
-      <point x="927" y="138"/>
-      <point x="907" y="94"/>
-      <point x="844" y="94" type="curve" smooth="yes"/>
-      <point x="823" y="94"/>
-      <point x="806" y="98"/>
-      <point x="788" y="105" type="curve"/>
-      <point x="744" y="6" type="line"/>
-      <point x="769" y="-7"/>
-      <point x="812" y="-16"/>
-      <point x="850" y="-16" type="curve" smooth="yes"/>
-      <point x="972" y="-16"/>
-      <point x="1044" y="64"/>
-      <point x="1044" y="184" type="curve" smooth="yes"/>
-      <point x="1044" y="285"/>
-      <point x="983" y="353"/>
-      <point x="840" y="353" type="curve" smooth="yes"/>
-      <point x="250" y="353" type="line" smooth="yes"/>
-      <point x="101" y="353"/>
-      <point x="14" y="273"/>
+      <point x="744" y="-382" type="curve" smooth="yes"/>
+      <point x="878" y="-382"/>
+      <point x="965" y="-325"/>
+      <point x="965" y="-237" type="curve" smooth="yes"/>
+      <point x="965" y="-168"/>
+      <point x="923" y="-129"/>
+      <point x="818" y="-118" type="curve" smooth="yes"/>
+      <point x="749" y="-111" type="line" smooth="yes"/>
+      <point x="716" y="-108"/>
+      <point x="695" y="-99"/>
+      <point x="695" y="-77" type="curve" smooth="yes"/>
+      <point x="695" y="-48"/>
+      <point x="727" y="-31"/>
+      <point x="803" y="-31" type="curve" smooth="yes"/>
+      <point x="866" y="-31"/>
+      <point x="915" y="-42"/>
+      <point x="960" y="-59" type="curve"/>
+      <point x="989" y="22" type="line"/>
+      <point x="974" y="29"/>
+      <point x="958" y="33"/>
+      <point x="939" y="36" type="curve"/>
+      <point x="941" y="47" type="line"/>
+      <point x="1007" y="78"/>
+      <point x="1042" y="133"/>
+      <point x="1042" y="196" type="curve" smooth="yes"/>
+      <point x="1042" y="310"/>
+      <point x="959" y="373"/>
+      <point x="828" y="373" type="curve" smooth="yes"/>
+      <point x="278" y="373" type="line" smooth="yes"/>
+      <point x="118" y="373"/>
+      <point x="14" y="285"/>
       <point x="14" y="151" type="curve" smooth="yes"/>
-      <point x="14" y="53"/>
-      <point x="76" y="-16"/>
-      <point x="185" y="-16" type="curve" smooth="yes"/>
-      <point x="272" y="-16"/>
-      <point x="326" y="31"/>
-      <point x="353" y="91" type="curve"/>
-      <point x="365" y="91" type="line"/>
-      <point x="393" y="26"/>
-      <point x="444" y="-16"/>
-      <point x="536" y="-14" type="curve" smooth="yes"/>
-      <point x="546" y="-14"/>
-      <point x="556" y="-13"/>
-      <point x="568" y="-10" type="curve"/>
-      <point x="572" y="-21" type="line"/>
-      <point x="557" y="-39"/>
-      <point x="549" y="-61"/>
-      <point x="549" y="-90" type="curve" smooth="yes"/>
-      <point x="549" y="-156"/>
-      <point x="602" y="-200"/>
-      <point x="699" y="-204" type="curve" smooth="yes"/>
-      <point x="757" y="-207" type="line" smooth="yes"/>
-      <point x="819" y="-210"/>
-      <point x="839" y="-225"/>
-      <point x="839" y="-249" type="curve" smooth="yes"/>
-      <point x="839" y="-276"/>
-      <point x="815" y="-296"/>
-      <point x="738" y="-296" type="curve" smooth="yes"/>
-      <point x="651" y="-296"/>
-      <point x="587" y="-277"/>
-      <point x="547" y="-255" type="curve"/>
-      <point x="500" y="-329" type="line"/>
-      <point x="552" y="-363"/>
-      <point x="641" y="-382"/>
+      <point x="14" y="55"/>
+      <point x="82" y="-16"/>
+      <point x="181" y="-16" type="curve" smooth="yes"/>
+      <point x="258" y="-16"/>
+      <point x="315" y="34"/>
+      <point x="345" y="100" type="curve"/>
+      <point x="360" y="100" type="line"/>
+      <point x="381" y="29"/>
+      <point x="433" y="-16"/>
+      <point x="516" y="-16" type="curve" smooth="yes"/>
+      <point x="717" y="-16"/>
+      <point x="805" y="247"/>
+      <point x="805" y="397" type="curve" smooth="yes"/>
+      <point x="805" y="533"/>
+      <point x="738" y="629"/>
+      <point x="616" y="629" type="curve" smooth="yes"/>
+      <point x="476" y="629"/>
+      <point x="367" y="509"/>
+      <point x="336" y="329" type="curve" smooth="yes"/>
+      <point x="330" y="296"/>
+      <point x="328" y="261"/>
+      <point x="323" y="229" type="curve" smooth="yes"/>
+      <point x="310" y="144"/>
+      <point x="267" y="95"/>
+      <point x="206" y="95" type="curve" smooth="yes"/>
+      <point x="162" y="95"/>
+      <point x="131" y="123"/>
+      <point x="131" y="169" type="curve" smooth="yes"/>
+      <point x="131" y="230"/>
+      <point x="177" y="273"/>
+      <point x="256" y="273" type="curve" smooth="yes"/>
+      <point x="818" y="273" type="line" smooth="yes"/>
+      <point x="892" y="273"/>
+      <point x="925" y="239"/>
+      <point x="925" y="185" type="curve" smooth="yes"/>
+      <point x="925" y="142"/>
+      <point x="897" y="94"/>
+      <point x="837" y="94" type="curve" smooth="yes"/>
+      <point x="817" y="94"/>
+      <point x="799" y="99"/>
+      <point x="783" y="107" type="curve"/>
+      <point x="752" y="32" type="line"/>
+      <point x="782" y="53" type="line"/>
+      <point x="678" y="46"/>
+      <point x="598" y="-9"/>
+      <point x="598" y="-87" type="curve" smooth="yes"/>
+      <point x="598" y="-149"/>
+      <point x="644" y="-189"/>
+      <point x="728" y="-198" type="curve" smooth="yes"/>
+      <point x="797" y="-205" type="line" smooth="yes"/>
+      <point x="853" y="-211"/>
+      <point x="867" y="-220"/>
+      <point x="867" y="-245" type="curve" smooth="yes"/>
+      <point x="867" y="-277"/>
+      <point x="833" y="-296"/>
+      <point x="758" y="-296" type="curve" smooth="yes"/>
+      <point x="688" y="-296"/>
+      <point x="627" y="-282"/>
+      <point x="580" y="-256" type="curve"/>
+      <point x="541" y="-339" type="line"/>
+      <point x="591" y="-366"/>
+      <point x="666" y="-382"/>
     </contour>
     <contour>
-      <point x="538" y="95" type="curve" smooth="yes"/>
-      <point x="466" y="95"/>
-      <point x="437" y="143"/>
-      <point x="437" y="229" type="curve" smooth="yes"/>
-      <point x="437" y="356"/>
-      <point x="484" y="518"/>
-      <point x="598" y="518" type="curve" smooth="yes"/>
-      <point x="662" y="518"/>
-      <point x="691" y="472"/>
-      <point x="691" y="384" type="curve" smooth="yes"/>
-      <point x="691" y="253"/>
-      <point x="649" y="95"/>
+      <point x="524" y="95" type="curve" smooth="yes"/>
+      <point x="463" y="95"/>
+      <point x="432" y="135"/>
+      <point x="432" y="212" type="curve" smooth="yes"/>
+      <point x="432" y="298"/>
+      <point x="473" y="518"/>
+      <point x="606" y="518" type="curve" smooth="yes"/>
+      <point x="661" y="518"/>
+      <point x="688" y="476"/>
+      <point x="688" y="405" type="curve" smooth="yes"/>
+      <point x="688" y="322"/>
+      <point x="654" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ka-malayalam.glif
@@ -2,80 +2,80 @@
 <glyph name="ka-malayalam" format="2">
   <advance width="1099"/>
   <unicode hex="0D15"/>
-  <anchor x="636" y="0" name="bottom"/>
-  <anchor x="624" y="613" name="top"/>
-  <anchor x="979" y="573" name="topright"/>
+  <anchor x="629" y="0" name="bottom"/>
+  <anchor x="618" y="613" name="top"/>
+  <anchor x="973" y="573" name="topright"/>
   <outline>
     <contour>
-      <point x="185" y="-16" type="curve" smooth="yes"/>
-      <point x="272" y="-16"/>
-      <point x="327" y="31"/>
-      <point x="353" y="91" type="curve"/>
-      <point x="365" y="91" type="line"/>
-      <point x="393" y="26"/>
-      <point x="444" y="-16"/>
-      <point x="536" y="-16" type="curve" smooth="yes"/>
-      <point x="726" y="-16"/>
-      <point x="811" y="191"/>
-      <point x="811" y="385" type="curve" smooth="yes"/>
-      <point x="811" y="530"/>
-      <point x="747" y="629"/>
-      <point x="606" y="629" type="curve" smooth="yes"/>
-      <point x="467" y="629"/>
-      <point x="368" y="522"/>
-      <point x="340" y="336" type="curve" smooth="yes"/>
-      <point x="334" y="295"/>
-      <point x="331" y="256"/>
-      <point x="327" y="227" type="curve" smooth="yes"/>
-      <point x="314" y="138"/>
-      <point x="271" y="95"/>
-      <point x="211" y="95" type="curve" smooth="yes"/>
-      <point x="160" y="95"/>
-      <point x="134" y="123"/>
-      <point x="134" y="169" type="curve" smooth="yes"/>
-      <point x="134" y="215"/>
-      <point x="166" y="253"/>
-      <point x="237" y="253" type="curve" smooth="yes"/>
-      <point x="834" y="253" type="line" smooth="yes"/>
-      <point x="901" y="253"/>
-      <point x="927" y="226"/>
-      <point x="927" y="181" type="curve" smooth="yes"/>
-      <point x="927" y="138"/>
-      <point x="907" y="94"/>
-      <point x="844" y="94" type="curve" smooth="yes"/>
-      <point x="823" y="94"/>
-      <point x="806" y="98"/>
-      <point x="788" y="105" type="curve"/>
-      <point x="744" y="6" type="line"/>
-      <point x="769" y="-7"/>
-      <point x="812" y="-16"/>
-      <point x="850" y="-16" type="curve" smooth="yes"/>
-      <point x="972" y="-16"/>
-      <point x="1044" y="64"/>
-      <point x="1044" y="184" type="curve" smooth="yes"/>
-      <point x="1044" y="285"/>
-      <point x="983" y="353"/>
-      <point x="840" y="353" type="curve" smooth="yes"/>
-      <point x="250" y="353" type="line" smooth="yes"/>
-      <point x="101" y="353"/>
-      <point x="14" y="273"/>
+      <point x="181" y="-16" type="curve" smooth="yes"/>
+      <point x="258" y="-16"/>
+      <point x="315" y="34"/>
+      <point x="345" y="100" type="curve"/>
+      <point x="360" y="100" type="line"/>
+      <point x="381" y="29"/>
+      <point x="436" y="-16"/>
+      <point x="519" y="-16" type="curve" smooth="yes"/>
+      <point x="730" y="-16"/>
+      <point x="805" y="244"/>
+      <point x="805" y="397" type="curve" smooth="yes"/>
+      <point x="805" y="533"/>
+      <point x="738" y="629"/>
+      <point x="616" y="629" type="curve" smooth="yes"/>
+      <point x="476" y="629"/>
+      <point x="367" y="509"/>
+      <point x="336" y="329" type="curve" smooth="yes"/>
+      <point x="330" y="296"/>
+      <point x="328" y="261"/>
+      <point x="323" y="229" type="curve" smooth="yes"/>
+      <point x="310" y="144"/>
+      <point x="267" y="95"/>
+      <point x="206" y="95" type="curve" smooth="yes"/>
+      <point x="162" y="95"/>
+      <point x="131" y="123"/>
+      <point x="131" y="169" type="curve" smooth="yes"/>
+      <point x="131" y="230"/>
+      <point x="177" y="273"/>
+      <point x="256" y="273" type="curve" smooth="yes"/>
+      <point x="818" y="273" type="line" smooth="yes"/>
+      <point x="887" y="273"/>
+      <point x="920" y="239"/>
+      <point x="920" y="188" type="curve" smooth="yes"/>
+      <point x="920" y="134"/>
+      <point x="884" y="94"/>
+      <point x="828" y="94" type="curve" smooth="yes"/>
+      <point x="807" y="94"/>
+      <point x="792" y="97"/>
+      <point x="777" y="102" type="curve"/>
+      <point x="747" y="-4" type="line"/>
+      <point x="773" y="-12"/>
+      <point x="799" y="-16"/>
+      <point x="831" y="-16" type="curve" smooth="yes"/>
+      <point x="957" y="-16"/>
+      <point x="1036" y="80"/>
+      <point x="1036" y="190" type="curve" smooth="yes"/>
+      <point x="1036" y="308"/>
+      <point x="955" y="373"/>
+      <point x="828" y="373" type="curve" smooth="yes"/>
+      <point x="278" y="373" type="line" smooth="yes"/>
+      <point x="118" y="373"/>
+      <point x="14" y="285"/>
       <point x="14" y="151" type="curve" smooth="yes"/>
-      <point x="14" y="53"/>
-      <point x="76" y="-16"/>
+      <point x="14" y="55"/>
+      <point x="82" y="-16"/>
     </contour>
     <contour>
-      <point x="538" y="95" type="curve" smooth="yes"/>
-      <point x="466" y="95"/>
-      <point x="437" y="143"/>
-      <point x="437" y="229" type="curve" smooth="yes"/>
-      <point x="437" y="356"/>
-      <point x="484" y="518"/>
-      <point x="598" y="518" type="curve" smooth="yes"/>
-      <point x="662" y="518"/>
-      <point x="691" y="472"/>
-      <point x="691" y="384" type="curve" smooth="yes"/>
-      <point x="691" y="253"/>
-      <point x="649" y="95"/>
+      <point x="524" y="95" type="curve" smooth="yes"/>
+      <point x="463" y="95"/>
+      <point x="432" y="135"/>
+      <point x="432" y="212" type="curve" smooth="yes"/>
+      <point x="432" y="298"/>
+      <point x="473" y="518"/>
+      <point x="606" y="518" type="curve" smooth="yes"/>
+      <point x="661" y="518"/>
+      <point x="688" y="476"/>
+      <point x="688" y="405" type="curve" smooth="yes"/>
+      <point x="688" y="322"/>
+      <point x="654" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/m_la-malayalam.glif
@@ -1,53 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="m_la-malayalam" format="2">
   <advance width="731"/>
-  <anchor x="255" y="-364" name="bottom"/>
+  <anchor x="268" y="-366" name="bottom"/>
   <anchor x="425" y="613" name="top"/>
   <anchor x="652" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="37" y="-382" type="curve" smooth="yes"/>
-      <point x="132" y="-382"/>
-      <point x="189" y="-323"/>
-      <point x="189" y="-233" type="curve" smooth="yes"/>
-      <point x="189" y="-153"/>
-      <point x="145" y="-118"/>
-      <point x="79" y="-118" type="curve" smooth="yes"/>
-      <point x="45" y="-118"/>
-      <point x="13" y="-130"/>
-      <point x="-9" y="-160" type="curve"/>
-      <point x="-22" y="-158" type="line"/>
-      <point x="-6" y="-92"/>
-      <point x="45" y="-33"/>
-      <point x="133" y="-33" type="curve" smooth="yes"/>
-      <point x="232" y="-33"/>
-      <point x="258" y="-84"/>
-      <point x="266" y="-177" type="curve" smooth="yes"/>
-      <point x="267" y="-189" type="line" smooth="yes"/>
-      <point x="278" y="-315"/>
-      <point x="328" y="-382"/>
-      <point x="455" y="-382" type="curve" smooth="yes"/>
-      <point x="598" y="-382"/>
-      <point x="654" y="-278"/>
-      <point x="654" y="-135" type="curve" smooth="yes"/>
-      <point x="654" y="-54"/>
-      <point x="630" y="13"/>
-      <point x="605" y="55" type="curve"/>
-      <point x="519" y="4" type="line"/>
-      <point x="536" y="-27"/>
-      <point x="553" y="-80"/>
-      <point x="553" y="-147" type="curve" smooth="yes"/>
-      <point x="553" y="-231"/>
-      <point x="527" y="-292"/>
-      <point x="455" y="-292" type="curve" smooth="yes"/>
-      <point x="398" y="-292"/>
-      <point x="374" y="-255"/>
-      <point x="366" y="-177" type="curve" smooth="yes"/>
-      <point x="363" y="-151" type="line" smooth="yes"/>
-      <point x="357" y="-90"/>
-      <point x="342" y="-39"/>
-      <point x="304" y="-13" type="curve"/>
-      <point x="306" y="0" type="line"/>
+      <point x="6" y="0" type="line"/>
       <point x="617" y="0" type="line"/>
       <point x="666" y="285" type="line" smooth="yes"/>
       <point x="674" y="332"/>
@@ -59,30 +18,75 @@
       <point x="220" y="629"/>
       <point x="100" y="532"/>
       <point x="68" y="351" type="curve" smooth="yes"/>
-      <point x="6" y="0" type="line"/>
-      <point x="45" y="0" type="line"/>
-      <point x="45" y="39" type="line"/>
-      <point x="-58" y="3"/>
-      <point x="-119" y="-90"/>
-      <point x="-119" y="-206" type="curve" smooth="yes"/>
-      <point x="-119" y="-327"/>
-      <point x="-54" y="-382"/>
     </contour>
     <contour>
-      <point x="41" y="-302" type="curve" smooth="yes"/>
-      <point x="-4" y="-302"/>
-      <point x="-25" y="-269"/>
-      <point x="-25" y="-226" type="curve"/>
-      <point x="-41" y="-214" type="line"/>
-      <point x="-33" y="-251" type="line"/>
-      <point x="-21" y="-213"/>
-      <point x="8" y="-191"/>
-      <point x="45" y="-191" type="curve" smooth="yes"/>
-      <point x="81" y="-191"/>
-      <point x="99" y="-207"/>
-      <point x="99" y="-241" type="curve" smooth="yes"/>
-      <point x="99" y="-277"/>
-      <point x="80" y="-302"/>
+      <point x="110" y="-382" type="curve" smooth="yes"/>
+      <point x="217" y="-382"/>
+      <point x="265" y="-297"/>
+      <point x="265" y="-205" type="curve" smooth="yes"/>
+      <point x="265" y="-131"/>
+      <point x="233" y="-86"/>
+      <point x="170" y="-86" type="curve" smooth="yes"/>
+      <point x="116" y="-86"/>
+      <point x="69" y="-119"/>
+      <point x="45" y="-200" type="curve"/>
+      <point x="92" y="-138" type="line"/>
+      <point x="39" y="-128" type="line"/>
+      <point x="52" y="-185" type="line"/>
+      <point x="67" y="-79"/>
+      <point x="122" y="-20"/>
+      <point x="203" y="-20" type="curve" smooth="yes"/>
+      <point x="275" y="-20"/>
+      <point x="303" y="-59"/>
+      <point x="303" y="-151" type="curve" smooth="yes"/>
+      <point x="303" y="-237" type="line" smooth="yes"/>
+      <point x="303" y="-330"/>
+      <point x="353" y="-382"/>
+      <point x="434" y="-382" type="curve" smooth="yes"/>
+      <point x="563" y="-382"/>
+      <point x="603" y="-263"/>
+      <point x="603" y="-164" type="curve" smooth="yes"/>
+      <point x="603" y="-85"/>
+      <point x="581" y="-4"/>
+      <point x="542" y="59" type="curve"/>
+      <point x="459" y="11" type="line"/>
+      <point x="492" y="-42"/>
+      <point x="507" y="-96"/>
+      <point x="507" y="-160" type="curve" smooth="yes"/>
+      <point x="507" y="-202"/>
+      <point x="498" y="-290"/>
+      <point x="444" y="-290" type="curve" smooth="yes"/>
+      <point x="411" y="-290"/>
+      <point x="396" y="-270"/>
+      <point x="396" y="-218" type="curve" smooth="yes"/>
+      <point x="396" y="-132" type="line" smooth="yes"/>
+      <point x="396" y="-17"/>
+      <point x="330" y="45"/>
+      <point x="210" y="45" type="curve" smooth="yes"/>
+      <point x="15" y="45"/>
+      <point x="-37" y="-119"/>
+      <point x="-37" y="-208" type="curve" smooth="yes"/>
+      <point x="-37" y="-315"/>
+      <point x="21" y="-382"/>
+    </contour>
+    <contour>
+      <point x="113" y="-302" type="curve" smooth="yes"/>
+      <point x="76" y="-302"/>
+      <point x="50" y="-277"/>
+      <point x="50" y="-228" type="curve" smooth="yes"/>
+      <point x="50" y="-217"/>
+      <point x="52" y="-208"/>
+      <point x="58" y="-196" type="curve"/>
+      <point x="35" y="-209" type="line"/>
+      <point x="47" y="-239" type="line"/>
+      <point x="66" y="-184"/>
+      <point x="91" y="-158"/>
+      <point x="129" y="-158" type="curve" smooth="yes"/>
+      <point x="161" y="-158"/>
+      <point x="177" y="-179"/>
+      <point x="177" y="-214" type="curve" smooth="yes"/>
+      <point x="177" y="-247"/>
+      <point x="164" y="-302"/>
     </contour>
     <contour>
       <point x="84" y="48" type="line"/>
@@ -101,12 +105,12 @@
     <contour>
       <point x="245" y="45" type="line"/>
       <point x="360" y="160" type="line" smooth="yes"/>
-      <point x="446" y="245"/>
+      <point x="447" y="247"/>
       <point x="488" y="321"/>
       <point x="488" y="394" type="curve" smooth="yes"/>
       <point x="488" y="479"/>
-      <point x="435" y="529"/>
-      <point x="342" y="531" type="curve"/>
+      <point x="435" y="528"/>
+      <point x="342" y="530" type="curve"/>
       <point x="342" y="587" type="line"/>
       <point x="308" y="538" type="line"/>
       <point x="332" y="544"/>
@@ -116,7 +120,7 @@
       <point x="556" y="498"/>
       <point x="556" y="383" type="curve" smooth="yes"/>
       <point x="556" y="359"/>
-      <point x="553" y="328"/>
+      <point x="552" y="328"/>
       <point x="546" y="291" type="curve" smooth="yes"/>
       <point x="504" y="50" type="line"/>
       <point x="583" y="104" type="line"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
@@ -1,103 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng_ka-malayalam" format="2">
-  <advance width="1099"/>
-  <anchor x="635" y="0" name="bottom"/>
+  <advance width="1104"/>
+  <anchor x="634" y="0" name="bottom"/>
   <anchor x="628" y="613" name="top"/>
   <anchor x="982" y="613" name="topright"/>
   <outline>
     <contour>
       <point x="184" y="-16" type="curve" smooth="yes"/>
-      <point x="272" y="-16"/>
-      <point x="326" y="31"/>
-      <point x="353" y="91" type="curve"/>
-      <point x="365" y="91" type="line"/>
-      <point x="393" y="26"/>
-      <point x="444" y="-16"/>
-      <point x="536" y="-16" type="curve" smooth="yes"/>
-      <point x="726" y="-16"/>
-      <point x="810" y="191"/>
-      <point x="810" y="385" type="curve" smooth="yes"/>
+      <point x="266" y="-16"/>
+      <point x="319" y="27"/>
+      <point x="350" y="100" type="curve"/>
+      <point x="365" y="100" type="line"/>
+      <point x="386" y="28"/>
+      <point x="442" y="-16"/>
+      <point x="523" y="-16" type="curve" smooth="yes"/>
+      <point x="735" y="-16"/>
+      <point x="810" y="244"/>
+      <point x="810" y="397" type="curve" smooth="yes"/>
       <point x="810" y="530"/>
-      <point x="745" y="629"/>
-      <point x="611" y="629" type="curve" smooth="yes"/>
-      <point x="532" y="629"/>
-      <point x="470" y="592"/>
-      <point x="432" y="525" type="curve"/>
-      <point x="419" y="525" type="line"/>
-      <point x="398" y="588"/>
-      <point x="348" y="629"/>
-      <point x="263" y="629" type="curve" smooth="yes"/>
-      <point x="152" y="629"/>
-      <point x="76" y="556"/>
-      <point x="76" y="452" type="curve" smooth="yes"/>
-      <point x="76" y="397"/>
-      <point x="101" y="349"/>
-      <point x="146" y="322" type="curve"/>
-      <point x="144" y="310" type="line"/>
-      <point x="65" y="291"/>
-      <point x="14" y="230"/>
-      <point x="14" y="146" type="curve" smooth="yes"/>
-      <point x="14" y="53"/>
-      <point x="75" y="-16"/>
+      <point x="743" y="629"/>
+      <point x="627" y="629" type="curve" smooth="yes"/>
+      <point x="545" y="629"/>
+      <point x="481" y="588"/>
+      <point x="436" y="520" type="curve"/>
+      <point x="422" y="520" type="line"/>
+      <point x="404" y="590"/>
+      <point x="352" y="629"/>
+      <point x="275" y="629" type="curve" smooth="yes"/>
+      <point x="160" y="629"/>
+      <point x="79" y="557"/>
+      <point x="79" y="454" type="curve" smooth="yes"/>
+      <point x="79" y="403"/>
+      <point x="104" y="360"/>
+      <point x="147" y="334" type="curve"/>
+      <point x="144" y="321" type="line"/>
+      <point x="66" y="292"/>
+      <point x="19" y="228"/>
+      <point x="19" y="150" type="curve" smooth="yes"/>
+      <point x="19" y="52"/>
+      <point x="87" y="-16"/>
     </contour>
     <contour>
-      <point x="537" y="95" type="curve" smooth="yes"/>
-      <point x="466" y="95"/>
-      <point x="437" y="143"/>
-      <point x="437" y="229" type="curve" smooth="yes"/>
-      <point x="437" y="356"/>
-      <point x="483" y="518"/>
-      <point x="598" y="518" type="curve" smooth="yes"/>
-      <point x="662" y="518"/>
-      <point x="690" y="472"/>
-      <point x="690" y="384" type="curve" smooth="yes"/>
-      <point x="690" y="253"/>
-      <point x="649" y="95"/>
+      <point x="836" y="-16" type="curve" smooth="yes"/>
+      <point x="962" y="-16"/>
+      <point x="1041" y="80"/>
+      <point x="1041" y="190" type="curve" smooth="yes"/>
+      <point x="1041" y="308"/>
+      <point x="960" y="373"/>
+      <point x="833" y="373" type="curve" smooth="yes"/>
+      <point x="267" y="373" type="line" smooth="yes"/>
+      <point x="219" y="373"/>
+      <point x="191" y="398"/>
+      <point x="191" y="439" type="curve" smooth="yes"/>
+      <point x="191" y="484"/>
+      <point x="228" y="518"/>
+      <point x="279" y="518" type="curve" smooth="yes"/>
+      <point x="332" y="518"/>
+      <point x="360" y="491"/>
+      <point x="360" y="438" type="curve" smooth="yes"/>
+      <point x="360" y="423"/>
+      <point x="359" y="405"/>
+      <point x="355" y="384" type="curve" smooth="yes"/>
+      <point x="326" y="219" type="line" smooth="yes"/>
+      <point x="312" y="137"/>
+      <point x="275" y="95"/>
+      <point x="214" y="95" type="curve" smooth="yes"/>
+      <point x="167" y="95"/>
+      <point x="136" y="125"/>
+      <point x="136" y="170" type="curve" smooth="yes"/>
+      <point x="136" y="232"/>
+      <point x="186" y="273"/>
+      <point x="272" y="273" type="curve" smooth="yes"/>
+      <point x="823" y="273" type="line" smooth="yes"/>
+      <point x="892" y="273"/>
+      <point x="925" y="239"/>
+      <point x="925" y="188" type="curve" smooth="yes"/>
+      <point x="925" y="134"/>
+      <point x="889" y="94"/>
+      <point x="833" y="94" type="curve" smooth="yes"/>
+      <point x="812" y="94"/>
+      <point x="797" y="97"/>
+      <point x="782" y="102" type="curve"/>
+      <point x="752" y="-4" type="line"/>
+      <point x="778" y="-12"/>
+      <point x="804" y="-16"/>
     </contour>
     <contour>
-      <point x="850" y="-16" type="curve" smooth="yes"/>
-      <point x="971" y="-16"/>
-      <point x="1043" y="64"/>
-      <point x="1043" y="184" type="curve" smooth="yes"/>
-      <point x="1043" y="285"/>
-      <point x="983" y="353"/>
-      <point x="840" y="353" type="curve" smooth="yes"/>
-      <point x="286" y="353" type="line" smooth="yes"/>
-      <point x="219" y="353"/>
-      <point x="190" y="389"/>
-      <point x="190" y="435" type="curve" smooth="yes"/>
-      <point x="190" y="483"/>
-      <point x="222" y="518"/>
-      <point x="277" y="518" type="curve" smooth="yes"/>
-      <point x="330" y="518"/>
-      <point x="359" y="486"/>
-      <point x="359" y="427" type="curve" smooth="yes"/>
-      <point x="359" y="411"/>
-      <point x="357" y="391"/>
-      <point x="353" y="368" type="curve" smooth="yes"/>
-      <point x="327" y="229" type="line" smooth="yes"/>
-      <point x="311" y="138"/>
-      <point x="271" y="95"/>
-      <point x="210" y="95" type="curve" smooth="yes"/>
-      <point x="161" y="95"/>
-      <point x="133" y="123"/>
-      <point x="133" y="167" type="curve" smooth="yes"/>
-      <point x="133" y="215"/>
-      <point x="165" y="253"/>
-      <point x="236" y="253" type="curve" smooth="yes"/>
-      <point x="833" y="253" type="line" smooth="yes"/>
-      <point x="900" y="253"/>
-      <point x="926" y="226"/>
-      <point x="926" y="181" type="curve" smooth="yes"/>
-      <point x="926" y="138"/>
-      <point x="907" y="94"/>
-      <point x="844" y="94" type="curve" smooth="yes"/>
-      <point x="823" y="94"/>
-      <point x="806" y="98"/>
-      <point x="788" y="105" type="curve"/>
-      <point x="743" y="6" type="line"/>
-      <point x="769" y="-7"/>
-      <point x="811" y="-16"/>
+      <point x="529" y="95" type="curve" smooth="yes"/>
+      <point x="468" y="95"/>
+      <point x="437" y="135"/>
+      <point x="437" y="212" type="curve" smooth="yes"/>
+      <point x="437" y="298"/>
+      <point x="478" y="518"/>
+      <point x="612" y="518" type="curve" smooth="yes"/>
+      <point x="666" y="518"/>
+      <point x="693" y="476"/>
+      <point x="693" y="405" type="curve" smooth="yes"/>
+      <point x="693" y="322"/>
+      <point x="659" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,192 +1,193 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1580"/>
-  <anchor x="1116" y="6" name="bottom"/>
-  <anchor x="887" y="613" name="top"/>
-  <anchor x="1497" y="613" name="topright"/>
+  <advance width="1630"/>
+  <anchor x="1139" y="-1" name="bottom"/>
+  <anchor x="869" y="613" name="top"/>
+  <anchor x="1506" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="271" y="-16" type="curve" smooth="yes"/>
-      <point x="392" y="-16"/>
-      <point x="470" y="66"/>
-      <point x="470" y="195" type="curve" smooth="yes"/>
-      <point x="470" y="303"/>
-      <point x="414" y="367"/>
-      <point x="319" y="367" type="curve" smooth="yes"/>
-      <point x="265" y="367"/>
-      <point x="219" y="346"/>
+      <point x="247" y="-16" type="curve" smooth="yes"/>
+      <point x="411" y="-16"/>
+      <point x="464" y="115"/>
+      <point x="464" y="208" type="curve" smooth="yes"/>
+      <point x="464" y="308"/>
+      <point x="410" y="367"/>
+      <point x="323" y="367" type="curve" smooth="yes"/>
+      <point x="266" y="367"/>
+      <point x="220" y="345"/>
       <point x="184" y="306" type="curve"/>
       <point x="131" y="322" type="line"/>
-      <point x="139" y="141" type="line"/>
-      <point x="162" y="221"/>
-      <point x="215" y="273"/>
-      <point x="273" y="273" type="curve" smooth="yes"/>
-      <point x="324" y="273"/>
-      <point x="350" y="245"/>
-      <point x="350" y="189" type="curve" smooth="yes"/>
-      <point x="350" y="130"/>
-      <point x="319" y="95"/>
-      <point x="268" y="95" type="curve" smooth="yes"/>
-      <point x="202" y="95"/>
-      <point x="164" y="144"/>
-      <point x="164" y="232" type="curve" smooth="yes"/>
-      <point x="164" y="401"/>
-      <point x="259" y="518"/>
-      <point x="397" y="518" type="curve" smooth="yes"/>
-      <point x="496" y="518"/>
-      <point x="550" y="464"/>
-      <point x="550" y="363" type="curve" smooth="yes"/>
-      <point x="550" y="345"/>
-      <point x="548" y="319"/>
-      <point x="543" y="292" type="curve" smooth="yes"/>
-      <point x="492" y="0" type="line"/>
-      <point x="613" y="0" type="line"/>
-      <point x="672" y="331" type="line" smooth="yes"/>
-      <point x="694" y="461"/>
-      <point x="754" y="549"/>
+      <point x="131" y="141" type="line"/>
+      <point x="157" y="222"/>
+      <point x="212" y="273"/>
+      <point x="274" y="273" type="curve" smooth="yes"/>
+      <point x="320" y="273"/>
+      <point x="344" y="249"/>
+      <point x="344" y="202" type="curve" smooth="yes"/>
+      <point x="344" y="156"/>
+      <point x="317" y="95"/>
+      <point x="253" y="95" type="curve" smooth="yes"/>
+      <point x="194" y="95"/>
+      <point x="162" y="140"/>
+      <point x="162" y="226" type="curve" smooth="yes"/>
+      <point x="162" y="370"/>
+      <point x="228" y="518"/>
+      <point x="394" y="518" type="curve" smooth="yes"/>
+      <point x="492" y="518"/>
+      <point x="546" y="464"/>
+      <point x="546" y="362" type="curve" smooth="yes"/>
+      <point x="546" y="344"/>
+      <point x="544" y="317"/>
+      <point x="539" y="290" type="curve" smooth="yes"/>
+      <point x="488" y="0" type="line"/>
+      <point x="610" y="0" type="line"/>
+      <point x="669" y="333" type="line" smooth="yes"/>
+      <point x="695" y="481"/>
+      <point x="767" y="549"/>
       <point x="897" y="549" type="curve" smooth="yes"/>
-      <point x="918" y="549"/>
-      <point x="940" y="547"/>
-      <point x="962" y="544" type="curve"/>
-      <point x="814" y="589" type="line"/>
-      <point x="844" y="527" type="line"/>
-      <point x="807" y="507"/>
-      <point x="787" y="476"/>
-      <point x="787" y="432" type="curve" smooth="yes"/>
-      <point x="787" y="362"/>
-      <point x="845" y="318"/>
-      <point x="932" y="318" type="curve" smooth="yes"/>
-      <point x="1031" y="318"/>
-      <point x="1089" y="370"/>
-      <point x="1089" y="452" type="curve" smooth="yes"/>
-      <point x="1089" y="489"/>
-      <point x="1073" y="526"/>
-      <point x="1032" y="547" type="curve"/>
-      <point x="1050" y="603" type="line"/>
-      <point x="975" y="556" type="line"/>
-      <point x="986" y="558"/>
-      <point x="999" y="559"/>
-      <point x="1012" y="559" type="curve" smooth="yes"/>
-      <point x="1096" y="559"/>
-      <point x="1138" y="518"/>
-      <point x="1138" y="442" type="curve" smooth="yes"/>
-      <point x="1138" y="428"/>
-      <point x="1136" y="412"/>
-      <point x="1133" y="397" type="curve" smooth="yes"/>
-      <point x="1126" y="354" type="line"/>
-      <point x="1244" y="354" type="line"/>
-      <point x="1253" y="407" type="line" smooth="yes"/>
-      <point x="1266" y="484"/>
-      <point x="1306" y="526"/>
-      <point x="1363" y="526" type="curve" smooth="yes"/>
-      <point x="1413" y="526"/>
-      <point x="1440" y="500"/>
-      <point x="1440" y="445" type="curve" smooth="yes"/>
-      <point x="1440" y="355"/>
-      <point x="1391" y="307"/>
-      <point x="1300" y="307" type="curve" smooth="yes"/>
-      <point x="947" y="307" type="line" smooth="yes"/>
-      <point x="818" y="307"/>
-      <point x="739" y="242"/>
-      <point x="739" y="133" type="curve" smooth="yes"/>
-      <point x="739" y="41"/>
-      <point x="799" y="-16"/>
+      <point x="906" y="549"/>
+      <point x="915" y="549"/>
+      <point x="926" y="549" type="curve"/>
+      <point x="830" y="562" type="line"/>
+      <point x="841" y="528" type="line"/>
+      <point x="802" y="499"/>
+      <point x="780" y="459"/>
+      <point x="780" y="412" type="curve" smooth="yes"/>
+      <point x="780" y="343"/>
+      <point x="835" y="291"/>
+      <point x="927" y="291" type="curve" smooth="yes"/>
+      <point x="1056" y="291"/>
+      <point x="1097" y="381"/>
+      <point x="1097" y="436" type="curve" smooth="yes"/>
+      <point x="1097" y="481"/>
+      <point x="1082" y="516"/>
+      <point x="1055" y="540" type="curve"/>
+      <point x="1075" y="572" type="line"/>
+      <point x="1009" y="553" type="line"/>
+      <point x="1018" y="554"/>
+      <point x="1031" y="555"/>
+      <point x="1043" y="555" type="curve" smooth="yes"/>
+      <point x="1114" y="555"/>
+      <point x="1147" y="518"/>
+      <point x="1147" y="457" type="curve" smooth="yes"/>
+      <point x="1147" y="434"/>
+      <point x="1144" y="410"/>
+      <point x="1140" y="387" type="curve" smooth="yes"/>
+      <point x="1130" y="330" type="line"/>
+      <point x="1244" y="330" type="line"/>
+      <point x="1256" y="398" type="line" smooth="yes"/>
+      <point x="1270" y="479"/>
+      <point x="1314" y="523"/>
+      <point x="1387" y="523" type="curve" smooth="yes"/>
+      <point x="1451" y="523"/>
+      <point x="1481" y="488"/>
+      <point x="1481" y="430" type="curve" smooth="yes"/>
+      <point x="1481" y="331"/>
+      <point x="1411" y="273"/>
+      <point x="1280" y="273" type="curve" smooth="yes"/>
+      <point x="925" y="273" type="line" smooth="yes"/>
+      <point x="796" y="273"/>
+      <point x="733" y="202"/>
+      <point x="733" y="121" type="curve" smooth="yes"/>
+      <point x="733" y="40"/>
+      <point x="794" y="-16"/>
       <point x="900" y="-16" type="curve" smooth="yes"/>
-      <point x="967" y="-16"/>
-      <point x="1032" y="6"/>
-      <point x="1124" y="61" type="curve" smooth="yes"/>
-      <point x="1170" y="88" type="line"/>
-      <point x="1274" y="156" type="line"/>
-      <point x="1289" y="154" type="line"/>
-      <point x="1324" y="172"/>
-      <point x="1343" y="176"/>
-      <point x="1364" y="176" type="curve" smooth="yes"/>
-      <point x="1395" y="176"/>
-      <point x="1410" y="161"/>
-      <point x="1410" y="132" type="curve" smooth="yes"/>
-      <point x="1410" y="95"/>
-      <point x="1390" y="73"/>
-      <point x="1357" y="73" type="curve" smooth="yes"/>
-      <point x="1329" y="73"/>
-      <point x="1311" y="91"/>
-      <point x="1311" y="119" type="curve" smooth="yes"/>
-      <point x="1311" y="144"/>
-      <point x="1321" y="164"/>
-      <point x="1344" y="183" type="curve"/>
-      <point x="1193" y="165" type="line"/>
-      <point x="1262" y="97" type="line"/>
-      <point x="1277" y="169" type="line"/>
-      <point x="1250" y="152"/>
-      <point x="1234" y="122"/>
-      <point x="1234" y="85" type="curve" smooth="yes"/>
-      <point x="1234" y="24"/>
-      <point x="1279" y="-16"/>
-      <point x="1353" y="-16" type="curve" smooth="yes"/>
-      <point x="1444" y="-16"/>
-      <point x="1500" y="42"/>
-      <point x="1500" y="136" type="curve" smooth="yes"/>
-      <point x="1500" y="216"/>
-      <point x="1458" y="260"/>
-      <point x="1380" y="260" type="curve" smooth="yes"/>
-      <point x="1329" y="260"/>
-      <point x="1282" y="243"/>
-      <point x="1185" y="193" type="curve" smooth="yes"/>
-      <point x="1106" y="151" type="line" smooth="yes"/>
-      <point x="1013" y="102"/>
-      <point x="967" y="87"/>
-      <point x="921" y="87" type="curve" smooth="yes"/>
-      <point x="880" y="87"/>
-      <point x="857" y="107"/>
-      <point x="857" y="143" type="curve" smooth="yes"/>
-      <point x="857" y="184"/>
-      <point x="889" y="208"/>
-      <point x="947" y="208" type="curve" smooth="yes"/>
-      <point x="1314" y="208" type="line" smooth="yes"/>
-      <point x="1466" y="208"/>
-      <point x="1559" y="300"/>
-      <point x="1559" y="452" type="curve" smooth="yes"/>
-      <point x="1559" y="564"/>
-      <point x="1494" y="629"/>
-      <point x="1386" y="629" type="curve" smooth="yes"/>
-      <point x="1307" y="629"/>
-      <point x="1244" y="589"/>
-      <point x="1214" y="516" type="curve"/>
-      <point x="1204" y="516" type="line"/>
-      <point x="1183" y="591"/>
-      <point x="1122" y="629"/>
-      <point x="1020" y="629" type="curve" smooth="yes"/>
-      <point x="969" y="629"/>
-      <point x="933" y="620"/>
-      <point x="904" y="606" type="curve"/>
-      <point x="916" y="543" type="line"/>
-      <point x="983" y="536"/>
-      <point x="998" y="501"/>
-      <point x="998" y="465" type="curve" smooth="yes"/>
-      <point x="998" y="429"/>
-      <point x="981" y="401"/>
-      <point x="939" y="401" type="curve" smooth="yes"/>
-      <point x="906" y="401"/>
-      <point x="881" y="422"/>
-      <point x="881" y="461" type="curve" smooth="yes"/>
-      <point x="881" y="499"/>
-      <point x="909" y="545"/>
-      <point x="989" y="545" type="curve"/>
-      <point x="992" y="602" type="line"/>
-      <point x="965" y="618"/>
-      <point x="920" y="629"/>
+      <point x="953" y="-16"/>
+      <point x="1006" y="-3"/>
+      <point x="1075" y="28" type="curve" smooth="yes"/>
+      <point x="1208" y="87" type="line"/>
+      <point x="1273" y="142" type="line"/>
+      <point x="1315" y="159" type="line"/>
+      <point x="1349" y="180"/>
+      <point x="1367" y="186"/>
+      <point x="1395" y="186" type="curve" smooth="yes"/>
+      <point x="1436" y="186"/>
+      <point x="1454" y="167"/>
+      <point x="1454" y="134" type="curve" smooth="yes"/>
+      <point x="1454" y="106"/>
+      <point x="1435" y="73"/>
+      <point x="1386" y="73" type="curve" smooth="yes"/>
+      <point x="1349" y="73"/>
+      <point x="1327" y="94"/>
+      <point x="1327" y="125" type="curve" smooth="yes"/>
+      <point x="1327" y="145"/>
+      <point x="1333" y="163"/>
+      <point x="1347" y="183" type="curve"/>
+      <point x="1246" y="142" type="line"/>
+      <point x="1267" y="123" type="line"/>
+      <point x="1261" y="110"/>
+      <point x="1259" y="97"/>
+      <point x="1259" y="81" type="curve" smooth="yes"/>
+      <point x="1259" y="26"/>
+      <point x="1305" y="-16"/>
+      <point x="1379" y="-16" type="curve" smooth="yes"/>
+      <point x="1497" y="-16"/>
+      <point x="1543" y="71"/>
+      <point x="1543" y="136" type="curve" smooth="yes"/>
+      <point x="1543" y="203"/>
+      <point x="1502" y="248"/>
+      <point x="1422" y="248" type="curve" smooth="yes"/>
+      <point x="1363" y="248"/>
+      <point x="1308" y="231"/>
+      <point x="1220" y="192" type="curve" smooth="yes"/>
+      <point x="1046" y="115" type="line" smooth="yes"/>
+      <point x="997" y="93"/>
+      <point x="956" y="84"/>
+      <point x="910" y="84" type="curve" smooth="yes"/>
+      <point x="871" y="84"/>
+      <point x="851" y="100"/>
+      <point x="851" y="129" type="curve" smooth="yes"/>
+      <point x="851" y="158"/>
+      <point x="874" y="178"/>
+      <point x="922" y="178" type="curve" smooth="yes"/>
+      <point x="1264" y="178" type="line" smooth="yes"/>
+      <point x="1440" y="178"/>
+      <point x="1599" y="266"/>
+      <point x="1599" y="446" type="curve" smooth="yes"/>
+      <point x="1599" y="556"/>
+      <point x="1543" y="629"/>
+      <point x="1423" y="629" type="curve" smooth="yes"/>
+      <point x="1334" y="629"/>
+      <point x="1267" y="585"/>
+      <point x="1233" y="514" type="curve"/>
+      <point x="1221" y="514" type="line"/>
+      <point x="1202" y="588"/>
+      <point x="1151" y="629"/>
+      <point x="1046" y="629" type="curve" smooth="yes"/>
+      <point x="1007" y="629"/>
+      <point x="969" y="623"/>
+      <point x="936" y="609" type="curve"/>
+      <point x="980" y="605" type="line"/>
+      <point x="952" y="619"/>
+      <point x="916" y="629"/>
       <point x="869" y="629" type="curve" smooth="yes"/>
-      <point x="761" y="629"/>
-      <point x="676" y="579"/>
-      <point x="628" y="490" type="curve"/>
-      <point x="615" y="490" type="line"/>
-      <point x="581" y="579"/>
-      <point x="506" y="629"/>
-      <point x="396" y="629" type="curve" smooth="yes"/>
-      <point x="189" y="629"/>
-      <point x="46" y="466"/>
-      <point x="46" y="233" type="curve" smooth="yes"/>
-      <point x="46" y="84"/>
-      <point x="137" y="-16"/>
+      <point x="763" y="629"/>
+      <point x="677" y="579"/>
+      <point x="630" y="490" type="curve"/>
+      <point x="617" y="490" type="line"/>
+      <point x="583" y="580"/>
+      <point x="519" y="629"/>
+      <point x="400" y="629" type="curve" smooth="yes"/>
+      <point x="140" y="629"/>
+      <point x="44" y="391"/>
+      <point x="44" y="230" type="curve" smooth="yes"/>
+      <point x="44" y="77"/>
+      <point x="126" y="-16"/>
+    </contour>
+    <contour>
+      <point x="935" y="379" type="curve" smooth="yes"/>
+      <point x="899" y="379"/>
+      <point x="878" y="403"/>
+      <point x="878" y="436" type="curve" smooth="yes"/>
+      <point x="878" y="482"/>
+      <point x="913" y="525"/>
+      <point x="980" y="552" type="curve"/>
+      <point x="938" y="552" type="line"/>
+      <point x="982" y="530"/>
+      <point x="1005" y="497"/>
+      <point x="1005" y="454" type="curve" smooth="yes"/>
+      <point x="1005" y="420"/>
+      <point x="985" y="379"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/rr_rra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/rr_rra-malayalam.glif
@@ -1,38 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="rr_rra-malayalam" format="2">
-  <advance width="763"/>
+  <advance width="760"/>
   <anchor x="283" y="-337" name="bottom"/>
   <anchor x="434" y="613" name="top"/>
   <anchor x="651" y="613" name="topright"/>
   <outline>
-    <contour>
-      <point x="145" y="-344" type="curve"/>
-      <point x="224" y="-285" type="line"/>
-      <point x="206" y="-260"/>
-      <point x="189" y="-221"/>
-      <point x="189" y="-162" type="curve" smooth="yes"/>
-      <point x="189" y="-76"/>
-      <point x="232" y="0"/>
-      <point x="334" y="0" type="curve" smooth="yes"/>
-      <point x="402" y="0"/>
-      <point x="453" y="-34"/>
-      <point x="453" y="-116" type="curve" smooth="yes"/>
-      <point x="453" y="-183"/>
-      <point x="420" y="-233"/>
-      <point x="364" y="-279" type="curve"/>
-      <point x="429" y="-344" type="line"/>
-      <point x="508" y="-283"/>
-      <point x="555" y="-215"/>
-      <point x="555" y="-110" type="curve" smooth="yes"/>
-      <point x="555" y="26"/>
-      <point x="468" y="93"/>
-      <point x="339" y="93" type="curve" smooth="yes"/>
-      <point x="174" y="93"/>
-      <point x="88" y="-21"/>
-      <point x="88" y="-168" type="curve" smooth="yes"/>
-      <point x="88" y="-236"/>
-      <point x="111" y="-304"/>
-    </contour>
     <contour>
       <point x="170" y="-16" type="curve"/>
       <point x="256" y="67" type="line"/>
@@ -60,6 +32,34 @@
       <point x="52" y="266" type="curve" smooth="yes"/>
       <point x="52" y="153"/>
       <point x="94" y="53"/>
+    </contour>
+    <contour>
+      <point x="145" y="-344" type="curve"/>
+      <point x="224" y="-285" type="line"/>
+      <point x="206" y="-260"/>
+      <point x="189" y="-221"/>
+      <point x="189" y="-162" type="curve" smooth="yes"/>
+      <point x="189" y="-76"/>
+      <point x="232" y="0"/>
+      <point x="334" y="0" type="curve" smooth="yes"/>
+      <point x="402" y="0"/>
+      <point x="453" y="-34"/>
+      <point x="453" y="-116" type="curve" smooth="yes"/>
+      <point x="453" y="-183"/>
+      <point x="420" y="-233"/>
+      <point x="364" y="-279" type="curve"/>
+      <point x="429" y="-344" type="line"/>
+      <point x="508" y="-283"/>
+      <point x="555" y="-215"/>
+      <point x="555" y="-110" type="curve" smooth="yes"/>
+      <point x="555" y="26"/>
+      <point x="468" y="93"/>
+      <point x="339" y="93" type="curve" smooth="yes"/>
+      <point x="174" y="93"/>
+      <point x="88" y="-21"/>
+      <point x="88" y="-168" type="curve" smooth="yes"/>
+      <point x="88" y="-236"/>
+      <point x="111" y="-304"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/t_la-malayalam.glif
@@ -1,136 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_la-malayalam" format="2">
   <advance width="1044"/>
-  <anchor x="507" y="-364" name="bottom"/>
-  <anchor x="578" y="613" name="top"/>
-  <anchor x="920" y="613" name="topright"/>
+  <anchor x="526" y="-366" name="bottom"/>
+  <anchor x="573" y="613" name="top"/>
+  <anchor x="915" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="289" y="-382" type="curve" smooth="yes"/>
-      <point x="384" y="-382"/>
-      <point x="440" y="-323"/>
-      <point x="440" y="-233" type="curve" smooth="yes"/>
-      <point x="440" y="-153"/>
-      <point x="396" y="-118"/>
-      <point x="330" y="-118" type="curve" smooth="yes"/>
-      <point x="296" y="-118"/>
-      <point x="265" y="-130"/>
-      <point x="243" y="-159" type="curve"/>
-      <point x="230" y="-158" type="line"/>
-      <point x="246" y="-92"/>
-      <point x="297" y="-33"/>
-      <point x="385" y="-33" type="curve" smooth="yes"/>
-      <point x="484" y="-33"/>
-      <point x="510" y="-84"/>
-      <point x="517" y="-177" type="curve" smooth="yes"/>
-      <point x="518" y="-189" type="line" smooth="yes"/>
-      <point x="529" y="-315"/>
-      <point x="579" y="-382"/>
-      <point x="707" y="-382" type="curve" smooth="yes"/>
-      <point x="850" y="-382"/>
-      <point x="906" y="-278"/>
-      <point x="906" y="-135" type="curve" smooth="yes"/>
-      <point x="906" y="-55"/>
-      <point x="882" y="12"/>
-      <point x="858" y="53" type="curve"/>
-      <point x="816" y="-4" type="line"/>
-      <point x="928" y="85"/>
-      <point x="992" y="199"/>
-      <point x="992" y="335" type="curve" smooth="yes"/>
-      <point x="992" y="526"/>
-      <point x="879" y="629"/>
-      <point x="703" y="629" type="curve" smooth="yes"/>
-      <point x="491" y="629"/>
-      <point x="284" y="442"/>
-      <point x="284" y="213" type="curve" smooth="yes"/>
-      <point x="284" y="149"/>
-      <point x="300" y="98"/>
-      <point x="343" y="59" type="curve"/>
-      <point x="340" y="46" type="line"/>
-      <point x="207" y="19"/>
-      <point x="133" y="-81"/>
-      <point x="133" y="-206" type="curve" smooth="yes"/>
-      <point x="133" y="-327"/>
-      <point x="198" y="-382"/>
+      <point x="295" y="-382" type="curve" smooth="yes"/>
+      <point x="390" y="-382"/>
+      <point x="447" y="-317"/>
+      <point x="447" y="-231" type="curve" smooth="yes"/>
+      <point x="447" y="-161"/>
+      <point x="409" y="-118"/>
+      <point x="344" y="-118" type="curve" smooth="yes"/>
+      <point x="291" y="-118"/>
+      <point x="242" y="-149"/>
+      <point x="223" y="-225" type="curve"/>
+      <point x="265" y="-164" type="line"/>
+      <point x="212" y="-164" type="line"/>
+      <point x="235" y="-186" type="line"/>
+      <point x="251" y="-98"/>
+      <point x="322" y="-33"/>
+      <point x="407" y="-33" type="curve" smooth="yes"/>
+      <point x="482" y="-33"/>
+      <point x="511" y="-70"/>
+      <point x="527" y="-163" type="curve" smooth="yes"/>
+      <point x="533" y="-199" type="line" smooth="yes"/>
+      <point x="554" y="-327"/>
+      <point x="605" y="-382"/>
+      <point x="702" y="-382" type="curve" smooth="yes"/>
+      <point x="847" y="-382"/>
+      <point x="911" y="-256"/>
+      <point x="911" y="-134" type="curve" smooth="yes"/>
+      <point x="911" y="-62"/>
+      <point x="892" y="0"/>
+      <point x="857" y="50" type="curve"/>
+      <point x="822" y="-16" type="line"/>
+      <point x="936" y="94"/>
+      <point x="996" y="222"/>
+      <point x="996" y="354" type="curve" smooth="yes"/>
+      <point x="996" y="519"/>
+      <point x="898" y="629"/>
+      <point x="719" y="629" type="curve" smooth="yes"/>
+      <point x="653" y="629"/>
+      <point x="588" y="611"/>
+      <point x="531" y="581" type="curve"/>
+      <point x="595" y="583" type="line"/>
+      <point x="550" y="612"/>
+      <point x="495" y="629"/>
+      <point x="430" y="629" type="curve" smooth="yes"/>
+      <point x="195" y="629"/>
+      <point x="47" y="446"/>
+      <point x="47" y="238" type="curve" smooth="yes"/>
+      <point x="47" y="146"/>
+      <point x="76" y="61"/>
+      <point x="132" y="-16" type="curve"/>
+      <point x="222" y="47" type="line"/>
+      <point x="184" y="101"/>
+      <point x="164" y="165"/>
+      <point x="164" y="236" type="curve" smooth="yes"/>
+      <point x="164" y="385"/>
+      <point x="254" y="522"/>
+      <point x="417" y="522" type="curve" smooth="yes"/>
+      <point x="444" y="522"/>
+      <point x="468" y="518"/>
+      <point x="489" y="510" type="curve"/>
+      <point x="478" y="548" type="line"/>
+      <point x="365" y="468"/>
+      <point x="286" y="337"/>
+      <point x="286" y="202" type="curve" smooth="yes"/>
+      <point x="286" y="140"/>
+      <point x="309" y="91"/>
+      <point x="344" y="54" type="curve"/>
+      <point x="341" y="36" type="line"/>
+      <point x="221" y="1"/>
+      <point x="140" y="-106"/>
+      <point x="140" y="-213" type="curve" smooth="yes"/>
+      <point x="140" y="-321"/>
+      <point x="209" y="-382"/>
     </contour>
     <contour>
-      <point x="707" y="-292" type="curve" smooth="yes"/>
-      <point x="649" y="-292"/>
-      <point x="625" y="-255"/>
-      <point x="618" y="-177" type="curve" smooth="yes"/>
-      <point x="615" y="-151" type="line" smooth="yes"/>
-      <point x="609" y="-93"/>
-      <point x="594" y="-42"/>
-      <point x="556" y="-3" type="curve"/>
-      <point x="558" y="9" type="line"/>
-      <point x="667" y="40"/>
-      <point x="723" y="146"/>
-      <point x="723" y="281" type="curve" smooth="yes"/>
-      <point x="723" y="395"/>
-      <point x="683" y="492"/>
-      <point x="613" y="554" type="curve"/>
-      <point x="503" y="498" type="line"/>
-      <point x="565" y="462"/>
-      <point x="600" y="386"/>
-      <point x="600" y="281" type="curve" smooth="yes"/>
-      <point x="600" y="160"/>
-      <point x="566" y="95"/>
-      <point x="492" y="95" type="curve" smooth="yes"/>
-      <point x="437" y="95"/>
-      <point x="401" y="133"/>
-      <point x="401" y="213" type="curve" smooth="yes"/>
-      <point x="401" y="388"/>
-      <point x="519" y="522"/>
-      <point x="695" y="522" type="curve" smooth="yes"/>
-      <point x="812" y="522"/>
-      <point x="871" y="452"/>
-      <point x="871" y="335" type="curve" smooth="yes"/>
-      <point x="871" y="231"/>
-      <point x="824" y="150"/>
-      <point x="730" y="73" type="curve"/>
-      <point x="764" y="28"/>
-      <point x="805" y="-49"/>
-      <point x="805" y="-147" type="curve" smooth="yes"/>
-      <point x="805" y="-231"/>
-      <point x="779" y="-292"/>
-    </contour>
-    <contour>
-      <point x="292" y="-302" type="curve" smooth="yes"/>
-      <point x="248" y="-302"/>
-      <point x="226" y="-269"/>
-      <point x="226" y="-226" type="curve"/>
-      <point x="211" y="-214" type="line"/>
-      <point x="219" y="-251" type="line"/>
-      <point x="231" y="-213"/>
-      <point x="260" y="-191"/>
-      <point x="296" y="-191" type="curve" smooth="yes"/>
-      <point x="333" y="-191"/>
-      <point x="350" y="-207"/>
-      <point x="350" y="-241" type="curve" smooth="yes"/>
-      <point x="350" y="-277"/>
+      <point x="295" y="-302" type="curve" smooth="yes"/>
+      <point x="255" y="-302"/>
+      <point x="232" y="-273"/>
+      <point x="232" y="-239" type="curve" smooth="yes"/>
+      <point x="232" y="-232"/>
+      <point x="233" y="-225"/>
+      <point x="234" y="-219" type="curve"/>
+      <point x="218" y="-220" type="line"/>
+      <point x="225" y="-267" type="line"/>
+      <point x="237" y="-221"/>
+      <point x="271" y="-191"/>
+      <point x="310" y="-191" type="curve" smooth="yes"/>
+      <point x="341" y="-191"/>
+      <point x="357" y="-207"/>
+      <point x="357" y="-239" type="curve" smooth="yes"/>
+      <point x="357" y="-277"/>
       <point x="332" y="-302"/>
     </contour>
     <contour>
-      <point x="134" y="-16" type="curve"/>
-      <point x="229" y="51" type="line"/>
-      <point x="190" y="101"/>
-      <point x="167" y="169"/>
-      <point x="167" y="247" type="curve" smooth="yes"/>
-      <point x="167" y="399"/>
-      <point x="253" y="522"/>
-      <point x="407" y="522" type="curve" smooth="yes"/>
-      <point x="444" y="522"/>
-      <point x="476" y="514"/>
-      <point x="503" y="498" type="curve"/>
-      <point x="613" y="554" type="line"/>
-      <point x="561" y="601"/>
-      <point x="492" y="629"/>
-      <point x="411" y="629" type="curve" smooth="yes"/>
-      <point x="180" y="629"/>
-      <point x="49" y="464"/>
-      <point x="49" y="247" type="curve" smooth="yes"/>
-      <point x="49" y="144"/>
-      <point x="79" y="51"/>
+      <point x="483" y="95" type="curve" smooth="yes"/>
+      <point x="434" y="95"/>
+      <point x="403" y="132"/>
+      <point x="403" y="208" type="curve" smooth="yes"/>
+      <point x="403" y="329"/>
+      <point x="468" y="443"/>
+      <point x="576" y="494" type="curve"/>
+      <point x="523" y="493" type="line"/>
+      <point x="580" y="455"/>
+      <point x="609" y="384"/>
+      <point x="609" y="295" type="curve" smooth="yes"/>
+      <point x="609" y="229"/>
+      <point x="580" y="95"/>
+    </contour>
+    <contour>
+      <point x="714" y="-292" type="curve" smooth="yes"/>
+      <point x="663" y="-292"/>
+      <point x="639" y="-263"/>
+      <point x="627" y="-182" type="curve" smooth="yes"/>
+      <point x="621" y="-144" type="line" smooth="yes"/>
+      <point x="608" y="-66"/>
+      <point x="592" y="-25"/>
+      <point x="557" y="-1" type="curve"/>
+      <point x="560" y="13" type="line"/>
+      <point x="670" y="50"/>
+      <point x="731" y="170"/>
+      <point x="731" y="292" type="curve" smooth="yes"/>
+      <point x="731" y="395"/>
+      <point x="698" y="488"/>
+      <point x="635" y="551" type="curve"/>
+      <point x="622" y="511" type="line"/>
+      <point x="648" y="518"/>
+      <point x="676" y="522"/>
+      <point x="706" y="522" type="curve" smooth="yes"/>
+      <point x="821" y="522"/>
+      <point x="874" y="458"/>
+      <point x="874" y="346" type="curve" smooth="yes"/>
+      <point x="874" y="249"/>
+      <point x="829" y="154"/>
+      <point x="731" y="62" type="curve"/>
+      <point x="785" y="0"/>
+      <point x="813" y="-69"/>
+      <point x="813" y="-145" type="curve" smooth="yes"/>
+      <point x="813" y="-197"/>
+      <point x="795" y="-292"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ta-malayalam.glif
@@ -2,61 +2,61 @@
 <glyph name="ta-malayalam" format="2">
   <advance width="1044"/>
   <unicode hex="0D24"/>
-  <anchor x="569" y="0" name="bottom"/>
-  <anchor x="578" y="613" name="top"/>
-  <anchor x="920" y="613" name="topright"/>
+  <anchor x="562" y="0" name="bottom"/>
+  <anchor x="573" y="613" name="top"/>
+  <anchor x="915" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="134" y="-16" type="curve"/>
-      <point x="229" y="51" type="line"/>
-      <point x="190" y="101"/>
-      <point x="167" y="169"/>
-      <point x="167" y="247" type="curve" smooth="yes"/>
-      <point x="167" y="399"/>
-      <point x="253" y="522"/>
-      <point x="407" y="522" type="curve" smooth="yes"/>
-      <point x="528" y="522"/>
-      <point x="600" y="433"/>
-      <point x="600" y="281" type="curve" smooth="yes"/>
-      <point x="600" y="160"/>
-      <point x="566" y="95"/>
-      <point x="492" y="95" type="curve" smooth="yes"/>
-      <point x="437" y="95"/>
-      <point x="401" y="133"/>
-      <point x="401" y="213" type="curve" smooth="yes"/>
-      <point x="401" y="388"/>
-      <point x="519" y="522"/>
-      <point x="695" y="522" type="curve" smooth="yes"/>
-      <point x="812" y="522"/>
-      <point x="871" y="452"/>
-      <point x="871" y="335" type="curve" smooth="yes"/>
-      <point x="871" y="231"/>
-      <point x="824" y="150"/>
-      <point x="725" y="75" type="curve"/>
-      <point x="802" y="-16" type="line"/>
-      <point x="924" y="76"/>
-      <point x="992" y="193"/>
-      <point x="992" y="335" type="curve" smooth="yes"/>
-      <point x="992" y="526"/>
-      <point x="879" y="629"/>
-      <point x="703" y="629" type="curve" smooth="yes"/>
-      <point x="491" y="629"/>
-      <point x="284" y="442"/>
-      <point x="284" y="213" type="curve" smooth="yes"/>
-      <point x="284" y="71"/>
-      <point x="361" y="-16"/>
-      <point x="491" y="-16" type="curve" smooth="yes"/>
-      <point x="638" y="-16"/>
-      <point x="723" y="114"/>
-      <point x="723" y="281" type="curve" smooth="yes"/>
-      <point x="723" y="482"/>
-      <point x="599" y="629"/>
-      <point x="411" y="629" type="curve" smooth="yes"/>
-      <point x="180" y="629"/>
-      <point x="49" y="464"/>
-      <point x="49" y="247" type="curve" smooth="yes"/>
-      <point x="49" y="144"/>
-      <point x="79" y="51"/>
+      <point x="132" y="-16" type="curve"/>
+      <point x="222" y="47" type="line"/>
+      <point x="184" y="101"/>
+      <point x="164" y="165"/>
+      <point x="164" y="236" type="curve" smooth="yes"/>
+      <point x="164" y="385"/>
+      <point x="254" y="522"/>
+      <point x="417" y="522" type="curve" smooth="yes"/>
+      <point x="542" y="522"/>
+      <point x="609" y="428"/>
+      <point x="609" y="295" type="curve" smooth="yes"/>
+      <point x="609" y="229"/>
+      <point x="580" y="95"/>
+      <point x="483" y="95" type="curve" smooth="yes"/>
+      <point x="434" y="95"/>
+      <point x="403" y="132"/>
+      <point x="403" y="208" type="curve" smooth="yes"/>
+      <point x="403" y="372"/>
+      <point x="522" y="522"/>
+      <point x="706" y="522" type="curve" smooth="yes"/>
+      <point x="821" y="522"/>
+      <point x="874" y="458"/>
+      <point x="874" y="346" type="curve" smooth="yes"/>
+      <point x="874" y="251"/>
+      <point x="831" y="157"/>
+      <point x="737" y="67" type="curve"/>
+      <point x="822" y="-16" type="line"/>
+      <point x="936" y="94"/>
+      <point x="996" y="222"/>
+      <point x="996" y="354" type="curve" smooth="yes"/>
+      <point x="996" y="519"/>
+      <point x="898" y="629"/>
+      <point x="719" y="629" type="curve" smooth="yes"/>
+      <point x="493" y="629"/>
+      <point x="286" y="421"/>
+      <point x="286" y="202" type="curve" smooth="yes"/>
+      <point x="286" y="72"/>
+      <point x="355" y="-16"/>
+      <point x="475" y="-16" type="curve" smooth="yes"/>
+      <point x="639" y="-16"/>
+      <point x="731" y="137"/>
+      <point x="731" y="292" type="curve" smooth="yes"/>
+      <point x="731" y="477"/>
+      <point x="626" y="629"/>
+      <point x="430" y="629" type="curve" smooth="yes"/>
+      <point x="195" y="629"/>
+      <point x="47" y="446"/>
+      <point x="47" y="238" type="curve" smooth="yes"/>
+      <point x="47" y="146"/>
+      <point x="76" y="61"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1044"/>
   <outline>
     <component base="ta-malayalam"/>
-    <component base="halant-malayalam" xOffset="837"/>
+    <component base="halant-malayalam" xOffset="832"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
-  <advance width="635"/>
-  <anchor x="320" y="0" name="bottom"/>
-  <anchor x="296" y="613" name="top"/>
-  <anchor x="481" y="613" name="topright"/>
+  <advance width="636"/>
+  <anchor x="251" y="-272" name="bottom"/>
+  <anchor x="365" y="613" name="top"/>
+  <anchor x="550" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="245" y="-229" type="curve" smooth="yes"/>
-      <point x="426" y="-229"/>
-      <point x="535" y="-175"/>
-      <point x="535" y="-62" type="curve" smooth="yes"/>
-      <point x="535" y="2"/>
-      <point x="498" y="35"/>
-      <point x="443" y="51" type="curve"/>
-      <point x="444" y="64" type="line"/>
-      <point x="520" y="74"/>
-      <point x="573" y="133"/>
-      <point x="573" y="220" type="curve" smooth="yes"/>
-      <point x="573" y="309"/>
-      <point x="524" y="370"/>
-      <point x="374" y="379" type="curve" smooth="yes"/>
-      <point x="268" y="386" type="line" smooth="yes"/>
+      <point x="240" y="-291" type="curve" smooth="yes"/>
+      <point x="449" y="-291"/>
+      <point x="521" y="-182"/>
+      <point x="521" y="-76" type="curve" smooth="yes"/>
+      <point x="521" y="-15"/>
+      <point x="492" y="25"/>
+      <point x="433" y="46" type="curve"/>
+      <point x="435" y="59" type="line"/>
+      <point x="520" y="80"/>
+      <point x="566" y="133"/>
+      <point x="566" y="208" type="curve" smooth="yes"/>
+      <point x="566" y="304"/>
+      <point x="507" y="355"/>
+      <point x="377" y="370" type="curve" smooth="yes"/>
+      <point x="256" y="384" type="line" smooth="yes"/>
       <point x="206" y="390"/>
-      <point x="179" y="410"/>
-      <point x="179" y="447" type="curve" smooth="yes"/>
-      <point x="179" y="495"/>
-      <point x="228" y="519"/>
-      <point x="313" y="519" type="curve" smooth="yes"/>
-      <point x="409" y="519"/>
-      <point x="476" y="495"/>
-      <point x="538" y="462" type="curve"/>
-      <point x="593" y="556" type="line"/>
-      <point x="522" y="599"/>
-      <point x="435" y="629"/>
-      <point x="323" y="629" type="curve" smooth="yes"/>
-      <point x="161" y="629"/>
-      <point x="59" y="556"/>
-      <point x="59" y="431" type="curve" smooth="yes"/>
-      <point x="59" y="337"/>
-      <point x="119" y="277"/>
-      <point x="236" y="267" type="curve" smooth="yes"/>
-      <point x="355" y="260" type="line" smooth="yes"/>
-      <point x="429" y="256"/>
-      <point x="452" y="229"/>
-      <point x="452" y="192" type="curve" smooth="yes"/>
-      <point x="452" y="142"/>
-      <point x="412" y="118"/>
-      <point x="345" y="118" type="curve" smooth="yes"/>
-      <point x="42" y="118" type="line"/>
-      <point x="24" y="13" type="line"/>
-      <point x="291" y="13" type="line" smooth="yes"/>
-      <point x="381" y="13"/>
-      <point x="415" y="-10"/>
-      <point x="415" y="-48" type="curve" smooth="yes"/>
-      <point x="415" y="-96"/>
-      <point x="371" y="-116"/>
-      <point x="262" y="-116" type="curve" smooth="yes"/>
-      <point x="149" y="-116"/>
-      <point x="76" y="-96"/>
-      <point x="26" y="-73" type="curve"/>
-      <point x="-36" y="-174" type="line"/>
-      <point x="26" y="-204"/>
-      <point x="117" y="-229"/>
+      <point x="180" y="412"/>
+      <point x="180" y="448" type="curve" smooth="yes"/>
+      <point x="180" y="492"/>
+      <point x="219" y="519"/>
+      <point x="328" y="519" type="curve" smooth="yes"/>
+      <point x="419" y="519"/>
+      <point x="489" y="502"/>
+      <point x="553" y="466" type="curve"/>
+      <point x="601" y="563" type="line"/>
+      <point x="523" y="608"/>
+      <point x="439" y="629"/>
+      <point x="340" y="629" type="curve" smooth="yes"/>
+      <point x="128" y="629"/>
+      <point x="60" y="521"/>
+      <point x="60" y="432" type="curve" smooth="yes"/>
+      <point x="60" y="332"/>
+      <point x="131" y="276"/>
+      <point x="228" y="265" type="curve" smooth="yes"/>
+      <point x="349" y="251" type="line" smooth="yes"/>
+      <point x="421" y="243"/>
+      <point x="446" y="226"/>
+      <point x="446" y="186" type="curve" smooth="yes"/>
+      <point x="446" y="135"/>
+      <point x="393" y="106"/>
+      <point x="302" y="106" type="curve" smooth="yes"/>
+      <point x="37" y="106" type="line"/>
+      <point x="18" y="1" type="line"/>
+      <point x="299" y="1" type="line" smooth="yes"/>
+      <point x="368" y="1"/>
+      <point x="402" y="-26"/>
+      <point x="402" y="-76" type="curve" smooth="yes"/>
+      <point x="402" y="-131"/>
+      <point x="360" y="-181"/>
+      <point x="250" y="-181" type="curve" smooth="yes"/>
+      <point x="166" y="-181"/>
+      <point x="84" y="-151"/>
+      <point x="19" y="-98" type="curve"/>
+      <point x="-47" y="-184" type="line"/>
+      <point x="37" y="-253"/>
+      <point x="139" y="-291"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/tta-malayalam.glif
@@ -2,51 +2,51 @@
 <glyph name="tta-malayalam" format="2">
   <advance width="638"/>
   <unicode hex="0D1F"/>
-  <anchor x="274" y="0" name="bottom"/>
-  <anchor x="357" y="613" name="top"/>
-  <anchor x="542" y="613" name="topright"/>
+  <anchor x="281" y="0" name="bottom"/>
+  <anchor x="365" y="613" name="top"/>
+  <anchor x="550" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="302" y="-16" type="curve" smooth="yes"/>
-      <point x="451" y="-16"/>
-      <point x="567" y="41"/>
-      <point x="567" y="189" type="curve" smooth="yes"/>
-      <point x="567" y="293"/>
-      <point x="504" y="355"/>
-      <point x="363" y="363" type="curve" smooth="yes"/>
-      <point x="271" y="367" type="line" smooth="yes"/>
-      <point x="204" y="371"/>
-      <point x="177" y="399"/>
-      <point x="177" y="438" type="curve" smooth="yes"/>
-      <point x="177" y="491"/>
-      <point x="227" y="519"/>
-      <point x="315" y="519" type="curve" smooth="yes"/>
-      <point x="408" y="519"/>
-      <point x="475" y="495"/>
-      <point x="536" y="462" type="curve"/>
-      <point x="592" y="556" type="line"/>
-      <point x="520" y="599"/>
-      <point x="434" y="629"/>
-      <point x="321" y="629" type="curve" smooth="yes"/>
-      <point x="162" y="629"/>
-      <point x="58" y="553"/>
-      <point x="58" y="421" type="curve" smooth="yes"/>
-      <point x="58" y="325"/>
-      <point x="118" y="254"/>
-      <point x="256" y="248" type="curve" smooth="yes"/>
-      <point x="341" y="244" type="line" smooth="yes"/>
-      <point x="421" y="240"/>
-      <point x="449" y="218"/>
-      <point x="449" y="174" type="curve" smooth="yes"/>
-      <point x="449" y="117"/>
-      <point x="396" y="94"/>
-      <point x="315" y="94" type="curve" smooth="yes"/>
-      <point x="215" y="94"/>
-      <point x="144" y="127"/>
-      <point x="73" y="177" type="curve"/>
-      <point x="2" y="82" type="line"/>
-      <point x="79" y="24"/>
-      <point x="178" y="-16"/>
+      <point x="309" y="-16" type="curve" smooth="yes"/>
+      <point x="489" y="-16"/>
+      <point x="570" y="77"/>
+      <point x="570" y="186" type="curve" smooth="yes"/>
+      <point x="570" y="282"/>
+      <point x="513" y="343"/>
+      <point x="382" y="358" type="curve" smooth="yes"/>
+      <point x="265" y="371" type="line" smooth="yes"/>
+      <point x="209" y="377"/>
+      <point x="184" y="397"/>
+      <point x="184" y="435" type="curve" smooth="yes"/>
+      <point x="184" y="479"/>
+      <point x="225" y="519"/>
+      <point x="340" y="519" type="curve" smooth="yes"/>
+      <point x="426" y="519"/>
+      <point x="490" y="505"/>
+      <point x="554" y="471" type="curve"/>
+      <point x="605" y="566" type="line"/>
+      <point x="527" y="608"/>
+      <point x="440" y="629"/>
+      <point x="350" y="629" type="curve" smooth="yes"/>
+      <point x="149" y="629"/>
+      <point x="66" y="528"/>
+      <point x="66" y="419" type="curve" smooth="yes"/>
+      <point x="66" y="325"/>
+      <point x="127" y="265"/>
+      <point x="237" y="253" type="curve" smooth="yes"/>
+      <point x="354" y="240" type="line" smooth="yes"/>
+      <point x="427" y="232"/>
+      <point x="452" y="212"/>
+      <point x="452" y="172" type="curve" smooth="yes"/>
+      <point x="452" y="127"/>
+      <point x="411" y="94"/>
+      <point x="318" y="94" type="curve" smooth="yes"/>
+      <point x="223" y="94"/>
+      <point x="135" y="118"/>
+      <point x="54" y="167" type="curve"/>
+      <point x="-7" y="68" type="line"/>
+      <point x="88" y="11"/>
+      <point x="189" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/tta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/tta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="638"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="halant-malayalam" xOffset="459"/>
+    <component base="halant-malayalam" xOffset="467"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="638"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="324"/>
+    <component base="lVocalicMatra-malayalam" xOffset="331"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="638"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="324"/>
+    <component base="llVocalicMatra-malayalam" xOffset="331"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
@@ -4,65 +4,71 @@
   <unicode hex="0D42"/>
   <outline>
     <contour>
-      <point x="40" y="24" type="curve"/>
-      <point x="155" y="24" type="line"/>
-      <point x="243" y="174"/>
-      <point x="289" y="302"/>
-      <point x="289" y="403" type="curve" smooth="yes"/>
-      <point x="289" y="537"/>
-      <point x="217" y="616"/>
-      <point x="86" y="627" type="curve" smooth="yes"/>
-      <point x="62" y="629" type="line"/>
-      <point x="43" y="519" type="line"/>
-      <point x="128" y="512"/>
-      <point x="167" y="474"/>
-      <point x="167" y="399" type="curve" smooth="yes"/>
-      <point x="167" y="305"/>
-      <point x="118" y="160"/>
+      <point x="63" y="38" type="curve"/>
+      <point x="166" y="38" type="line"/>
+      <point x="255" y="181"/>
+      <point x="299" y="310"/>
+      <point x="299" y="414" type="curve" smooth="yes"/>
+      <point x="299" y="550"/>
+      <point x="229" y="629"/>
+      <point x="90" y="629" type="curve" smooth="yes"/>
+      <point x="71" y="629" type="line"/>
+      <point x="52" y="520" type="line"/>
+      <point x="139" y="520"/>
+      <point x="178" y="486"/>
+      <point x="178" y="405" type="curve" smooth="yes"/>
+      <point x="178" y="316"/>
+      <point x="138" y="190"/>
     </contour>
     <contour>
-      <point x="87" y="-287" type="curve" smooth="yes"/>
-      <point x="208" y="-287"/>
-      <point x="295" y="-205"/>
-      <point x="295" y="-91" type="curve" smooth="yes"/>
-      <point x="295" y="13"/>
-      <point x="214" y="90"/>
-      <point x="104" y="90" type="curve" smooth="yes"/>
-      <point x="-15" y="90"/>
+      <point x="81" y="-192" type="curve" smooth="yes"/>
+      <point x="15" y="-192"/>
+      <point x="-21" y="-161"/>
+      <point x="-21" y="-104" type="curve" smooth="yes"/>
+      <point x="-21" y="-90"/>
+      <point x="-19" y="-74"/>
+      <point x="-15" y="-62" type="curve"/>
+      <point x="-2" y="-62" type="line"/>
+      <point x="3" y="-109"/>
+      <point x="33" y="-134"/>
+      <point x="84" y="-134" type="curve" smooth="yes"/>
+      <point x="134" y="-134"/>
+      <point x="169" y="-109"/>
+      <point x="185" y="-62" type="curve"/>
+      <point x="198" y="-62" type="line"/>
+      <point x="200" y="-71"/>
+      <point x="201" y="-77"/>
+      <point x="201" y="-86" type="curve" smooth="yes"/>
+      <point x="201" y="-134"/>
+      <point x="170" y="-192"/>
+    </contour>
+    <contour>
+      <point x="83" y="-287" type="curve" smooth="yes"/>
+      <point x="202" y="-287"/>
+      <point x="288" y="-205"/>
+      <point x="288" y="-91" type="curve" smooth="yes"/>
+      <point x="288" y="13"/>
+      <point x="208" y="90"/>
+      <point x="100" y="90" type="curve" smooth="yes"/>
+      <point x="-17" y="90"/>
       <point x="-108" y="4"/>
       <point x="-108" y="-107" type="curve" smooth="yes"/>
       <point x="-108" y="-215"/>
-      <point x="-30" y="-287"/>
+      <point x="-32" y="-287"/>
     </contour>
     <contour>
-      <point x="87" y="-192" type="curve" smooth="yes"/>
-      <point x="24" y="-192"/>
-      <point x="-12" y="-159"/>
-      <point x="-12" y="-103" type="curve" smooth="yes"/>
-      <point x="-12" y="-34"/>
-      <point x="32" y="12"/>
-      <point x="100" y="12" type="curve" smooth="yes"/>
-      <point x="164" y="12"/>
-      <point x="199" y="-19"/>
-      <point x="199" y="-73" type="curve" smooth="yes"/>
-      <point x="199" y="-144"/>
-      <point x="154" y="-192"/>
-    </contour>
-    <contour>
-      <point x="111" y="-123" type="curve" smooth="yes"/>
-      <point x="158" y="-123"/>
-      <point x="197" y="-112"/>
-      <point x="231" y="-89" type="curve"/>
-      <point x="211" y="-51" type="line"/>
-      <point x="196" y="-55"/>
-      <point x="175" y="-57"/>
-      <point x="151" y="-57" type="curve" smooth="yes"/>
-      <point x="96" y="-57"/>
-      <point x="22" y="-47"/>
-      <point x="-9" y="-33" type="curve"/>
-      <point x="-41" y="-66" type="line"/>
-      <point x="-7" y="-102"/>
-      <point x="46" y="-123"/>
+      <point x="90" y="-60" type="curve" smooth="yes"/>
+      <point x="48" y="-60"/>
+      <point x="20" y="-42"/>
+      <point x="20" y="-16" type="curve" smooth="yes"/>
+      <point x="20" y="5"/>
+      <point x="46" y="22"/>
+      <point x="107" y="22" type="curve" smooth="yes"/>
+      <point x="152" y="22"/>
+      <point x="169" y="11"/>
+      <point x="169" y="-7" type="curve" smooth="yes"/>
+      <point x="169" y="-33"/>
+      <point x="143" y="-60"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/y_ya-malayalam.glif
@@ -1,96 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="1047"/>
-  <anchor x="529" y="-305" name="bottom"/>
-  <anchor x="599" y="613" name="top"/>
-  <anchor x="900" y="613" name="topright"/>
+  <anchor x="545" y="-305" name="bottom"/>
+  <anchor x="594" y="613" name="top"/>
+  <anchor x="895" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="219" y="-305" type="line"/>
-      <point x="834" y="-305" type="line"/>
-      <point x="904" y="100" type="line"/>
-      <point x="878" y="51" type="line"/>
-      <point x="962" y="117"/>
-      <point x="1013" y="229"/>
-      <point x="1013" y="371" type="curve" smooth="yes"/>
-      <point x="1013" y="469"/>
-      <point x="985" y="563"/>
-      <point x="937" y="629" type="curve"/>
-      <point x="832" y="570" type="line"/>
-      <point x="871" y="516"/>
-      <point x="892" y="446"/>
-      <point x="892" y="371" type="curve" smooth="yes"/>
-      <point x="892" y="201"/>
-      <point x="808" y="95"/>
-      <point x="673" y="95" type="curve" smooth="yes"/>
-      <point x="538" y="95"/>
-      <point x="468" y="172"/>
-      <point x="468" y="322" type="curve" smooth="yes"/>
-      <point x="468" y="439"/>
-      <point x="511" y="518"/>
-      <point x="574" y="518" type="curve" smooth="yes"/>
-      <point x="621" y="518"/>
-      <point x="644" y="484"/>
-      <point x="644" y="410" type="curve" smooth="yes"/>
-      <point x="644" y="291"/>
-      <point x="590" y="185"/>
-      <point x="497" y="118" type="curve"/>
-      <point x="564" y="48" type="line"/>
-      <point x="701" y="141"/>
-      <point x="765" y="255"/>
-      <point x="765" y="410" type="curve" smooth="yes"/>
-      <point x="765" y="554"/>
-      <point x="705" y="629"/>
-      <point x="590" y="629" type="curve" smooth="yes"/>
-      <point x="453" y="629"/>
-      <point x="350" y="497"/>
-      <point x="350" y="321" type="curve" smooth="yes"/>
-      <point x="350" y="124"/>
-      <point x="487" y="-17"/>
-      <point x="675" y="-17" type="curve" smooth="yes"/>
-      <point x="688" y="-17"/>
-      <point x="703" y="-16"/>
-      <point x="717" y="-14" type="curve"/>
-      <point x="596" y="38" type="line"/>
-      <point x="604" y="-22" type="line"/>
-      <point x="486" y="-84" type="line"/>
-      <point x="231" y="-235" type="line"/>
+      <point x="211" y="-305" type="line"/>
+      <point x="825" y="-305" type="line"/>
+      <point x="900" y="122" type="line"/>
+      <point x="878" y="74" type="line"/>
+      <point x="958" y="144"/>
+      <point x="998" y="247"/>
+      <point x="998" y="352" type="curve" smooth="yes"/>
+      <point x="998" y="450"/>
+      <point x="967" y="546"/>
+      <point x="910" y="629" type="curve"/>
+      <point x="807" y="564" type="line"/>
+      <point x="854" y="496"/>
+      <point x="878" y="424"/>
+      <point x="878" y="345" type="curve" smooth="yes"/>
+      <point x="878" y="220"/>
+      <point x="803" y="94"/>
+      <point x="649" y="94" type="curve" smooth="yes"/>
+      <point x="506" y="94"/>
+      <point x="432" y="192"/>
+      <point x="432" y="340" type="curve" smooth="yes"/>
+      <point x="432" y="409"/>
+      <point x="461" y="519"/>
+      <point x="558" y="519" type="curve" smooth="yes"/>
+      <point x="617" y="519"/>
+      <point x="645" y="479"/>
+      <point x="645" y="398" type="curve" smooth="yes"/>
+      <point x="645" y="285"/>
+      <point x="586" y="178"/>
+      <point x="491" y="126" type="curve"/>
+      <point x="556" y="62" type="line"/>
+      <point x="685" y="133"/>
+      <point x="765" y="266"/>
+      <point x="765" y="408" type="curve" smooth="yes"/>
+      <point x="765" y="547"/>
+      <point x="701" y="629"/>
+      <point x="564" y="629" type="curve" smooth="yes"/>
+      <point x="402" y="629"/>
+      <point x="314" y="468"/>
+      <point x="314" y="344" type="curve" smooth="yes"/>
+      <point x="314" y="125"/>
+      <point x="451" y="-10"/>
+      <point x="645" y="-10" type="curve" smooth="yes"/>
+      <point x="665" y="-10"/>
+      <point x="685" y="-8"/>
+      <point x="703" y="-5" type="curve"/>
+      <point x="606" y="48" type="line"/>
+      <point x="599" y="-23" type="line"/>
+      <point x="501" y="-64" type="line"/>
+      <point x="224" y="-235" type="line"/>
     </contour>
     <contour>
-      <point x="332" y="-273" type="line"/>
-      <point x="801" y="8" type="line"/>
-      <point x="772" y="8" type="line"/>
-      <point x="726" y="-252" type="line"/>
-      <point x="793" y="-220" type="line"/>
-      <point x="379" y="-220" type="line"/>
+      <point x="337" y="-269" type="line"/>
+      <point x="799" y="16" type="line"/>
+      <point x="766" y="16" type="line"/>
+      <point x="719" y="-252" type="line"/>
+      <point x="786" y="-220" type="line"/>
+      <point x="372" y="-220" type="line"/>
     </contour>
     <contour>
-      <point x="355" y="-16" type="curve" smooth="yes"/>
-      <point x="424" y="-16"/>
-      <point x="479" y="-1"/>
-      <point x="531" y="30" type="curve"/>
-      <point x="453" y="109" type="line"/>
-      <point x="425" y="99"/>
-      <point x="398" y="95"/>
-      <point x="366" y="95" type="curve" smooth="yes"/>
-      <point x="243" y="95"/>
-      <point x="174" y="167"/>
-      <point x="174" y="296" type="curve" smooth="yes"/>
-      <point x="174" y="431"/>
-      <point x="240" y="519"/>
-      <point x="339" y="519" type="curve" smooth="yes"/>
-      <point x="375" y="519"/>
-      <point x="401" y="506"/>
-      <point x="424" y="477" type="curve"/>
-      <point x="499" y="560" type="line"/>
-      <point x="462" y="607"/>
-      <point x="412" y="629"/>
-      <point x="341" y="629" type="curve" smooth="yes"/>
-      <point x="174" y="629"/>
-      <point x="56" y="491"/>
-      <point x="56" y="295" type="curve" smooth="yes"/>
-      <point x="56" y="102"/>
-      <point x="170" y="-16"/>
+      <point x="343" y="-16" type="curve" smooth="yes"/>
+      <point x="410" y="-16"/>
+      <point x="470" y="0"/>
+      <point x="524" y="34" type="curve"/>
+      <point x="447" y="110" type="line"/>
+      <point x="417" y="99"/>
+      <point x="390" y="94"/>
+      <point x="355" y="94" type="curve" smooth="yes"/>
+      <point x="238" y="94"/>
+      <point x="175" y="168"/>
+      <point x="175" y="297" type="curve" smooth="yes"/>
+      <point x="175" y="386"/>
+      <point x="216" y="519"/>
+      <point x="340" y="519" type="curve" smooth="yes"/>
+      <point x="377" y="519"/>
+      <point x="395" y="508"/>
+      <point x="417" y="483" type="curve"/>
+      <point x="498" y="568" type="line"/>
+      <point x="457" y="610"/>
+      <point x="414" y="629"/>
+      <point x="350" y="629" type="curve" smooth="yes"/>
+      <point x="145" y="629"/>
+      <point x="55" y="444"/>
+      <point x="55" y="295" type="curve" smooth="yes"/>
+      <point x="55" y="115"/>
+      <point x="171" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ya-malayalam.glif
@@ -2,78 +2,78 @@
 <glyph name="ya-malayalam" format="2">
   <advance width="1047"/>
   <unicode hex="0D2F"/>
-  <anchor x="572" y="0" name="bottom"/>
-  <anchor x="865" y="-6" name="bottomright"/>
-  <anchor x="599" y="613" name="top"/>
-  <anchor x="900" y="613" name="topright"/>
+  <anchor x="565" y="0" name="bottom"/>
+  <anchor x="858" y="-6" name="bottomright"/>
+  <anchor x="594" y="613" name="top"/>
+  <anchor x="895" y="613" name="topright"/>
   <outline>
     <contour>
-      <point x="674" y="-16" type="curve" smooth="yes"/>
-      <point x="876" y="-16"/>
-      <point x="1013" y="138"/>
-      <point x="1013" y="371" type="curve" smooth="yes"/>
-      <point x="1013" y="469"/>
-      <point x="985" y="563"/>
-      <point x="937" y="629" type="curve"/>
-      <point x="832" y="570" type="line"/>
-      <point x="871" y="516"/>
-      <point x="892" y="446"/>
-      <point x="892" y="371" type="curve" smooth="yes"/>
-      <point x="892" y="201"/>
-      <point x="808" y="95"/>
-      <point x="673" y="95" type="curve" smooth="yes"/>
-      <point x="538" y="95"/>
-      <point x="468" y="172"/>
-      <point x="468" y="322" type="curve" smooth="yes"/>
-      <point x="468" y="439"/>
-      <point x="511" y="518"/>
-      <point x="574" y="518" type="curve" smooth="yes"/>
-      <point x="621" y="518"/>
-      <point x="644" y="484"/>
-      <point x="644" y="410" type="curve" smooth="yes"/>
-      <point x="644" y="291"/>
-      <point x="590" y="185"/>
-      <point x="497" y="118" type="curve"/>
-      <point x="564" y="48" type="line"/>
-      <point x="701" y="141"/>
-      <point x="765" y="255"/>
-      <point x="765" y="410" type="curve" smooth="yes"/>
-      <point x="765" y="554"/>
-      <point x="705" y="629"/>
-      <point x="590" y="629" type="curve" smooth="yes"/>
-      <point x="453" y="629"/>
-      <point x="350" y="497"/>
-      <point x="350" y="321" type="curve" smooth="yes"/>
-      <point x="350" y="125"/>
-      <point x="485" y="-16"/>
+      <point x="645" y="-16" type="curve" smooth="yes"/>
+      <point x="878" y="-16"/>
+      <point x="997" y="164"/>
+      <point x="997" y="352" type="curve" smooth="yes"/>
+      <point x="997" y="450"/>
+      <point x="967" y="546"/>
+      <point x="910" y="629" type="curve"/>
+      <point x="807" y="564" type="line"/>
+      <point x="854" y="496"/>
+      <point x="877" y="424"/>
+      <point x="877" y="345" type="curve" smooth="yes"/>
+      <point x="877" y="220"/>
+      <point x="803" y="94"/>
+      <point x="649" y="94" type="curve" smooth="yes"/>
+      <point x="506" y="94"/>
+      <point x="432" y="192"/>
+      <point x="432" y="340" type="curve" smooth="yes"/>
+      <point x="432" y="409"/>
+      <point x="461" y="519"/>
+      <point x="558" y="519" type="curve" smooth="yes"/>
+      <point x="617" y="519"/>
+      <point x="645" y="479"/>
+      <point x="645" y="398" type="curve" smooth="yes"/>
+      <point x="645" y="285"/>
+      <point x="586" y="178"/>
+      <point x="491" y="126" type="curve"/>
+      <point x="556" y="62" type="line"/>
+      <point x="685" y="133"/>
+      <point x="765" y="266"/>
+      <point x="765" y="408" type="curve" smooth="yes"/>
+      <point x="765" y="547"/>
+      <point x="701" y="629"/>
+      <point x="564" y="629" type="curve" smooth="yes"/>
+      <point x="402" y="629"/>
+      <point x="314" y="468"/>
+      <point x="314" y="344" type="curve" smooth="yes"/>
+      <point x="314" y="122"/>
+      <point x="451" y="-16"/>
     </contour>
     <contour>
-      <point x="355" y="-16" type="curve" smooth="yes"/>
-      <point x="424" y="-16"/>
-      <point x="479" y="-1"/>
-      <point x="531" y="30" type="curve"/>
-      <point x="453" y="109" type="line"/>
-      <point x="425" y="99"/>
-      <point x="398" y="95"/>
-      <point x="366" y="95" type="curve" smooth="yes"/>
-      <point x="243" y="95"/>
-      <point x="174" y="167"/>
-      <point x="174" y="296" type="curve" smooth="yes"/>
-      <point x="174" y="431"/>
-      <point x="240" y="519"/>
-      <point x="339" y="519" type="curve" smooth="yes"/>
-      <point x="375" y="519"/>
-      <point x="401" y="506"/>
-      <point x="424" y="477" type="curve"/>
-      <point x="499" y="560" type="line"/>
-      <point x="462" y="607"/>
-      <point x="412" y="629"/>
-      <point x="341" y="629" type="curve" smooth="yes"/>
-      <point x="174" y="629"/>
-      <point x="56" y="491"/>
-      <point x="56" y="295" type="curve" smooth="yes"/>
-      <point x="56" y="102"/>
-      <point x="170" y="-16"/>
+      <point x="343" y="-16" type="curve" smooth="yes"/>
+      <point x="410" y="-16"/>
+      <point x="470" y="0"/>
+      <point x="524" y="34" type="curve"/>
+      <point x="447" y="110" type="line"/>
+      <point x="417" y="99"/>
+      <point x="390" y="94"/>
+      <point x="355" y="94" type="curve" smooth="yes"/>
+      <point x="238" y="94"/>
+      <point x="175" y="168"/>
+      <point x="175" y="297" type="curve" smooth="yes"/>
+      <point x="175" y="386"/>
+      <point x="216" y="519"/>
+      <point x="340" y="519" type="curve" smooth="yes"/>
+      <point x="377" y="519"/>
+      <point x="395" y="508"/>
+      <point x="417" y="483" type="curve"/>
+      <point x="498" y="568" type="line"/>
+      <point x="457" y="610"/>
+      <point x="414" y="629"/>
+      <point x="350" y="629" type="curve" smooth="yes"/>
+      <point x="145" y="629"/>
+      <point x="55" y="444"/>
+      <point x="55" y="295" type="curve" smooth="yes"/>
+      <point x="55" y="115"/>
+      <point x="171" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ya-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ya-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1047"/>
   <outline>
     <component base="ya-malayalam"/>
-    <component base="halant-malayalam" xOffset="817"/>
+    <component base="halant-malayalam" xOffset="812"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/kerning.plist
@@ -49251,8 +49251,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>67</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -49364,7 +49362,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>93</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49420,7 +49418,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>127</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49473,7 +49471,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>246</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>187</integer>
+      <integer>160</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>207</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -49520,7 +49518,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -49555,7 +49553,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>113</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>63</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -49583,8 +49581,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>47</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49619,7 +49615,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>133</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>93</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49688,7 +49684,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>63</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>17</integer>
+      <integer>14</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49748,7 +49744,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>127</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49799,7 +49795,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>226</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>177</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>197</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49857,7 +49853,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>77</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>27</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49898,7 +49894,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>133</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50034,8 +50030,6 @@
       <integer>-30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50113,7 +50107,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>56</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>13</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>26</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50207,8 +50201,6 @@
       <integer>50</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>87</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>47</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>57</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -50241,7 +50233,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>87</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50318,8 +50310,6 @@
       <integer>-47</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -50363,8 +50353,6 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>28</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -50484,8 +50472,6 @@
       <integer>3</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>53</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50595,7 +50581,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>157</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50646,7 +50632,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>157</integer>
+      <integer>130</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>177</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50692,43 +50678,43 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>43</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_braceright.loclMALM_R</key>
       <integer>40</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
-      <integer>27</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>40</integer>
-      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>77</integer>
-      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
+      <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
+      <integer>70</integer>
+      <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>130</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
-      <integer>107</integer>
+      <integer>80</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
       <integer>20</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
-      <integer>-27</integer>
-      <key>public.kern2.MAL_rVocalic-malayalam_L</key>
-      <integer>20</integer>
+      <integer>-20</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
-      <integer>57</integer>
+      <integer>70</integer>
+      <key>public.kern2.MAL_tt_tta-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
-      <integer>127</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_uMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>220</integer>
+      <integer>200</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
-      <integer>150</integer>
+      <integer>160</integer>
     </dict>
     <key>public.kern1.MAL_ma_lVocalicMatra-malayalam_R</key>
     <dict>
@@ -50753,7 +50739,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>153</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50802,7 +50788,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>167</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>173</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50837,8 +50823,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>66</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>27</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -50880,7 +50864,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>43</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -51085,7 +51069,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>113</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -51112,7 +51096,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>43</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -51139,7 +51123,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>33</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -51195,7 +51179,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>97</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -51227,8 +51211,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -51338,8 +51320,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_p_pa-malayalam_L</key>
@@ -51406,7 +51386,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>200</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>167</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
@@ -51451,7 +51431,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>133</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -51492,7 +51472,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>193</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>147</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -51582,7 +51562,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>197</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>137</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -51724,7 +51704,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>73</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>33</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -51774,8 +51754,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>63</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>33</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -51842,7 +51820,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>193</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>153</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -51895,7 +51873,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>266</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>197</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>226</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -51980,7 +51958,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>73</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -52025,7 +52003,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>130</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>153</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -52122,8 +52100,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>47</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -52227,7 +52203,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>127</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>87</integer>
       <key>public.kern2.MAL_ng_ka-malayalam_L</key>
@@ -52279,6 +52255,24 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-30</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>67</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>73</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>-20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>30</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.Man-georgian</key>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/archaicii-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/archaicii-malayalam.glif
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="archaicii-malayalam" format="2">
-  <advance width="1347"/>
+  <advance width="1361"/>
   <unicode hex="0D5F"/>
   <outline>
     <component base="archaicii-malayalam.part"/>
-    <component base="ra-malayalam" xOffset="314"/>
-    <component base="archaicii-malayalam.part" xOffset="1033"/>
+    <component base="ra-malayalam" xOffset="321"/>
+    <component base="archaicii-malayalam.part" xOffset="1040"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/d_da-malayalam.glif
@@ -1,76 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
-  <advance width="665"/>
-  <guideline x="1234" y="-225" angle="0"/>
-  <guideline x="605" y="162" angle="90"/>
-  <guideline x="1428" y="185" angle="90"/>
-  <anchor x="349" y="580" name="top"/>
+  <advance width="655"/>
+  <anchor x="279" y="-263" name="bottom"/>
+  <anchor x="414" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="375" y="-225" type="curve" smooth="yes"/>
-      <point x="503" y="-225"/>
-      <point x="569" y="-175"/>
-      <point x="569" y="-83" type="curve" smooth="yes"/>
-      <point x="569" y="-32"/>
-      <point x="537" y="9"/>
-      <point x="477" y="21" type="curve"/>
-      <point x="477" y="26" type="line"/>
-      <point x="529" y="39"/>
-      <point x="601" y="68"/>
-      <point x="601" y="166" type="curve" smooth="yes"/>
-      <point x="601" y="221"/>
-      <point x="573" y="269"/>
-      <point x="503" y="286" type="curve"/>
-      <point x="504" y="291" type="line"/>
-      <point x="587" y="306"/>
-      <point x="628" y="359"/>
-      <point x="628" y="429" type="curve" smooth="yes"/>
-      <point x="628" y="526"/>
-      <point x="551" y="596"/>
-      <point x="392" y="596" type="curve" smooth="yes"/>
-      <point x="178" y="596"/>
-      <point x="39" y="445"/>
-      <point x="39" y="234" type="curve" smooth="yes"/>
-      <point x="39" y="140"/>
-      <point x="60" y="61"/>
-      <point x="104" y="-16" type="curve"/>
-      <point x="177" y="29" type="line"/>
-      <point x="139" y="91"/>
-      <point x="122" y="156"/>
-      <point x="122" y="237" type="curve" smooth="yes"/>
-      <point x="122" y="399"/>
-      <point x="216" y="518"/>
-      <point x="387" y="518" type="curve" smooth="yes"/>
-      <point x="497" y="518"/>
-      <point x="543" y="478"/>
-      <point x="543" y="425" type="curve" smooth="yes"/>
-      <point x="543" y="365"/>
-      <point x="499" y="329"/>
-      <point x="431" y="329" type="curve" smooth="yes"/>
-      <point x="371" y="329" type="line"/>
-      <point x="358" y="255" type="line"/>
-      <point x="400" y="255" type="line" smooth="yes"/>
+      <point x="319" y="-279" type="curve" smooth="yes"/>
+      <point x="464" y="-279"/>
+      <point x="547" y="-191"/>
+      <point x="547" y="-103" type="curve" smooth="yes"/>
+      <point x="547" y="-44"/>
+      <point x="522" y="-1"/>
+      <point x="471" y="20" type="curve"/>
+      <point x="472" y="26" type="line"/>
+      <point x="547" y="47"/>
+      <point x="596" y="100"/>
+      <point x="596" y="173" type="curve" smooth="yes"/>
+      <point x="596" y="233"/>
+      <point x="564" y="273"/>
+      <point x="499" y="289" type="curve"/>
+      <point x="500" y="295" type="line"/>
+      <point x="576" y="313"/>
+      <point x="624" y="362"/>
+      <point x="624" y="434" type="curve" smooth="yes"/>
+      <point x="624" y="525"/>
+      <point x="549" y="596"/>
+      <point x="404" y="596" type="curve" smooth="yes"/>
+      <point x="137" y="596"/>
+      <point x="39" y="400"/>
+      <point x="39" y="235" type="curve" smooth="yes"/>
+      <point x="39" y="147"/>
+      <point x="62" y="61"/>
+      <point x="107" y="-16" type="curve"/>
+      <point x="179" y="27" type="line"/>
+      <point x="141" y="94"/>
+      <point x="122" y="162"/>
+      <point x="122" y="236" type="curve" smooth="yes"/>
+      <point x="122" y="374"/>
+      <point x="192" y="518"/>
+      <point x="396" y="518" type="curve" smooth="yes"/>
+      <point x="494" y="518"/>
+      <point x="541" y="485"/>
+      <point x="541" y="424" type="curve" smooth="yes"/>
+      <point x="541" y="367"/>
+      <point x="494" y="329"/>
+      <point x="413" y="329" type="curve" smooth="yes"/>
+      <point x="367" y="329" type="line"/>
+      <point x="354" y="255" type="line"/>
+      <point x="408" y="255" type="line" smooth="yes"/>
       <point x="477" y="255"/>
-      <point x="520" y="229"/>
-      <point x="520" y="169" type="curve" smooth="yes"/>
-      <point x="520" y="82"/>
-      <point x="458" y="62"/>
-      <point x="397" y="62" type="curve" smooth="yes"/>
-      <point x="324" y="62" type="line"/>
-      <point x="311" y="-12" type="line"/>
-      <point x="364" y="-12" type="line" smooth="yes"/>
-      <point x="453" y="-12"/>
-      <point x="488" y="-37"/>
-      <point x="488" y="-77" type="curve" smooth="yes"/>
-      <point x="488" y="-125"/>
-      <point x="450" y="-147"/>
-      <point x="388" y="-147" type="curve" smooth="yes"/>
-      <point x="320" y="-147"/>
-      <point x="283" y="-139"/>
-      <point x="255" y="-129" type="curve"/>
-      <point x="214" y="-201" type="line"/>
-      <point x="249" y="-215"/>
-      <point x="309" y="-225"/>
+      <point x="513" y="224"/>
+      <point x="513" y="170" type="curve" smooth="yes"/>
+      <point x="513" y="101"/>
+      <point x="464" y="62"/>
+      <point x="377" y="62" type="curve" smooth="yes"/>
+      <point x="304" y="62" type="line"/>
+      <point x="291" y="-12" type="line"/>
+      <point x="349" y="-12" type="line" smooth="yes"/>
+      <point x="434" y="-12"/>
+      <point x="464" y="-45"/>
+      <point x="464" y="-99" type="curve" smooth="yes"/>
+      <point x="464" y="-152"/>
+      <point x="426" y="-201"/>
+      <point x="325" y="-201" type="curve" smooth="yes"/>
+      <point x="261" y="-201"/>
+      <point x="211" y="-187"/>
+      <point x="160" y="-158" type="curve"/>
+      <point x="121" y="-227" type="line"/>
+      <point x="181" y="-261"/>
+      <point x="249" y="-279"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="963"/>
-  <anchor x="611" y="0" name="bottom"/>
-  <anchor x="531" y="580" name="top"/>
-  <anchor x="903" y="580" name="topright"/>
+  <advance width="956"/>
+  <anchor x="599" y="0" name="bottom"/>
+  <anchor x="526" y="580" name="top"/>
+  <anchor x="891" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="243" y="-16" type="curve" smooth="yes"/>
-      <point x="363" y="-16"/>
-      <point x="440" y="58"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="548" y="451"/>
-      <point x="603" y="516"/>
-      <point x="717" y="516" type="curve" smooth="yes"/>
-      <point x="808" y="516"/>
-      <point x="856" y="487"/>
-      <point x="856" y="423" type="curve" smooth="yes"/>
-      <point x="856" y="365"/>
-      <point x="812" y="329"/>
-      <point x="741" y="329" type="curve" smooth="yes"/>
-      <point x="681" y="329" type="line"/>
-      <point x="668" y="255" type="line"/>
-      <point x="710" y="255" type="line" smooth="yes"/>
-      <point x="788" y="255"/>
-      <point x="829" y="222"/>
-      <point x="829" y="159" type="curve" smooth="yes"/>
-      <point x="829" y="96"/>
-      <point x="790" y="62"/>
-      <point x="718" y="62" type="curve" smooth="yes"/>
-      <point x="677" y="62"/>
-      <point x="642" y="71"/>
-      <point x="608" y="90" type="curve"/>
-      <point x="565" y="20" type="line"/>
-      <point x="604" y="-3"/>
-      <point x="657" y="-16"/>
-      <point x="713" y="-16" type="curve" smooth="yes"/>
-      <point x="834" y="-16"/>
-      <point x="911" y="52"/>
-      <point x="911" y="159" type="curve" smooth="yes"/>
-      <point x="911" y="220"/>
-      <point x="875" y="269"/>
-      <point x="813" y="285" type="curve"/>
-      <point x="813" y="290" type="line"/>
-      <point x="892" y="303"/>
-      <point x="938" y="354"/>
-      <point x="938" y="431" type="curve" smooth="yes"/>
-      <point x="938" y="536"/>
-      <point x="860" y="596"/>
-      <point x="721" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="474" y="508"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="72"/>
-      <point x="115" y="-16"/>
+      <point x="253" y="-16" type="curve" smooth="yes"/>
+      <point x="380" y="-16"/>
+      <point x="468" y="70"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="592" y="516"/>
+      <point x="702" y="516" type="curve" smooth="yes"/>
+      <point x="792" y="516"/>
+      <point x="839" y="482"/>
+      <point x="839" y="422" type="curve" smooth="yes"/>
+      <point x="839" y="365"/>
+      <point x="795" y="329"/>
+      <point x="724" y="329" type="curve" smooth="yes"/>
+      <point x="664" y="329" type="line"/>
+      <point x="651" y="255" type="line"/>
+      <point x="693" y="255" type="line" smooth="yes"/>
+      <point x="771" y="255"/>
+      <point x="812" y="222"/>
+      <point x="812" y="159" type="curve" smooth="yes"/>
+      <point x="812" y="96"/>
+      <point x="773" y="62"/>
+      <point x="701" y="62" type="curve" smooth="yes"/>
+      <point x="660" y="62"/>
+      <point x="625" y="71"/>
+      <point x="591" y="90" type="curve"/>
+      <point x="548" y="20" type="line"/>
+      <point x="587" y="-3"/>
+      <point x="640" y="-16"/>
+      <point x="696" y="-16" type="curve" smooth="yes"/>
+      <point x="817" y="-16"/>
+      <point x="894" y="52"/>
+      <point x="894" y="159" type="curve" smooth="yes"/>
+      <point x="894" y="220"/>
+      <point x="858" y="267"/>
+      <point x="796" y="283" type="curve"/>
+      <point x="796" y="288" type="line"/>
+      <point x="874" y="302"/>
+      <point x="921" y="355"/>
+      <point x="921" y="426" type="curve" smooth="yes"/>
+      <point x="921" y="532"/>
+      <point x="841" y="596"/>
+      <point x="705" y="596" type="curve" smooth="yes"/>
+      <point x="543" y="596"/>
+      <point x="442" y="504"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="75"/>
+      <point x="121" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/g_ga-malayalam.glif
@@ -1,92 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ga-malayalam" format="2">
   <advance width="910"/>
-  <anchor x="416" y="-351" name="bottom"/>
-  <anchor x="515" y="580" name="top"/>
-  <anchor x="819" y="580" name="topright"/>
+  <anchor x="427" y="-351" name="bottom"/>
+  <anchor x="510" y="580" name="top"/>
+  <anchor x="814" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="605" y="-369" type="line"/>
-      <point x="679" y="-303"/>
-      <point x="733" y="-222"/>
-      <point x="733" y="-115" type="curve" smooth="yes"/>
-      <point x="733" y="-14"/>
-      <point x="670" y="43"/>
-      <point x="575" y="43" type="curve" smooth="yes"/>
-      <point x="479" y="43"/>
-      <point x="424" y="-12"/>
-      <point x="394" y="-146" type="curve" smooth="yes"/>
-      <point x="389" y="-168" type="line" smooth="yes"/>
-      <point x="366" y="-269"/>
-      <point x="335" y="-297"/>
-      <point x="281" y="-297" type="curve" smooth="yes"/>
-      <point x="230" y="-297"/>
-      <point x="195" y="-264"/>
-      <point x="195" y="-196" type="curve" smooth="yes"/>
-      <point x="195" y="-124"/>
-      <point x="234" y="-59"/>
-      <point x="292" y="-4" type="curve"/>
-      <point x="269" y="-15" type="line"/>
-      <point x="374" y="-5"/>
-      <point x="443" y="70"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="603" y="516"/>
-      <point x="683" y="516" type="curve" smooth="yes"/>
-      <point x="762" y="516"/>
-      <point x="804" y="465"/>
-      <point x="804" y="369" type="curve" smooth="yes"/>
-      <point x="804" y="244"/>
-      <point x="742" y="127"/>
-      <point x="608" y="24" type="curve"/>
-      <point x="683" y="-16" type="line"/>
-      <point x="812" y="90"/>
-      <point x="886" y="230"/>
-      <point x="886" y="369" type="curve" smooth="yes"/>
-      <point x="886" y="511"/>
-      <point x="811" y="596"/>
-      <point x="685" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="476" y="517"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="93"/>
-      <point x="92" y="12"/>
-      <point x="191" y="-10" type="curve"/>
-      <point x="191" y="-15" type="line"/>
-      <point x="144" y="-75"/>
-      <point x="120" y="-136"/>
-      <point x="120" y="-204" type="curve" smooth="yes"/>
-      <point x="120" y="-306"/>
-      <point x="178" y="-367"/>
-      <point x="283" y="-367" type="curve" smooth="yes"/>
-      <point x="377" y="-367"/>
-      <point x="430" y="-313"/>
-      <point x="460" y="-175" type="curve" smooth="yes"/>
-      <point x="465" y="-152" type="line" smooth="yes"/>
-      <point x="486" y="-53"/>
-      <point x="518" y="-27"/>
-      <point x="570" y="-27" type="curve" smooth="yes"/>
-      <point x="628" y="-27"/>
-      <point x="657" y="-64"/>
-      <point x="657" y="-126" type="curve" smooth="yes"/>
-      <point x="657" y="-201"/>
-      <point x="614" y="-268"/>
-      <point x="556" y="-321" type="curve"/>
+      <point x="253" y="-12" type="curve" smooth="yes"/>
+      <point x="380" y="-12"/>
+      <point x="468" y="73"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="580" y="514"/>
+      <point x="668" y="514" type="curve" smooth="yes"/>
+      <point x="749" y="514"/>
+      <point x="793" y="462"/>
+      <point x="793" y="367" type="curve" smooth="yes"/>
+      <point x="793" y="253"/>
+      <point x="727" y="132"/>
+      <point x="609" y="31" type="curve"/>
+      <point x="681" y="-12" type="line"/>
+      <point x="800" y="90"/>
+      <point x="877" y="239"/>
+      <point x="877" y="369" type="curve" smooth="yes"/>
+      <point x="877" y="511"/>
+      <point x="798" y="596"/>
+      <point x="668" y="596" type="curve" smooth="yes"/>
+      <point x="538" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="77"/>
+      <point x="121" y="-12"/>
+    </contour>
+    <contour>
+      <point x="620" y="-369" type="line"/>
+      <point x="703" y="-303"/>
+      <point x="746" y="-220"/>
+      <point x="746" y="-128" type="curve" smooth="yes"/>
+      <point x="746" y="-27"/>
+      <point x="681" y="43"/>
+      <point x="587" y="43" type="curve" smooth="yes"/>
+      <point x="490" y="43"/>
+      <point x="425" y="-16"/>
+      <point x="410" y="-117" type="curve" smooth="yes"/>
+      <point x="407" y="-139"/>
+      <point x="405" y="-166"/>
+      <point x="402" y="-187" type="curve" smooth="yes"/>
+      <point x="391" y="-260"/>
+      <point x="358" y="-297"/>
+      <point x="303" y="-297" type="curve" smooth="yes"/>
+      <point x="244" y="-297"/>
+      <point x="210" y="-261"/>
+      <point x="210" y="-193" type="curve" smooth="yes"/>
+      <point x="210" y="-115"/>
+      <point x="240" y="-57"/>
+      <point x="310" y="8" type="curve"/>
+      <point x="221" y="8" type="line"/>
+      <point x="167" y="-46"/>
+      <point x="136" y="-122"/>
+      <point x="136" y="-195" type="curve" smooth="yes"/>
+      <point x="136" y="-298"/>
+      <point x="203" y="-367"/>
+      <point x="301" y="-367" type="curve" smooth="yes"/>
+      <point x="395" y="-367"/>
+      <point x="459" y="-306"/>
+      <point x="474" y="-200" type="curve" smooth="yes"/>
+      <point x="477" y="-177"/>
+      <point x="479" y="-153"/>
+      <point x="482" y="-130" type="curve" smooth="yes"/>
+      <point x="492" y="-63"/>
+      <point x="528" y="-27"/>
+      <point x="585" y="-27" type="curve" smooth="yes"/>
+      <point x="641" y="-27"/>
+      <point x="672" y="-63"/>
+      <point x="672" y="-130" type="curve" smooth="yes"/>
+      <point x="672" y="-199"/>
+      <point x="639" y="-263"/>
+      <point x="575" y="-313" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/g_la-malayalam.glif
@@ -1,116 +1,125 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_la-malayalam" format="2">
   <advance width="910"/>
-  <anchor x="428" y="-351" name="bottom"/>
-  <anchor x="515" y="580" name="top"/>
-  <anchor x="819" y="580" name="topright"/>
+  <anchor x="408" y="-351" name="bottom"/>
+  <anchor x="510" y="580" name="top"/>
+  <anchor x="814" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="206" y="-367" type="curve" smooth="yes"/>
-      <point x="291" y="-367"/>
-      <point x="343" y="-313"/>
-      <point x="343" y="-228" type="curve" smooth="yes"/>
-      <point x="343" y="-154"/>
-      <point x="303" y="-118"/>
-      <point x="234" y="-118" type="curve" smooth="yes"/>
-      <point x="202" y="-118"/>
-      <point x="164" y="-131"/>
-      <point x="138" y="-164" type="curve"/>
-      <point x="132" y="-163" type="line"/>
-      <point x="152" y="-78"/>
-      <point x="209" y="-27"/>
-      <point x="296" y="-27" type="curve" smooth="yes"/>
-      <point x="401" y="-27"/>
-      <point x="428" y="-86"/>
-      <point x="433" y="-174" type="curve" smooth="yes"/>
-      <point x="434" y="-192" type="line" smooth="yes"/>
-      <point x="440" y="-303"/>
-      <point x="490" y="-367"/>
-      <point x="600" y="-367" type="curve" smooth="yes"/>
-      <point x="729" y="-367"/>
-      <point x="784" y="-271"/>
-      <point x="784" y="-131" type="curve" smooth="yes"/>
-      <point x="784" y="-62"/>
-      <point x="767" y="-6"/>
-      <point x="729" y="44" type="curve"/>
-      <point x="729" y="26" type="line"/>
-      <point x="829" y="125"/>
-      <point x="886" y="248"/>
-      <point x="886" y="369" type="curve" smooth="yes"/>
-      <point x="886" y="511"/>
-      <point x="811" y="596"/>
-      <point x="685" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="476" y="517"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="68"/>
-      <point x="243" y="68" type="curve" smooth="yes"/>
-      <point x="163" y="68"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="110"/>
-      <point x="75" y="39"/>
-      <point x="165" y="8" type="curve"/>
-      <point x="165" y="3" type="line"/>
-      <point x="96" y="-49"/>
-      <point x="60" y="-125"/>
-      <point x="60" y="-210" type="curve" smooth="yes"/>
-      <point x="60" y="-316"/>
-      <point x="124" y="-367"/>
+      <point x="191" y="-367" type="curve" smooth="yes"/>
+      <point x="282" y="-367"/>
+      <point x="332" y="-297"/>
+      <point x="332" y="-229" type="curve" smooth="yes"/>
+      <point x="332" y="-161"/>
+      <point x="295" y="-118"/>
+      <point x="224" y="-118" type="curve" smooth="yes"/>
+      <point x="171" y="-118"/>
+      <point x="124" y="-149"/>
+      <point x="111" y="-197" type="curve"/>
+      <point x="144" y="-171" type="line"/>
+      <point x="104" y="-155" type="line"/>
+      <point x="117" y="-188" type="line"/>
+      <point x="138" y="-82"/>
+      <point x="198" y="-27"/>
+      <point x="292" y="-27" type="curve" smooth="yes"/>
+      <point x="372" y="-27"/>
+      <point x="406" y="-67"/>
+      <point x="421" y="-157" type="curve" smooth="yes"/>
+      <point x="428" y="-200" type="line" smooth="yes"/>
+      <point x="446" y="-312"/>
+      <point x="503" y="-367"/>
+      <point x="596" y="-367" type="curve" smooth="yes"/>
+      <point x="727" y="-367"/>
+      <point x="774" y="-244"/>
+      <point x="774" y="-148" type="curve" smooth="yes"/>
+      <point x="774" y="-76"/>
+      <point x="758" y="-13"/>
+      <point x="717" y="41" type="curve"/>
+      <point x="719" y="23" type="line"/>
+      <point x="816" y="123"/>
+      <point x="877" y="255"/>
+      <point x="877" y="369" type="curve" smooth="yes"/>
+      <point x="877" y="511"/>
+      <point x="798" y="596"/>
+      <point x="668" y="596" type="curve" smooth="yes"/>
+      <point x="538" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="112"/>
+      <point x="81" y="38"/>
+      <point x="162" y="8" type="curve"/>
+      <point x="162" y="3" type="line"/>
+      <point x="97" y="-35"/>
+      <point x="49" y="-120"/>
+      <point x="49" y="-205" type="curve" smooth="yes"/>
+      <point x="49" y="-310"/>
+      <point x="110" y="-367"/>
     </contour>
     <contour>
-      <point x="206" y="-302" type="curve" smooth="yes"/>
-      <point x="151" y="-302"/>
-      <point x="128" y="-264"/>
-      <point x="128" y="-218" type="curve"/>
-      <point x="109" y="-197" type="line"/>
-      <point x="120" y="-253" type="line"/>
-      <point x="128" y="-213"/>
-      <point x="161" y="-178"/>
-      <point x="210" y="-178" type="curve" smooth="yes"/>
-      <point x="252" y="-178"/>
-      <point x="272" y="-199"/>
-      <point x="272" y="-233" type="curve" smooth="yes"/>
-      <point x="272" y="-276"/>
-      <point x="248" y="-302"/>
+      <point x="192" y="-302" type="curve" smooth="yes"/>
+      <point x="144" y="-302"/>
+      <point x="116" y="-269"/>
+      <point x="116" y="-223" type="curve" smooth="yes"/>
+      <point x="116" y="-216"/>
+      <point x="117" y="-208"/>
+      <point x="119" y="-200" type="curve"/>
+      <point x="98" y="-216" type="line"/>
+      <point x="108" y="-265" type="line"/>
+      <point x="116" y="-213"/>
+      <point x="157" y="-178"/>
+      <point x="206" y="-178" type="curve" smooth="yes"/>
+      <point x="243" y="-178"/>
+      <point x="262" y="-198"/>
+      <point x="262" y="-233" type="curve" smooth="yes"/>
+      <point x="262" y="-268"/>
+      <point x="238" y="-302"/>
     </contour>
     <contour>
-      <point x="602" y="-297" type="curve" smooth="yes"/>
-      <point x="542" y="-297"/>
-      <point x="517" y="-265"/>
-      <point x="509" y="-174" type="curve" smooth="yes"/>
-      <point x="507" y="-151" type="line" smooth="yes"/>
-      <point x="498" y="-52"/>
-      <point x="463" y="8"/>
-      <point x="374" y="34" type="curve"/>
-      <point x="374" y="39" type="line"/>
-      <point x="432" y="71"/>
-      <point x="461" y="137"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="603" y="512"/>
-      <point x="683" y="512" type="curve" smooth="yes"/>
-      <point x="762" y="512"/>
-      <point x="804" y="465"/>
-      <point x="804" y="369" type="curve" smooth="yes"/>
-      <point x="804" y="252"/>
-      <point x="745" y="143"/>
-      <point x="637" y="48" type="curve"/>
-      <point x="681" y="3"/>
-      <point x="709" y="-61"/>
-      <point x="709" y="-149" type="curve" smooth="yes"/>
-      <point x="709" y="-226"/>
-      <point x="681" y="-297"/>
+      <point x="600" y="-297" type="curve" smooth="yes"/>
+      <point x="546" y="-297"/>
+      <point x="514" y="-267"/>
+      <point x="501" y="-185" type="curve" smooth="yes"/>
+      <point x="494" y="-142" type="line" smooth="yes"/>
+      <point x="479" y="-51"/>
+      <point x="445" y="3"/>
+      <point x="378" y="26" type="curve"/>
+      <point x="378" y="31" type="line"/>
+      <point x="436" y="70"/>
+      <point x="477" y="133"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="580" y="514"/>
+      <point x="668" y="514" type="curve" smooth="yes"/>
+      <point x="749" y="514"/>
+      <point x="793" y="462"/>
+      <point x="793" y="367" type="curve" smooth="yes"/>
+      <point x="793" y="251"/>
+      <point x="733" y="138"/>
+      <point x="618" y="42" type="curve"/>
+      <point x="679" y="-20"/>
+      <point x="700" y="-76"/>
+      <point x="700" y="-151" type="curve" smooth="yes"/>
+      <point x="700" y="-214"/>
+      <point x="676" y="-297"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/g_ma-malayalam.glif
@@ -1,99 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ma-malayalam" format="2">
   <advance width="1401"/>
-  <anchor x="1029" y="0" name="bottom"/>
-  <anchor x="746" y="580" name="top"/>
-  <anchor x="1356" y="580" name="topright"/>
+  <anchor x="1024" y="0" name="bottom"/>
+  <anchor x="741" y="580" name="top"/>
+  <anchor x="1351" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="243" y="-16" type="curve" smooth="yes"/>
-      <point x="363" y="-16"/>
-      <point x="440" y="58"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="603" y="512"/>
-      <point x="683" y="512" type="curve" smooth="yes"/>
-      <point x="762" y="512"/>
-      <point x="804" y="465"/>
-      <point x="806" y="384" type="curve" smooth="yes"/>
-      <point x="806" y="365"/>
-      <point x="804" y="345"/>
-      <point x="800" y="323" type="curve" smooth="yes"/>
-      <point x="743" y="0" type="line"/>
-      <point x="1309" y="0" type="line"/>
-      <point x="1357" y="266" type="line" smooth="yes"/>
-      <point x="1363" y="299"/>
-      <point x="1366" y="342"/>
-      <point x="1366" y="362" type="curve" smooth="yes"/>
-      <point x="1366" y="521"/>
-      <point x="1264" y="596"/>
-      <point x="1118" y="596" type="curve" smooth="yes"/>
-      <point x="1005" y="596"/>
-      <point x="923" y="556"/>
-      <point x="868" y="474" type="curve"/>
-      <point x="863" y="474" type="line"/>
-      <point x="831" y="557"/>
-      <point x="769" y="596"/>
-      <point x="679" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="476" y="517"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="72"/>
-      <point x="115" y="-16"/>
+      <point x="253" y="-16" type="curve" smooth="yes"/>
+      <point x="380" y="-16"/>
+      <point x="468" y="70"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="580" y="514"/>
+      <point x="668" y="514" type="curve" smooth="yes"/>
+      <point x="750" y="514"/>
+      <point x="796" y="468"/>
+      <point x="796" y="386" type="curve" smooth="yes"/>
+      <point x="796" y="366"/>
+      <point x="794" y="346"/>
+      <point x="790" y="323" type="curve" smooth="yes"/>
+      <point x="733" y="0" type="line"/>
+      <point x="1299" y="0" type="line"/>
+      <point x="1347" y="271" type="line" smooth="yes"/>
+      <point x="1353" y="305"/>
+      <point x="1357" y="343"/>
+      <point x="1357" y="362" type="curve" smooth="yes"/>
+      <point x="1357" y="510"/>
+      <point x="1270" y="596"/>
+      <point x="1114" y="596" type="curve" smooth="yes"/>
+      <point x="997" y="596"/>
+      <point x="912" y="551"/>
+      <point x="857" y="474" type="curve"/>
+      <point x="852" y="474" type="line"/>
+      <point x="824" y="550"/>
+      <point x="760" y="596"/>
+      <point x="668" y="596" type="curve" smooth="yes"/>
+      <point x="539" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="75"/>
+      <point x="121" y="-16"/>
     </contour>
     <contour>
-      <point x="801" y="45" type="line"/>
-      <point x="833" y="45" type="line"/>
-      <point x="883" y="323" type="line" smooth="yes"/>
-      <point x="902" y="426"/>
-      <point x="943" y="482"/>
-      <point x="1026" y="482" type="curve" smooth="yes"/>
-      <point x="1083" y="482"/>
-      <point x="1112" y="455"/>
-      <point x="1112" y="408" type="curve" smooth="yes"/>
-      <point x="1112" y="336"/>
-      <point x="1088" y="303"/>
-      <point x="930" y="161" type="curve" smooth="yes"/>
+      <point x="790" y="45" type="line"/>
+      <point x="823" y="45" type="line"/>
+      <point x="873" y="328" type="line" smooth="yes"/>
+      <point x="891" y="430"/>
+      <point x="941" y="482"/>
+      <point x="1015" y="482" type="curve" smooth="yes"/>
+      <point x="1070" y="482"/>
+      <point x="1103" y="452"/>
+      <point x="1103" y="402" type="curve" smooth="yes"/>
+      <point x="1103" y="338"/>
+      <point x="1078" y="304"/>
+      <point x="919" y="161" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="913" y="42" type="line"/>
-      <point x="1039" y="155" type="line" smooth="yes"/>
-      <point x="1134" y="240"/>
-      <point x="1194" y="311"/>
-      <point x="1194" y="396" type="curve" smooth="yes"/>
-      <point x="1194" y="467"/>
-      <point x="1147" y="516"/>
-      <point x="1046" y="516" type="curve"/>
-      <point x="1060" y="488" type="line"/>
-      <point x="1060" y="561" type="line"/>
-      <point x="1049" y="519" type="line"/>
-      <point x="1059" y="521"/>
-      <point x="1070" y="522"/>
-      <point x="1083" y="522" type="curve" smooth="yes"/>
-      <point x="1209" y="522"/>
-      <point x="1284" y="476"/>
-      <point x="1284" y="354" type="curve" smooth="yes"/>
-      <point x="1284" y="337"/>
-      <point x="1283" y="313"/>
-      <point x="1275" y="266" type="curve" smooth="yes"/>
-      <point x="1236" y="46" type="line"/>
-      <point x="1278" y="74" type="line"/>
-      <point x="900" y="74" type="line"/>
+      <point x="902" y="42" type="line"/>
+      <point x="1028" y="155" type="line" smooth="yes"/>
+      <point x="1139" y="255"/>
+      <point x="1183" y="321"/>
+      <point x="1183" y="394" type="curve" smooth="yes"/>
+      <point x="1183" y="477"/>
+      <point x="1132" y="528"/>
+      <point x="1043" y="528" type="curve"/>
+      <point x="1049" y="500" type="line"/>
+      <point x="1062" y="573" type="line"/>
+      <point x="1046" y="531" type="line"/>
+      <point x="1062" y="533"/>
+      <point x="1079" y="534"/>
+      <point x="1099" y="534" type="curve" smooth="yes"/>
+      <point x="1216" y="534"/>
+      <point x="1275" y="475"/>
+      <point x="1275" y="358" type="curve" smooth="yes"/>
+      <point x="1275" y="340"/>
+      <point x="1272" y="315"/>
+      <point x="1264" y="267" type="curve" smooth="yes"/>
+      <point x="1225" y="46" type="line"/>
+      <point x="1267" y="74" type="line"/>
+      <point x="889" y="74" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/g_na-malayalam.glif
@@ -1,70 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_na-malayalam" format="2">
   <advance width="1308"/>
-  <anchor x="852" y="0" name="bottom"/>
-  <anchor x="706" y="580" name="top"/>
-  <anchor x="1243" y="580" name="topright"/>
+  <anchor x="847" y="0" name="bottom"/>
+  <anchor x="701" y="580" name="top"/>
+  <anchor x="1238" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="243" y="-16" type="curve" smooth="yes"/>
-      <point x="363" y="-16"/>
-      <point x="439" y="58"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="524" y="362" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="596" y="512"/>
-      <point x="679" y="512" type="curve" smooth="yes"/>
-      <point x="754" y="512"/>
-      <point x="800" y="472"/>
-      <point x="800" y="390" type="curve" smooth="yes"/>
-      <point x="800" y="363"/>
-      <point x="797" y="337"/>
-      <point x="793" y="313" type="curve" smooth="yes"/>
-      <point x="738" y="0" type="line"/>
-      <point x="822" y="0" type="line"/>
-      <point x="881" y="337" type="line" smooth="yes"/>
-      <point x="901" y="451"/>
-      <point x="969" y="518"/>
-      <point x="1058" y="518" type="curve" smooth="yes"/>
-      <point x="1148" y="518"/>
-      <point x="1198" y="461"/>
-      <point x="1198" y="358" type="curve" smooth="yes"/>
-      <point x="1198" y="241"/>
-      <point x="1147" y="147"/>
-      <point x="1029" y="49" type="curve"/>
-      <point x="1082" y="-16" type="line"/>
-      <point x="1217" y="98"/>
-      <point x="1282" y="219"/>
-      <point x="1282" y="358" type="curve" smooth="yes"/>
-      <point x="1282" y="508"/>
-      <point x="1203" y="596"/>
-      <point x="1066" y="596" type="curve" smooth="yes"/>
-      <point x="978" y="596"/>
-      <point x="906" y="555"/>
-      <point x="858" y="479" type="curve"/>
-      <point x="853" y="479" type="line"/>
-      <point x="828" y="555"/>
-      <point x="767" y="596"/>
-      <point x="680" y="596" type="curve" smooth="yes"/>
-      <point x="554" y="596"/>
-      <point x="478" y="526"/>
-      <point x="432" y="354" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="369" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="72"/>
-      <point x="115" y="-16"/>
+      <point x="253" y="-16" type="curve" smooth="yes"/>
+      <point x="380" y="-16"/>
+      <point x="468" y="70"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="454"/>
+      <point x="581" y="518"/>
+      <point x="670" y="518" type="curve" smooth="yes"/>
+      <point x="751" y="518"/>
+      <point x="795" y="469"/>
+      <point x="795" y="390" type="curve" smooth="yes"/>
+      <point x="795" y="363"/>
+      <point x="792" y="337"/>
+      <point x="788" y="313" type="curve" smooth="yes"/>
+      <point x="733" y="0" type="line"/>
+      <point x="817" y="0" type="line"/>
+      <point x="876" y="336" type="line" smooth="yes"/>
+      <point x="896" y="450"/>
+      <point x="961" y="518"/>
+      <point x="1047" y="518" type="curve" smooth="yes"/>
+      <point x="1137" y="518"/>
+      <point x="1187" y="461"/>
+      <point x="1187" y="358" type="curve" smooth="yes"/>
+      <point x="1187" y="241"/>
+      <point x="1136" y="147"/>
+      <point x="1018" y="49" type="curve"/>
+      <point x="1071" y="-16" type="line"/>
+      <point x="1206" y="98"/>
+      <point x="1271" y="219"/>
+      <point x="1271" y="358" type="curve" smooth="yes"/>
+      <point x="1271" y="508"/>
+      <point x="1192" y="596"/>
+      <point x="1055" y="596" type="curve" smooth="yes"/>
+      <point x="971" y="596"/>
+      <point x="897" y="553"/>
+      <point x="853" y="479" type="curve"/>
+      <point x="848" y="479" type="line"/>
+      <point x="822" y="550"/>
+      <point x="764" y="596"/>
+      <point x="666" y="596" type="curve" smooth="yes"/>
+      <point x="538" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="75"/>
+      <point x="121" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ga-malayalam.glif
@@ -2,51 +2,55 @@
 <glyph name="ga-malayalam" format="2">
   <advance width="910"/>
   <unicode hex="0D17"/>
-  <anchor x="456" y="0" name="bottom"/>
-  <anchor x="515" y="580" name="top"/>
-  <anchor x="819" y="580" name="topright"/>
+  <anchor x="451" y="0" name="bottom"/>
+  <anchor x="510" y="580" name="top"/>
+  <anchor x="814" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="243" y="-16" type="curve" smooth="yes"/>
-      <point x="363" y="-16"/>
-      <point x="440" y="58"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="603" y="516"/>
-      <point x="683" y="516" type="curve" smooth="yes"/>
-      <point x="762" y="516"/>
-      <point x="804" y="465"/>
-      <point x="804" y="369" type="curve" smooth="yes"/>
-      <point x="804" y="252"/>
-      <point x="745" y="143"/>
-      <point x="628" y="45" type="curve"/>
-      <point x="683" y="-16" type="line"/>
-      <point x="812" y="90"/>
-      <point x="886" y="230"/>
-      <point x="886" y="369" type="curve" smooth="yes"/>
-      <point x="886" y="511"/>
-      <point x="811" y="596"/>
-      <point x="685" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="477" y="517"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="72"/>
-      <point x="115" y="-16"/>
+      <point x="253" y="-16" type="curve" smooth="yes"/>
+      <point x="380" y="-16"/>
+      <point x="468" y="70"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="580" y="514"/>
+      <point x="668" y="514" type="curve" smooth="yes"/>
+      <point x="749" y="514"/>
+      <point x="793" y="462"/>
+      <point x="793" y="367" type="curve" smooth="yes"/>
+      <point x="793" y="253"/>
+      <point x="734" y="141"/>
+      <point x="623" y="46" type="curve"/>
+      <point x="678" y="-16" type="line"/>
+      <point x="798" y="87"/>
+      <point x="877" y="239"/>
+      <point x="877" y="369" type="curve" smooth="yes"/>
+      <point x="877" y="511"/>
+      <point x="798" y="596"/>
+      <point x="668" y="596" type="curve" smooth="yes"/>
+      <point x="538" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="75"/>
+      <point x="121" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ga-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="910"/>
   <outline>
     <component base="ga-malayalam"/>
-    <component base="halant-malayalam" xOffset="746"/>
+    <component base="halant-malayalam" xOffset="741"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/j_ja-malayalam.glif
@@ -1,231 +1,230 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1602"/>
-  <anchor x="1163" y="0" name="bottom"/>
-  <anchor x="845" y="580" name="top"/>
-  <anchor x="1533" y="580" name="topright"/>
+  <advance width="1668"/>
+  <anchor x="1207" y="0" name="bottom"/>
+  <anchor x="885" y="580" name="top"/>
+  <anchor x="1578" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="307" y="-16" type="curve" smooth="yes"/>
-      <point x="570" y="-16"/>
-      <point x="745" y="95"/>
-      <point x="859" y="317" type="curve"/>
-      <point x="882" y="374" type="line"/>
-      <point x="887" y="374" type="line"/>
-      <point x="896" y="328"/>
-      <point x="935" y="294"/>
-      <point x="1003" y="294" type="curve" smooth="yes"/>
-      <point x="1085" y="294"/>
-      <point x="1138" y="340"/>
-      <point x="1138" y="413" type="curve" smooth="yes"/>
-      <point x="1138" y="477"/>
-      <point x="1100" y="515"/>
-      <point x="1037" y="515" type="curve" smooth="yes"/>
-      <point x="1016" y="515"/>
-      <point x="994" y="511"/>
-      <point x="976" y="505" type="curve"/>
-      <point x="965" y="528" type="line"/>
-      <point x="966" y="503" type="line"/>
-      <point x="989" y="524"/>
-      <point x="1027" y="536"/>
-      <point x="1069" y="536" type="curve" smooth="yes"/>
-      <point x="1149" y="536"/>
-      <point x="1190" y="494"/>
-      <point x="1190" y="411" type="curve" smooth="yes"/>
-      <point x="1190" y="394"/>
-      <point x="1187" y="373"/>
-      <point x="1184" y="354" type="curve" smooth="yes"/>
-      <point x="1182" y="343" type="line"/>
-      <point x="1266" y="343" type="line"/>
-      <point x="1274" y="387" type="line" smooth="yes"/>
-      <point x="1289" y="470"/>
-      <point x="1341" y="518"/>
-      <point x="1415" y="518" type="curve" smooth="yes"/>
-      <point x="1473" y="518"/>
-      <point x="1503" y="486"/>
-      <point x="1503" y="423" type="curve" smooth="yes"/>
-      <point x="1503" y="336"/>
-      <point x="1444" y="287"/>
-      <point x="1339" y="287" type="curve" smooth="yes"/>
-      <point x="1031" y="287" type="line" smooth="yes"/>
-      <point x="903" y="287"/>
-      <point x="823" y="225"/>
-      <point x="823" y="122" type="curve" smooth="yes"/>
-      <point x="823" y="34"/>
-      <point x="874" y="-16"/>
-      <point x="974" y="-16" type="curve" smooth="yes"/>
-      <point x="1018" y="-16"/>
-      <point x="1064" y="-5"/>
-      <point x="1157" y="52" type="curve" smooth="yes"/>
-      <point x="1220" y="91" type="line"/>
-      <point x="1328" y="158" type="line"/>
-      <point x="1349" y="158" type="line"/>
-      <point x="1374" y="166"/>
-      <point x="1390" y="167"/>
-      <point x="1407" y="167" type="curve" smooth="yes"/>
-      <point x="1442" y="167"/>
-      <point x="1459" y="149"/>
-      <point x="1459" y="114" type="curve" smooth="yes"/>
-      <point x="1459" y="73"/>
-      <point x="1436" y="48"/>
-      <point x="1397" y="48" type="curve" smooth="yes"/>
-      <point x="1364" y="48"/>
-      <point x="1344" y="67"/>
-      <point x="1344" y="99" type="curve" smooth="yes"/>
-      <point x="1344" y="131"/>
-      <point x="1359" y="159"/>
-      <point x="1391" y="185" type="curve"/>
-      <point x="1270" y="162" type="line"/>
-      <point x="1305" y="113" type="line"/>
-      <point x="1316" y="156" type="line"/>
-      <point x="1295" y="135"/>
-      <point x="1284" y="109"/>
-      <point x="1284" y="80" type="curve" smooth="yes"/>
-      <point x="1284" y="22"/>
-      <point x="1327" y="-16"/>
-      <point x="1394" y="-16" type="curve" smooth="yes"/>
-      <point x="1476" y="-16"/>
-      <point x="1526" y="35"/>
-      <point x="1526" y="121" type="curve" smooth="yes"/>
-      <point x="1526" y="189"/>
-      <point x="1484" y="233"/>
-      <point x="1419" y="233" type="curve" smooth="yes"/>
-      <point x="1373" y="233"/>
-      <point x="1328" y="230"/>
-      <point x="1214" y="162" type="curve" smooth="yes"/>
-      <point x="1135" y="115" type="line" smooth="yes"/>
-      <point x="1061" y="71"/>
-      <point x="1019" y="61"/>
-      <point x="978" y="61" type="curve" smooth="yes"/>
-      <point x="927" y="61"/>
-      <point x="903" y="86"/>
-      <point x="903" y="126" type="curve" smooth="yes"/>
-      <point x="903" y="184"/>
-      <point x="949" y="215"/>
-      <point x="1028" y="215" type="curve" smooth="yes"/>
-      <point x="1335" y="215" type="line" smooth="yes"/>
-      <point x="1483" y="215"/>
-      <point x="1587" y="301"/>
-      <point x="1587" y="423" type="curve" smooth="yes"/>
-      <point x="1587" y="529"/>
-      <point x="1522" y="596"/>
-      <point x="1421" y="596" type="curve" smooth="yes"/>
-      <point x="1342" y="596"/>
-      <point x="1283" y="557"/>
-      <point x="1245" y="478" type="curve"/>
-      <point x="1240" y="478" type="line"/>
-      <point x="1229" y="553"/>
-      <point x="1169" y="596"/>
-      <point x="1072" y="596" type="curve" smooth="yes"/>
-      <point x="980" y="596"/>
-      <point x="911" y="560"/>
-      <point x="860" y="459" type="curve" smooth="yes"/>
-      <point x="813" y="366" type="line" smooth="yes"/>
-      <point x="693" y="129"/>
-      <point x="529" y="61"/>
-      <point x="320" y="61" type="curve" smooth="yes"/>
-      <point x="157" y="61"/>
-      <point x="101" y="97"/>
-      <point x="101" y="149" type="curve" smooth="yes"/>
-      <point x="101" y="194"/>
-      <point x="141" y="215"/>
-      <point x="216" y="215" type="curve" smooth="yes"/>
-      <point x="533" y="215" type="line" smooth="yes"/>
-      <point x="681" y="215"/>
-      <point x="785" y="301"/>
-      <point x="785" y="433" type="curve" smooth="yes"/>
-      <point x="785" y="539"/>
-      <point x="720" y="596"/>
-      <point x="622" y="596" type="curve" smooth="yes"/>
-      <point x="548" y="596"/>
-      <point x="485" y="563"/>
-      <point x="451" y="478" type="curve"/>
-      <point x="446" y="478" type="line"/>
-      <point x="431" y="553"/>
-      <point x="378" y="596"/>
-      <point x="282" y="596" type="curve" smooth="yes"/>
-      <point x="159" y="596"/>
-      <point x="69" y="525"/>
-      <point x="69" y="427" type="curve" smooth="yes"/>
-      <point x="69" y="344"/>
-      <point x="123" y="294"/>
-      <point x="212" y="294" type="curve" smooth="yes"/>
-      <point x="294" y="294"/>
-      <point x="347" y="340"/>
-      <point x="347" y="413" type="curve" smooth="yes"/>
-      <point x="347" y="477"/>
-      <point x="309" y="515"/>
-      <point x="246" y="515" type="curve" smooth="yes"/>
-      <point x="225" y="515"/>
-      <point x="203" y="511"/>
-      <point x="185" y="505" type="curve"/>
-      <point x="174" y="528" type="line"/>
-      <point x="175" y="503" type="line"/>
-      <point x="198" y="524"/>
-      <point x="236" y="536"/>
-      <point x="278" y="536" type="curve" smooth="yes"/>
-      <point x="358" y="536"/>
-      <point x="396" y="494"/>
-      <point x="396" y="411" type="curve" smooth="yes"/>
-      <point x="396" y="394"/>
-      <point x="393" y="373"/>
-      <point x="390" y="354" type="curve" smooth="yes"/>
-      <point x="388" y="343" type="line"/>
-      <point x="472" y="343" type="line"/>
-      <point x="480" y="387" type="line" smooth="yes"/>
-      <point x="495" y="470"/>
-      <point x="543" y="518"/>
-      <point x="609" y="518" type="curve" smooth="yes"/>
-      <point x="671" y="518"/>
-      <point x="701" y="486"/>
-      <point x="701" y="433" type="curve" smooth="yes"/>
-      <point x="701" y="336"/>
-      <point x="642" y="287"/>
-      <point x="537" y="287" type="curve" smooth="yes"/>
-      <point x="219" y="287" type="line" smooth="yes"/>
-      <point x="95" y="287"/>
-      <point x="21" y="235"/>
-      <point x="21" y="144" type="curve" smooth="yes"/>
-      <point x="21" y="51"/>
-      <point x="100" y="-16"/>
+      <point x="257" y="-16" type="curve" smooth="yes"/>
+      <point x="553" y="-16"/>
+      <point x="748" y="83"/>
+      <point x="879" y="284" type="curve"/>
+      <point x="902" y="344" type="line"/>
+      <point x="907" y="344" type="line"/>
+      <point x="915" y="304"/>
+      <point x="949" y="273"/>
+      <point x="1012" y="273" type="curve" smooth="yes"/>
+      <point x="1122" y="273"/>
+      <point x="1168" y="357"/>
+      <point x="1168" y="414" type="curve" smooth="yes"/>
+      <point x="1168" y="478"/>
+      <point x="1133" y="515"/>
+      <point x="1069" y="515" type="curve" smooth="yes"/>
+      <point x="1044" y="515"/>
+      <point x="1028" y="512"/>
+      <point x="1007" y="505" type="curve"/>
+      <point x="997" y="523" type="line"/>
+      <point x="982" y="494" type="line"/>
+      <point x="1019" y="522"/>
+      <point x="1058" y="536"/>
+      <point x="1118" y="536" type="curve" smooth="yes"/>
+      <point x="1195" y="536"/>
+      <point x="1234" y="497"/>
+      <point x="1234" y="425" type="curve" smooth="yes"/>
+      <point x="1234" y="409"/>
+      <point x="1232" y="392"/>
+      <point x="1229" y="375" type="curve" smooth="yes"/>
+      <point x="1220" y="324" type="line"/>
+      <point x="1304" y="324" type="line"/>
+      <point x="1313" y="375" type="line" smooth="yes"/>
+      <point x="1328" y="464"/>
+      <point x="1385" y="518"/>
+      <point x="1465" y="518" type="curve" smooth="yes"/>
+      <point x="1531" y="518"/>
+      <point x="1567" y="484"/>
+      <point x="1567" y="422" type="curve" smooth="yes"/>
+      <point x="1567" y="321"/>
+      <point x="1491" y="267"/>
+      <point x="1368" y="267" type="curve" smooth="yes"/>
+      <point x="1025" y="267" type="line" smooth="yes"/>
+      <point x="890" y="267"/>
+      <point x="835" y="181"/>
+      <point x="835" y="114" type="curve" smooth="yes"/>
+      <point x="835" y="39"/>
+      <point x="894" y="-16"/>
+      <point x="978" y="-16" type="curve" smooth="yes"/>
+      <point x="1025" y="-16"/>
+      <point x="1062" y="-4"/>
+      <point x="1148" y="35" type="curve" smooth="yes"/>
+      <point x="1276" y="93" type="line"/>
+      <point x="1351" y="141" type="line"/>
+      <point x="1388" y="153" type="line"/>
+      <point x="1416" y="170"/>
+      <point x="1436" y="176"/>
+      <point x="1465" y="176" type="curve" smooth="yes"/>
+      <point x="1501" y="176"/>
+      <point x="1522" y="155"/>
+      <point x="1522" y="121" type="curve" smooth="yes"/>
+      <point x="1522" y="91"/>
+      <point x="1501" y="54"/>
+      <point x="1449" y="54" type="curve" smooth="yes"/>
+      <point x="1412" y="54"/>
+      <point x="1391" y="74"/>
+      <point x="1391" y="110" type="curve" smooth="yes"/>
+      <point x="1391" y="134"/>
+      <point x="1401" y="159"/>
+      <point x="1422" y="180" type="curve"/>
+      <point x="1330" y="145" type="line"/>
+      <point x="1346" y="131" type="line"/>
+      <point x="1339" y="117"/>
+      <point x="1335" y="101"/>
+      <point x="1335" y="85" type="curve" smooth="yes"/>
+      <point x="1335" y="24"/>
+      <point x="1377" y="-16"/>
+      <point x="1446" y="-16" type="curve" smooth="yes"/>
+      <point x="1550" y="-16"/>
+      <point x="1594" y="67"/>
+      <point x="1594" y="125" type="curve" smooth="yes"/>
+      <point x="1594" y="189"/>
+      <point x="1554" y="236"/>
+      <point x="1480" y="236" type="curve" smooth="yes"/>
+      <point x="1441" y="236"/>
+      <point x="1395" y="221"/>
+      <point x="1315" y="185" type="curve" smooth="yes"/>
+      <point x="1127" y="100" type="line" smooth="yes"/>
+      <point x="1066" y="72"/>
+      <point x="1029" y="60"/>
+      <point x="989" y="60" type="curve" smooth="yes"/>
+      <point x="943" y="60"/>
+      <point x="917" y="85"/>
+      <point x="917" y="120" type="curve" smooth="yes"/>
+      <point x="917" y="158"/>
+      <point x="947" y="195"/>
+      <point x="1021" y="195" type="curve" smooth="yes"/>
+      <point x="1343" y="195" type="line" smooth="yes"/>
+      <point x="1513" y="195"/>
+      <point x="1650" y="283"/>
+      <point x="1650" y="436" type="curve" smooth="yes"/>
+      <point x="1650" y="532"/>
+      <point x="1594" y="596"/>
+      <point x="1486" y="596" type="curve" smooth="yes"/>
+      <point x="1399" y="596"/>
+      <point x="1329" y="552"/>
+      <point x="1292" y="475" type="curve"/>
+      <point x="1287" y="475" type="line"/>
+      <point x="1275" y="552"/>
+      <point x="1215" y="596"/>
+      <point x="1123" y="596" type="curve" smooth="yes"/>
+      <point x="1017" y="596"/>
+      <point x="932" y="546"/>
+      <point x="883" y="447" type="curve" smooth="yes"/>
+      <point x="844" y="369" type="line" smooth="yes"/>
+      <point x="740" y="159"/>
+      <point x="557" y="61"/>
+      <point x="265" y="61" type="curve" smooth="yes"/>
+      <point x="144" y="61"/>
+      <point x="99" y="84"/>
+      <point x="99" y="131" type="curve" smooth="yes"/>
+      <point x="99" y="165"/>
+      <point x="125" y="195"/>
+      <point x="192" y="195" type="curve" smooth="yes"/>
+      <point x="485" y="195" type="line" smooth="yes"/>
+      <point x="655" y="195"/>
+      <point x="789" y="285"/>
+      <point x="789" y="435" type="curve" smooth="yes"/>
+      <point x="789" y="529"/>
+      <point x="743" y="596"/>
+      <point x="648" y="596" type="curve" smooth="yes"/>
+      <point x="569" y="596"/>
+      <point x="504" y="552"/>
+      <point x="472" y="475" type="curve"/>
+      <point x="467" y="475" type="line"/>
+      <point x="455" y="552"/>
+      <point x="395" y="596"/>
+      <point x="303" y="596" type="curve" smooth="yes"/>
+      <point x="142" y="596"/>
+      <point x="64" y="488"/>
+      <point x="64" y="399" type="curve" smooth="yes"/>
+      <point x="64" y="324"/>
+      <point x="114" y="273"/>
+      <point x="192" y="273" type="curve" smooth="yes"/>
+      <point x="302" y="273"/>
+      <point x="348" y="357"/>
+      <point x="348" y="414" type="curve" smooth="yes"/>
+      <point x="348" y="478"/>
+      <point x="313" y="515"/>
+      <point x="249" y="515" type="curve" smooth="yes"/>
+      <point x="224" y="515"/>
+      <point x="208" y="512"/>
+      <point x="187" y="505" type="curve"/>
+      <point x="177" y="523" type="line"/>
+      <point x="162" y="494" type="line"/>
+      <point x="199" y="522"/>
+      <point x="238" y="536"/>
+      <point x="298" y="536" type="curve" smooth="yes"/>
+      <point x="375" y="536"/>
+      <point x="414" y="497"/>
+      <point x="414" y="425" type="curve" smooth="yes"/>
+      <point x="414" y="409"/>
+      <point x="412" y="392"/>
+      <point x="409" y="375" type="curve" smooth="yes"/>
+      <point x="400" y="324" type="line"/>
+      <point x="484" y="324" type="line"/>
+      <point x="493" y="375" type="line" smooth="yes"/>
+      <point x="508" y="464"/>
+      <point x="555" y="518"/>
+      <point x="629" y="518" type="curve" smooth="yes"/>
+      <point x="684" y="518"/>
+      <point x="711" y="488"/>
+      <point x="711" y="431" type="curve" smooth="yes"/>
+      <point x="711" y="329"/>
+      <point x="629" y="267"/>
+      <point x="490" y="267" type="curve" smooth="yes"/>
+      <point x="196" y="267" type="line" smooth="yes"/>
+      <point x="68" y="267"/>
+      <point x="15" y="194"/>
+      <point x="15" y="126" type="curve" smooth="yes"/>
+      <point x="15" y="42"/>
+      <point x="83" y="-16"/>
     </contour>
     <contour>
-      <point x="214" y="357" type="curve" smooth="yes"/>
-      <point x="171" y="357"/>
-      <point x="146" y="383"/>
-      <point x="146" y="427" type="curve" smooth="yes"/>
-      <point x="146" y="449"/>
-      <point x="151" y="467"/>
-      <point x="161" y="481" type="curve"/>
-      <point x="137" y="481" type="line"/>
-      <point x="114" y="431" type="line"/>
-      <point x="144" y="455"/>
-      <point x="176" y="467"/>
-      <point x="210" y="467" type="curve" smooth="yes"/>
-      <point x="253" y="467"/>
-      <point x="275" y="449"/>
-      <point x="275" y="412" type="curve" smooth="yes"/>
-      <point x="275" y="379"/>
-      <point x="251" y="357"/>
+      <point x="196" y="341" type="curve" smooth="yes"/>
+      <point x="158" y="341"/>
+      <point x="132" y="368"/>
+      <point x="132" y="406" type="curve" smooth="yes"/>
+      <point x="132" y="429"/>
+      <point x="137" y="449"/>
+      <point x="150" y="475" type="curve"/>
+      <point x="131" y="475" type="line"/>
+      <point x="116" y="425" type="line"/>
+      <point x="143" y="451"/>
+      <point x="182" y="467"/>
+      <point x="217" y="467" type="curve" smooth="yes"/>
+      <point x="255" y="467"/>
+      <point x="273" y="448"/>
+      <point x="273" y="413" type="curve" smooth="yes"/>
+      <point x="273" y="382"/>
+      <point x="254" y="341"/>
     </contour>
     <contour>
-      <point x="1005" y="357" type="curve" smooth="yes"/>
-      <point x="962" y="357"/>
-      <point x="937" y="383"/>
-      <point x="937" y="427" type="curve" smooth="yes"/>
-      <point x="937" y="449"/>
-      <point x="942" y="467"/>
-      <point x="952" y="481" type="curve"/>
-      <point x="928" y="481" type="line"/>
-      <point x="905" y="431" type="line"/>
-      <point x="935" y="455"/>
-      <point x="967" y="467"/>
-      <point x="1001" y="467" type="curve" smooth="yes"/>
-      <point x="1044" y="467"/>
-      <point x="1066" y="449"/>
-      <point x="1066" y="412" type="curve" smooth="yes"/>
-      <point x="1066" y="379"/>
-      <point x="1042" y="357"/>
+      <point x="1016" y="341" type="curve" smooth="yes"/>
+      <point x="978" y="341"/>
+      <point x="952" y="368"/>
+      <point x="952" y="406" type="curve" smooth="yes"/>
+      <point x="952" y="429"/>
+      <point x="957" y="449"/>
+      <point x="970" y="475" type="curve"/>
+      <point x="951" y="475" type="line"/>
+      <point x="936" y="425" type="line"/>
+      <point x="963" y="451"/>
+      <point x="1002" y="467"/>
+      <point x="1037" y="467" type="curve" smooth="yes"/>
+      <point x="1075" y="467"/>
+      <point x="1093" y="448"/>
+      <point x="1093" y="413" type="curve" smooth="yes"/>
+      <point x="1093" y="382"/>
+      <point x="1074" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/j_nya-malayalam.glif
@@ -1,194 +1,194 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2195"/>
-  <anchor x="1787" y="0" name="bottom"/>
-  <anchor x="1092" y="580" name="top"/>
-  <anchor x="2060" y="580" name="topright"/>
+  <advance width="2228"/>
+  <anchor x="1768" y="0" name="bottom"/>
+  <anchor x="1165" y="580" name="top"/>
+  <anchor x="2143" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="314" y="-16" type="curve" smooth="yes"/>
-      <point x="547" y="-16"/>
-      <point x="673" y="43"/>
-      <point x="787" y="188" type="curve"/>
-      <point x="834" y="188" type="line"/>
-      <point x="798" y="244" type="line"/>
-      <point x="794" y="226"/>
-      <point x="792" y="207"/>
-      <point x="792" y="189" type="curve" smooth="yes"/>
-      <point x="792" y="82"/>
-      <point x="857" y="-16"/>
-      <point x="986" y="-16" type="curve" smooth="yes"/>
-      <point x="1095" y="-16"/>
-      <point x="1171" y="67"/>
-      <point x="1171" y="187" type="curve" smooth="yes"/>
-      <point x="1171" y="277"/>
-      <point x="1110" y="336"/>
-      <point x="1015" y="336" type="curve" smooth="yes"/>
-      <point x="959" y="336"/>
-      <point x="908" y="314"/>
-      <point x="870" y="275" type="curve"/>
-      <point x="840" y="283" type="line"/>
-      <point x="840" y="143" type="line"/>
-      <point x="869" y="219"/>
-      <point x="928" y="267"/>
-      <point x="994" y="267" type="curve" smooth="yes"/>
-      <point x="1053" y="267"/>
-      <point x="1088" y="235"/>
-      <point x="1088" y="181" type="curve" smooth="yes"/>
-      <point x="1088" y="109"/>
-      <point x="1048" y="62"/>
-      <point x="985" y="62" type="curve" smooth="yes"/>
-      <point x="903" y="62"/>
-      <point x="862" y="120"/>
-      <point x="862" y="225" type="curve" smooth="yes"/>
-      <point x="862" y="399"/>
-      <point x="961" y="518"/>
-      <point x="1106" y="518" type="curve" smooth="yes"/>
-      <point x="1219" y="518"/>
-      <point x="1276" y="457"/>
-      <point x="1276" y="360" type="curve" smooth="yes"/>
-      <point x="1276" y="343"/>
-      <point x="1273" y="314"/>
-      <point x="1268" y="285" type="curve" smooth="yes"/>
-      <point x="1218" y="0" type="line"/>
-      <point x="1302" y="0" type="line"/>
-      <point x="1361" y="336" type="line" smooth="yes"/>
-      <point x="1383" y="459"/>
-      <point x="1453" y="518"/>
-      <point x="1569" y="518" type="curve" smooth="yes"/>
-      <point x="1730" y="518"/>
-      <point x="1806" y="430"/>
-      <point x="1806" y="272" type="curve" smooth="yes"/>
-      <point x="1806" y="168"/>
-      <point x="1765" y="64"/>
-      <point x="1670" y="64" type="curve" smooth="yes"/>
-      <point x="1603" y="64"/>
-      <point x="1565" y="105"/>
-      <point x="1565" y="196" type="curve" smooth="yes"/>
-      <point x="1565" y="361"/>
-      <point x="1694" y="518"/>
-      <point x="1881" y="518" type="curve" smooth="yes"/>
-      <point x="2000" y="518"/>
-      <point x="2079" y="458"/>
-      <point x="2079" y="342" type="curve" smooth="yes"/>
-      <point x="2079" y="217"/>
-      <point x="2017" y="131"/>
-      <point x="1921" y="44" type="curve"/>
-      <point x="1982" y="-14" type="line"/>
-      <point x="2093" y="86"/>
-      <point x="2162" y="196"/>
-      <point x="2162" y="336" type="curve" smooth="yes"/>
-      <point x="2162" y="510"/>
-      <point x="2057" y="596"/>
-      <point x="1891" y="596" type="curve" smooth="yes"/>
-      <point x="1662" y="596"/>
-      <point x="1483" y="413"/>
-      <point x="1483" y="191" type="curve" smooth="yes"/>
-      <point x="1483" y="60"/>
-      <point x="1547" y="-16"/>
-      <point x="1666" y="-16" type="curve" smooth="yes"/>
-      <point x="1806" y="-16"/>
-      <point x="1887" y="108"/>
-      <point x="1887" y="273" type="curve" smooth="yes"/>
-      <point x="1887" y="471"/>
-      <point x="1769" y="596"/>
-      <point x="1577" y="596" type="curve" smooth="yes"/>
-      <point x="1463" y="596"/>
-      <point x="1383" y="554"/>
-      <point x="1332" y="470" type="curve"/>
-      <point x="1327" y="470" type="line"/>
-      <point x="1289" y="556"/>
-      <point x="1214" y="596"/>
-      <point x="1107" y="596" type="curve" smooth="yes"/>
-      <point x="978" y="596"/>
-      <point x="879" y="538"/>
-      <point x="802" y="365" type="curve" smooth="yes"/>
-      <point x="690" y="113"/>
-      <point x="540" y="61"/>
-      <point x="317" y="61" type="curve" smooth="yes"/>
-      <point x="157" y="61"/>
-      <point x="101" y="97"/>
-      <point x="101" y="149" type="curve" smooth="yes"/>
-      <point x="101" y="194"/>
-      <point x="141" y="215"/>
-      <point x="216" y="215" type="curve" smooth="yes"/>
-      <point x="521" y="215" type="line" smooth="yes"/>
-      <point x="669" y="215"/>
-      <point x="773" y="301"/>
-      <point x="773" y="433" type="curve" smooth="yes"/>
-      <point x="773" y="539"/>
-      <point x="708" y="596"/>
-      <point x="616" y="596" type="curve" smooth="yes"/>
-      <point x="548" y="596"/>
-      <point x="489" y="562"/>
-      <point x="454" y="478" type="curve"/>
-      <point x="449" y="478" type="line"/>
-      <point x="438" y="553"/>
-      <point x="378" y="596"/>
-      <point x="282" y="596" type="curve" smooth="yes"/>
-      <point x="159" y="596"/>
-      <point x="69" y="525"/>
-      <point x="69" y="427" type="curve" smooth="yes"/>
-      <point x="69" y="344"/>
-      <point x="123" y="294"/>
-      <point x="212" y="294" type="curve" smooth="yes"/>
-      <point x="294" y="294"/>
-      <point x="347" y="340"/>
-      <point x="347" y="413" type="curve" smooth="yes"/>
-      <point x="347" y="477"/>
-      <point x="309" y="515"/>
-      <point x="246" y="515" type="curve" smooth="yes"/>
-      <point x="225" y="515"/>
-      <point x="203" y="511"/>
-      <point x="185" y="505" type="curve"/>
-      <point x="174" y="528" type="line"/>
-      <point x="175" y="503" type="line"/>
-      <point x="198" y="524"/>
-      <point x="236" y="536"/>
-      <point x="278" y="536" type="curve" smooth="yes"/>
-      <point x="358" y="536"/>
-      <point x="396" y="494"/>
-      <point x="396" y="411" type="curve" smooth="yes"/>
-      <point x="396" y="394"/>
-      <point x="393" y="373"/>
-      <point x="390" y="354" type="curve" smooth="yes"/>
-      <point x="388" y="343" type="line"/>
-      <point x="472" y="343" type="line"/>
-      <point x="480" y="387" type="line" smooth="yes"/>
-      <point x="495" y="470"/>
-      <point x="543" y="518"/>
-      <point x="603" y="518" type="curve" smooth="yes"/>
-      <point x="659" y="518"/>
-      <point x="689" y="486"/>
-      <point x="689" y="433" type="curve" smooth="yes"/>
-      <point x="689" y="336"/>
-      <point x="630" y="287"/>
-      <point x="525" y="287" type="curve" smooth="yes"/>
-      <point x="219" y="287" type="line" smooth="yes"/>
-      <point x="95" y="287"/>
-      <point x="21" y="235"/>
-      <point x="21" y="144" type="curve" smooth="yes"/>
-      <point x="21" y="51"/>
-      <point x="100" y="-16"/>
+      <point x="257" y="-16" type="curve" smooth="yes"/>
+      <point x="530" y="-16"/>
+      <point x="696" y="48"/>
+      <point x="817" y="200" type="curve"/>
+      <point x="864" y="200" type="line"/>
+      <point x="830" y="244" type="line"/>
+      <point x="825" y="226"/>
+      <point x="822" y="207"/>
+      <point x="822" y="189" type="curve" smooth="yes"/>
+      <point x="822" y="73"/>
+      <point x="889" y="-16"/>
+      <point x="1004" y="-16" type="curve" smooth="yes"/>
+      <point x="1146" y="-16"/>
+      <point x="1210" y="99"/>
+      <point x="1210" y="195" type="curve" smooth="yes"/>
+      <point x="1210" y="287"/>
+      <point x="1155" y="347"/>
+      <point x="1062" y="347" type="curve" smooth="yes"/>
+      <point x="998" y="347"/>
+      <point x="945" y="321"/>
+      <point x="903" y="275" type="curve"/>
+      <point x="872" y="281" type="line"/>
+      <point x="872" y="126" type="line"/>
+      <point x="904" y="216"/>
+      <point x="969" y="273"/>
+      <point x="1042" y="273" type="curve" smooth="yes"/>
+      <point x="1103" y="273"/>
+      <point x="1128" y="242"/>
+      <point x="1128" y="189" type="curve" smooth="yes"/>
+      <point x="1128" y="132"/>
+      <point x="1093" y="62"/>
+      <point x="1008" y="62" type="curve" smooth="yes"/>
+      <point x="937" y="62"/>
+      <point x="894" y="115"/>
+      <point x="894" y="223" type="curve" smooth="yes"/>
+      <point x="894" y="389"/>
+      <point x="1018" y="518"/>
+      <point x="1147" y="518" type="curve" smooth="yes"/>
+      <point x="1258" y="518"/>
+      <point x="1308" y="460"/>
+      <point x="1308" y="369" type="curve" smooth="yes"/>
+      <point x="1308" y="347"/>
+      <point x="1306" y="317"/>
+      <point x="1300" y="285" type="curve" smooth="yes"/>
+      <point x="1250" y="0" type="line"/>
+      <point x="1334" y="0" type="line"/>
+      <point x="1388" y="306" type="line" smooth="yes"/>
+      <point x="1412" y="443"/>
+      <point x="1484" y="518"/>
+      <point x="1605" y="518" type="curve" smooth="yes"/>
+      <point x="1762" y="518"/>
+      <point x="1836" y="423"/>
+      <point x="1836" y="252" type="curve" smooth="yes"/>
+      <point x="1836" y="172"/>
+      <point x="1808" y="64"/>
+      <point x="1709" y="64" type="curve" smooth="yes"/>
+      <point x="1641" y="64"/>
+      <point x="1598" y="112"/>
+      <point x="1598" y="201" type="curve" smooth="yes"/>
+      <point x="1598" y="347"/>
+      <point x="1728" y="518"/>
+      <point x="1913" y="518" type="curve" smooth="yes"/>
+      <point x="2034" y="518"/>
+      <point x="2106" y="449"/>
+      <point x="2106" y="335" type="curve" smooth="yes"/>
+      <point x="2106" y="233"/>
+      <point x="2059" y="135"/>
+      <point x="1965" y="41" type="curve"/>
+      <point x="2024" y="-16" type="line"/>
+      <point x="2136" y="96"/>
+      <point x="2188" y="208"/>
+      <point x="2188" y="336" type="curve" smooth="yes"/>
+      <point x="2188" y="502"/>
+      <point x="2091" y="596"/>
+      <point x="1922" y="596" type="curve" smooth="yes"/>
+      <point x="1701" y="596"/>
+      <point x="1516" y="402"/>
+      <point x="1516" y="197" type="curve" smooth="yes"/>
+      <point x="1516" y="65"/>
+      <point x="1593" y="-16"/>
+      <point x="1706" y="-16" type="curve" smooth="yes"/>
+      <point x="1864" y="-16"/>
+      <point x="1917" y="135"/>
+      <point x="1917" y="253" type="curve" smooth="yes"/>
+      <point x="1917" y="463"/>
+      <point x="1801" y="596"/>
+      <point x="1613" y="596" type="curve" smooth="yes"/>
+      <point x="1501" y="596"/>
+      <point x="1423" y="549"/>
+      <point x="1371" y="461" type="curve"/>
+      <point x="1366" y="461" type="line"/>
+      <point x="1330" y="548"/>
+      <point x="1263" y="596"/>
+      <point x="1148" y="596" type="curve" smooth="yes"/>
+      <point x="1011" y="596"/>
+      <point x="912" y="516"/>
+      <point x="831" y="349" type="curve" smooth="yes"/>
+      <point x="728" y="136"/>
+      <point x="562" y="61"/>
+      <point x="265" y="61" type="curve" smooth="yes"/>
+      <point x="144" y="61"/>
+      <point x="99" y="84"/>
+      <point x="99" y="132" type="curve" smooth="yes"/>
+      <point x="99" y="165"/>
+      <point x="125" y="195"/>
+      <point x="192" y="195" type="curve" smooth="yes"/>
+      <point x="476" y="195" type="line" smooth="yes"/>
+      <point x="652" y="195"/>
+      <point x="791" y="289"/>
+      <point x="791" y="435" type="curve" smooth="yes"/>
+      <point x="791" y="527"/>
+      <point x="740" y="596"/>
+      <point x="642" y="596" type="curve" smooth="yes"/>
+      <point x="564" y="596"/>
+      <point x="503" y="552"/>
+      <point x="472" y="475" type="curve"/>
+      <point x="467" y="475" type="line"/>
+      <point x="455" y="552"/>
+      <point x="395" y="596"/>
+      <point x="303" y="596" type="curve" smooth="yes"/>
+      <point x="142" y="596"/>
+      <point x="64" y="488"/>
+      <point x="64" y="399" type="curve" smooth="yes"/>
+      <point x="64" y="324"/>
+      <point x="114" y="273"/>
+      <point x="192" y="273" type="curve" smooth="yes"/>
+      <point x="302" y="273"/>
+      <point x="348" y="357"/>
+      <point x="348" y="414" type="curve" smooth="yes"/>
+      <point x="348" y="478"/>
+      <point x="313" y="515"/>
+      <point x="249" y="515" type="curve" smooth="yes"/>
+      <point x="224" y="515"/>
+      <point x="208" y="512"/>
+      <point x="187" y="505" type="curve"/>
+      <point x="177" y="523" type="line"/>
+      <point x="162" y="494" type="line"/>
+      <point x="199" y="522"/>
+      <point x="238" y="536"/>
+      <point x="298" y="536" type="curve" smooth="yes"/>
+      <point x="375" y="536"/>
+      <point x="414" y="497"/>
+      <point x="414" y="425" type="curve" smooth="yes"/>
+      <point x="414" y="409"/>
+      <point x="412" y="392"/>
+      <point x="409" y="375" type="curve" smooth="yes"/>
+      <point x="400" y="324" type="line"/>
+      <point x="484" y="324" type="line"/>
+      <point x="493" y="375" type="line" smooth="yes"/>
+      <point x="508" y="464"/>
+      <point x="553" y="518"/>
+      <point x="625" y="518" type="curve" smooth="yes"/>
+      <point x="678" y="518"/>
+      <point x="707" y="486"/>
+      <point x="707" y="431" type="curve" smooth="yes"/>
+      <point x="707" y="331"/>
+      <point x="621" y="267"/>
+      <point x="481" y="267" type="curve" smooth="yes"/>
+      <point x="196" y="267" type="line" smooth="yes"/>
+      <point x="68" y="267"/>
+      <point x="15" y="195"/>
+      <point x="15" y="128" type="curve" smooth="yes"/>
+      <point x="15" y="43"/>
+      <point x="83" y="-16"/>
     </contour>
     <contour>
-      <point x="214" y="357" type="curve" smooth="yes"/>
-      <point x="171" y="357"/>
-      <point x="146" y="383"/>
-      <point x="146" y="427" type="curve" smooth="yes"/>
-      <point x="146" y="449"/>
-      <point x="151" y="467"/>
-      <point x="161" y="481" type="curve"/>
-      <point x="137" y="481" type="line"/>
-      <point x="114" y="431" type="line"/>
-      <point x="144" y="455"/>
-      <point x="176" y="467"/>
-      <point x="210" y="467" type="curve" smooth="yes"/>
-      <point x="253" y="467"/>
-      <point x="275" y="449"/>
-      <point x="275" y="412" type="curve" smooth="yes"/>
-      <point x="275" y="379"/>
-      <point x="251" y="357"/>
+      <point x="196" y="341" type="curve" smooth="yes"/>
+      <point x="158" y="341"/>
+      <point x="132" y="368"/>
+      <point x="132" y="406" type="curve" smooth="yes"/>
+      <point x="132" y="429"/>
+      <point x="137" y="449"/>
+      <point x="150" y="475" type="curve"/>
+      <point x="131" y="475" type="line"/>
+      <point x="116" y="425" type="line"/>
+      <point x="143" y="451"/>
+      <point x="182" y="467"/>
+      <point x="217" y="467" type="curve" smooth="yes"/>
+      <point x="255" y="467"/>
+      <point x="273" y="448"/>
+      <point x="273" y="413" type="curve" smooth="yes"/>
+      <point x="273" y="382"/>
+      <point x="254" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ja-malayalam.glif
@@ -1,141 +1,138 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <unicode hex="0D1C"/>
-  <guideline x="52" y="133" angle="91.1496"/>
-  <guideline x="770" y="416" angle="269.0789"/>
-  <anchor x="374" y="0" name="bottom"/>
+  <anchor x="389" y="0" name="bottom"/>
   <anchor x="476" y="580" name="top"/>
-  <anchor x="744" y="580" name="topright"/>
+  <anchor x="760" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="150" y="-16" type="curve" smooth="yes"/>
-      <point x="209" y="-16"/>
-      <point x="257" y="0"/>
-      <point x="359" y="54" type="curve" smooth="yes"/>
-      <point x="429" y="91" type="line"/>
-      <point x="536" y="148" type="line"/>
-      <point x="549" y="151" type="line"/>
-      <point x="579" y="164"/>
-      <point x="597" y="167"/>
-      <point x="616" y="167" type="curve" smooth="yes"/>
-      <point x="651" y="167"/>
-      <point x="668" y="149"/>
-      <point x="668" y="114" type="curve" smooth="yes"/>
-      <point x="668" y="73"/>
-      <point x="645" y="48"/>
-      <point x="606" y="48" type="curve" smooth="yes"/>
-      <point x="573" y="48"/>
-      <point x="553" y="67"/>
-      <point x="553" y="99" type="curve" smooth="yes"/>
-      <point x="553" y="131"/>
-      <point x="568" y="159"/>
-      <point x="600" y="185" type="curve"/>
-      <point x="477" y="161" type="line"/>
-      <point x="516" y="102" type="line"/>
-      <point x="525" y="156" type="line"/>
-      <point x="504" y="135"/>
-      <point x="493" y="109"/>
-      <point x="493" y="80" type="curve" smooth="yes"/>
-      <point x="493" y="22"/>
-      <point x="536" y="-16"/>
-      <point x="603" y="-16" type="curve" smooth="yes"/>
-      <point x="685" y="-16"/>
-      <point x="735" y="35"/>
-      <point x="735" y="121" type="curve" smooth="yes"/>
-      <point x="735" y="189"/>
-      <point x="693" y="233"/>
-      <point x="628" y="233" type="curve" smooth="yes"/>
-      <point x="582" y="233"/>
-      <point x="543" y="220"/>
-      <point x="423" y="162" type="curve" smooth="yes"/>
-      <point x="340" y="122" type="line" smooth="yes"/>
-      <point x="229" y="68"/>
-      <point x="208" y="61"/>
-      <point x="165" y="61" type="curve" smooth="yes"/>
-      <point x="125" y="61"/>
-      <point x="101" y="86"/>
-      <point x="101" y="126" type="curve" smooth="yes"/>
-      <point x="101" y="184"/>
-      <point x="141" y="215"/>
-      <point x="216" y="215" type="curve" smooth="yes"/>
-      <point x="544" y="215" type="line" smooth="yes"/>
-      <point x="692" y="215"/>
-      <point x="796" y="301"/>
-      <point x="796" y="423" type="curve" smooth="yes"/>
-      <point x="796" y="529"/>
-      <point x="734" y="596"/>
-      <point x="627" y="596" type="curve" smooth="yes"/>
-      <point x="546" y="596"/>
-      <point x="483" y="559"/>
-      <point x="452" y="478" type="curve"/>
-      <point x="447" y="478" type="line"/>
-      <point x="436" y="553"/>
-      <point x="378" y="596"/>
-      <point x="282" y="596" type="curve" smooth="yes"/>
-      <point x="159" y="596"/>
-      <point x="69" y="525"/>
-      <point x="69" y="427" type="curve" smooth="yes"/>
-      <point x="69" y="344"/>
-      <point x="123" y="294"/>
-      <point x="212" y="294" type="curve" smooth="yes"/>
-      <point x="294" y="294"/>
-      <point x="347" y="340"/>
-      <point x="347" y="413" type="curve" smooth="yes"/>
-      <point x="347" y="477"/>
-      <point x="309" y="515"/>
-      <point x="246" y="515" type="curve" smooth="yes"/>
-      <point x="225" y="515"/>
-      <point x="203" y="511"/>
-      <point x="185" y="505" type="curve"/>
-      <point x="174" y="528" type="line"/>
-      <point x="175" y="503" type="line"/>
-      <point x="198" y="524"/>
-      <point x="236" y="536"/>
-      <point x="278" y="536" type="curve" smooth="yes"/>
-      <point x="358" y="536"/>
-      <point x="399" y="494"/>
-      <point x="399" y="411" type="curve" smooth="yes"/>
-      <point x="399" y="394"/>
-      <point x="396" y="373"/>
-      <point x="393" y="354" type="curve" smooth="yes"/>
-      <point x="391" y="343" type="line"/>
-      <point x="475" y="343" type="line"/>
-      <point x="483" y="387" type="line" smooth="yes"/>
-      <point x="498" y="470"/>
-      <point x="545" y="518"/>
-      <point x="618" y="518" type="curve" smooth="yes"/>
-      <point x="682" y="518"/>
-      <point x="712" y="486"/>
-      <point x="712" y="423" type="curve" smooth="yes"/>
-      <point x="712" y="336"/>
-      <point x="653" y="287"/>
-      <point x="548" y="287" type="curve" smooth="yes"/>
-      <point x="219" y="287" type="line" smooth="yes"/>
-      <point x="95" y="287"/>
-      <point x="21" y="225"/>
-      <point x="21" y="120" type="curve" smooth="yes"/>
-      <point x="21" y="34"/>
-      <point x="69" y="-16"/>
+      <point x="158" y="-16" type="curve" smooth="yes"/>
+      <point x="205" y="-16"/>
+      <point x="242" y="-4"/>
+      <point x="328" y="35" type="curve" smooth="yes"/>
+      <point x="456" y="93" type="line"/>
+      <point x="531" y="141" type="line"/>
+      <point x="568" y="153" type="line"/>
+      <point x="596" y="170"/>
+      <point x="616" y="176"/>
+      <point x="645" y="176" type="curve" smooth="yes"/>
+      <point x="681" y="176"/>
+      <point x="702" y="155"/>
+      <point x="702" y="121" type="curve" smooth="yes"/>
+      <point x="702" y="91"/>
+      <point x="681" y="54"/>
+      <point x="629" y="54" type="curve" smooth="yes"/>
+      <point x="592" y="54"/>
+      <point x="571" y="74"/>
+      <point x="571" y="110" type="curve" smooth="yes"/>
+      <point x="571" y="134"/>
+      <point x="581" y="159"/>
+      <point x="602" y="180" type="curve"/>
+      <point x="510" y="145" type="line"/>
+      <point x="526" y="131" type="line"/>
+      <point x="519" y="117"/>
+      <point x="515" y="101"/>
+      <point x="515" y="85" type="curve" smooth="yes"/>
+      <point x="515" y="24"/>
+      <point x="557" y="-16"/>
+      <point x="626" y="-16" type="curve" smooth="yes"/>
+      <point x="730" y="-16"/>
+      <point x="774" y="67"/>
+      <point x="774" y="125" type="curve" smooth="yes"/>
+      <point x="774" y="189"/>
+      <point x="734" y="236"/>
+      <point x="660" y="236" type="curve" smooth="yes"/>
+      <point x="621" y="236"/>
+      <point x="575" y="221"/>
+      <point x="495" y="185" type="curve" smooth="yes"/>
+      <point x="307" y="100" type="line" smooth="yes"/>
+      <point x="246" y="72"/>
+      <point x="209" y="60"/>
+      <point x="169" y="60" type="curve" smooth="yes"/>
+      <point x="123" y="60"/>
+      <point x="97" y="85"/>
+      <point x="97" y="120" type="curve" smooth="yes"/>
+      <point x="97" y="158"/>
+      <point x="127" y="195"/>
+      <point x="201" y="195" type="curve" smooth="yes"/>
+      <point x="523" y="195" type="line" smooth="yes"/>
+      <point x="693" y="195"/>
+      <point x="830" y="283"/>
+      <point x="830" y="436" type="curve" smooth="yes"/>
+      <point x="830" y="532"/>
+      <point x="774" y="596"/>
+      <point x="666" y="596" type="curve" smooth="yes"/>
+      <point x="579" y="596"/>
+      <point x="509" y="552"/>
+      <point x="472" y="475" type="curve"/>
+      <point x="467" y="475" type="line"/>
+      <point x="455" y="552"/>
+      <point x="395" y="596"/>
+      <point x="303" y="596" type="curve" smooth="yes"/>
+      <point x="142" y="596"/>
+      <point x="64" y="488"/>
+      <point x="64" y="399" type="curve" smooth="yes"/>
+      <point x="64" y="324"/>
+      <point x="114" y="273"/>
+      <point x="192" y="273" type="curve" smooth="yes"/>
+      <point x="302" y="273"/>
+      <point x="348" y="357"/>
+      <point x="348" y="414" type="curve" smooth="yes"/>
+      <point x="348" y="478"/>
+      <point x="313" y="515"/>
+      <point x="249" y="515" type="curve" smooth="yes"/>
+      <point x="224" y="515"/>
+      <point x="208" y="512"/>
+      <point x="187" y="505" type="curve"/>
+      <point x="177" y="523" type="line"/>
+      <point x="162" y="494" type="line"/>
+      <point x="199" y="522"/>
+      <point x="238" y="536"/>
+      <point x="298" y="536" type="curve" smooth="yes"/>
+      <point x="375" y="536"/>
+      <point x="414" y="497"/>
+      <point x="414" y="425" type="curve" smooth="yes"/>
+      <point x="414" y="409"/>
+      <point x="412" y="392"/>
+      <point x="409" y="375" type="curve" smooth="yes"/>
+      <point x="400" y="324" type="line"/>
+      <point x="484" y="324" type="line"/>
+      <point x="493" y="375" type="line" smooth="yes"/>
+      <point x="508" y="464"/>
+      <point x="565" y="518"/>
+      <point x="645" y="518" type="curve" smooth="yes"/>
+      <point x="711" y="518"/>
+      <point x="747" y="484"/>
+      <point x="747" y="422" type="curve" smooth="yes"/>
+      <point x="747" y="321"/>
+      <point x="671" y="267"/>
+      <point x="548" y="267" type="curve" smooth="yes"/>
+      <point x="205" y="267" type="line" smooth="yes"/>
+      <point x="70" y="267"/>
+      <point x="15" y="181"/>
+      <point x="15" y="114" type="curve" smooth="yes"/>
+      <point x="15" y="39"/>
+      <point x="74" y="-16"/>
     </contour>
     <contour>
-      <point x="214" y="357" type="curve" smooth="yes"/>
-      <point x="171" y="357"/>
-      <point x="146" y="383"/>
-      <point x="146" y="427" type="curve" smooth="yes"/>
-      <point x="146" y="449"/>
-      <point x="151" y="467"/>
-      <point x="161" y="481" type="curve"/>
-      <point x="137" y="481" type="line"/>
-      <point x="114" y="431" type="line"/>
-      <point x="144" y="455"/>
-      <point x="176" y="467"/>
-      <point x="210" y="467" type="curve" smooth="yes"/>
-      <point x="253" y="467"/>
-      <point x="275" y="449"/>
-      <point x="275" y="412" type="curve" smooth="yes"/>
-      <point x="275" y="379"/>
-      <point x="251" y="357"/>
+      <point x="196" y="341" type="curve" smooth="yes"/>
+      <point x="158" y="341"/>
+      <point x="132" y="368"/>
+      <point x="132" y="406" type="curve" smooth="yes"/>
+      <point x="132" y="429"/>
+      <point x="137" y="449"/>
+      <point x="150" y="475" type="curve"/>
+      <point x="131" y="475" type="line"/>
+      <point x="116" y="425" type="line"/>
+      <point x="143" y="451"/>
+      <point x="182" y="467"/>
+      <point x="217" y="467" type="curve" smooth="yes"/>
+      <point x="255" y="467"/>
+      <point x="273" y="448"/>
+      <point x="273" y="413" type="curve" smooth="yes"/>
+      <point x="273" y="382"/>
+      <point x="254" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="671"/>
+    <component base="halant-malayalam" xOffset="687"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <guideline x="103" y="133" angle="91.1496"/>
   <guideline x="821" y="416" angle="269.0789"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="420"/>
+    <component base="lVocalicMatra-malayalam" xOffset="435"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <guideline x="88" y="133" angle="91.1496"/>
   <guideline x="806" y="416" angle="269.0789"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="420"/>
+    <component base="llVocalicMatra-malayalam" xOffset="435"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/kC_hillu-malayalam.glif
@@ -2,114 +2,112 @@
 <glyph name="kChillu-malayalam" format="2">
   <advance width="1040"/>
   <unicode hex="0D7F"/>
-  <guideline x="1034"/>
-  <anchor x="667" y="0" name="bottom"/>
-  <anchor x="390" y="580" name="top"/>
+  <anchor x="593" y="0" name="bottom"/>
+  <anchor x="418" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="594" y="-16"/>
-      <point x="639" y="25"/>
-      <point x="670" y="85" type="curve"/>
-      <point x="675" y="85" type="line"/>
-      <point x="690" y="34"/>
-      <point x="732" y="-16"/>
-      <point x="829" y="-16" type="curve" smooth="yes"/>
-      <point x="922" y="-16"/>
-      <point x="995" y="42"/>
-      <point x="995" y="161" type="curve" smooth="yes"/>
-      <point x="995" y="257"/>
-      <point x="943" y="324"/>
-      <point x="795" y="324" type="curve" smooth="yes"/>
-      <point x="778" y="324" type="line"/>
-      <point x="732" y="250" type="line"/>
-      <point x="787" y="250" type="line" smooth="yes"/>
-      <point x="883" y="250"/>
-      <point x="910" y="210"/>
-      <point x="910" y="160" type="curve" smooth="yes"/>
-      <point x="910" y="98"/>
-      <point x="878" y="62"/>
-      <point x="819" y="62" type="curve" smooth="yes"/>
-      <point x="761" y="62"/>
-      <point x="732" y="98"/>
-      <point x="732" y="163" type="curve" smooth="yes"/>
-      <point x="732" y="242"/>
-      <point x="787" y="332"/>
-      <point x="874" y="426" type="curve" smooth="yes"/>
-      <point x="939" y="496"/>
-      <point x="993" y="563"/>
-      <point x="993" y="653" type="curve" smooth="yes"/>
-      <point x="993" y="740"/>
-      <point x="940" y="789"/>
-      <point x="836" y="789" type="curve" smooth="yes"/>
-      <point x="787" y="789"/>
-      <point x="737" y="776"/>
-      <point x="693" y="751" type="curve"/>
-      <point x="720" y="679" type="line"/>
-      <point x="749" y="697"/>
-      <point x="790" y="711"/>
-      <point x="828" y="711" type="curve" smooth="yes"/>
-      <point x="884" y="711"/>
-      <point x="911" y="688"/>
-      <point x="911" y="643" type="curve" smooth="yes"/>
-      <point x="911" y="582"/>
-      <point x="873" y="536"/>
-      <point x="806" y="455" type="curve" smooth="yes"/>
-      <point x="782" y="425"/>
-      <point x="763" y="400"/>
-      <point x="749" y="368" type="curve"/>
-      <point x="703" y="368" type="line"/>
-      <point x="743" y="309" type="line"/>
-      <point x="744" y="325"/>
-      <point x="744" y="340"/>
-      <point x="744" y="356" type="curve" smooth="yes"/>
-      <point x="744" y="477"/>
-      <point x="715" y="596"/>
-      <point x="569" y="596" type="curve" smooth="yes"/>
-      <point x="436" y="596"/>
-      <point x="355" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="721" y="250" type="line"/>
-      <point x="721" y="324" type="line"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="551" y="-16"/>
+      <point x="607" y="19"/>
+      <point x="648" y="82" type="curve"/>
+      <point x="654" y="82" type="line"/>
+      <point x="674" y="24"/>
+      <point x="724" y="-16"/>
+      <point x="800" y="-16" type="curve" smooth="yes"/>
+      <point x="915" y="-16"/>
+      <point x="987" y="68"/>
+      <point x="987" y="174" type="curve" smooth="yes"/>
+      <point x="987" y="278"/>
+      <point x="923" y="344"/>
+      <point x="792" y="344" type="curve" smooth="yes"/>
+      <point x="776" y="344" type="line"/>
+      <point x="728" y="270" type="line"/>
+      <point x="788" y="270" type="line" smooth="yes"/>
+      <point x="865" y="270"/>
+      <point x="903" y="236"/>
+      <point x="903" y="172" type="curve" smooth="yes"/>
+      <point x="903" y="106"/>
+      <point x="859" y="62"/>
+      <point x="802" y="62" type="curve" smooth="yes"/>
+      <point x="745" y="62"/>
+      <point x="713" y="96"/>
+      <point x="713" y="152" type="curve" smooth="yes"/>
+      <point x="713" y="215"/>
+      <point x="756" y="290"/>
+      <point x="870" y="424" type="curve" smooth="yes"/>
+      <point x="931" y="496"/>
+      <point x="987" y="567"/>
+      <point x="987" y="646" type="curve" smooth="yes"/>
+      <point x="987" y="732"/>
+      <point x="935" y="789"/>
+      <point x="838" y="789" type="curve" smooth="yes"/>
+      <point x="784" y="789"/>
+      <point x="736" y="774"/>
+      <point x="679" y="739" type="curve"/>
+      <point x="716" y="670" type="line"/>
+      <point x="758" y="697"/>
+      <point x="796" y="710"/>
+      <point x="834" y="710" type="curve" smooth="yes"/>
+      <point x="881" y="710"/>
+      <point x="904" y="688"/>
+      <point x="904" y="644" type="curve" smooth="yes"/>
+      <point x="904" y="592"/>
+      <point x="872" y="544"/>
+      <point x="805" y="460" type="curve" smooth="yes"/>
+      <point x="769" y="415"/>
+      <point x="756" y="394"/>
+      <point x="743" y="365" type="curve"/>
+      <point x="737" y="365" type="line"/>
+      <point x="738" y="376"/>
+      <point x="739" y="391"/>
+      <point x="739" y="403" type="curve" smooth="yes"/>
+      <point x="739" y="524"/>
+      <point x="682" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="694" y="270" type="line"/>
+      <point x="715" y="344" type="line"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
     </contour>
     <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="644" y="518"/>
+      <point x="671" y="468"/>
+      <point x="671" y="391" type="curve" smooth="yes"/>
+      <point x="671" y="287"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/k_ka-malayalam.glif
@@ -1,99 +1,98 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ka-malayalam" format="2">
   <advance width="1437"/>
-  <guideline x="1400"/>
-  <anchor x="1033" y="0" name="bottom"/>
-  <anchor x="816" y="580" name="top"/>
-  <anchor x="1315" y="580" name="topright"/>
+  <anchor x="976" y="0" name="bottom"/>
+  <anchor x="861" y="580" name="top"/>
+  <anchor x="1360" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="660" y="-16"/>
-      <point x="760" y="140"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="502"/>
-      <point x="705" y="596"/>
-      <point x="574" y="596" type="curve" smooth="yes"/>
-      <point x="436" y="596"/>
-      <point x="355" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="928" y="250" type="line" smooth="yes"/>
-      <point x="1019" y="250"/>
-      <point x="1044" y="207"/>
-      <point x="1044" y="147" type="curve" smooth="yes"/>
-      <point x="1044" y="106"/>
-      <point x="1026" y="62"/>
-      <point x="972" y="62" type="curve" smooth="yes"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="696" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="941" y="270" type="line" smooth="yes"/>
+      <point x="1017" y="270"/>
+      <point x="1053" y="241"/>
+      <point x="1053" y="175" type="curve" smooth="yes"/>
+      <point x="1053" y="124"/>
+      <point x="1024" y="62"/>
+      <point x="963" y="62" type="curve" smooth="yes"/>
       <point x="911" y="62"/>
-      <point x="889" y="116"/>
-      <point x="889" y="202" type="curve" smooth="yes"/>
-      <point x="889" y="361"/>
-      <point x="978" y="517"/>
-      <point x="1148" y="517" type="curve" smooth="yes"/>
-      <point x="1272" y="517"/>
-      <point x="1324" y="441"/>
-      <point x="1324" y="339" type="curve" smooth="yes"/>
-      <point x="1324" y="209"/>
-      <point x="1262" y="120"/>
-      <point x="1182" y="38" type="curve"/>
+      <point x="882" y="100"/>
+      <point x="882" y="173" type="curve" smooth="yes"/>
+      <point x="882" y="304"/>
+      <point x="948" y="517"/>
+      <point x="1150" y="517" type="curve" smooth="yes"/>
+      <point x="1254" y="517"/>
+      <point x="1315" y="450"/>
+      <point x="1315" y="330" type="curve" smooth="yes"/>
+      <point x="1315" y="228"/>
+      <point x="1267" y="124"/>
+      <point x="1184" y="42" type="curve"/>
       <point x="1243" y="-16" type="line"/>
-      <point x="1343" y="83"/>
-      <point x="1407" y="190"/>
-      <point x="1407" y="343" type="curve" smooth="yes"/>
-      <point x="1407" y="498"/>
-      <point x="1314" y="596"/>
-      <point x="1150" y="596" type="curve" smooth="yes"/>
-      <point x="937" y="596"/>
-      <point x="807" y="408"/>
-      <point x="807" y="205" type="curve" smooth="yes"/>
-      <point x="807" y="75"/>
+      <point x="1336" y="74"/>
+      <point x="1397" y="214"/>
+      <point x="1397" y="334" type="curve" smooth="yes"/>
+      <point x="1397" y="495"/>
+      <point x="1310" y="596"/>
+      <point x="1160" y="596" type="curve" smooth="yes"/>
+      <point x="900" y="596"/>
+      <point x="801" y="332"/>
+      <point x="801" y="172" type="curve" smooth="yes"/>
+      <point x="801" y="56"/>
       <point x="858" y="-16"/>
-      <point x="975" y="-16" type="curve" smooth="yes"/>
-      <point x="1069" y="-16"/>
-      <point x="1126" y="49"/>
-      <point x="1126" y="145" type="curve" smooth="yes"/>
-      <point x="1126" y="239"/>
-      <point x="1081" y="324"/>
-      <point x="928" y="324" type="curve" smooth="yes"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
+      <point x="957" y="-16" type="curve" smooth="yes"/>
+      <point x="1071" y="-16"/>
+      <point x="1135" y="86"/>
+      <point x="1135" y="180" type="curve" smooth="yes"/>
+      <point x="1135" y="286"/>
+      <point x="1076" y="344"/>
+      <point x="949" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
     </contour>
     <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/k_la-malayalam.glif
@@ -1,145 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_la-malayalam" format="2">
   <advance width="1035"/>
-  <anchor x="565" y="-351" name="bottom"/>
-  <anchor x="589" y="580" name="top"/>
-  <anchor x="929" y="540" name="topright"/>
+  <anchor x="555" y="-351" name="bottom"/>
+  <anchor x="583" y="580" name="top"/>
+  <anchor x="923" y="540" name="topright"/>
   <outline>
     <contour>
-      <point x="343" y="-367" type="curve" smooth="yes"/>
-      <point x="428" y="-367"/>
-      <point x="480" y="-313"/>
-      <point x="480" y="-228" type="curve" smooth="yes"/>
-      <point x="480" y="-154"/>
-      <point x="440" y="-118"/>
-      <point x="371" y="-118" type="curve" smooth="yes"/>
-      <point x="339" y="-118"/>
-      <point x="301" y="-131"/>
-      <point x="275" y="-164" type="curve"/>
-      <point x="232" y="-154" type="line"/>
-      <point x="265" y="-181" type="line"/>
-      <point x="281" y="-85"/>
-      <point x="340" y="-27"/>
-      <point x="433" y="-27" type="curve" smooth="yes"/>
-      <point x="538" y="-27"/>
-      <point x="565" y="-86"/>
-      <point x="570" y="-174" type="curve" smooth="yes"/>
-      <point x="571" y="-192" type="line" smooth="yes"/>
-      <point x="577" y="-303"/>
-      <point x="627" y="-367"/>
-      <point x="737" y="-367" type="curve" smooth="yes"/>
-      <point x="866" y="-367"/>
-      <point x="921" y="-271"/>
-      <point x="921" y="-131" type="curve" smooth="yes"/>
-      <point x="921" y="-58"/>
-      <point x="902" y="1"/>
-      <point x="872" y="43" type="curve"/>
+      <point x="338" y="-367" type="curve" smooth="yes"/>
+      <point x="426" y="-367"/>
+      <point x="479" y="-301"/>
+      <point x="479" y="-229" type="curve" smooth="yes"/>
+      <point x="479" y="-162"/>
+      <point x="443" y="-118"/>
+      <point x="376" y="-118" type="curve" smooth="yes"/>
+      <point x="328" y="-118"/>
+      <point x="262" y="-150"/>
+      <point x="249" y="-232" type="curve"/>
+      <point x="288" y="-176" type="line"/>
+      <point x="258" y="-163" type="line"/>
+      <point x="264" y="-188" type="line"/>
+      <point x="284" y="-90"/>
+      <point x="360" y="-25"/>
+      <point x="446" y="-25" type="curve" smooth="yes"/>
+      <point x="520" y="-25"/>
+      <point x="554" y="-63"/>
+      <point x="569" y="-157" type="curve" smooth="yes"/>
+      <point x="576" y="-200" type="line" smooth="yes"/>
+      <point x="595" y="-317"/>
+      <point x="646" y="-367"/>
+      <point x="738" y="-367" type="curve" smooth="yes"/>
+      <point x="873" y="-367"/>
+      <point x="921" y="-239"/>
+      <point x="921" y="-140" type="curve" smooth="yes"/>
+      <point x="921" y="-71"/>
+      <point x="905" y="-10"/>
+      <point x="874" y="41" type="curve"/>
       <point x="809" y="5" type="line"/>
-      <point x="831" y="-33"/>
-      <point x="846" y="-82"/>
-      <point x="846" y="-139" type="curve" smooth="yes"/>
-      <point x="846" y="-226"/>
-      <point x="818" y="-297"/>
-      <point x="739" y="-297" type="curve" smooth="yes"/>
-      <point x="679" y="-297"/>
-      <point x="654" y="-265"/>
-      <point x="646" y="-174" type="curve" smooth="yes"/>
-      <point x="644" y="-151" type="line" smooth="yes"/>
-      <point x="638" y="-87"/>
-      <point x="622" y="-36"/>
-      <point x="581" y="-2" type="curve"/>
-      <point x="581" y="3" type="line"/>
-      <point x="710" y="55"/>
-      <point x="760" y="215"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="502"/>
-      <point x="706" y="596"/>
-      <point x="579" y="596" type="curve" smooth="yes"/>
-      <point x="447" y="596"/>
-      <point x="354" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="790" y="250" type="line" smooth="yes"/>
-      <point x="873" y="250"/>
-      <point x="908" y="214"/>
-      <point x="908" y="155" type="curve" smooth="yes"/>
-      <point x="908" y="109"/>
-      <point x="884" y="62"/>
-      <point x="812" y="62" type="curve" smooth="yes"/>
-      <point x="785" y="62"/>
-      <point x="767" y="66"/>
-      <point x="751" y="72" type="curve"/>
-      <point x="719" y="2" type="line"/>
-      <point x="742" y="-9"/>
-      <point x="770" y="-16"/>
-      <point x="807" y="-16" type="curve" smooth="yes"/>
-      <point x="931" y="-16"/>
-      <point x="990" y="65"/>
-      <point x="990" y="159" type="curve" smooth="yes"/>
-      <point x="990" y="256"/>
-      <point x="924" y="324"/>
-      <point x="791" y="324" type="curve" smooth="yes"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="353" y="70"/>
-      <point x="367" y="52"/>
-      <point x="383" y="41" type="curve"/>
-      <point x="382" y="36" type="line"/>
-      <point x="265" y="10"/>
-      <point x="197" y="-86"/>
-      <point x="197" y="-210" type="curve" smooth="yes"/>
-      <point x="197" y="-316"/>
-      <point x="261" y="-367"/>
+      <point x="836" y="-43"/>
+      <point x="848" y="-89"/>
+      <point x="848" y="-142" type="curve" smooth="yes"/>
+      <point x="848" y="-208"/>
+      <point x="825" y="-297"/>
+      <point x="744" y="-297" type="curve" smooth="yes"/>
+      <point x="691" y="-297"/>
+      <point x="663" y="-269"/>
+      <point x="649" y="-185" type="curve" smooth="yes"/>
+      <point x="642" y="-142" type="line" smooth="yes"/>
+      <point x="629" y="-62"/>
+      <point x="610" y="-17"/>
+      <point x="568" y="7" type="curve"/>
+      <point x="569" y="14" type="line"/>
+      <point x="722" y="81"/>
+      <point x="754" y="280"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="789" y="270" type="line" smooth="yes"/>
+      <point x="863" y="270"/>
+      <point x="900" y="238"/>
+      <point x="900" y="175" type="curve" smooth="yes"/>
+      <point x="900" y="108"/>
+      <point x="856" y="62"/>
+      <point x="792" y="62" type="curve" smooth="yes"/>
+      <point x="772" y="62"/>
+      <point x="755" y="64"/>
+      <point x="741" y="69" type="curve"/>
+      <point x="713" y="-4" type="line"/>
+      <point x="736" y="-12"/>
+      <point x="760" y="-16"/>
+      <point x="787" y="-16" type="curve" smooth="yes"/>
+      <point x="901" y="-16"/>
+      <point x="983" y="65"/>
+      <point x="983" y="178" type="curve" smooth="yes"/>
+      <point x="983" y="282"/>
+      <point x="914" y="344"/>
+      <point x="795" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="328" y="90" type="line"/>
+      <point x="337" y="67"/>
+      <point x="352" y="47"/>
+      <point x="371" y="32" type="curve"/>
+      <point x="369" y="23" type="line"/>
+      <point x="257" y="-18"/>
+      <point x="196" y="-121"/>
+      <point x="196" y="-214" type="curve" smooth="yes"/>
+      <point x="196" y="-313"/>
+      <point x="257" y="-367"/>
     </contour>
     <contour>
-      <point x="343" y="-302" type="curve" smooth="yes"/>
-      <point x="288" y="-302"/>
-      <point x="265" y="-264"/>
-      <point x="265" y="-218" type="curve"/>
-      <point x="246" y="-197" type="line"/>
-      <point x="257" y="-253" type="line"/>
-      <point x="265" y="-213"/>
-      <point x="298" y="-178"/>
-      <point x="347" y="-178" type="curve" smooth="yes"/>
-      <point x="389" y="-178"/>
-      <point x="409" y="-199"/>
+      <point x="338" y="-302" type="curve" smooth="yes"/>
+      <point x="290" y="-302"/>
+      <point x="263" y="-269"/>
+      <point x="263" y="-224" type="curve" smooth="yes"/>
+      <point x="263" y="-217"/>
+      <point x="264" y="-208"/>
+      <point x="266" y="-200" type="curve"/>
+      <point x="235" y="-205" type="line"/>
+      <point x="255" y="-265" type="line"/>
+      <point x="263" y="-213"/>
+      <point x="304" y="-178"/>
+      <point x="353" y="-178" type="curve" smooth="yes"/>
+      <point x="392" y="-178"/>
+      <point x="409" y="-201"/>
       <point x="409" y="-233" type="curve" smooth="yes"/>
-      <point x="409" y="-276"/>
-      <point x="385" y="-302"/>
+      <point x="409" y="-272"/>
+      <point x="382" y="-302"/>
     </contour>
     <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.glif
@@ -1,116 +1,115 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam" format="2">
   <advance width="1702"/>
-  <guideline x="1632"/>
-  <anchor x="1214" y="0" name="bottom"/>
-  <anchor x="933" y="580" name="top"/>
-  <anchor x="1638" y="580" name="topright"/>
+  <anchor x="1208" y="0" name="bottom"/>
+  <anchor x="927" y="580" name="top"/>
+  <anchor x="1632" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="660" y="-16"/>
-      <point x="760" y="140"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="515"/>
-      <point x="694" y="596"/>
-      <point x="579" y="596" type="curve" smooth="yes"/>
-      <point x="447" y="596"/>
-      <point x="354" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="127" y="62"/>
-      <point x="90" y="96"/>
-      <point x="90" y="150" type="curve" smooth="yes"/>
-      <point x="90" y="218"/>
-      <point x="136" y="256"/>
-      <point x="219" y="256" type="curve" smooth="yes"/>
-      <point x="801" y="256" type="line" smooth="yes"/>
-      <point x="885" y="256"/>
-      <point x="911" y="224"/>
-      <point x="911" y="173" type="curve" smooth="yes"/>
-      <point x="911" y="122"/>
-      <point x="885" y="93"/>
-      <point x="827" y="56" type="curve"/>
-      <point x="836" y="0" type="line"/>
-      <point x="1580" y="0" type="line"/>
-      <point x="1682" y="580" type="line"/>
-      <point x="1632" y="580" type="line"/>
-      <point x="1537" y="405"/>
-      <point x="1415" y="312"/>
-      <point x="1287" y="312" type="curve" smooth="yes"/>
-      <point x="1187" y="312"/>
-      <point x="1132" y="358"/>
-      <point x="1132" y="430" type="curve" smooth="yes"/>
-      <point x="1132" y="486"/>
-      <point x="1164" y="518"/>
-      <point x="1213" y="518" type="curve" smooth="yes"/>
-      <point x="1264" y="518"/>
-      <point x="1282" y="491"/>
-      <point x="1282" y="447" type="curve" smooth="yes"/>
-      <point x="1282" y="438"/>
-      <point x="1279" y="413"/>
-      <point x="1277" y="400" type="curve" smooth="yes"/>
-      <point x="1218" y="61" type="line"/>
-      <point x="1300" y="61" type="line"/>
-      <point x="1359" y="398" type="line" smooth="yes"/>
-      <point x="1364" y="427"/>
-      <point x="1365" y="446"/>
-      <point x="1365" y="458" type="curve" smooth="yes"/>
-      <point x="1365" y="540"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="696" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="797" y="270" type="line" smooth="yes"/>
+      <point x="871" y="270"/>
+      <point x="906" y="239"/>
+      <point x="906" y="184" type="curve" smooth="yes"/>
+      <point x="906" y="140"/>
+      <point x="880" y="102"/>
+      <point x="826" y="56" type="curve"/>
+      <point x="835" y="0" type="line"/>
+      <point x="1574" y="0" type="line"/>
+      <point x="1676" y="580" type="line"/>
+      <point x="1624" y="580" type="line"/>
+      <point x="1520" y="412"/>
+      <point x="1403" y="312"/>
+      <point x="1259" y="312" type="curve" smooth="yes"/>
+      <point x="1174" y="312"/>
+      <point x="1125" y="355"/>
+      <point x="1125" y="419" type="curve" smooth="yes"/>
+      <point x="1125" y="476"/>
+      <point x="1165" y="518"/>
+      <point x="1220" y="518" type="curve" smooth="yes"/>
+      <point x="1260" y="518"/>
+      <point x="1279" y="495"/>
+      <point x="1279" y="458" type="curve" smooth="yes"/>
+      <point x="1279" y="446"/>
+      <point x="1278" y="433"/>
+      <point x="1275" y="418" type="curve" smooth="yes"/>
+      <point x="1212" y="61" type="line"/>
+      <point x="1294" y="61" type="line"/>
+      <point x="1357" y="420" type="line" smooth="yes"/>
+      <point x="1360" y="437"/>
+      <point x="1362" y="453"/>
+      <point x="1362" y="468" type="curve" smooth="yes"/>
+      <point x="1362" y="542"/>
       <point x="1317" y="596"/>
-      <point x="1220" y="596" type="curve" smooth="yes"/>
-      <point x="1120" y="596"/>
-      <point x="1049" y="533"/>
-      <point x="1049" y="426" type="curve" smooth="yes"/>
-      <point x="1049" y="305"/>
-      <point x="1152" y="234"/>
-      <point x="1281" y="234" type="curve" smooth="yes"/>
-      <point x="1384" y="234"/>
-      <point x="1475" y="277"/>
-      <point x="1554" y="356" type="curve"/>
-      <point x="1559" y="354" type="line"/>
-      <point x="1503" y="40" type="line"/>
-      <point x="1549" y="74" type="line"/>
-      <point x="905" y="74" type="line"/>
-      <point x="905" y="45" type="line"/>
-      <point x="956" y="67"/>
-      <point x="996" y="114"/>
-      <point x="996" y="188" type="curve" smooth="yes"/>
-      <point x="996" y="268"/>
-      <point x="946" y="330"/>
-      <point x="802" y="330" type="curve" smooth="yes"/>
-      <point x="224" y="330" type="line" smooth="yes"/>
-      <point x="89" y="330"/>
-      <point x="8" y="261"/>
-      <point x="8" y="146" type="curve" smooth="yes"/>
-      <point x="8" y="49"/>
-      <point x="76" y="-16"/>
+      <point x="1228" y="596" type="curve" smooth="yes"/>
+      <point x="1119" y="596"/>
+      <point x="1043" y="519"/>
+      <point x="1043" y="415" type="curve" smooth="yes"/>
+      <point x="1043" y="310"/>
+      <point x="1130" y="236"/>
+      <point x="1253" y="236" type="curve" smooth="yes"/>
+      <point x="1363" y="236"/>
+      <point x="1464" y="287"/>
+      <point x="1550" y="380" type="curve"/>
+      <point x="1557" y="380" type="line"/>
+      <point x="1497" y="40" type="line"/>
+      <point x="1543" y="74" type="line"/>
+      <point x="933" y="74" type="line"/>
+      <point x="932" y="79" type="line"/>
+      <point x="967" y="113"/>
+      <point x="989" y="153"/>
+      <point x="989" y="197" type="curve" smooth="yes"/>
+      <point x="989" y="289"/>
+      <point x="924" y="344"/>
+      <point x="803" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
     </contour>
     <contour>
-      <point x="507" y="62" type="curve" smooth="yes"/>
-      <point x="434" y="62"/>
-      <point x="397" y="118"/>
-      <point x="397" y="217" type="curve" smooth="yes"/>
-      <point x="397" y="348"/>
-      <point x="439" y="518"/>
-      <point x="569" y="518" type="curve" smooth="yes"/>
-      <point x="648" y="518"/>
-      <point x="677" y="460"/>
-      <point x="677" y="363" type="curve" smooth="yes"/>
-      <point x="677" y="238"/>
-      <point x="636" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1702"/>
   <outline>
     <component base="k_ssa-malayalam"/>
-    <component base="halant-malayalam" xOffset="1565"/>
+    <component base="halant-malayalam" xOffset="1559"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/k_ta-malayalam.glif
@@ -1,114 +1,114 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ta-malayalam" format="2">
   <advance width="1796"/>
-  <anchor x="1348" y="0" name="bottom"/>
-  <anchor x="872" y="580" name="top"/>
-  <anchor x="1696" y="580" name="topright"/>
+  <anchor x="1336" y="0" name="bottom"/>
+  <anchor x="866" y="580" name="top"/>
+  <anchor x="1684" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="660" y="-16"/>
-      <point x="760" y="140"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="502"/>
-      <point x="705" y="596"/>
-      <point x="574" y="596" type="curve" smooth="yes"/>
-      <point x="436" y="596"/>
-      <point x="355" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="891" y="250" type="line"/>
-      <point x="891" y="324" type="line"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
-    </contour>
-    <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
-    </contour>
-    <contour>
-      <point x="941" y="-16" type="curve"/>
-      <point x="1007" y="33" type="line"/>
-      <point x="964" y="90"/>
-      <point x="943" y="157"/>
-      <point x="943" y="243" type="curve" smooth="yes"/>
-      <point x="943" y="407"/>
-      <point x="1046" y="518"/>
-      <point x="1196" y="518" type="curve" smooth="yes"/>
-      <point x="1339" y="518"/>
-      <point x="1425" y="425"/>
-      <point x="1425" y="271" type="curve" smooth="yes"/>
-      <point x="1425" y="148"/>
-      <point x="1370" y="62"/>
-      <point x="1291" y="62" type="curve" smooth="yes"/>
-      <point x="1225" y="62"/>
-      <point x="1188" y="111"/>
-      <point x="1188" y="197" type="curve" smooth="yes"/>
-      <point x="1188" y="379"/>
-      <point x="1320" y="518"/>
-      <point x="1494" y="518" type="curve" smooth="yes"/>
-      <point x="1616" y="518"/>
-      <point x="1689" y="447"/>
-      <point x="1689" y="326" type="curve" smooth="yes"/>
-      <point x="1689" y="221"/>
-      <point x="1640" y="130"/>
-      <point x="1539" y="46" type="curve"/>
-      <point x="1594" y="-16" type="line"/>
-      <point x="1715" y="84"/>
-      <point x="1773" y="196"/>
-      <point x="1773" y="326" type="curve" smooth="yes"/>
-      <point x="1773" y="495"/>
+      <point x="931" y="-16" type="curve"/>
+      <point x="995" y="31" type="line"/>
+      <point x="954" y="85"/>
+      <point x="931" y="159"/>
+      <point x="931" y="236" type="curve" smooth="yes"/>
+      <point x="931" y="380"/>
+      <point x="1020" y="518"/>
+      <point x="1184" y="518" type="curve" smooth="yes"/>
+      <point x="1337" y="518"/>
+      <point x="1406" y="412"/>
+      <point x="1406" y="273" type="curve" smooth="yes"/>
+      <point x="1406" y="179"/>
+      <point x="1372" y="62"/>
+      <point x="1270" y="62" type="curve" smooth="yes"/>
+      <point x="1204" y="62"/>
+      <point x="1171" y="108"/>
+      <point x="1171" y="189" type="curve" smooth="yes"/>
+      <point x="1171" y="361"/>
+      <point x="1314" y="518"/>
+      <point x="1487" y="518" type="curve" smooth="yes"/>
+      <point x="1614" y="518"/>
+      <point x="1673" y="444"/>
+      <point x="1673" y="330" type="curve" smooth="yes"/>
+      <point x="1673" y="231"/>
+      <point x="1624" y="138"/>
+      <point x="1525" y="46" type="curve"/>
+      <point x="1588" y="-16" type="line"/>
+      <point x="1695" y="87"/>
+      <point x="1757" y="213"/>
+      <point x="1757" y="338" type="curve" smooth="yes"/>
+      <point x="1757" y="493"/>
       <point x="1669" y="596"/>
-      <point x="1494" y="596" type="curve" smooth="yes"/>
-      <point x="1282" y="596"/>
-      <point x="1106" y="415"/>
-      <point x="1106" y="197" type="curve" smooth="yes"/>
-      <point x="1106" y="67"/>
-      <point x="1178" y="-16"/>
-      <point x="1291" y="-16" type="curve" smooth="yes"/>
-      <point x="1424" y="-16"/>
-      <point x="1511" y="97"/>
-      <point x="1511" y="271" type="curve" smooth="yes"/>
-      <point x="1511" y="462"/>
-      <point x="1381" y="596"/>
-      <point x="1196" y="596" type="curve" smooth="yes"/>
-      <point x="1002" y="596"/>
-      <point x="861" y="447"/>
-      <point x="861" y="243" type="curve" smooth="yes"/>
-      <point x="861" y="141"/>
-      <point x="888" y="52"/>
+      <point x="1500" y="596" type="curve" smooth="yes"/>
+      <point x="1269" y="596"/>
+      <point x="1088" y="381"/>
+      <point x="1088" y="186" type="curve" smooth="yes"/>
+      <point x="1088" y="63"/>
+      <point x="1156" y="-16"/>
+      <point x="1264" y="-16" type="curve" smooth="yes"/>
+      <point x="1416" y="-16"/>
+      <point x="1493" y="144"/>
+      <point x="1493" y="271" type="curve" smooth="yes"/>
+      <point x="1493" y="446"/>
+      <point x="1383" y="596"/>
+      <point x="1190" y="596" type="curve" smooth="yes"/>
+      <point x="973" y="596"/>
+      <point x="850" y="412"/>
+      <point x="850" y="234" type="curve" smooth="yes"/>
+      <point x="850" y="137"/>
+      <point x="875" y="59"/>
+    </contour>
+    <contour>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="696" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="902" y="270" type="line"/>
+      <point x="902" y="344" type="line"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
+    </contour>
+    <contour>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/k_tta-malayalam.glif
@@ -1,128 +1,119 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_tta-malayalam" format="2">
   <advance width="1035"/>
-  <anchor x="682" y="-351" name="bottom"/>
-  <anchor x="589" y="580" name="top"/>
-  <anchor x="929" y="540" name="topright"/>
+  <anchor x="727" y="-351" name="bottom"/>
+  <anchor x="583" y="580" name="top"/>
+  <anchor x="923" y="540" name="topright"/>
   <outline>
     <contour>
-      <point x="705" y="-365" type="curve" smooth="yes"/>
-      <point x="833" y="-365"/>
-      <point x="889" y="-312"/>
-      <point x="889" y="-235" type="curve" smooth="yes"/>
-      <point x="889" y="-172"/>
-      <point x="856" y="-131"/>
-      <point x="755" y="-125" type="curve" smooth="yes"/>
-      <point x="702" y="-122" type="line" smooth="yes"/>
-      <point x="644" y="-119"/>
-      <point x="619" y="-100"/>
-      <point x="619" y="-72" type="curve" smooth="yes"/>
-      <point x="619" y="-43"/>
-      <point x="649" y="-20"/>
-      <point x="730" y="-20" type="curve" smooth="yes"/>
-      <point x="791" y="-20"/>
-      <point x="840" y="-32"/>
-      <point x="881" y="-49" type="curve"/>
-      <point x="910" y="10" type="line"/>
-      <point x="867" y="30"/>
-      <point x="806" y="45"/>
-      <point x="736" y="45" type="curve" smooth="yes"/>
-      <point x="707" y="45"/>
-      <point x="680" y="42"/>
-      <point x="655" y="36" type="curve"/>
-      <point x="652" y="41" type="line"/>
-      <point x="728" y="115"/>
-      <point x="760" y="246"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="502"/>
-      <point x="705" y="596"/>
-      <point x="574" y="596" type="curve" smooth="yes"/>
-      <point x="436" y="596"/>
-      <point x="355" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="790" y="250" type="line" smooth="yes"/>
-      <point x="873" y="250"/>
-      <point x="908" y="214"/>
-      <point x="908" y="155" type="curve" smooth="yes"/>
-      <point x="908" y="109"/>
-      <point x="884" y="62"/>
-      <point x="812" y="62" type="curve" smooth="yes"/>
-      <point x="785" y="62"/>
-      <point x="767" y="66"/>
-      <point x="751" y="72" type="curve"/>
-      <point x="719" y="2" type="line"/>
-      <point x="742" y="-9"/>
-      <point x="770" y="-16"/>
-      <point x="807" y="-16" type="curve" smooth="yes"/>
-      <point x="931" y="-16"/>
-      <point x="990" y="65"/>
-      <point x="990" y="159" type="curve" smooth="yes"/>
-      <point x="990" y="256"/>
-      <point x="924" y="324"/>
-      <point x="791" y="324" type="curve" smooth="yes"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="432" y="-16"/>
-      <point x="511" y="-16" type="curve" smooth="yes"/>
-      <point x="529" y="-16"/>
-      <point x="548" y="-14"/>
-      <point x="563" y="-9" type="curve"/>
-      <point x="566" y="-14" type="line"/>
-      <point x="551" y="-34"/>
-      <point x="543" y="-57"/>
-      <point x="543" y="-85" type="curve" smooth="yes"/>
-      <point x="543" y="-141"/>
-      <point x="591" y="-187"/>
-      <point x="684" y="-192" type="curve" smooth="yes"/>
-      <point x="737" y="-195" type="line" smooth="yes"/>
-      <point x="809" y="-199"/>
-      <point x="814" y="-224"/>
-      <point x="814" y="-245" type="curve" smooth="yes"/>
-      <point x="814" y="-278"/>
-      <point x="786" y="-300"/>
-      <point x="705" y="-300" type="curve" smooth="yes"/>
-      <point x="630" y="-300"/>
-      <point x="575" y="-282"/>
-      <point x="534" y="-258" type="curve"/>
-      <point x="497" y="-314" type="line"/>
-      <point x="544" y="-345"/>
-      <point x="610" y="-365"/>
+      <point x="719" y="-367" type="curve" smooth="yes"/>
+      <point x="845" y="-367"/>
+      <point x="922" y="-316"/>
+      <point x="922" y="-236" type="curve" smooth="yes"/>
+      <point x="922" y="-178"/>
+      <point x="886" y="-139"/>
+      <point x="786" y="-127" type="curve" smooth="yes"/>
+      <point x="717" y="-119" type="line" smooth="yes"/>
+      <point x="676" y="-114"/>
+      <point x="656" y="-103"/>
+      <point x="656" y="-77" type="curve" smooth="yes"/>
+      <point x="656" y="-42"/>
+      <point x="701" y="-20"/>
+      <point x="780" y="-20" type="curve" smooth="yes"/>
+      <point x="834" y="-20"/>
+      <point x="876" y="-31"/>
+      <point x="917" y="-52" type="curve"/>
+      <point x="942" y="9" type="line"/>
+      <point x="928" y="16"/>
+      <point x="915" y="21"/>
+      <point x="896" y="26" type="curve"/>
+      <point x="897" y="33" type="line"/>
+      <point x="952" y="62"/>
+      <point x="987" y="116"/>
+      <point x="987" y="179" type="curve" smooth="yes"/>
+      <point x="987" y="281"/>
+      <point x="914" y="344"/>
+      <point x="795" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="690" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="781" y="270" type="line" smooth="yes"/>
+      <point x="863" y="270"/>
+      <point x="904" y="236"/>
+      <point x="904" y="168" type="curve" smooth="yes"/>
+      <point x="904" y="109"/>
+      <point x="867" y="62"/>
+      <point x="803" y="62" type="curve" smooth="yes"/>
+      <point x="782" y="62"/>
+      <point x="764" y="66"/>
+      <point x="746" y="75" type="curve"/>
+      <point x="721" y="19" type="line"/>
+      <point x="757" y="42" type="line"/>
+      <point x="657" y="37"/>
+      <point x="578" y="-15"/>
+      <point x="578" y="-87" type="curve" smooth="yes"/>
+      <point x="578" y="-145"/>
+      <point x="624" y="-179"/>
+      <point x="704" y="-188" type="curve" smooth="yes"/>
+      <point x="773" y="-196" type="line" smooth="yes"/>
+      <point x="832" y="-203"/>
+      <point x="844" y="-219"/>
+      <point x="844" y="-243" type="curve" smooth="yes"/>
+      <point x="844" y="-280"/>
+      <point x="799" y="-302"/>
+      <point x="724" y="-302" type="curve" smooth="yes"/>
+      <point x="664" y="-302"/>
+      <point x="611" y="-288"/>
+      <point x="564" y="-260" type="curve"/>
+      <point x="532" y="-324" type="line"/>
+      <point x="585" y="-353"/>
+      <point x="646" y="-367"/>
     </contour>
     <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ka-malayalam.glif
@@ -2,80 +2,80 @@
 <glyph name="ka-malayalam" format="2">
   <advance width="1035"/>
   <unicode hex="0D15"/>
-  <anchor x="594" y="0" name="bottom"/>
-  <anchor x="589" y="580" name="top"/>
-  <anchor x="929" y="540" name="topright"/>
+  <anchor x="588" y="0" name="bottom"/>
+  <anchor x="583" y="580" name="top"/>
+  <anchor x="923" y="540" name="topright"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="660" y="-16"/>
-      <point x="760" y="140"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="515"/>
-      <point x="694" y="596"/>
-      <point x="579" y="596" type="curve" smooth="yes"/>
-      <point x="447" y="596"/>
-      <point x="354" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="790" y="250" type="line" smooth="yes"/>
-      <point x="868" y="250"/>
-      <point x="908" y="218"/>
-      <point x="908" y="155" type="curve" smooth="yes"/>
-      <point x="908" y="97"/>
-      <point x="872" y="62"/>
-      <point x="812" y="62" type="curve" smooth="yes"/>
-      <point x="788" y="62"/>
-      <point x="769" y="65"/>
-      <point x="751" y="72" type="curve"/>
-      <point x="719" y="2" type="line"/>
-      <point x="744" y="-10"/>
-      <point x="773" y="-16"/>
-      <point x="807" y="-16" type="curve" smooth="yes"/>
-      <point x="918" y="-16"/>
-      <point x="990" y="53"/>
-      <point x="990" y="159" type="curve" smooth="yes"/>
-      <point x="990" y="263"/>
-      <point x="916" y="324"/>
-      <point x="791" y="324" type="curve" smooth="yes"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="696" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="789" y="270" type="line" smooth="yes"/>
+      <point x="863" y="270"/>
+      <point x="900" y="238"/>
+      <point x="900" y="175" type="curve" smooth="yes"/>
+      <point x="900" y="108"/>
+      <point x="856" y="62"/>
+      <point x="792" y="62" type="curve" smooth="yes"/>
+      <point x="772" y="62"/>
+      <point x="755" y="64"/>
+      <point x="741" y="69" type="curve"/>
+      <point x="713" y="-4" type="line"/>
+      <point x="736" y="-12"/>
+      <point x="760" y="-16"/>
+      <point x="787" y="-16" type="curve" smooth="yes"/>
+      <point x="901" y="-16"/>
+      <point x="983" y="65"/>
+      <point x="983" y="178" type="curve" smooth="yes"/>
+      <point x="983" y="282"/>
+      <point x="914" y="344"/>
+      <point x="795" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
     </contour>
     <contour>
-      <point x="511" y="62" type="curve" smooth="yes"/>
-      <point x="436" y="62"/>
-      <point x="396" y="116"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="408"/>
-      <point x="464" y="518"/>
-      <point x="572" y="518" type="curve" smooth="yes"/>
-      <point x="642" y="518"/>
-      <point x="676" y="468"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="186"/>
-      <point x="608" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/m_la-malayalam.glif
@@ -1,53 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="m_la-malayalam" format="2">
   <advance width="668"/>
-  <anchor x="248" y="-351" name="bottom"/>
+  <anchor x="235" y="-351" name="bottom"/>
   <anchor x="394" y="580" name="top"/>
   <anchor x="624" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="26" y="-367" type="curve" smooth="yes"/>
-      <point x="111" y="-367"/>
-      <point x="163" y="-313"/>
-      <point x="163" y="-228" type="curve" smooth="yes"/>
-      <point x="163" y="-154"/>
-      <point x="123" y="-118"/>
-      <point x="54" y="-118" type="curve" smooth="yes"/>
-      <point x="22" y="-118"/>
-      <point x="-16" y="-131"/>
-      <point x="-42" y="-164" type="curve"/>
-      <point x="-48" y="-163" type="line"/>
-      <point x="-28" y="-78"/>
-      <point x="29" y="-27"/>
-      <point x="116" y="-27" type="curve" smooth="yes"/>
-      <point x="221" y="-27"/>
-      <point x="248" y="-86"/>
-      <point x="253" y="-174" type="curve" smooth="yes"/>
-      <point x="254" y="-192" type="line" smooth="yes"/>
-      <point x="260" y="-303"/>
-      <point x="310" y="-367"/>
-      <point x="420" y="-367" type="curve" smooth="yes"/>
-      <point x="549" y="-367"/>
-      <point x="604" y="-271"/>
-      <point x="604" y="-131" type="curve" smooth="yes"/>
-      <point x="604" y="-58"/>
-      <point x="585" y="1"/>
-      <point x="555" y="43" type="curve"/>
-      <point x="492" y="5" type="line"/>
-      <point x="514" y="-33"/>
-      <point x="529" y="-82"/>
-      <point x="529" y="-139" type="curve" smooth="yes"/>
-      <point x="529" y="-226"/>
-      <point x="501" y="-297"/>
-      <point x="422" y="-297" type="curve" smooth="yes"/>
-      <point x="362" y="-297"/>
-      <point x="337" y="-265"/>
-      <point x="329" y="-174" type="curve" smooth="yes"/>
-      <point x="327" y="-151" type="line" smooth="yes"/>
-      <point x="322" y="-88"/>
-      <point x="309" y="-37"/>
-      <point x="268" y="-5" type="curve"/>
-      <point x="269" y="0" type="line"/>
+      <point x="0" y="0" type="line"/>
       <point x="566" y="0" type="line"/>
       <point x="614" y="266" type="line" smooth="yes"/>
       <point x="619" y="292"/>
@@ -59,30 +18,75 @@
       <point x="205" y="596"/>
       <point x="88" y="499"/>
       <point x="59" y="333" type="curve" smooth="yes"/>
-      <point x="0" y="0" type="line"/>
-      <point x="26" y="0" type="line"/>
-      <point x="28" y="27" type="line"/>
-      <point x="-64" y="-8"/>
-      <point x="-120" y="-97"/>
-      <point x="-120" y="-210" type="curve" smooth="yes"/>
-      <point x="-120" y="-316"/>
-      <point x="-56" y="-367"/>
     </contour>
     <contour>
-      <point x="26" y="-302" type="curve" smooth="yes"/>
-      <point x="-29" y="-302"/>
-      <point x="-52" y="-264"/>
-      <point x="-52" y="-218" type="curve"/>
-      <point x="-71" y="-197" type="line"/>
-      <point x="-60" y="-253" type="line"/>
-      <point x="-52" y="-213"/>
-      <point x="-19" y="-178"/>
-      <point x="30" y="-178" type="curve" smooth="yes"/>
-      <point x="72" y="-178"/>
-      <point x="92" y="-199"/>
-      <point x="92" y="-233" type="curve" smooth="yes"/>
-      <point x="92" y="-276"/>
-      <point x="68" y="-302"/>
+      <point x="79" y="-367" type="curve" smooth="yes"/>
+      <point x="179" y="-367"/>
+      <point x="222" y="-288"/>
+      <point x="222" y="-218" type="curve" smooth="yes"/>
+      <point x="222" y="-154"/>
+      <point x="187" y="-109"/>
+      <point x="127" y="-109" type="curve" smooth="yes"/>
+      <point x="65" y="-109"/>
+      <point x="13" y="-154"/>
+      <point x="1" y="-220" type="curve"/>
+      <point x="28" y="-176" type="line"/>
+      <point x="2" y="-170" type="line"/>
+      <point x="9" y="-198" type="line"/>
+      <point x="28" y="-90"/>
+      <point x="87" y="-23"/>
+      <point x="179" y="-23" type="curve" smooth="yes"/>
+      <point x="252" y="-23"/>
+      <point x="279" y="-62"/>
+      <point x="279" y="-146" type="curve" smooth="yes"/>
+      <point x="279" y="-219" type="line" smooth="yes"/>
+      <point x="279" y="-314"/>
+      <point x="328" y="-367"/>
+      <point x="407" y="-367" type="curve" smooth="yes"/>
+      <point x="526" y="-367"/>
+      <point x="557" y="-252"/>
+      <point x="557" y="-163" type="curve" smooth="yes"/>
+      <point x="557" y="-83"/>
+      <point x="534" y="-15"/>
+      <point x="490" y="48" type="curve"/>
+      <point x="432" y="9" type="line"/>
+      <point x="468" y="-43"/>
+      <point x="485" y="-98"/>
+      <point x="485" y="-159" type="curve" smooth="yes"/>
+      <point x="485" y="-219"/>
+      <point x="475" y="-297"/>
+      <point x="410" y="-297" type="curve" smooth="yes"/>
+      <point x="371" y="-297"/>
+      <point x="351" y="-269"/>
+      <point x="351" y="-217" type="curve" smooth="yes"/>
+      <point x="351" y="-144" type="line" smooth="yes"/>
+      <point x="351" y="-30"/>
+      <point x="305" y="37"/>
+      <point x="188" y="37" type="curve" smooth="yes"/>
+      <point x="39" y="37"/>
+      <point x="-55" y="-85"/>
+      <point x="-55" y="-222" type="curve" smooth="yes"/>
+      <point x="-55" y="-307"/>
+      <point x="-1" y="-367"/>
+    </contour>
+    <contour>
+      <point x="81" y="-303" type="curve" smooth="yes"/>
+      <point x="38" y="-303"/>
+      <point x="11" y="-271"/>
+      <point x="11" y="-230" type="curve" smooth="yes"/>
+      <point x="11" y="-220"/>
+      <point x="13" y="-210"/>
+      <point x="16" y="-200" type="curve"/>
+      <point x="-7" y="-205" type="line"/>
+      <point x="4" y="-257" type="line"/>
+      <point x="16" y="-198"/>
+      <point x="56" y="-167"/>
+      <point x="98" y="-167" type="curve" smooth="yes"/>
+      <point x="134" y="-167"/>
+      <point x="152" y="-189"/>
+      <point x="152" y="-224" type="curve" smooth="yes"/>
+      <point x="152" y="-264"/>
+      <point x="128" y="-303"/>
     </contour>
     <contour>
       <point x="58" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ng_ka-malayalam.glif
@@ -1,103 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng_ka-malayalam" format="2">
   <advance width="1040"/>
-  <anchor x="610" y="0" name="bottom"/>
-  <anchor x="596" y="580" name="top"/>
-  <anchor x="917" y="580" name="topright"/>
+  <anchor x="604" y="0" name="bottom"/>
+  <anchor x="590" y="580" name="top"/>
+  <anchor x="911" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="181" y="-16" type="curve" smooth="yes"/>
-      <point x="267" y="-16"/>
-      <point x="323" y="30"/>
-      <point x="346" y="91" type="curve"/>
-      <point x="351" y="91" type="line"/>
-      <point x="379" y="18"/>
-      <point x="437" y="-16"/>
-      <point x="515" y="-16" type="curve" smooth="yes"/>
-      <point x="692" y="-16"/>
-      <point x="764" y="182"/>
-      <point x="764" y="376" type="curve" smooth="yes"/>
-      <point x="764" y="502"/>
-      <point x="708" y="596"/>
-      <point x="582" y="596" type="curve" smooth="yes"/>
-      <point x="506" y="596"/>
-      <point x="440" y="560"/>
-      <point x="402" y="486" type="curve"/>
-      <point x="397" y="486" type="line"/>
-      <point x="381" y="549"/>
-      <point x="334" y="596"/>
-      <point x="242" y="596" type="curve" smooth="yes"/>
-      <point x="133" y="596"/>
-      <point x="70" y="524"/>
-      <point x="70" y="434" type="curve" smooth="yes"/>
-      <point x="70" y="376"/>
-      <point x="95" y="328"/>
-      <point x="142" y="303" type="curve"/>
-      <point x="142" y="298" type="line"/>
-      <point x="62" y="283"/>
-      <point x="11" y="224"/>
-      <point x="11" y="140" type="curve" smooth="yes"/>
-      <point x="11" y="40"/>
-      <point x="80" y="-16"/>
+      <point x="164" y="-16" type="curve" smooth="yes"/>
+      <point x="235" y="-16"/>
+      <point x="293" y="20"/>
+      <point x="332" y="90" type="curve"/>
+      <point x="337" y="90" type="line"/>
+      <point x="360" y="23"/>
+      <point x="413" y="-16"/>
+      <point x="489" y="-16" type="curve" smooth="yes"/>
+      <point x="701" y="-16"/>
+      <point x="759" y="247"/>
+      <point x="759" y="389" type="curve" smooth="yes"/>
+      <point x="759" y="517"/>
+      <point x="698" y="596"/>
+      <point x="588" y="596" type="curve" smooth="yes"/>
+      <point x="510" y="596"/>
+      <point x="442" y="557"/>
+      <point x="400" y="481" type="curve"/>
+      <point x="395" y="481" type="line"/>
+      <point x="380" y="551"/>
+      <point x="336" y="596"/>
+      <point x="253" y="596" type="curve" smooth="yes"/>
+      <point x="138" y="596"/>
+      <point x="67" y="518"/>
+      <point x="67" y="432" type="curve" smooth="yes"/>
+      <point x="67" y="378"/>
+      <point x="97" y="336"/>
+      <point x="141" y="314" type="curve"/>
+      <point x="140" y="309" type="line"/>
+      <point x="52" y="279"/>
+      <point x="9" y="207"/>
+      <point x="9" y="134" type="curve" smooth="yes"/>
+      <point x="9" y="45"/>
+      <point x="72" y="-16"/>
     </contour>
     <contour>
-      <point x="510" y="62" type="curve" smooth="yes"/>
-      <point x="437" y="62"/>
-      <point x="400" y="118"/>
-      <point x="400" y="217" type="curve" smooth="yes"/>
-      <point x="400" y="348"/>
-      <point x="442" y="518"/>
-      <point x="570" y="518" type="curve" smooth="yes"/>
-      <point x="651" y="518"/>
-      <point x="680" y="460"/>
-      <point x="680" y="363" type="curve" smooth="yes"/>
-      <point x="680" y="238"/>
-      <point x="639" y="62"/>
+      <point x="792" y="-16" type="curve" smooth="yes"/>
+      <point x="906" y="-16"/>
+      <point x="988" y="65"/>
+      <point x="988" y="178" type="curve" smooth="yes"/>
+      <point x="988" y="282"/>
+      <point x="919" y="344"/>
+      <point x="800" y="344" type="curve" smooth="yes"/>
+      <point x="247" y="344" type="line" smooth="yes"/>
+      <point x="185" y="344"/>
+      <point x="147" y="375"/>
+      <point x="147" y="425" type="curve" smooth="yes"/>
+      <point x="147" y="475"/>
+      <point x="186" y="518"/>
+      <point x="255" y="518" type="curve" smooth="yes"/>
+      <point x="318" y="518"/>
+      <point x="345" y="483"/>
+      <point x="345" y="424" type="curve" smooth="yes"/>
+      <point x="345" y="407"/>
+      <point x="343" y="388"/>
+      <point x="339" y="366" type="curve" smooth="yes"/>
+      <point x="311" y="206" type="line" smooth="yes"/>
+      <point x="295" y="115"/>
+      <point x="249" y="62"/>
+      <point x="179" y="62" type="curve" smooth="yes"/>
+      <point x="121" y="62"/>
+      <point x="91" y="92"/>
+      <point x="91" y="144" type="curve" smooth="yes"/>
+      <point x="91" y="215"/>
+      <point x="147" y="270"/>
+      <point x="239" y="270" type="curve" smooth="yes"/>
+      <point x="794" y="270" type="line" smooth="yes"/>
+      <point x="868" y="270"/>
+      <point x="905" y="238"/>
+      <point x="905" y="175" type="curve" smooth="yes"/>
+      <point x="905" y="108"/>
+      <point x="861" y="62"/>
+      <point x="797" y="62" type="curve" smooth="yes"/>
+      <point x="777" y="62"/>
+      <point x="760" y="64"/>
+      <point x="746" y="69" type="curve"/>
+      <point x="718" y="-4" type="line"/>
+      <point x="741" y="-12"/>
+      <point x="765" y="-16"/>
     </contour>
     <contour>
-      <point x="811" y="-16" type="curve" smooth="yes"/>
-      <point x="935" y="-16"/>
-      <point x="994" y="65"/>
-      <point x="994" y="159" type="curve" smooth="yes"/>
-      <point x="994" y="256"/>
-      <point x="928" y="324"/>
-      <point x="795" y="324" type="curve" smooth="yes"/>
-      <point x="278" y="324" type="line" smooth="yes"/>
-      <point x="188" y="324"/>
-      <point x="151" y="370"/>
-      <point x="151" y="425" type="curve" smooth="yes"/>
-      <point x="151" y="476"/>
-      <point x="185" y="518"/>
-      <point x="251" y="518" type="curve" smooth="yes"/>
-      <point x="315" y="518"/>
-      <point x="348" y="476"/>
-      <point x="348" y="409" type="curve" smooth="yes"/>
-      <point x="348" y="392"/>
-      <point x="346" y="374"/>
-      <point x="343" y="354" type="curve" smooth="yes"/>
-      <point x="317" y="204" type="line" smooth="yes"/>
-      <point x="302" y="116"/>
-      <point x="262" y="62"/>
-      <point x="182" y="62" type="curve" smooth="yes"/>
-      <point x="135" y="62"/>
-      <point x="94" y="89"/>
-      <point x="94" y="149" type="curve" smooth="yes"/>
-      <point x="94" y="210"/>
-      <point x="133" y="250"/>
-      <point x="222" y="250" type="curve" smooth="yes"/>
-      <point x="794" y="250" type="line" smooth="yes"/>
-      <point x="877" y="250"/>
-      <point x="912" y="214"/>
-      <point x="912" y="155" type="curve" smooth="yes"/>
-      <point x="912" y="109"/>
-      <point x="888" y="62"/>
-      <point x="816" y="62" type="curve" smooth="yes"/>
-      <point x="789" y="62"/>
-      <point x="771" y="66"/>
-      <point x="755" y="72" type="curve"/>
-      <point x="723" y="2" type="line"/>
-      <point x="746" y="-9"/>
-      <point x="774" y="-16"/>
+      <point x="495" y="62" type="curve" smooth="yes"/>
+      <point x="428" y="62"/>
+      <point x="395" y="106"/>
+      <point x="395" y="191" type="curve" smooth="yes"/>
+      <point x="395" y="296"/>
+      <point x="431" y="518"/>
+      <point x="580" y="518" type="curve" smooth="yes"/>
+      <point x="644" y="518"/>
+      <point x="676" y="476"/>
+      <point x="676" y="390" type="curve" smooth="yes"/>
+      <point x="676" y="297"/>
+      <point x="634" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,192 +1,193 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1518"/>
-  <anchor x="1084" y="0" name="bottom"/>
-  <anchor x="847" y="580" name="top"/>
-  <anchor x="1454" y="580" name="topright"/>
+  <advance width="1560"/>
+  <anchor x="1099" y="0" name="bottom"/>
+  <anchor x="831" y="580" name="top"/>
+  <anchor x="1470" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="244" y="-16" type="curve" smooth="yes"/>
-      <point x="353" y="-16"/>
-      <point x="429" y="67"/>
+      <point x="232" y="-16" type="curve" smooth="yes"/>
+      <point x="386" y="-16"/>
+      <point x="429" y="111"/>
       <point x="429" y="187" type="curve" smooth="yes"/>
-      <point x="429" y="277"/>
-      <point x="368" y="336"/>
-      <point x="273" y="336" type="curve" smooth="yes"/>
-      <point x="217" y="336"/>
-      <point x="166" y="314"/>
+      <point x="429" y="284"/>
+      <point x="374" y="347"/>
+      <point x="275" y="347" type="curve" smooth="yes"/>
+      <point x="218" y="347"/>
+      <point x="167" y="321"/>
       <point x="128" y="275" type="curve"/>
       <point x="98" y="283" type="line"/>
       <point x="98" y="143" type="line"/>
-      <point x="127" y="219"/>
-      <point x="186" y="267"/>
-      <point x="252" y="267" type="curve" smooth="yes"/>
-      <point x="311" y="267"/>
-      <point x="346" y="235"/>
+      <point x="128" y="223"/>
+      <point x="189" y="273"/>
+      <point x="257" y="273" type="curve" smooth="yes"/>
+      <point x="316" y="273"/>
+      <point x="346" y="239"/>
       <point x="346" y="181" type="curve" smooth="yes"/>
-      <point x="346" y="109"/>
-      <point x="306" y="62"/>
-      <point x="243" y="62" type="curve" smooth="yes"/>
-      <point x="161" y="62"/>
-      <point x="120" y="120"/>
-      <point x="120" y="225" type="curve" smooth="yes"/>
-      <point x="120" y="399"/>
-      <point x="219" y="518"/>
-      <point x="364" y="518" type="curve" smooth="yes"/>
-      <point x="477" y="518"/>
-      <point x="534" y="457"/>
-      <point x="534" y="360" type="curve" smooth="yes"/>
-      <point x="534" y="343"/>
-      <point x="531" y="314"/>
-      <point x="526" y="285" type="curve" smooth="yes"/>
-      <point x="476" y="0" type="line"/>
-      <point x="560" y="0" type="line"/>
-      <point x="619" y="336" type="line" smooth="yes"/>
-      <point x="641" y="459"/>
-      <point x="711" y="529"/>
-      <point x="830" y="529" type="curve" smooth="yes"/>
-      <point x="842" y="529"/>
-      <point x="847" y="529"/>
-      <point x="863" y="527" type="curve"/>
-      <point x="839" y="572" type="line"/>
-      <point x="842" y="523" type="line"/>
-      <point x="804" y="501"/>
-      <point x="779" y="460"/>
-      <point x="779" y="421" type="curve" smooth="yes"/>
-      <point x="779" y="352"/>
-      <point x="831" y="310"/>
-      <point x="915" y="310" type="curve" smooth="yes"/>
-      <point x="995" y="310"/>
-      <point x="1061" y="353"/>
-      <point x="1061" y="433" type="curve" smooth="yes"/>
-      <point x="1061" y="468"/>
-      <point x="1045" y="507"/>
-      <point x="995" y="534" type="curve"/>
-      <point x="1007" y="581" type="line"/>
-      <point x="955" y="538" type="line"/>
-      <point x="970" y="540"/>
-      <point x="975" y="540"/>
-      <point x="982" y="540" type="curve" smooth="yes"/>
-      <point x="1078" y="540"/>
-      <point x="1115" y="494"/>
-      <point x="1115" y="411" type="curve" smooth="yes"/>
-      <point x="1115" y="394"/>
-      <point x="1112" y="373"/>
-      <point x="1109" y="354" type="curve" smooth="yes"/>
-      <point x="1107" y="343" type="line"/>
-      <point x="1191" y="343" type="line"/>
-      <point x="1199" y="387" type="line" smooth="yes"/>
-      <point x="1214" y="470"/>
-      <point x="1261" y="518"/>
-      <point x="1330" y="518" type="curve" smooth="yes"/>
-      <point x="1394" y="518"/>
-      <point x="1424" y="486"/>
-      <point x="1424" y="423" type="curve" smooth="yes"/>
-      <point x="1424" y="336"/>
-      <point x="1365" y="287"/>
-      <point x="1260" y="287" type="curve" smooth="yes"/>
-      <point x="931" y="287" type="line" smooth="yes"/>
-      <point x="807" y="287"/>
-      <point x="733" y="225"/>
-      <point x="733" y="120" type="curve" smooth="yes"/>
-      <point x="733" y="34"/>
-      <point x="781" y="-16"/>
-      <point x="862" y="-16" type="curve" smooth="yes"/>
-      <point x="921" y="-16"/>
-      <point x="969" y="0"/>
-      <point x="1071" y="54" type="curve" smooth="yes"/>
-      <point x="1141" y="91" type="line"/>
-      <point x="1253" y="152" type="line"/>
-      <point x="1262" y="151" type="line"/>
-      <point x="1291" y="164"/>
-      <point x="1309" y="167"/>
-      <point x="1328" y="167" type="curve" smooth="yes"/>
-      <point x="1363" y="167"/>
-      <point x="1380" y="149"/>
-      <point x="1380" y="114" type="curve" smooth="yes"/>
-      <point x="1380" y="73"/>
-      <point x="1357" y="48"/>
-      <point x="1318" y="48" type="curve" smooth="yes"/>
-      <point x="1285" y="48"/>
-      <point x="1265" y="67"/>
-      <point x="1265" y="99" type="curve" smooth="yes"/>
-      <point x="1265" y="131"/>
-      <point x="1280" y="159"/>
-      <point x="1312" y="185" type="curve"/>
-      <point x="1188" y="161" type="line"/>
-      <point x="1229" y="102" type="line"/>
-      <point x="1237" y="156" type="line"/>
-      <point x="1216" y="135"/>
-      <point x="1205" y="109"/>
-      <point x="1205" y="80" type="curve" smooth="yes"/>
-      <point x="1205" y="22"/>
-      <point x="1248" y="-16"/>
-      <point x="1315" y="-16" type="curve" smooth="yes"/>
-      <point x="1397" y="-16"/>
-      <point x="1447" y="35"/>
-      <point x="1447" y="121" type="curve" smooth="yes"/>
-      <point x="1447" y="189"/>
-      <point x="1405" y="233"/>
-      <point x="1340" y="233" type="curve" smooth="yes"/>
-      <point x="1294" y="233"/>
-      <point x="1255" y="220"/>
-      <point x="1135" y="162" type="curve" smooth="yes"/>
-      <point x="1052" y="122" type="line" smooth="yes"/>
-      <point x="941" y="68"/>
-      <point x="920" y="61"/>
-      <point x="877" y="61" type="curve" smooth="yes"/>
-      <point x="837" y="61"/>
-      <point x="813" y="86"/>
-      <point x="813" y="126" type="curve" smooth="yes"/>
-      <point x="813" y="184"/>
-      <point x="853" y="215"/>
-      <point x="928" y="215" type="curve" smooth="yes"/>
-      <point x="1256" y="215" type="line" smooth="yes"/>
-      <point x="1404" y="215"/>
-      <point x="1508" y="301"/>
-      <point x="1508" y="423" type="curve" smooth="yes"/>
-      <point x="1508" y="529"/>
-      <point x="1447" y="596"/>
-      <point x="1341" y="596" type="curve" smooth="yes"/>
-      <point x="1267" y="596"/>
-      <point x="1201" y="563"/>
-      <point x="1170" y="478" type="curve"/>
-      <point x="1165" y="478" type="line"/>
-      <point x="1146" y="560"/>
-      <point x="1094" y="596"/>
-      <point x="998" y="596" type="curve" smooth="yes"/>
-      <point x="934" y="596"/>
-      <point x="890" y="575"/>
-      <point x="873" y="564" type="curve"/>
-      <point x="881" y="528" type="line"/>
-      <point x="960" y="526"/>
-      <point x="986" y="485"/>
-      <point x="986" y="444" type="curve" smooth="yes"/>
-      <point x="986" y="410"/>
-      <point x="963" y="380"/>
-      <point x="918" y="380" type="curve" smooth="yes"/>
-      <point x="882" y="380"/>
-      <point x="854" y="398"/>
-      <point x="854" y="439" type="curve" smooth="yes"/>
-      <point x="854" y="469"/>
-      <point x="880" y="520"/>
-      <point x="953" y="528" type="curve"/>
-      <point x="953" y="571" type="line"/>
-      <point x="921" y="586"/>
-      <point x="883" y="596"/>
+      <point x="346" y="130"/>
+      <point x="318" y="62"/>
+      <point x="238" y="62" type="curve" smooth="yes"/>
+      <point x="162" y="62"/>
+      <point x="119" y="120"/>
+      <point x="119" y="225" type="curve" smooth="yes"/>
+      <point x="119" y="379"/>
+      <point x="200" y="518"/>
+      <point x="370" y="518" type="curve" smooth="yes"/>
+      <point x="472" y="518"/>
+      <point x="528" y="465"/>
+      <point x="528" y="369" type="curve" smooth="yes"/>
+      <point x="528" y="350"/>
+      <point x="525" y="318"/>
+      <point x="519" y="285" type="curve" smooth="yes"/>
+      <point x="469" y="0" type="line"/>
+      <point x="553" y="0" type="line"/>
+      <point x="609" y="319" type="line" smooth="yes"/>
+      <point x="633" y="454"/>
+      <point x="713" y="529"/>
+      <point x="833" y="529" type="curve" smooth="yes"/>
+      <point x="851" y="529"/>
+      <point x="864" y="528"/>
+      <point x="881" y="525" type="curve"/>
+      <point x="839" y="544" type="line"/>
+      <point x="838" y="523" type="line"/>
+      <point x="793" y="498"/>
+      <point x="769" y="456"/>
+      <point x="769" y="408" type="curve" smooth="yes"/>
+      <point x="769" y="338"/>
+      <point x="823" y="287"/>
+      <point x="903" y="287" type="curve" smooth="yes"/>
+      <point x="1020" y="287"/>
+      <point x="1056" y="369"/>
+      <point x="1056" y="424" type="curve" smooth="yes"/>
+      <point x="1056" y="465"/>
+      <point x="1039" y="503"/>
+      <point x="1003" y="530" type="curve"/>
+      <point x="1018" y="564" type="line"/>
+      <point x="979" y="534" type="line"/>
+      <point x="986" y="535"/>
+      <point x="998" y="536"/>
+      <point x="1010" y="536" type="curve" smooth="yes"/>
+      <point x="1085" y="536"/>
+      <point x="1124" y="497"/>
+      <point x="1124" y="425" type="curve" smooth="yes"/>
+      <point x="1124" y="409"/>
+      <point x="1122" y="392"/>
+      <point x="1119" y="375" type="curve" smooth="yes"/>
+      <point x="1110" y="324" type="line"/>
+      <point x="1194" y="324" type="line"/>
+      <point x="1203" y="375" type="line" smooth="yes"/>
+      <point x="1218" y="464"/>
+      <point x="1275" y="518"/>
+      <point x="1355" y="518" type="curve" smooth="yes"/>
+      <point x="1421" y="518"/>
+      <point x="1457" y="484"/>
+      <point x="1457" y="422" type="curve" smooth="yes"/>
+      <point x="1457" y="321"/>
+      <point x="1381" y="267"/>
+      <point x="1258" y="267" type="curve" smooth="yes"/>
+      <point x="915" y="267" type="line" smooth="yes"/>
+      <point x="778" y="267"/>
+      <point x="725" y="184"/>
+      <point x="725" y="115" type="curve" smooth="yes"/>
+      <point x="725" y="39"/>
+      <point x="783" y="-16"/>
+      <point x="868" y="-16" type="curve" smooth="yes"/>
+      <point x="915" y="-16"/>
+      <point x="952" y="-4"/>
+      <point x="1038" y="35" type="curve" smooth="yes"/>
+      <point x="1166" y="93" type="line"/>
+      <point x="1241" y="141" type="line"/>
+      <point x="1278" y="153" type="line"/>
+      <point x="1306" y="170"/>
+      <point x="1326" y="176"/>
+      <point x="1355" y="176" type="curve" smooth="yes"/>
+      <point x="1391" y="176"/>
+      <point x="1412" y="155"/>
+      <point x="1412" y="121" type="curve" smooth="yes"/>
+      <point x="1412" y="91"/>
+      <point x="1391" y="54"/>
+      <point x="1339" y="54" type="curve" smooth="yes"/>
+      <point x="1302" y="54"/>
+      <point x="1281" y="74"/>
+      <point x="1281" y="110" type="curve" smooth="yes"/>
+      <point x="1281" y="134"/>
+      <point x="1291" y="159"/>
+      <point x="1312" y="180" type="curve"/>
+      <point x="1220" y="145" type="line"/>
+      <point x="1236" y="131" type="line"/>
+      <point x="1229" y="117"/>
+      <point x="1225" y="101"/>
+      <point x="1225" y="85" type="curve" smooth="yes"/>
+      <point x="1225" y="24"/>
+      <point x="1267" y="-16"/>
+      <point x="1336" y="-16" type="curve" smooth="yes"/>
+      <point x="1440" y="-16"/>
+      <point x="1484" y="67"/>
+      <point x="1484" y="125" type="curve" smooth="yes"/>
+      <point x="1484" y="189"/>
+      <point x="1444" y="236"/>
+      <point x="1370" y="236" type="curve" smooth="yes"/>
+      <point x="1331" y="236"/>
+      <point x="1285" y="221"/>
+      <point x="1205" y="185" type="curve" smooth="yes"/>
+      <point x="1017" y="100" type="line" smooth="yes"/>
+      <point x="956" y="72"/>
+      <point x="919" y="60"/>
+      <point x="879" y="60" type="curve" smooth="yes"/>
+      <point x="833" y="60"/>
+      <point x="807" y="85"/>
+      <point x="807" y="121" type="curve" smooth="yes"/>
+      <point x="807" y="158"/>
+      <point x="835" y="195"/>
+      <point x="911" y="195" type="curve" smooth="yes"/>
+      <point x="1233" y="195" type="line" smooth="yes"/>
+      <point x="1403" y="195"/>
+      <point x="1540" y="283"/>
+      <point x="1540" y="436" type="curve" smooth="yes"/>
+      <point x="1540" y="532"/>
+      <point x="1484" y="596"/>
+      <point x="1376" y="596" type="curve" smooth="yes"/>
+      <point x="1289" y="596"/>
+      <point x="1219" y="552"/>
+      <point x="1182" y="475" type="curve"/>
+      <point x="1177" y="475" type="line"/>
+      <point x="1165" y="552"/>
+      <point x="1112" y="596"/>
+      <point x="1014" y="596" type="curve" smooth="yes"/>
+      <point x="980" y="596"/>
+      <point x="941" y="589"/>
+      <point x="910" y="575" type="curve"/>
+      <point x="943" y="575" type="line"/>
+      <point x="912" y="589"/>
+      <point x="877" y="596"/>
       <point x="835" y="596" type="curve" smooth="yes"/>
-      <point x="721" y="596"/>
-      <point x="641" y="554"/>
-      <point x="590" y="470" type="curve"/>
-      <point x="585" y="470" type="line"/>
-      <point x="547" y="556"/>
-      <point x="472" y="596"/>
-      <point x="365" y="596" type="curve" smooth="yes"/>
-      <point x="173" y="596"/>
-      <point x="38" y="442"/>
-      <point x="38" y="223" type="curve" smooth="yes"/>
-      <point x="38" y="77"/>
-      <point x="115" y="-16"/>
+      <point x="722" y="596"/>
+      <point x="640" y="547"/>
+      <point x="591" y="464" type="curve"/>
+      <point x="586" y="464" type="line"/>
+      <point x="552" y="549"/>
+      <point x="484" y="596"/>
+      <point x="374" y="596" type="curve" smooth="yes"/>
+      <point x="145" y="596"/>
+      <point x="37" y="402"/>
+      <point x="37" y="223" type="curve" smooth="yes"/>
+      <point x="37" y="77"/>
+      <point x="114" y="-16"/>
+    </contour>
+    <contour>
+      <point x="909" y="357" type="curve" smooth="yes"/>
+      <point x="869" y="357"/>
+      <point x="846" y="380"/>
+      <point x="846" y="418" type="curve" smooth="yes"/>
+      <point x="846" y="473"/>
+      <point x="896" y="519"/>
+      <point x="963" y="536" type="curve"/>
+      <point x="895" y="536" type="line"/>
+      <point x="954" y="517"/>
+      <point x="982" y="483"/>
+      <point x="982" y="433" type="curve" smooth="yes"/>
+      <point x="982" y="394"/>
+      <point x="955" y="357"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/oo-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/oo-malayalam.glif
@@ -4,7 +4,7 @@
   <unicode hex="0D13"/>
   <outline>
     <component base="o-malayalam"/>
-    <component base="aaMatra-malayalam" xOffset="793"/>
+    <component base="aaMatra-malayalam" xOffset="780"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/rr_rra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/rr_rra-malayalam.glif
@@ -1,38 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="rr_rra-malayalam" format="2">
-  <advance width="695"/>
+  <advance width="696"/>
   <anchor x="254" y="-311" name="bottom"/>
   <anchor x="404" y="580" name="top"/>
   <anchor x="612" y="580" name="topright"/>
   <outline>
-    <contour>
-      <point x="149" y="-327" type="curve"/>
-      <point x="206" y="-278" type="line"/>
-      <point x="184" y="-252"/>
-      <point x="160" y="-215"/>
-      <point x="160" y="-144" type="curve" smooth="yes"/>
-      <point x="160" y="-57"/>
-      <point x="207" y="13"/>
-      <point x="306" y="13" type="curve" smooth="yes"/>
-      <point x="384" y="13"/>
-      <point x="431" y="-25"/>
-      <point x="431" y="-106" type="curve" smooth="yes"/>
-      <point x="431" y="-190"/>
-      <point x="385" y="-228"/>
-      <point x="329" y="-275" type="curve"/>
-      <point x="375" y="-327" type="line"/>
-      <point x="456" y="-266"/>
-      <point x="506" y="-198"/>
-      <point x="506" y="-102" type="curve" smooth="yes"/>
-      <point x="506" y="24"/>
-      <point x="429" y="83"/>
-      <point x="308" y="83" type="curve" smooth="yes"/>
-      <point x="163" y="83"/>
-      <point x="84" y="-12"/>
-      <point x="84" y="-148" type="curve" smooth="yes"/>
-      <point x="84" y="-223"/>
-      <point x="108" y="-283"/>
-    </contour>
     <contour>
       <point x="165" y="-16" type="curve"/>
       <point x="222" y="44" type="line"/>
@@ -60,6 +32,34 @@
       <point x="43" y="258" type="curve" smooth="yes"/>
       <point x="43" y="151"/>
       <point x="85" y="56"/>
+    </contour>
+    <contour>
+      <point x="149" y="-327" type="curve"/>
+      <point x="206" y="-278" type="line"/>
+      <point x="184" y="-252"/>
+      <point x="160" y="-215"/>
+      <point x="160" y="-144" type="curve" smooth="yes"/>
+      <point x="160" y="-57"/>
+      <point x="207" y="13"/>
+      <point x="306" y="13" type="curve" smooth="yes"/>
+      <point x="384" y="13"/>
+      <point x="431" y="-25"/>
+      <point x="431" y="-106" type="curve" smooth="yes"/>
+      <point x="431" y="-190"/>
+      <point x="385" y="-228"/>
+      <point x="329" y="-275" type="curve"/>
+      <point x="375" y="-327" type="line"/>
+      <point x="456" y="-266"/>
+      <point x="506" y="-198"/>
+      <point x="506" y="-102" type="curve" smooth="yes"/>
+      <point x="506" y="24"/>
+      <point x="429" y="83"/>
+      <point x="308" y="83" type="curve" smooth="yes"/>
+      <point x="163" y="83"/>
+      <point x="84" y="-12"/>
+      <point x="84" y="-148" type="curve" smooth="yes"/>
+      <point x="84" y="-223"/>
+      <point x="108" y="-283"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/t_la-malayalam.glif
@@ -1,136 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_la-malayalam" format="2">
   <advance width="981"/>
-  <anchor x="509" y="-351" name="bottom"/>
-  <anchor x="551" y="580" name="top"/>
-  <anchor x="875" y="580" name="topright"/>
+  <anchor x="494" y="-351" name="bottom"/>
+  <anchor x="545" y="580" name="top"/>
+  <anchor x="869" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="287" y="-367" type="curve" smooth="yes"/>
-      <point x="372" y="-367"/>
-      <point x="424" y="-313"/>
-      <point x="424" y="-228" type="curve" smooth="yes"/>
-      <point x="424" y="-154"/>
-      <point x="384" y="-118"/>
-      <point x="315" y="-118" type="curve" smooth="yes"/>
-      <point x="283" y="-118"/>
-      <point x="245" y="-131"/>
-      <point x="219" y="-164" type="curve"/>
-      <point x="213" y="-163" type="line"/>
-      <point x="233" y="-78"/>
-      <point x="290" y="-27"/>
-      <point x="377" y="-27" type="curve" smooth="yes"/>
-      <point x="482" y="-27"/>
-      <point x="509" y="-86"/>
-      <point x="514" y="-174" type="curve" smooth="yes"/>
-      <point x="515" y="-192" type="line" smooth="yes"/>
-      <point x="521" y="-303"/>
-      <point x="571" y="-367"/>
-      <point x="681" y="-367" type="curve" smooth="yes"/>
+      <point x="276" y="-367" type="curve" smooth="yes"/>
+      <point x="364" y="-367"/>
+      <point x="417" y="-301"/>
+      <point x="417" y="-229" type="curve" smooth="yes"/>
+      <point x="417" y="-162"/>
+      <point x="381" y="-118"/>
+      <point x="314" y="-118" type="curve" smooth="yes"/>
+      <point x="266" y="-118"/>
+      <point x="200" y="-150"/>
+      <point x="187" y="-232" type="curve"/>
+      <point x="226" y="-176" type="line"/>
+      <point x="196" y="-163" type="line"/>
+      <point x="202" y="-188" type="line"/>
+      <point x="222" y="-91"/>
+      <point x="287" y="-27"/>
+      <point x="384" y="-27" type="curve" smooth="yes"/>
+      <point x="458" y="-27"/>
+      <point x="492" y="-64"/>
+      <point x="507" y="-157" type="curve" smooth="yes"/>
+      <point x="514" y="-200" type="line" smooth="yes"/>
+      <point x="533" y="-317"/>
+      <point x="584" y="-367"/>
+      <point x="676" y="-367" type="curve" smooth="yes"/>
       <point x="810" y="-367"/>
-      <point x="865" y="-271"/>
-      <point x="865" y="-131" type="curve" smooth="yes"/>
-      <point x="865" y="-58"/>
-      <point x="846" y="1"/>
-      <point x="816" y="43" type="curve"/>
-      <point x="773" y="-16" type="line"/>
-      <point x="894" y="84"/>
-      <point x="952" y="196"/>
-      <point x="952" y="326" type="curve" smooth="yes"/>
-      <point x="952" y="495"/>
-      <point x="848" y="596"/>
-      <point x="673" y="596" type="curve" smooth="yes"/>
-      <point x="461" y="596"/>
-      <point x="285" y="415"/>
-      <point x="285" y="197" type="curve" smooth="yes"/>
-      <point x="285" y="136"/>
-      <point x="301" y="86"/>
-      <point x="343" y="46" type="curve"/>
-      <point x="342" y="41" type="line"/>
-      <point x="212" y="16"/>
-      <point x="141" y="-83"/>
-      <point x="141" y="-210" type="curve" smooth="yes"/>
-      <point x="141" y="-316"/>
-      <point x="205" y="-367"/>
+      <point x="858" y="-239"/>
+      <point x="858" y="-140" type="curve" smooth="yes"/>
+      <point x="858" y="-71"/>
+      <point x="842" y="-10"/>
+      <point x="812" y="41" type="curve"/>
+      <point x="804" y="13" type="line"/>
+      <point x="891" y="110"/>
+      <point x="941" y="225"/>
+      <point x="941" y="338" type="curve" smooth="yes"/>
+      <point x="941" y="493"/>
+      <point x="856" y="596"/>
+      <point x="692" y="596" type="curve" smooth="yes"/>
+      <point x="626" y="596"/>
+      <point x="564" y="578"/>
+      <point x="508" y="548" type="curve"/>
+      <point x="554" y="546" type="line"/>
+      <point x="507" y="577"/>
+      <point x="450" y="596"/>
+      <point x="382" y="596" type="curve" smooth="yes"/>
+      <point x="162" y="596"/>
+      <point x="38" y="412"/>
+      <point x="38" y="234" type="curve" smooth="yes"/>
+      <point x="38" y="137"/>
+      <point x="63" y="59"/>
+      <point x="119" y="-16" type="curve"/>
+      <point x="183" y="31" type="line"/>
+      <point x="142" y="85"/>
+      <point x="119" y="159"/>
+      <point x="119" y="236" type="curve" smooth="yes"/>
+      <point x="119" y="380"/>
+      <point x="209" y="518"/>
+      <point x="376" y="518" type="curve" smooth="yes"/>
+      <point x="411" y="518"/>
+      <point x="442" y="512"/>
+      <point x="468" y="502" type="curve"/>
+      <point x="467" y="523" type="line"/>
+      <point x="354" y="443"/>
+      <point x="280" y="311"/>
+      <point x="280" y="186" type="curve" smooth="yes"/>
+      <point x="280" y="126"/>
+      <point x="298" y="77"/>
+      <point x="330" y="42" type="curve"/>
+      <point x="329" y="37" type="line"/>
+      <point x="200" y="-2"/>
+      <point x="134" y="-116"/>
+      <point x="134" y="-214" type="curve" smooth="yes"/>
+      <point x="134" y="-313"/>
+      <point x="195" y="-367"/>
     </contour>
     <contour>
-      <point x="683" y="-297" type="curve" smooth="yes"/>
-      <point x="623" y="-297"/>
-      <point x="598" y="-265"/>
-      <point x="590" y="-174" type="curve" smooth="yes"/>
-      <point x="588" y="-151" type="line" smooth="yes"/>
-      <point x="583" y="-90"/>
-      <point x="567" y="-39"/>
-      <point x="528" y="-4" type="curve"/>
-      <point x="529" y="1" type="line"/>
-      <point x="633" y="27"/>
-      <point x="690" y="130"/>
-      <point x="690" y="271" type="curve" smooth="yes"/>
-      <point x="690" y="390"/>
-      <point x="639" y="487"/>
-      <point x="557" y="543" type="curve"/>
-      <point x="469" y="502" type="line"/>
-      <point x="555" y="469"/>
-      <point x="604" y="387"/>
-      <point x="604" y="271" type="curve" smooth="yes"/>
-      <point x="604" y="148"/>
-      <point x="549" y="62"/>
-      <point x="470" y="62" type="curve" smooth="yes"/>
-      <point x="404" y="62"/>
-      <point x="367" y="111"/>
-      <point x="367" y="197" type="curve" smooth="yes"/>
-      <point x="367" y="379"/>
-      <point x="499" y="518"/>
-      <point x="673" y="518" type="curve" smooth="yes"/>
-      <point x="795" y="518"/>
-      <point x="868" y="447"/>
-      <point x="868" y="326" type="curve" smooth="yes"/>
-      <point x="868" y="221"/>
-      <point x="819" y="130"/>
-      <point x="728" y="46" type="curve"/>
-      <point x="762" y="3"/>
-      <point x="790" y="-61"/>
-      <point x="790" y="-139" type="curve" smooth="yes"/>
-      <point x="790" y="-226"/>
-      <point x="762" y="-297"/>
-    </contour>
-    <contour>
-      <point x="287" y="-302" type="curve" smooth="yes"/>
-      <point x="232" y="-302"/>
-      <point x="209" y="-264"/>
-      <point x="209" y="-218" type="curve"/>
-      <point x="190" y="-197" type="line"/>
-      <point x="201" y="-253" type="line"/>
-      <point x="209" y="-213"/>
+      <point x="276" y="-302" type="curve" smooth="yes"/>
+      <point x="228" y="-302"/>
+      <point x="201" y="-269"/>
+      <point x="201" y="-224" type="curve" smooth="yes"/>
+      <point x="201" y="-217"/>
+      <point x="202" y="-208"/>
+      <point x="204" y="-200" type="curve"/>
+      <point x="173" y="-205" type="line"/>
+      <point x="193" y="-265" type="line"/>
+      <point x="201" y="-213"/>
       <point x="242" y="-178"/>
       <point x="291" y="-178" type="curve" smooth="yes"/>
-      <point x="333" y="-178"/>
-      <point x="353" y="-199"/>
-      <point x="353" y="-233" type="curve" smooth="yes"/>
-      <point x="353" y="-276"/>
-      <point x="329" y="-302"/>
+      <point x="330" y="-178"/>
+      <point x="347" y="-201"/>
+      <point x="347" y="-233" type="curve" smooth="yes"/>
+      <point x="347" y="-272"/>
+      <point x="320" y="-302"/>
     </contour>
     <contour>
-      <point x="120" y="-16" type="curve"/>
-      <point x="186" y="33" type="line"/>
-      <point x="143" y="90"/>
-      <point x="122" y="157"/>
-      <point x="122" y="243" type="curve" smooth="yes"/>
-      <point x="122" y="407"/>
-      <point x="225" y="518"/>
-      <point x="375" y="518" type="curve" smooth="yes"/>
-      <point x="410" y="518"/>
-      <point x="442" y="512"/>
-      <point x="469" y="502" type="curve"/>
-      <point x="557" y="543" type="line"/>
-      <point x="507" y="577"/>
-      <point x="445" y="596"/>
-      <point x="375" y="596" type="curve" smooth="yes"/>
-      <point x="181" y="596"/>
-      <point x="40" y="447"/>
-      <point x="40" y="243" type="curve" smooth="yes"/>
-      <point x="40" y="141"/>
-      <point x="67" y="52"/>
+      <point x="462" y="62" type="curve" smooth="yes"/>
+      <point x="396" y="62"/>
+      <point x="363" y="108"/>
+      <point x="363" y="189" type="curve" smooth="yes"/>
+      <point x="363" y="312"/>
+      <point x="435" y="428"/>
+      <point x="542" y="484" type="curve"/>
+      <point x="503" y="484" type="line"/>
+      <point x="568" y="443"/>
+      <point x="598" y="365"/>
+      <point x="598" y="273" type="curve" smooth="yes"/>
+      <point x="598" y="179"/>
+      <point x="564" y="62"/>
+    </contour>
+    <contour>
+      <point x="682" y="-297" type="curve" smooth="yes"/>
+      <point x="629" y="-297"/>
+      <point x="601" y="-269"/>
+      <point x="587" y="-185" type="curve" smooth="yes"/>
+      <point x="580" y="-142" type="line" smooth="yes"/>
+      <point x="568" y="-67"/>
+      <point x="550" y="-27"/>
+      <point x="516" y="-3" type="curve"/>
+      <point x="517" y="2" type="line"/>
+      <point x="629" y="39"/>
+      <point x="685" y="166"/>
+      <point x="685" y="271" type="curve" smooth="yes"/>
+      <point x="685" y="370"/>
+      <point x="649" y="462"/>
+      <point x="583" y="523" type="curve"/>
+      <point x="579" y="500" type="line"/>
+      <point x="610" y="512"/>
+      <point x="644" y="518"/>
+      <point x="679" y="518" type="curve" smooth="yes"/>
+      <point x="801" y="518"/>
+      <point x="857" y="444"/>
+      <point x="857" y="330" type="curve" smooth="yes"/>
+      <point x="857" y="230"/>
+      <point x="809" y="136"/>
+      <point x="712" y="42" type="curve"/>
+      <point x="763" y="-18"/>
+      <point x="785" y="-75"/>
+      <point x="785" y="-142" type="curve" smooth="yes"/>
+      <point x="785" y="-208"/>
+      <point x="762" y="-297"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ta-malayalam.glif
@@ -2,61 +2,61 @@
 <glyph name="ta-malayalam" format="2">
   <advance width="981"/>
   <unicode hex="0D24"/>
-  <anchor x="527" y="0" name="bottom"/>
-  <anchor x="551" y="580" name="top"/>
-  <anchor x="875" y="580" name="topright"/>
+  <anchor x="521" y="0" name="bottom"/>
+  <anchor x="545" y="580" name="top"/>
+  <anchor x="869" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="120" y="-16" type="curve"/>
-      <point x="186" y="33" type="line"/>
-      <point x="143" y="90"/>
-      <point x="122" y="157"/>
-      <point x="122" y="243" type="curve" smooth="yes"/>
-      <point x="122" y="407"/>
-      <point x="225" y="518"/>
-      <point x="375" y="518" type="curve" smooth="yes"/>
-      <point x="518" y="518"/>
-      <point x="604" y="425"/>
-      <point x="604" y="271" type="curve" smooth="yes"/>
-      <point x="604" y="148"/>
-      <point x="549" y="62"/>
-      <point x="470" y="62" type="curve" smooth="yes"/>
-      <point x="404" y="62"/>
-      <point x="367" y="111"/>
-      <point x="367" y="197" type="curve" smooth="yes"/>
-      <point x="367" y="379"/>
-      <point x="499" y="518"/>
-      <point x="673" y="518" type="curve" smooth="yes"/>
-      <point x="795" y="518"/>
-      <point x="868" y="447"/>
-      <point x="868" y="326" type="curve" smooth="yes"/>
-      <point x="868" y="221"/>
-      <point x="819" y="130"/>
-      <point x="718" y="46" type="curve"/>
-      <point x="773" y="-16" type="line"/>
-      <point x="894" y="84"/>
-      <point x="952" y="196"/>
-      <point x="952" y="326" type="curve" smooth="yes"/>
-      <point x="952" y="495"/>
-      <point x="848" y="596"/>
-      <point x="673" y="596" type="curve" smooth="yes"/>
+      <point x="119" y="-16" type="curve"/>
+      <point x="183" y="31" type="line"/>
+      <point x="142" y="85"/>
+      <point x="119" y="159"/>
+      <point x="119" y="236" type="curve" smooth="yes"/>
+      <point x="119" y="380"/>
+      <point x="209" y="518"/>
+      <point x="376" y="518" type="curve" smooth="yes"/>
+      <point x="529" y="518"/>
+      <point x="598" y="412"/>
+      <point x="598" y="273" type="curve" smooth="yes"/>
+      <point x="598" y="179"/>
+      <point x="564" y="62"/>
+      <point x="462" y="62" type="curve" smooth="yes"/>
+      <point x="396" y="62"/>
+      <point x="363" y="108"/>
+      <point x="363" y="189" type="curve" smooth="yes"/>
+      <point x="363" y="361"/>
+      <point x="506" y="518"/>
+      <point x="679" y="518" type="curve" smooth="yes"/>
+      <point x="801" y="518"/>
+      <point x="857" y="444"/>
+      <point x="857" y="330" type="curve" smooth="yes"/>
+      <point x="857" y="232"/>
+      <point x="811" y="139"/>
+      <point x="716" y="46" type="curve"/>
+      <point x="777" y="-16" type="line"/>
+      <point x="883" y="88"/>
+      <point x="941" y="214"/>
+      <point x="941" y="338" type="curve" smooth="yes"/>
+      <point x="941" y="493"/>
+      <point x="856" y="596"/>
+      <point x="692" y="596" type="curve" smooth="yes"/>
       <point x="461" y="596"/>
-      <point x="285" y="415"/>
-      <point x="285" y="197" type="curve" smooth="yes"/>
-      <point x="285" y="67"/>
-      <point x="357" y="-16"/>
-      <point x="470" y="-16" type="curve" smooth="yes"/>
-      <point x="603" y="-16"/>
-      <point x="690" y="97"/>
-      <point x="690" y="271" type="curve" smooth="yes"/>
-      <point x="690" y="462"/>
-      <point x="560" y="596"/>
-      <point x="375" y="596" type="curve" smooth="yes"/>
-      <point x="181" y="596"/>
-      <point x="40" y="447"/>
-      <point x="40" y="243" type="curve" smooth="yes"/>
-      <point x="40" y="141"/>
-      <point x="67" y="52"/>
+      <point x="280" y="381"/>
+      <point x="280" y="186" type="curve" smooth="yes"/>
+      <point x="280" y="63"/>
+      <point x="348" y="-16"/>
+      <point x="456" y="-16" type="curve" smooth="yes"/>
+      <point x="608" y="-16"/>
+      <point x="685" y="144"/>
+      <point x="685" y="271" type="curve" smooth="yes"/>
+      <point x="685" y="446"/>
+      <point x="575" y="596"/>
+      <point x="382" y="596" type="curve" smooth="yes"/>
+      <point x="162" y="596"/>
+      <point x="38" y="412"/>
+      <point x="38" y="234" type="curve" smooth="yes"/>
+      <point x="38" y="137"/>
+      <point x="63" y="59"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="981"/>
   <outline>
     <component base="ta-malayalam"/>
-    <component base="halant-malayalam" xOffset="802"/>
+    <component base="halant-malayalam" xOffset="796"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="572"/>
-  <anchor x="291" y="0" name="bottom"/>
-  <anchor x="270" y="580" name="top"/>
-  <anchor x="421" y="580" name="topright"/>
+  <anchor x="215" y="-235" name="bottom"/>
+  <anchor x="334" y="580" name="top"/>
+  <anchor x="485" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="235" y="-225" type="curve" smooth="yes"/>
-      <point x="383" y="-225"/>
-      <point x="482" y="-182"/>
-      <point x="482" y="-73" type="curve" smooth="yes"/>
-      <point x="482" y="-26"/>
-      <point x="452" y="16"/>
-      <point x="392" y="32" type="curve"/>
-      <point x="392" y="37" type="line"/>
-      <point x="477" y="59"/>
-      <point x="518" y="112"/>
-      <point x="518" y="193" type="curve" smooth="yes"/>
-      <point x="518" y="288"/>
-      <point x="467" y="340"/>
-      <point x="332" y="347" type="curve" smooth="yes"/>
-      <point x="235" y="352" type="line" smooth="yes"/>
-      <point x="173" y="355"/>
-      <point x="140" y="381"/>
-      <point x="140" y="426" type="curve" smooth="yes"/>
-      <point x="140" y="486"/>
-      <point x="196" y="515"/>
-      <point x="290" y="515" type="curve" smooth="yes"/>
-      <point x="379" y="515"/>
-      <point x="440" y="494"/>
-      <point x="499" y="463" type="curve"/>
-      <point x="541" y="533" type="line"/>
-      <point x="478" y="570"/>
-      <point x="391" y="596"/>
-      <point x="289" y="596" type="curve" smooth="yes"/>
-      <point x="140" y="596"/>
-      <point x="51" y="527"/>
-      <point x="51" y="421" type="curve" smooth="yes"/>
-      <point x="51" y="333"/>
-      <point x="108" y="271"/>
-      <point x="211" y="265" type="curve" smooth="yes"/>
-      <point x="316" y="259" type="line" smooth="yes"/>
-      <point x="408" y="254"/>
-      <point x="432" y="225"/>
-      <point x="432" y="176" type="curve" smooth="yes"/>
-      <point x="432" y="104"/>
-      <point x="374" y="80"/>
-      <point x="293" y="80" type="curve" smooth="yes"/>
-      <point x="37" y="80" type="line"/>
-      <point x="24" y="6" type="line"/>
-      <point x="231" y="6" type="line" smooth="yes"/>
-      <point x="361" y="6"/>
-      <point x="399" y="-26"/>
-      <point x="399" y="-72" type="curve" smooth="yes"/>
-      <point x="399" y="-126"/>
-      <point x="352" y="-147"/>
-      <point x="236" y="-147" type="curve" smooth="yes"/>
-      <point x="133" y="-147"/>
-      <point x="61" y="-124"/>
-      <point x="6" y="-98" type="curve"/>
-      <point x="-40" y="-166" type="line"/>
-      <point x="15" y="-198"/>
-      <point x="114" y="-225"/>
+      <point x="216" y="-251" type="curve" smooth="yes"/>
+      <point x="395" y="-251"/>
+      <point x="472" y="-167"/>
+      <point x="472" y="-69" type="curve" smooth="yes"/>
+      <point x="472" y="-13"/>
+      <point x="443" y="29"/>
+      <point x="385" y="46" type="curve"/>
+      <point x="386" y="52" type="line"/>
+      <point x="469" y="78"/>
+      <point x="510" y="128"/>
+      <point x="510" y="199" type="curve" smooth="yes"/>
+      <point x="510" y="286"/>
+      <point x="452" y="334"/>
+      <point x="334" y="345" type="curve" smooth="yes"/>
+      <point x="228" y="355" type="line" smooth="yes"/>
+      <point x="167" y="361"/>
+      <point x="137" y="382"/>
+      <point x="137" y="426" type="curve" smooth="yes"/>
+      <point x="137" y="478"/>
+      <point x="181" y="516"/>
+      <point x="306" y="516" type="curve" smooth="yes"/>
+      <point x="383" y="516"/>
+      <point x="449" y="500"/>
+      <point x="505" y="468" type="curve"/>
+      <point x="544" y="538" type="line"/>
+      <point x="474" y="579"/>
+      <point x="405" y="596"/>
+      <point x="314" y="596" type="curve" smooth="yes"/>
+      <point x="115" y="596"/>
+      <point x="49" y="499"/>
+      <point x="49" y="414" type="curve" smooth="yes"/>
+      <point x="49" y="329"/>
+      <point x="108" y="277"/>
+      <point x="208" y="268" type="curve" smooth="yes"/>
+      <point x="314" y="258" type="line" smooth="yes"/>
+      <point x="394" y="250"/>
+      <point x="422" y="229"/>
+      <point x="422" y="181" type="curve" smooth="yes"/>
+      <point x="422" y="128"/>
+      <point x="377" y="86"/>
+      <point x="262" y="86" type="curve" smooth="yes"/>
+      <point x="33" y="86" type="line"/>
+      <point x="20" y="12" type="line"/>
+      <point x="274" y="12" type="line" smooth="yes"/>
+      <point x="356" y="12"/>
+      <point x="389" y="-17"/>
+      <point x="389" y="-69" type="curve" smooth="yes"/>
+      <point x="389" y="-126"/>
+      <point x="340" y="-171"/>
+      <point x="226" y="-171" type="curve" smooth="yes"/>
+      <point x="140" y="-171"/>
+      <point x="61" y="-144"/>
+      <point x="7" y="-95" type="curve"/>
+      <point x="-45" y="-156" type="line"/>
+      <point x="24" y="-218"/>
+      <point x="114" y="-251"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/tta-malayalam.glif
@@ -2,51 +2,51 @@
 <glyph name="tta-malayalam" format="2">
   <advance width="574"/>
   <unicode hex="0D1F"/>
-  <anchor x="246" y="0" name="bottom"/>
-  <anchor x="327" y="580" name="top"/>
-  <anchor x="478" y="580" name="topright"/>
+  <anchor x="253" y="0" name="bottom"/>
+  <anchor x="334" y="580" name="top"/>
+  <anchor x="485" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="279" y="-16" type="curve" smooth="yes"/>
-      <point x="427" y="-16"/>
-      <point x="514" y="50"/>
-      <point x="514" y="166" type="curve" smooth="yes"/>
-      <point x="514" y="259"/>
-      <point x="459" y="324"/>
-      <point x="316" y="334" type="curve" smooth="yes"/>
-      <point x="244" y="339" type="line" smooth="yes"/>
-      <point x="170" y="344"/>
-      <point x="137" y="374"/>
-      <point x="137" y="420" type="curve" smooth="yes"/>
-      <point x="137" y="486"/>
-      <point x="193" y="515"/>
-      <point x="287" y="515" type="curve" smooth="yes"/>
-      <point x="376" y="515"/>
-      <point x="437" y="494"/>
-      <point x="496" y="463" type="curve"/>
-      <point x="538" y="533" type="line"/>
-      <point x="475" y="570"/>
-      <point x="388" y="596"/>
-      <point x="286" y="596" type="curve" smooth="yes"/>
-      <point x="137" y="596"/>
-      <point x="49" y="527"/>
-      <point x="49" y="409" type="curve" smooth="yes"/>
-      <point x="49" y="323"/>
-      <point x="105" y="256"/>
-      <point x="223" y="249" type="curve" smooth="yes"/>
-      <point x="309" y="244" type="line" smooth="yes"/>
-      <point x="395" y="239"/>
-      <point x="428" y="205"/>
-      <point x="428" y="161" type="curve" smooth="yes"/>
-      <point x="428" y="96"/>
-      <point x="373" y="65"/>
-      <point x="281" y="65" type="curve" smooth="yes"/>
-      <point x="182" y="65"/>
-      <point x="111" y="99"/>
-      <point x="47" y="147" type="curve"/>
-      <point x="-9" y="76" type="line"/>
-      <point x="63" y="23"/>
-      <point x="148" y="-16"/>
+      <point x="270" y="-16" type="curve" smooth="yes"/>
+      <point x="440" y="-16"/>
+      <point x="516" y="74"/>
+      <point x="516" y="169" type="curve" smooth="yes"/>
+      <point x="516" y="267"/>
+      <point x="458" y="323"/>
+      <point x="344" y="333" type="curve" smooth="yes"/>
+      <point x="240" y="342" type="line" smooth="yes"/>
+      <point x="174" y="348"/>
+      <point x="143" y="372"/>
+      <point x="143" y="418" type="curve" smooth="yes"/>
+      <point x="143" y="473"/>
+      <point x="195" y="516"/>
+      <point x="314" y="516" type="curve" smooth="yes"/>
+      <point x="395" y="516"/>
+      <point x="453" y="502"/>
+      <point x="511" y="470" type="curve"/>
+      <point x="549" y="540" type="line"/>
+      <point x="481" y="578"/>
+      <point x="408" y="596"/>
+      <point x="320" y="596" type="curve" smooth="yes"/>
+      <point x="132" y="596"/>
+      <point x="57" y="500"/>
+      <point x="57" y="409" type="curve" smooth="yes"/>
+      <point x="57" y="318"/>
+      <point x="120" y="262"/>
+      <point x="221" y="253" type="curve" smooth="yes"/>
+      <point x="325" y="244" type="line" smooth="yes"/>
+      <point x="400" y="238"/>
+      <point x="430" y="214"/>
+      <point x="430" y="163" type="curve" smooth="yes"/>
+      <point x="430" y="108"/>
+      <point x="382" y="64"/>
+      <point x="276" y="64" type="curve" smooth="yes"/>
+      <point x="183" y="64"/>
+      <point x="105" y="89"/>
+      <point x="37" y="141" type="curve"/>
+      <point x="-12" y="78" type="line"/>
+      <point x="68" y="15"/>
+      <point x="161" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/tta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/tta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="574"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="halant-malayalam" xOffset="405"/>
+    <component base="halant-malayalam" xOffset="412"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="574"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="292"/>
+    <component base="lVocalicMatra-malayalam" xOffset="299"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="574"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="292"/>
+    <component base="llVocalicMatra-malayalam" xOffset="299"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/uuM_atra-malayalam.glif
@@ -4,65 +4,71 @@
   <unicode hex="0D42"/>
   <outline>
     <contour>
-      <point x="22" y="13" type="curve"/>
-      <point x="112" y="13" type="line"/>
-      <point x="173" y="124"/>
-      <point x="233" y="282"/>
-      <point x="233" y="396" type="curve" smooth="yes"/>
-      <point x="233" y="512"/>
-      <point x="172" y="585"/>
-      <point x="62" y="595" type="curve" smooth="yes"/>
-      <point x="51" y="596" type="line"/>
-      <point x="37" y="518" type="line"/>
-      <point x="113" y="511"/>
-      <point x="151" y="468"/>
-      <point x="151" y="389" type="curve" smooth="yes"/>
-      <point x="151" y="280"/>
-      <point x="88" y="124"/>
+      <point x="41" y="16" type="curve"/>
+      <point x="125" y="16" type="line"/>
+      <point x="194" y="145"/>
+      <point x="243" y="299"/>
+      <point x="243" y="394" type="curve" smooth="yes"/>
+      <point x="243" y="522"/>
+      <point x="183" y="596"/>
+      <point x="67" y="596" type="curve" smooth="yes"/>
+      <point x="59" y="596" type="line"/>
+      <point x="45" y="519" type="line"/>
+      <point x="124" y="519"/>
+      <point x="160" y="475"/>
+      <point x="160" y="388" type="curve" smooth="yes"/>
+      <point x="160" y="290"/>
+      <point x="117" y="155"/>
     </contour>
     <contour>
-      <point x="52" y="-256" type="curve" smooth="yes"/>
-      <point x="148" y="-256"/>
-      <point x="222" y="-187"/>
-      <point x="222" y="-96" type="curve" smooth="yes"/>
-      <point x="222" y="-11"/>
-      <point x="157" y="52"/>
-      <point x="67" y="52" type="curve" smooth="yes"/>
-      <point x="-28" y="52"/>
+      <point x="53" y="-185" type="curve" smooth="yes"/>
+      <point x="0" y="-185"/>
+      <point x="-37" y="-156"/>
+      <point x="-37" y="-112" type="curve" smooth="yes"/>
+      <point x="-37" y="-91"/>
+      <point x="-31" y="-74"/>
+      <point x="-19" y="-60" type="curve"/>
+      <point x="-15" y="-60" type="line"/>
+      <point x="-11" y="-100"/>
+      <point x="15" y="-127"/>
+      <point x="58" y="-127" type="curve" smooth="yes"/>
+      <point x="100" y="-127"/>
+      <point x="129" y="-103"/>
+      <point x="141" y="-60" type="curve"/>
+      <point x="145" y="-60" type="line"/>
+      <point x="148" y="-70"/>
+      <point x="150" y="-80"/>
+      <point x="150" y="-92" type="curve" smooth="yes"/>
+      <point x="150" y="-140"/>
+      <point x="122" y="-185"/>
+    </contour>
+    <contour>
+      <point x="49" y="-256" type="curve" smooth="yes"/>
+      <point x="145" y="-256"/>
+      <point x="217" y="-187"/>
+      <point x="217" y="-96" type="curve" smooth="yes"/>
+      <point x="217" y="-11"/>
+      <point x="153" y="52"/>
+      <point x="64" y="52" type="curve" smooth="yes"/>
+      <point x="-30" y="52"/>
       <point x="-104" y="-20"/>
       <point x="-104" y="-110" type="curve" smooth="yes"/>
       <point x="-104" y="-195"/>
-      <point x="-39" y="-256"/>
+      <point x="-40" y="-256"/>
     </contour>
     <contour>
-      <point x="54" y="-185" type="curve" smooth="yes"/>
-      <point x="4" y="-185"/>
-      <point x="-30" y="-153"/>
-      <point x="-30" y="-106" type="curve" smooth="yes"/>
-      <point x="-30" y="-54"/>
-      <point x="10" y="-15"/>
-      <point x="65" y="-15" type="curve" smooth="yes"/>
-      <point x="114" y="-15"/>
-      <point x="148" y="-46"/>
-      <point x="148" y="-92" type="curve" smooth="yes"/>
-      <point x="148" y="-147"/>
-      <point x="109" y="-185"/>
-    </contour>
-    <contour>
-      <point x="69" y="-125" type="curve" smooth="yes"/>
-      <point x="107" y="-125"/>
-      <point x="141" y="-114"/>
-      <point x="170" y="-93" type="curve"/>
-      <point x="154" y="-51" type="line"/>
-      <point x="130" y="-68"/>
-      <point x="104" y="-76"/>
-      <point x="71" y="-76" type="curve" smooth="yes"/>
-      <point x="25" y="-76"/>
-      <point x="-5" y="-61"/>
-      <point x="-26" y="-35" type="curve"/>
-      <point x="-55" y="-73" type="line"/>
-      <point x="-27" y="-107"/>
-      <point x="13" y="-125"/>
+      <point x="62" y="-63" type="curve" smooth="yes"/>
+      <point x="29" y="-63"/>
+      <point x="6" y="-50"/>
+      <point x="6" y="-31" type="curve" smooth="yes"/>
+      <point x="6" y="-14"/>
+      <point x="24" y="0"/>
+      <point x="76" y="0" type="curve" smooth="yes"/>
+      <point x="115" y="0"/>
+      <point x="133" y="-10"/>
+      <point x="133" y="-26" type="curve" smooth="yes"/>
+      <point x="133" y="-46"/>
+      <point x="111" y="-63"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/y_ya-malayalam.glif
@@ -1,96 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="984"/>
-  <anchor x="528" y="-281" name="bottom"/>
-  <anchor x="562" y="580" name="top"/>
-  <anchor x="868" y="580" name="topright"/>
+  <anchor x="524" y="-268" name="bottom"/>
+  <anchor x="556" y="580" name="top"/>
+  <anchor x="862" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="210" y="-291" type="line"/>
-      <point x="780" y="-291" type="line"/>
-      <point x="844" y="79" type="line"/>
-      <point x="829" y="45" type="line"/>
-      <point x="909" y="107"/>
-      <point x="956" y="213"/>
-      <point x="956" y="349" type="curve" smooth="yes"/>
-      <point x="956" y="450"/>
-      <point x="935" y="530"/>
-      <point x="891" y="596" type="curve"/>
-      <point x="822" y="553" type="line"/>
-      <point x="857" y="499"/>
-      <point x="874" y="432"/>
-      <point x="874" y="349" type="curve" smooth="yes"/>
-      <point x="874" y="173"/>
-      <point x="783" y="62"/>
-      <point x="639" y="62" type="curve" smooth="yes"/>
-      <point x="496" y="62"/>
-      <point x="419" y="152"/>
-      <point x="419" y="320" type="curve" smooth="yes"/>
-      <point x="419" y="435"/>
-      <point x="469" y="518"/>
+      <point x="204" y="-278" type="line"/>
+      <point x="774" y="-278" type="line"/>
+      <point x="844" y="121" type="line"/>
+      <point x="820" y="69" type="line"/>
+      <point x="903" y="137"/>
+      <point x="947" y="245"/>
+      <point x="947" y="349" type="curve" smooth="yes"/>
+      <point x="947" y="438"/>
+      <point x="919" y="526"/>
+      <point x="869" y="596" type="curve"/>
+      <point x="802" y="552" type="line"/>
+      <point x="846" y="489"/>
+      <point x="868" y="421"/>
+      <point x="868" y="350" type="curve" smooth="yes"/>
+      <point x="868" y="197"/>
+      <point x="767" y="62"/>
+      <point x="605" y="62" type="curve" smooth="yes"/>
+      <point x="446" y="62"/>
+      <point x="376" y="165"/>
+      <point x="376" y="303" type="curve" smooth="yes"/>
+      <point x="376" y="386"/>
+      <point x="414" y="518"/>
       <point x="539" y="518" type="curve" smooth="yes"/>
-      <point x="599" y="518"/>
-      <point x="630" y="474"/>
-      <point x="630" y="389" type="curve" smooth="yes"/>
-      <point x="630" y="247"/>
-      <point x="574" y="142"/>
-      <point x="468" y="85" type="curve"/>
-      <point x="519" y="30" type="line"/>
-      <point x="643" y="99"/>
-      <point x="712" y="228"/>
-      <point x="712" y="389" type="curve" smooth="yes"/>
-      <point x="712" y="525"/>
-      <point x="654" y="596"/>
-      <point x="543" y="596" type="curve" smooth="yes"/>
-      <point x="425" y="596"/>
-      <point x="337" y="478"/>
-      <point x="337" y="320" type="curve" smooth="yes"/>
-      <point x="337" y="122"/>
-      <point x="461" y="-16"/>
-      <point x="637" y="-16" type="curve" smooth="yes"/>
-      <point x="642" y="-16"/>
-      <point x="646" y="-16"/>
-      <point x="651" y="-16" type="curve"/>
-      <point x="595" y="30" type="line"/>
-      <point x="604" y="-19" type="line"/>
-      <point x="508" y="-70" type="line"/>
-      <point x="219" y="-235" type="line"/>
+      <point x="609" y="518"/>
+      <point x="644" y="471"/>
+      <point x="644" y="387" type="curve" smooth="yes"/>
+      <point x="644" y="269"/>
+      <point x="572" y="155"/>
+      <point x="456" y="96" type="curve"/>
+      <point x="507" y="49" type="line"/>
+      <point x="653" y="122"/>
+      <point x="726" y="259"/>
+      <point x="726" y="389" type="curve" smooth="yes"/>
+      <point x="726" y="516"/>
+      <point x="663" y="596"/>
+      <point x="547" y="596" type="curve" smooth="yes"/>
+      <point x="388" y="596"/>
+      <point x="294" y="442"/>
+      <point x="294" y="305" type="curve" smooth="yes"/>
+      <point x="294" y="126"/>
+      <point x="418" y="-12"/>
+      <point x="599" y="-12" type="curve" smooth="yes"/>
+      <point x="623" y="-12"/>
+      <point x="647" y="-10"/>
+      <point x="669" y="-5" type="curve"/>
+      <point x="582" y="33" type="line"/>
+      <point x="575" y="-15" type="line"/>
+      <point x="492" y="-57" type="line"/>
+      <point x="214" y="-222" type="line"/>
     </contour>
     <contour>
-      <point x="311" y="-262" type="line"/>
-      <point x="775" y="10" type="line"/>
-      <point x="750" y="10" type="line"/>
-      <point x="706" y="-244" type="line"/>
-      <point x="747" y="-226" type="line"/>
-      <point x="347" y="-226" type="line"/>
+      <point x="315" y="-243" type="line"/>
+      <point x="757" y="19" type="line"/>
+      <point x="744" y="18" type="line"/>
+      <point x="700" y="-231" type="line"/>
+      <point x="742" y="-213" type="line"/>
+      <point x="320" y="-213" type="line"/>
     </contour>
     <contour>
-      <point x="343" y="-16" type="curve" smooth="yes"/>
-      <point x="407" y="-16"/>
-      <point x="459" y="-3"/>
-      <point x="508" y="27" type="curve"/>
-      <point x="438" y="77" type="line"/>
-      <point x="408" y="67"/>
-      <point x="377" y="62"/>
-      <point x="343" y="62" type="curve" smooth="yes"/>
-      <point x="209" y="62"/>
-      <point x="129" y="150"/>
-      <point x="129" y="296" type="curve" smooth="yes"/>
-      <point x="129" y="429"/>
-      <point x="200" y="518"/>
-      <point x="306" y="518" type="curve" smooth="yes"/>
-      <point x="357" y="518"/>
-      <point x="390" y="503"/>
-      <point x="413" y="470" type="curve"/>
-      <point x="464" y="520" type="line"/>
-      <point x="433" y="571"/>
-      <point x="384" y="596"/>
-      <point x="312" y="596" type="curve" smooth="yes"/>
-      <point x="158" y="596"/>
-      <point x="49" y="471"/>
-      <point x="49" y="296" type="curve" smooth="yes"/>
-      <point x="49" y="107"/>
-      <point x="165" y="-16"/>
+      <point x="325" y="-16" type="curve" smooth="yes"/>
+      <point x="382" y="-16"/>
+      <point x="429" y="-3"/>
+      <point x="482" y="30" type="curve"/>
+      <point x="428" y="81" type="line"/>
+      <point x="400" y="69"/>
+      <point x="370" y="62"/>
+      <point x="333" y="62" type="curve" smooth="yes"/>
+      <point x="198" y="62"/>
+      <point x="125" y="146"/>
+      <point x="125" y="279" type="curve" smooth="yes"/>
+      <point x="125" y="385"/>
+      <point x="179" y="518"/>
+      <point x="320" y="518" type="curve" smooth="yes"/>
+      <point x="363" y="518"/>
+      <point x="387" y="505"/>
+      <point x="409" y="479" type="curve"/>
+      <point x="469" y="536" type="line"/>
+      <point x="430" y="575"/>
+      <point x="389" y="596"/>
+      <point x="323" y="596" type="curve" smooth="yes"/>
+      <point x="133" y="596"/>
+      <point x="46" y="416"/>
+      <point x="46" y="281" type="curve" smooth="yes"/>
+      <point x="46" y="105"/>
+      <point x="157" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ya-malayalam.glif
@@ -2,78 +2,78 @@
 <glyph name="ya-malayalam" format="2">
   <advance width="984"/>
   <unicode hex="0D2F"/>
-  <anchor x="531" y="0" name="bottom"/>
-  <anchor x="810" y="0" name="bottomright"/>
-  <anchor x="562" y="580" name="top"/>
-  <anchor x="868" y="580" name="topright"/>
+  <anchor x="525" y="0" name="bottom"/>
+  <anchor x="804" y="0" name="bottomright"/>
+  <anchor x="556" y="580" name="top"/>
+  <anchor x="862" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="639" y="-16" type="curve" smooth="yes"/>
-      <point x="831" y="-16"/>
-      <point x="956" y="127"/>
-      <point x="956" y="349" type="curve" smooth="yes"/>
-      <point x="956" y="450"/>
-      <point x="935" y="530"/>
-      <point x="891" y="596" type="curve"/>
-      <point x="822" y="553" type="line"/>
-      <point x="857" y="499"/>
-      <point x="874" y="432"/>
-      <point x="874" y="349" type="curve" smooth="yes"/>
-      <point x="874" y="173"/>
-      <point x="783" y="62"/>
-      <point x="639" y="62" type="curve" smooth="yes"/>
-      <point x="496" y="62"/>
-      <point x="419" y="152"/>
-      <point x="419" y="320" type="curve" smooth="yes"/>
-      <point x="419" y="435"/>
-      <point x="469" y="518"/>
+      <point x="599" y="-16" type="curve" smooth="yes"/>
+      <point x="815" y="-16"/>
+      <point x="947" y="170"/>
+      <point x="947" y="349" type="curve" smooth="yes"/>
+      <point x="947" y="438"/>
+      <point x="919" y="526"/>
+      <point x="869" y="596" type="curve"/>
+      <point x="802" y="552" type="line"/>
+      <point x="846" y="489"/>
+      <point x="868" y="421"/>
+      <point x="868" y="350" type="curve" smooth="yes"/>
+      <point x="868" y="197"/>
+      <point x="767" y="62"/>
+      <point x="605" y="62" type="curve" smooth="yes"/>
+      <point x="446" y="62"/>
+      <point x="376" y="165"/>
+      <point x="376" y="303" type="curve" smooth="yes"/>
+      <point x="376" y="386"/>
+      <point x="414" y="518"/>
       <point x="539" y="518" type="curve" smooth="yes"/>
-      <point x="599" y="518"/>
-      <point x="630" y="474"/>
-      <point x="630" y="389" type="curve" smooth="yes"/>
-      <point x="630" y="247"/>
-      <point x="574" y="142"/>
-      <point x="468" y="85" type="curve"/>
-      <point x="519" y="30" type="line"/>
-      <point x="643" y="99"/>
-      <point x="712" y="228"/>
-      <point x="712" y="389" type="curve" smooth="yes"/>
-      <point x="712" y="525"/>
-      <point x="654" y="596"/>
-      <point x="543" y="596" type="curve" smooth="yes"/>
-      <point x="425" y="596"/>
-      <point x="337" y="478"/>
-      <point x="337" y="320" type="curve" smooth="yes"/>
-      <point x="337" y="122"/>
-      <point x="462" y="-16"/>
+      <point x="609" y="518"/>
+      <point x="644" y="471"/>
+      <point x="644" y="387" type="curve" smooth="yes"/>
+      <point x="644" y="269"/>
+      <point x="572" y="155"/>
+      <point x="456" y="96" type="curve"/>
+      <point x="507" y="49" type="line"/>
+      <point x="653" y="122"/>
+      <point x="726" y="259"/>
+      <point x="726" y="389" type="curve" smooth="yes"/>
+      <point x="726" y="516"/>
+      <point x="663" y="596"/>
+      <point x="547" y="596" type="curve" smooth="yes"/>
+      <point x="388" y="596"/>
+      <point x="294" y="442"/>
+      <point x="294" y="305" type="curve" smooth="yes"/>
+      <point x="294" y="124"/>
+      <point x="418" y="-16"/>
     </contour>
     <contour>
-      <point x="343" y="-16" type="curve" smooth="yes"/>
-      <point x="407" y="-16"/>
-      <point x="459" y="-3"/>
-      <point x="508" y="27" type="curve"/>
-      <point x="438" y="77" type="line"/>
-      <point x="408" y="67"/>
-      <point x="377" y="62"/>
-      <point x="343" y="62" type="curve" smooth="yes"/>
-      <point x="209" y="62"/>
-      <point x="129" y="150"/>
-      <point x="129" y="296" type="curve" smooth="yes"/>
-      <point x="129" y="429"/>
-      <point x="200" y="518"/>
-      <point x="306" y="518" type="curve" smooth="yes"/>
-      <point x="357" y="518"/>
-      <point x="390" y="503"/>
-      <point x="413" y="470" type="curve"/>
-      <point x="464" y="520" type="line"/>
-      <point x="433" y="571"/>
-      <point x="384" y="596"/>
-      <point x="312" y="596" type="curve" smooth="yes"/>
-      <point x="158" y="596"/>
-      <point x="49" y="471"/>
-      <point x="49" y="296" type="curve" smooth="yes"/>
-      <point x="49" y="107"/>
-      <point x="165" y="-16"/>
+      <point x="325" y="-16" type="curve" smooth="yes"/>
+      <point x="382" y="-16"/>
+      <point x="429" y="-3"/>
+      <point x="482" y="30" type="curve"/>
+      <point x="428" y="81" type="line"/>
+      <point x="400" y="69"/>
+      <point x="370" y="62"/>
+      <point x="333" y="62" type="curve" smooth="yes"/>
+      <point x="198" y="62"/>
+      <point x="125" y="146"/>
+      <point x="125" y="279" type="curve" smooth="yes"/>
+      <point x="125" y="385"/>
+      <point x="179" y="518"/>
+      <point x="320" y="518" type="curve" smooth="yes"/>
+      <point x="363" y="518"/>
+      <point x="387" y="505"/>
+      <point x="409" y="479" type="curve"/>
+      <point x="469" y="536" type="line"/>
+      <point x="430" y="575"/>
+      <point x="389" y="596"/>
+      <point x="323" y="596" type="curve" smooth="yes"/>
+      <point x="133" y="596"/>
+      <point x="46" y="416"/>
+      <point x="46" y="281" type="curve" smooth="yes"/>
+      <point x="46" y="105"/>
+      <point x="157" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ya-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ya-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="984"/>
   <outline>
     <component base="ya-malayalam"/>
-    <component base="halant-malayalam" xOffset="795"/>
+    <component base="halant-malayalam" xOffset="789"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/kerning.plist
@@ -47215,7 +47215,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -47329,7 +47329,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47385,7 +47385,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47440,7 +47440,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>200</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -47487,7 +47487,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -47522,7 +47522,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>110</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -47550,8 +47550,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47586,7 +47584,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47653,7 +47651,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47713,7 +47711,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>130</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47764,7 +47762,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>170</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47822,7 +47820,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47865,7 +47863,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48003,8 +48001,6 @@
       <integer>-10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48090,7 +48086,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48190,8 +48186,6 @@
       <integer>60</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48224,7 +48218,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48304,7 +48298,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48346,8 +48340,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla-malayalam_L</key>
       <integer>-30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48465,8 +48457,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -48580,7 +48570,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48629,7 +48619,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>200</integer>
+      <integer>190</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48679,17 +48669,17 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>70</integer>
-      <key>public.kern2.MAL_braceright.loclMALM_R</key>
       <integer>50</integer>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>40</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
       <integer>40</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
@@ -48699,23 +48689,25 @@
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
       <integer>40</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
-      <integer>-30</integer>
+      <integer>-20</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>70</integer>
+      <key>public.kern2.MAL_tt_tta-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
-      <integer>130</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
-      <integer>90</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_uMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>74</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>220</integer>
+      <integer>210</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
       <integer>170</integer>
     </dict>
@@ -48742,7 +48734,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48791,7 +48783,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>160</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48867,7 +48859,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49078,7 +49070,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49104,8 +49096,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49134,7 +49124,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49188,7 +49178,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -49220,8 +49210,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -49338,7 +49326,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_p_pa-malayalam_L</key>
@@ -49450,7 +49438,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49495,7 +49483,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49591,7 +49579,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -49731,7 +49719,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49784,7 +49772,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49851,7 +49839,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49904,7 +49892,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>290</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>240</integer>
+      <integer>220</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -49991,7 +49979,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>130</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50140,7 +50128,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -50248,7 +50236,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_ng_ka-malayalam_L</key>
@@ -50300,6 +50288,26 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-40</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>110</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>100</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+      <key>public.kern2.MAL_quoteright.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.Man-georgian</key>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/archaicii-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/archaicii-malayalam.glif
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="archaicii-malayalam" format="2">
-  <advance width="1347"/>
+  <advance width="1361"/>
   <unicode hex="0D5F"/>
   <outline>
     <component base="archaicii-malayalam.part"/>
-    <component base="ra-malayalam" xOffset="314"/>
-    <component base="archaicii-malayalam.part" xOffset="1033"/>
+    <component base="ra-malayalam" xOffset="321"/>
+    <component base="archaicii-malayalam.part" xOffset="1040"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/d_da-malayalam.glif
@@ -1,76 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
-  <advance width="665"/>
-  <guideline x="1234" y="-225" angle="0"/>
-  <guideline x="605" y="162" angle="90"/>
-  <guideline x="1428" y="185" angle="90"/>
-  <anchor x="349" y="580" name="top"/>
+  <advance width="655"/>
+  <anchor x="279" y="-263" name="bottom"/>
+  <anchor x="414" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="375" y="-225" type="curve" smooth="yes"/>
-      <point x="503" y="-225"/>
-      <point x="569" y="-175"/>
-      <point x="569" y="-83" type="curve" smooth="yes"/>
-      <point x="569" y="-32"/>
-      <point x="537" y="9"/>
-      <point x="477" y="21" type="curve"/>
-      <point x="477" y="26" type="line"/>
-      <point x="529" y="39"/>
-      <point x="601" y="68"/>
-      <point x="601" y="166" type="curve" smooth="yes"/>
-      <point x="601" y="221"/>
-      <point x="573" y="269"/>
-      <point x="503" y="286" type="curve"/>
-      <point x="504" y="291" type="line"/>
-      <point x="587" y="306"/>
-      <point x="628" y="359"/>
-      <point x="628" y="429" type="curve" smooth="yes"/>
-      <point x="628" y="526"/>
-      <point x="551" y="596"/>
-      <point x="392" y="596" type="curve" smooth="yes"/>
-      <point x="178" y="596"/>
-      <point x="39" y="445"/>
-      <point x="39" y="234" type="curve" smooth="yes"/>
-      <point x="39" y="140"/>
-      <point x="60" y="61"/>
-      <point x="104" y="-16" type="curve"/>
-      <point x="177" y="29" type="line"/>
-      <point x="139" y="91"/>
-      <point x="122" y="156"/>
-      <point x="122" y="237" type="curve" smooth="yes"/>
-      <point x="122" y="399"/>
-      <point x="216" y="518"/>
-      <point x="387" y="518" type="curve" smooth="yes"/>
-      <point x="497" y="518"/>
-      <point x="543" y="478"/>
-      <point x="543" y="425" type="curve" smooth="yes"/>
-      <point x="543" y="365"/>
-      <point x="499" y="329"/>
-      <point x="431" y="329" type="curve" smooth="yes"/>
-      <point x="371" y="329" type="line"/>
-      <point x="358" y="255" type="line"/>
-      <point x="400" y="255" type="line" smooth="yes"/>
+      <point x="319" y="-279" type="curve" smooth="yes"/>
+      <point x="464" y="-279"/>
+      <point x="547" y="-191"/>
+      <point x="547" y="-103" type="curve" smooth="yes"/>
+      <point x="547" y="-44"/>
+      <point x="522" y="-1"/>
+      <point x="471" y="20" type="curve"/>
+      <point x="472" y="26" type="line"/>
+      <point x="547" y="47"/>
+      <point x="596" y="100"/>
+      <point x="596" y="173" type="curve" smooth="yes"/>
+      <point x="596" y="233"/>
+      <point x="564" y="273"/>
+      <point x="499" y="289" type="curve"/>
+      <point x="500" y="295" type="line"/>
+      <point x="576" y="313"/>
+      <point x="624" y="362"/>
+      <point x="624" y="434" type="curve" smooth="yes"/>
+      <point x="624" y="525"/>
+      <point x="549" y="596"/>
+      <point x="404" y="596" type="curve" smooth="yes"/>
+      <point x="137" y="596"/>
+      <point x="39" y="400"/>
+      <point x="39" y="235" type="curve" smooth="yes"/>
+      <point x="39" y="147"/>
+      <point x="62" y="61"/>
+      <point x="107" y="-16" type="curve"/>
+      <point x="179" y="27" type="line"/>
+      <point x="141" y="94"/>
+      <point x="122" y="162"/>
+      <point x="122" y="236" type="curve" smooth="yes"/>
+      <point x="122" y="374"/>
+      <point x="192" y="518"/>
+      <point x="396" y="518" type="curve" smooth="yes"/>
+      <point x="494" y="518"/>
+      <point x="541" y="485"/>
+      <point x="541" y="424" type="curve" smooth="yes"/>
+      <point x="541" y="367"/>
+      <point x="494" y="329"/>
+      <point x="413" y="329" type="curve" smooth="yes"/>
+      <point x="367" y="329" type="line"/>
+      <point x="354" y="255" type="line"/>
+      <point x="408" y="255" type="line" smooth="yes"/>
       <point x="477" y="255"/>
-      <point x="520" y="229"/>
-      <point x="520" y="169" type="curve" smooth="yes"/>
-      <point x="520" y="82"/>
-      <point x="458" y="62"/>
-      <point x="397" y="62" type="curve" smooth="yes"/>
-      <point x="324" y="62" type="line"/>
-      <point x="311" y="-12" type="line"/>
-      <point x="364" y="-12" type="line" smooth="yes"/>
-      <point x="453" y="-12"/>
-      <point x="488" y="-37"/>
-      <point x="488" y="-77" type="curve" smooth="yes"/>
-      <point x="488" y="-125"/>
-      <point x="450" y="-147"/>
-      <point x="388" y="-147" type="curve" smooth="yes"/>
-      <point x="320" y="-147"/>
-      <point x="283" y="-139"/>
-      <point x="255" y="-129" type="curve"/>
-      <point x="214" y="-201" type="line"/>
-      <point x="249" y="-215"/>
-      <point x="309" y="-225"/>
+      <point x="513" y="224"/>
+      <point x="513" y="170" type="curve" smooth="yes"/>
+      <point x="513" y="101"/>
+      <point x="464" y="62"/>
+      <point x="377" y="62" type="curve" smooth="yes"/>
+      <point x="304" y="62" type="line"/>
+      <point x="291" y="-12" type="line"/>
+      <point x="349" y="-12" type="line" smooth="yes"/>
+      <point x="434" y="-12"/>
+      <point x="464" y="-45"/>
+      <point x="464" y="-99" type="curve" smooth="yes"/>
+      <point x="464" y="-152"/>
+      <point x="426" y="-201"/>
+      <point x="325" y="-201" type="curve" smooth="yes"/>
+      <point x="261" y="-201"/>
+      <point x="211" y="-187"/>
+      <point x="160" y="-158" type="curve"/>
+      <point x="121" y="-227" type="line"/>
+      <point x="181" y="-261"/>
+      <point x="249" y="-279"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="963"/>
-  <anchor x="611" y="0" name="bottom"/>
-  <anchor x="531" y="580" name="top"/>
-  <anchor x="903" y="580" name="topright"/>
+  <advance width="956"/>
+  <anchor x="599" y="0" name="bottom"/>
+  <anchor x="526" y="580" name="top"/>
+  <anchor x="891" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="243" y="-16" type="curve" smooth="yes"/>
-      <point x="363" y="-16"/>
-      <point x="440" y="58"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="548" y="451"/>
-      <point x="603" y="516"/>
-      <point x="717" y="516" type="curve" smooth="yes"/>
-      <point x="808" y="516"/>
-      <point x="856" y="487"/>
-      <point x="856" y="423" type="curve" smooth="yes"/>
-      <point x="856" y="365"/>
-      <point x="812" y="329"/>
-      <point x="741" y="329" type="curve" smooth="yes"/>
-      <point x="681" y="329" type="line"/>
-      <point x="668" y="255" type="line"/>
-      <point x="710" y="255" type="line" smooth="yes"/>
-      <point x="788" y="255"/>
-      <point x="829" y="222"/>
-      <point x="829" y="159" type="curve" smooth="yes"/>
-      <point x="829" y="96"/>
-      <point x="790" y="62"/>
-      <point x="718" y="62" type="curve" smooth="yes"/>
-      <point x="677" y="62"/>
-      <point x="642" y="71"/>
-      <point x="608" y="90" type="curve"/>
-      <point x="565" y="20" type="line"/>
-      <point x="604" y="-3"/>
-      <point x="657" y="-16"/>
-      <point x="713" y="-16" type="curve" smooth="yes"/>
-      <point x="834" y="-16"/>
-      <point x="911" y="52"/>
-      <point x="911" y="159" type="curve" smooth="yes"/>
-      <point x="911" y="220"/>
-      <point x="875" y="269"/>
-      <point x="813" y="285" type="curve"/>
-      <point x="813" y="290" type="line"/>
-      <point x="892" y="303"/>
-      <point x="938" y="354"/>
-      <point x="938" y="431" type="curve" smooth="yes"/>
-      <point x="938" y="536"/>
-      <point x="860" y="596"/>
-      <point x="721" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="474" y="508"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="72"/>
-      <point x="115" y="-16"/>
+      <point x="253" y="-16" type="curve" smooth="yes"/>
+      <point x="380" y="-16"/>
+      <point x="468" y="70"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="592" y="516"/>
+      <point x="702" y="516" type="curve" smooth="yes"/>
+      <point x="792" y="516"/>
+      <point x="839" y="482"/>
+      <point x="839" y="422" type="curve" smooth="yes"/>
+      <point x="839" y="365"/>
+      <point x="795" y="329"/>
+      <point x="724" y="329" type="curve" smooth="yes"/>
+      <point x="664" y="329" type="line"/>
+      <point x="651" y="255" type="line"/>
+      <point x="693" y="255" type="line" smooth="yes"/>
+      <point x="771" y="255"/>
+      <point x="812" y="222"/>
+      <point x="812" y="159" type="curve" smooth="yes"/>
+      <point x="812" y="96"/>
+      <point x="773" y="62"/>
+      <point x="701" y="62" type="curve" smooth="yes"/>
+      <point x="660" y="62"/>
+      <point x="625" y="71"/>
+      <point x="591" y="90" type="curve"/>
+      <point x="548" y="20" type="line"/>
+      <point x="587" y="-3"/>
+      <point x="640" y="-16"/>
+      <point x="696" y="-16" type="curve" smooth="yes"/>
+      <point x="817" y="-16"/>
+      <point x="894" y="52"/>
+      <point x="894" y="159" type="curve" smooth="yes"/>
+      <point x="894" y="220"/>
+      <point x="858" y="267"/>
+      <point x="796" y="283" type="curve"/>
+      <point x="796" y="288" type="line"/>
+      <point x="874" y="302"/>
+      <point x="921" y="355"/>
+      <point x="921" y="426" type="curve" smooth="yes"/>
+      <point x="921" y="532"/>
+      <point x="841" y="596"/>
+      <point x="705" y="596" type="curve" smooth="yes"/>
+      <point x="543" y="596"/>
+      <point x="442" y="504"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="75"/>
+      <point x="121" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/g_ga-malayalam.glif
@@ -1,92 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ga-malayalam" format="2">
   <advance width="910"/>
-  <anchor x="416" y="-351" name="bottom"/>
-  <anchor x="515" y="580" name="top"/>
-  <anchor x="819" y="580" name="topright"/>
+  <anchor x="427" y="-351" name="bottom"/>
+  <anchor x="510" y="580" name="top"/>
+  <anchor x="814" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="605" y="-369" type="line"/>
-      <point x="679" y="-303"/>
-      <point x="733" y="-222"/>
-      <point x="733" y="-115" type="curve" smooth="yes"/>
-      <point x="733" y="-14"/>
-      <point x="670" y="43"/>
-      <point x="575" y="43" type="curve" smooth="yes"/>
-      <point x="479" y="43"/>
-      <point x="424" y="-12"/>
-      <point x="394" y="-146" type="curve" smooth="yes"/>
-      <point x="389" y="-168" type="line" smooth="yes"/>
-      <point x="366" y="-269"/>
-      <point x="335" y="-297"/>
-      <point x="281" y="-297" type="curve" smooth="yes"/>
-      <point x="230" y="-297"/>
-      <point x="195" y="-264"/>
-      <point x="195" y="-196" type="curve" smooth="yes"/>
-      <point x="195" y="-124"/>
-      <point x="234" y="-59"/>
-      <point x="292" y="-4" type="curve"/>
-      <point x="269" y="-15" type="line"/>
-      <point x="374" y="-5"/>
-      <point x="443" y="70"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="603" y="516"/>
-      <point x="683" y="516" type="curve" smooth="yes"/>
-      <point x="762" y="516"/>
-      <point x="804" y="465"/>
-      <point x="804" y="369" type="curve" smooth="yes"/>
-      <point x="804" y="244"/>
-      <point x="742" y="127"/>
-      <point x="608" y="24" type="curve"/>
-      <point x="683" y="-16" type="line"/>
-      <point x="812" y="90"/>
-      <point x="886" y="230"/>
-      <point x="886" y="369" type="curve" smooth="yes"/>
-      <point x="886" y="511"/>
-      <point x="811" y="596"/>
-      <point x="685" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="476" y="517"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="93"/>
-      <point x="92" y="12"/>
-      <point x="191" y="-10" type="curve"/>
-      <point x="191" y="-15" type="line"/>
-      <point x="144" y="-75"/>
-      <point x="120" y="-136"/>
-      <point x="120" y="-204" type="curve" smooth="yes"/>
-      <point x="120" y="-306"/>
-      <point x="178" y="-367"/>
-      <point x="283" y="-367" type="curve" smooth="yes"/>
-      <point x="377" y="-367"/>
-      <point x="430" y="-313"/>
-      <point x="460" y="-175" type="curve" smooth="yes"/>
-      <point x="465" y="-152" type="line" smooth="yes"/>
-      <point x="486" y="-53"/>
-      <point x="518" y="-27"/>
-      <point x="570" y="-27" type="curve" smooth="yes"/>
-      <point x="628" y="-27"/>
-      <point x="657" y="-64"/>
-      <point x="657" y="-126" type="curve" smooth="yes"/>
-      <point x="657" y="-201"/>
-      <point x="614" y="-268"/>
-      <point x="556" y="-321" type="curve"/>
+      <point x="253" y="-12" type="curve" smooth="yes"/>
+      <point x="380" y="-12"/>
+      <point x="468" y="73"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="580" y="514"/>
+      <point x="668" y="514" type="curve" smooth="yes"/>
+      <point x="749" y="514"/>
+      <point x="793" y="462"/>
+      <point x="793" y="367" type="curve" smooth="yes"/>
+      <point x="793" y="253"/>
+      <point x="727" y="132"/>
+      <point x="609" y="31" type="curve"/>
+      <point x="681" y="-12" type="line"/>
+      <point x="800" y="90"/>
+      <point x="877" y="239"/>
+      <point x="877" y="369" type="curve" smooth="yes"/>
+      <point x="877" y="511"/>
+      <point x="798" y="596"/>
+      <point x="668" y="596" type="curve" smooth="yes"/>
+      <point x="538" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="77"/>
+      <point x="121" y="-12"/>
+    </contour>
+    <contour>
+      <point x="620" y="-369" type="line"/>
+      <point x="703" y="-303"/>
+      <point x="746" y="-220"/>
+      <point x="746" y="-128" type="curve" smooth="yes"/>
+      <point x="746" y="-27"/>
+      <point x="681" y="43"/>
+      <point x="587" y="43" type="curve" smooth="yes"/>
+      <point x="490" y="43"/>
+      <point x="425" y="-16"/>
+      <point x="410" y="-117" type="curve" smooth="yes"/>
+      <point x="407" y="-139"/>
+      <point x="405" y="-166"/>
+      <point x="402" y="-187" type="curve" smooth="yes"/>
+      <point x="391" y="-260"/>
+      <point x="358" y="-297"/>
+      <point x="303" y="-297" type="curve" smooth="yes"/>
+      <point x="244" y="-297"/>
+      <point x="210" y="-261"/>
+      <point x="210" y="-193" type="curve" smooth="yes"/>
+      <point x="210" y="-115"/>
+      <point x="240" y="-57"/>
+      <point x="310" y="8" type="curve"/>
+      <point x="221" y="8" type="line"/>
+      <point x="167" y="-46"/>
+      <point x="136" y="-122"/>
+      <point x="136" y="-195" type="curve" smooth="yes"/>
+      <point x="136" y="-298"/>
+      <point x="203" y="-367"/>
+      <point x="301" y="-367" type="curve" smooth="yes"/>
+      <point x="395" y="-367"/>
+      <point x="459" y="-306"/>
+      <point x="474" y="-200" type="curve" smooth="yes"/>
+      <point x="477" y="-177"/>
+      <point x="479" y="-153"/>
+      <point x="482" y="-130" type="curve" smooth="yes"/>
+      <point x="492" y="-63"/>
+      <point x="528" y="-27"/>
+      <point x="585" y="-27" type="curve" smooth="yes"/>
+      <point x="641" y="-27"/>
+      <point x="672" y="-63"/>
+      <point x="672" y="-130" type="curve" smooth="yes"/>
+      <point x="672" y="-199"/>
+      <point x="639" y="-263"/>
+      <point x="575" y="-313" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/g_la-malayalam.glif
@@ -1,116 +1,125 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_la-malayalam" format="2">
   <advance width="910"/>
-  <anchor x="428" y="-351" name="bottom"/>
-  <anchor x="515" y="580" name="top"/>
-  <anchor x="819" y="580" name="topright"/>
+  <anchor x="408" y="-351" name="bottom"/>
+  <anchor x="510" y="580" name="top"/>
+  <anchor x="814" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="206" y="-367" type="curve" smooth="yes"/>
-      <point x="291" y="-367"/>
-      <point x="343" y="-313"/>
-      <point x="343" y="-228" type="curve" smooth="yes"/>
-      <point x="343" y="-154"/>
-      <point x="303" y="-118"/>
-      <point x="234" y="-118" type="curve" smooth="yes"/>
-      <point x="202" y="-118"/>
-      <point x="164" y="-131"/>
-      <point x="138" y="-164" type="curve"/>
-      <point x="132" y="-163" type="line"/>
-      <point x="152" y="-78"/>
-      <point x="209" y="-27"/>
-      <point x="296" y="-27" type="curve" smooth="yes"/>
-      <point x="401" y="-27"/>
-      <point x="428" y="-86"/>
-      <point x="433" y="-174" type="curve" smooth="yes"/>
-      <point x="434" y="-192" type="line" smooth="yes"/>
-      <point x="440" y="-303"/>
-      <point x="490" y="-367"/>
-      <point x="600" y="-367" type="curve" smooth="yes"/>
-      <point x="729" y="-367"/>
-      <point x="784" y="-271"/>
-      <point x="784" y="-131" type="curve" smooth="yes"/>
-      <point x="784" y="-62"/>
-      <point x="767" y="-6"/>
-      <point x="729" y="44" type="curve"/>
-      <point x="729" y="26" type="line"/>
-      <point x="829" y="125"/>
-      <point x="886" y="248"/>
-      <point x="886" y="369" type="curve" smooth="yes"/>
-      <point x="886" y="511"/>
-      <point x="811" y="596"/>
-      <point x="685" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="476" y="517"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="68"/>
-      <point x="243" y="68" type="curve" smooth="yes"/>
-      <point x="163" y="68"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="110"/>
-      <point x="75" y="39"/>
-      <point x="165" y="8" type="curve"/>
-      <point x="165" y="3" type="line"/>
-      <point x="96" y="-49"/>
-      <point x="60" y="-125"/>
-      <point x="60" y="-210" type="curve" smooth="yes"/>
-      <point x="60" y="-316"/>
-      <point x="124" y="-367"/>
+      <point x="191" y="-367" type="curve" smooth="yes"/>
+      <point x="282" y="-367"/>
+      <point x="332" y="-297"/>
+      <point x="332" y="-229" type="curve" smooth="yes"/>
+      <point x="332" y="-161"/>
+      <point x="295" y="-118"/>
+      <point x="224" y="-118" type="curve" smooth="yes"/>
+      <point x="171" y="-118"/>
+      <point x="124" y="-149"/>
+      <point x="111" y="-197" type="curve"/>
+      <point x="144" y="-171" type="line"/>
+      <point x="104" y="-155" type="line"/>
+      <point x="117" y="-188" type="line"/>
+      <point x="138" y="-82"/>
+      <point x="198" y="-27"/>
+      <point x="292" y="-27" type="curve" smooth="yes"/>
+      <point x="372" y="-27"/>
+      <point x="406" y="-67"/>
+      <point x="421" y="-157" type="curve" smooth="yes"/>
+      <point x="428" y="-200" type="line" smooth="yes"/>
+      <point x="446" y="-312"/>
+      <point x="503" y="-367"/>
+      <point x="596" y="-367" type="curve" smooth="yes"/>
+      <point x="727" y="-367"/>
+      <point x="774" y="-244"/>
+      <point x="774" y="-148" type="curve" smooth="yes"/>
+      <point x="774" y="-76"/>
+      <point x="758" y="-13"/>
+      <point x="717" y="41" type="curve"/>
+      <point x="719" y="23" type="line"/>
+      <point x="816" y="123"/>
+      <point x="877" y="255"/>
+      <point x="877" y="369" type="curve" smooth="yes"/>
+      <point x="877" y="511"/>
+      <point x="798" y="596"/>
+      <point x="668" y="596" type="curve" smooth="yes"/>
+      <point x="538" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="112"/>
+      <point x="81" y="38"/>
+      <point x="162" y="8" type="curve"/>
+      <point x="162" y="3" type="line"/>
+      <point x="97" y="-35"/>
+      <point x="49" y="-120"/>
+      <point x="49" y="-205" type="curve" smooth="yes"/>
+      <point x="49" y="-310"/>
+      <point x="110" y="-367"/>
     </contour>
     <contour>
-      <point x="206" y="-302" type="curve" smooth="yes"/>
-      <point x="151" y="-302"/>
-      <point x="128" y="-264"/>
-      <point x="128" y="-218" type="curve"/>
-      <point x="109" y="-197" type="line"/>
-      <point x="120" y="-253" type="line"/>
-      <point x="128" y="-213"/>
-      <point x="161" y="-178"/>
-      <point x="210" y="-178" type="curve" smooth="yes"/>
-      <point x="252" y="-178"/>
-      <point x="272" y="-199"/>
-      <point x="272" y="-233" type="curve" smooth="yes"/>
-      <point x="272" y="-276"/>
-      <point x="248" y="-302"/>
+      <point x="192" y="-302" type="curve" smooth="yes"/>
+      <point x="144" y="-302"/>
+      <point x="116" y="-269"/>
+      <point x="116" y="-223" type="curve" smooth="yes"/>
+      <point x="116" y="-216"/>
+      <point x="117" y="-208"/>
+      <point x="119" y="-200" type="curve"/>
+      <point x="98" y="-216" type="line"/>
+      <point x="108" y="-265" type="line"/>
+      <point x="116" y="-213"/>
+      <point x="157" y="-178"/>
+      <point x="206" y="-178" type="curve" smooth="yes"/>
+      <point x="243" y="-178"/>
+      <point x="262" y="-198"/>
+      <point x="262" y="-233" type="curve" smooth="yes"/>
+      <point x="262" y="-268"/>
+      <point x="238" y="-302"/>
     </contour>
     <contour>
-      <point x="602" y="-297" type="curve" smooth="yes"/>
-      <point x="542" y="-297"/>
-      <point x="517" y="-265"/>
-      <point x="509" y="-174" type="curve" smooth="yes"/>
-      <point x="507" y="-151" type="line" smooth="yes"/>
-      <point x="498" y="-52"/>
-      <point x="463" y="8"/>
-      <point x="374" y="34" type="curve"/>
-      <point x="374" y="39" type="line"/>
-      <point x="432" y="71"/>
-      <point x="461" y="137"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="603" y="512"/>
-      <point x="683" y="512" type="curve" smooth="yes"/>
-      <point x="762" y="512"/>
-      <point x="804" y="465"/>
-      <point x="804" y="369" type="curve" smooth="yes"/>
-      <point x="804" y="252"/>
-      <point x="745" y="143"/>
-      <point x="637" y="48" type="curve"/>
-      <point x="681" y="3"/>
-      <point x="709" y="-61"/>
-      <point x="709" y="-149" type="curve" smooth="yes"/>
-      <point x="709" y="-226"/>
-      <point x="681" y="-297"/>
+      <point x="600" y="-297" type="curve" smooth="yes"/>
+      <point x="546" y="-297"/>
+      <point x="514" y="-267"/>
+      <point x="501" y="-185" type="curve" smooth="yes"/>
+      <point x="494" y="-142" type="line" smooth="yes"/>
+      <point x="479" y="-51"/>
+      <point x="445" y="3"/>
+      <point x="378" y="26" type="curve"/>
+      <point x="378" y="31" type="line"/>
+      <point x="436" y="70"/>
+      <point x="477" y="133"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="580" y="514"/>
+      <point x="668" y="514" type="curve" smooth="yes"/>
+      <point x="749" y="514"/>
+      <point x="793" y="462"/>
+      <point x="793" y="367" type="curve" smooth="yes"/>
+      <point x="793" y="251"/>
+      <point x="733" y="138"/>
+      <point x="618" y="42" type="curve"/>
+      <point x="679" y="-20"/>
+      <point x="700" y="-76"/>
+      <point x="700" y="-151" type="curve" smooth="yes"/>
+      <point x="700" y="-214"/>
+      <point x="676" y="-297"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/g_ma-malayalam.glif
@@ -1,99 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ma-malayalam" format="2">
   <advance width="1401"/>
-  <anchor x="1029" y="0" name="bottom"/>
-  <anchor x="746" y="580" name="top"/>
-  <anchor x="1356" y="580" name="topright"/>
+  <anchor x="1024" y="0" name="bottom"/>
+  <anchor x="741" y="580" name="top"/>
+  <anchor x="1351" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="243" y="-16" type="curve" smooth="yes"/>
-      <point x="363" y="-16"/>
-      <point x="440" y="58"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="603" y="512"/>
-      <point x="683" y="512" type="curve" smooth="yes"/>
-      <point x="762" y="512"/>
-      <point x="804" y="465"/>
-      <point x="806" y="384" type="curve" smooth="yes"/>
-      <point x="806" y="365"/>
-      <point x="804" y="345"/>
-      <point x="800" y="323" type="curve" smooth="yes"/>
-      <point x="743" y="0" type="line"/>
-      <point x="1309" y="0" type="line"/>
-      <point x="1357" y="266" type="line" smooth="yes"/>
-      <point x="1363" y="299"/>
-      <point x="1366" y="342"/>
-      <point x="1366" y="362" type="curve" smooth="yes"/>
-      <point x="1366" y="521"/>
-      <point x="1264" y="596"/>
-      <point x="1118" y="596" type="curve" smooth="yes"/>
-      <point x="1005" y="596"/>
-      <point x="923" y="556"/>
-      <point x="868" y="474" type="curve"/>
-      <point x="863" y="474" type="line"/>
-      <point x="831" y="557"/>
-      <point x="769" y="596"/>
-      <point x="679" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="476" y="517"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="72"/>
-      <point x="115" y="-16"/>
+      <point x="253" y="-16" type="curve" smooth="yes"/>
+      <point x="380" y="-16"/>
+      <point x="468" y="70"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="580" y="514"/>
+      <point x="668" y="514" type="curve" smooth="yes"/>
+      <point x="750" y="514"/>
+      <point x="796" y="468"/>
+      <point x="796" y="386" type="curve" smooth="yes"/>
+      <point x="796" y="366"/>
+      <point x="794" y="346"/>
+      <point x="790" y="323" type="curve" smooth="yes"/>
+      <point x="733" y="0" type="line"/>
+      <point x="1299" y="0" type="line"/>
+      <point x="1347" y="271" type="line" smooth="yes"/>
+      <point x="1353" y="305"/>
+      <point x="1357" y="343"/>
+      <point x="1357" y="362" type="curve" smooth="yes"/>
+      <point x="1357" y="510"/>
+      <point x="1270" y="596"/>
+      <point x="1114" y="596" type="curve" smooth="yes"/>
+      <point x="997" y="596"/>
+      <point x="912" y="551"/>
+      <point x="857" y="474" type="curve"/>
+      <point x="852" y="474" type="line"/>
+      <point x="824" y="550"/>
+      <point x="760" y="596"/>
+      <point x="668" y="596" type="curve" smooth="yes"/>
+      <point x="539" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="75"/>
+      <point x="121" y="-16"/>
     </contour>
     <contour>
-      <point x="801" y="45" type="line"/>
-      <point x="833" y="45" type="line"/>
-      <point x="883" y="323" type="line" smooth="yes"/>
-      <point x="902" y="426"/>
-      <point x="943" y="482"/>
-      <point x="1026" y="482" type="curve" smooth="yes"/>
-      <point x="1083" y="482"/>
-      <point x="1112" y="455"/>
-      <point x="1112" y="408" type="curve" smooth="yes"/>
-      <point x="1112" y="336"/>
-      <point x="1088" y="303"/>
-      <point x="930" y="161" type="curve" smooth="yes"/>
+      <point x="790" y="45" type="line"/>
+      <point x="823" y="45" type="line"/>
+      <point x="873" y="328" type="line" smooth="yes"/>
+      <point x="891" y="430"/>
+      <point x="941" y="482"/>
+      <point x="1015" y="482" type="curve" smooth="yes"/>
+      <point x="1070" y="482"/>
+      <point x="1103" y="452"/>
+      <point x="1103" y="402" type="curve" smooth="yes"/>
+      <point x="1103" y="338"/>
+      <point x="1078" y="304"/>
+      <point x="919" y="161" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="913" y="42" type="line"/>
-      <point x="1039" y="155" type="line" smooth="yes"/>
-      <point x="1134" y="240"/>
-      <point x="1194" y="311"/>
-      <point x="1194" y="396" type="curve" smooth="yes"/>
-      <point x="1194" y="467"/>
-      <point x="1147" y="516"/>
-      <point x="1046" y="516" type="curve"/>
-      <point x="1060" y="488" type="line"/>
-      <point x="1060" y="561" type="line"/>
-      <point x="1049" y="519" type="line"/>
-      <point x="1059" y="521"/>
-      <point x="1070" y="522"/>
-      <point x="1083" y="522" type="curve" smooth="yes"/>
-      <point x="1209" y="522"/>
-      <point x="1284" y="476"/>
-      <point x="1284" y="354" type="curve" smooth="yes"/>
-      <point x="1284" y="337"/>
-      <point x="1283" y="313"/>
-      <point x="1275" y="266" type="curve" smooth="yes"/>
-      <point x="1236" y="46" type="line"/>
-      <point x="1278" y="74" type="line"/>
-      <point x="900" y="74" type="line"/>
+      <point x="902" y="42" type="line"/>
+      <point x="1028" y="155" type="line" smooth="yes"/>
+      <point x="1139" y="255"/>
+      <point x="1183" y="321"/>
+      <point x="1183" y="394" type="curve" smooth="yes"/>
+      <point x="1183" y="477"/>
+      <point x="1132" y="528"/>
+      <point x="1043" y="528" type="curve"/>
+      <point x="1049" y="500" type="line"/>
+      <point x="1062" y="573" type="line"/>
+      <point x="1046" y="531" type="line"/>
+      <point x="1062" y="533"/>
+      <point x="1079" y="534"/>
+      <point x="1099" y="534" type="curve" smooth="yes"/>
+      <point x="1216" y="534"/>
+      <point x="1275" y="475"/>
+      <point x="1275" y="358" type="curve" smooth="yes"/>
+      <point x="1275" y="340"/>
+      <point x="1272" y="315"/>
+      <point x="1264" y="267" type="curve" smooth="yes"/>
+      <point x="1225" y="46" type="line"/>
+      <point x="1267" y="74" type="line"/>
+      <point x="889" y="74" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/g_na-malayalam.glif
@@ -1,70 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_na-malayalam" format="2">
   <advance width="1308"/>
-  <anchor x="852" y="0" name="bottom"/>
-  <anchor x="706" y="580" name="top"/>
-  <anchor x="1243" y="580" name="topright"/>
+  <anchor x="847" y="0" name="bottom"/>
+  <anchor x="701" y="580" name="top"/>
+  <anchor x="1238" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="243" y="-16" type="curve" smooth="yes"/>
-      <point x="363" y="-16"/>
-      <point x="439" y="58"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="524" y="362" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="596" y="512"/>
-      <point x="679" y="512" type="curve" smooth="yes"/>
-      <point x="754" y="512"/>
-      <point x="800" y="472"/>
-      <point x="800" y="390" type="curve" smooth="yes"/>
-      <point x="800" y="363"/>
-      <point x="797" y="337"/>
-      <point x="793" y="313" type="curve" smooth="yes"/>
-      <point x="738" y="0" type="line"/>
-      <point x="822" y="0" type="line"/>
-      <point x="881" y="337" type="line" smooth="yes"/>
-      <point x="901" y="451"/>
-      <point x="969" y="518"/>
-      <point x="1058" y="518" type="curve" smooth="yes"/>
-      <point x="1148" y="518"/>
-      <point x="1198" y="461"/>
-      <point x="1198" y="358" type="curve" smooth="yes"/>
-      <point x="1198" y="241"/>
-      <point x="1147" y="147"/>
-      <point x="1029" y="49" type="curve"/>
-      <point x="1082" y="-16" type="line"/>
-      <point x="1217" y="98"/>
-      <point x="1282" y="219"/>
-      <point x="1282" y="358" type="curve" smooth="yes"/>
-      <point x="1282" y="508"/>
-      <point x="1203" y="596"/>
-      <point x="1066" y="596" type="curve" smooth="yes"/>
-      <point x="978" y="596"/>
-      <point x="906" y="555"/>
-      <point x="858" y="479" type="curve"/>
-      <point x="853" y="479" type="line"/>
-      <point x="828" y="555"/>
-      <point x="767" y="596"/>
-      <point x="680" y="596" type="curve" smooth="yes"/>
-      <point x="554" y="596"/>
-      <point x="478" y="526"/>
-      <point x="432" y="354" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="369" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="72"/>
-      <point x="115" y="-16"/>
+      <point x="253" y="-16" type="curve" smooth="yes"/>
+      <point x="380" y="-16"/>
+      <point x="468" y="70"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="454"/>
+      <point x="581" y="518"/>
+      <point x="670" y="518" type="curve" smooth="yes"/>
+      <point x="751" y="518"/>
+      <point x="795" y="469"/>
+      <point x="795" y="390" type="curve" smooth="yes"/>
+      <point x="795" y="363"/>
+      <point x="792" y="337"/>
+      <point x="788" y="313" type="curve" smooth="yes"/>
+      <point x="733" y="0" type="line"/>
+      <point x="817" y="0" type="line"/>
+      <point x="876" y="336" type="line" smooth="yes"/>
+      <point x="896" y="450"/>
+      <point x="961" y="518"/>
+      <point x="1047" y="518" type="curve" smooth="yes"/>
+      <point x="1137" y="518"/>
+      <point x="1187" y="461"/>
+      <point x="1187" y="358" type="curve" smooth="yes"/>
+      <point x="1187" y="241"/>
+      <point x="1136" y="147"/>
+      <point x="1018" y="49" type="curve"/>
+      <point x="1071" y="-16" type="line"/>
+      <point x="1206" y="98"/>
+      <point x="1271" y="219"/>
+      <point x="1271" y="358" type="curve" smooth="yes"/>
+      <point x="1271" y="508"/>
+      <point x="1192" y="596"/>
+      <point x="1055" y="596" type="curve" smooth="yes"/>
+      <point x="971" y="596"/>
+      <point x="897" y="553"/>
+      <point x="853" y="479" type="curve"/>
+      <point x="848" y="479" type="line"/>
+      <point x="822" y="550"/>
+      <point x="764" y="596"/>
+      <point x="666" y="596" type="curve" smooth="yes"/>
+      <point x="538" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="75"/>
+      <point x="121" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ga-malayalam.glif
@@ -2,51 +2,55 @@
 <glyph name="ga-malayalam" format="2">
   <advance width="910"/>
   <unicode hex="0D17"/>
-  <anchor x="456" y="0" name="bottom"/>
-  <anchor x="515" y="580" name="top"/>
-  <anchor x="819" y="580" name="topright"/>
+  <anchor x="451" y="0" name="bottom"/>
+  <anchor x="510" y="580" name="top"/>
+  <anchor x="814" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="243" y="-16" type="curve" smooth="yes"/>
-      <point x="363" y="-16"/>
-      <point x="440" y="58"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="603" y="516"/>
-      <point x="683" y="516" type="curve" smooth="yes"/>
-      <point x="762" y="516"/>
-      <point x="804" y="465"/>
-      <point x="804" y="369" type="curve" smooth="yes"/>
-      <point x="804" y="252"/>
-      <point x="745" y="143"/>
-      <point x="628" y="45" type="curve"/>
-      <point x="683" y="-16" type="line"/>
-      <point x="812" y="90"/>
-      <point x="886" y="230"/>
-      <point x="886" y="369" type="curve" smooth="yes"/>
-      <point x="886" y="511"/>
-      <point x="811" y="596"/>
-      <point x="685" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="477" y="517"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="72"/>
-      <point x="115" y="-16"/>
+      <point x="253" y="-16" type="curve" smooth="yes"/>
+      <point x="380" y="-16"/>
+      <point x="468" y="70"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="580" y="514"/>
+      <point x="668" y="514" type="curve" smooth="yes"/>
+      <point x="749" y="514"/>
+      <point x="793" y="462"/>
+      <point x="793" y="367" type="curve" smooth="yes"/>
+      <point x="793" y="253"/>
+      <point x="734" y="141"/>
+      <point x="623" y="46" type="curve"/>
+      <point x="678" y="-16" type="line"/>
+      <point x="798" y="87"/>
+      <point x="877" y="239"/>
+      <point x="877" y="369" type="curve" smooth="yes"/>
+      <point x="877" y="511"/>
+      <point x="798" y="596"/>
+      <point x="668" y="596" type="curve" smooth="yes"/>
+      <point x="538" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="75"/>
+      <point x="121" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ga-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="910"/>
   <outline>
     <component base="ga-malayalam"/>
-    <component base="halant-malayalam" xOffset="746"/>
+    <component base="halant-malayalam" xOffset="741"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/j_ja-malayalam.glif
@@ -1,231 +1,230 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1602"/>
-  <anchor x="1163" y="0" name="bottom"/>
-  <anchor x="845" y="580" name="top"/>
-  <anchor x="1533" y="580" name="topright"/>
+  <advance width="1668"/>
+  <anchor x="1207" y="0" name="bottom"/>
+  <anchor x="885" y="580" name="top"/>
+  <anchor x="1578" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="307" y="-16" type="curve" smooth="yes"/>
-      <point x="570" y="-16"/>
-      <point x="745" y="95"/>
-      <point x="859" y="317" type="curve"/>
-      <point x="882" y="374" type="line"/>
-      <point x="887" y="374" type="line"/>
-      <point x="896" y="328"/>
-      <point x="935" y="294"/>
-      <point x="1003" y="294" type="curve" smooth="yes"/>
-      <point x="1085" y="294"/>
-      <point x="1138" y="340"/>
-      <point x="1138" y="413" type="curve" smooth="yes"/>
-      <point x="1138" y="477"/>
-      <point x="1100" y="515"/>
-      <point x="1037" y="515" type="curve" smooth="yes"/>
-      <point x="1016" y="515"/>
-      <point x="994" y="511"/>
-      <point x="976" y="505" type="curve"/>
-      <point x="965" y="528" type="line"/>
-      <point x="966" y="503" type="line"/>
-      <point x="989" y="524"/>
-      <point x="1027" y="536"/>
-      <point x="1069" y="536" type="curve" smooth="yes"/>
-      <point x="1149" y="536"/>
-      <point x="1190" y="494"/>
-      <point x="1190" y="411" type="curve" smooth="yes"/>
-      <point x="1190" y="394"/>
-      <point x="1187" y="373"/>
-      <point x="1184" y="354" type="curve" smooth="yes"/>
-      <point x="1182" y="343" type="line"/>
-      <point x="1266" y="343" type="line"/>
-      <point x="1274" y="387" type="line" smooth="yes"/>
-      <point x="1289" y="470"/>
-      <point x="1341" y="518"/>
-      <point x="1415" y="518" type="curve" smooth="yes"/>
-      <point x="1473" y="518"/>
-      <point x="1503" y="486"/>
-      <point x="1503" y="423" type="curve" smooth="yes"/>
-      <point x="1503" y="336"/>
-      <point x="1444" y="287"/>
-      <point x="1339" y="287" type="curve" smooth="yes"/>
-      <point x="1031" y="287" type="line" smooth="yes"/>
-      <point x="903" y="287"/>
-      <point x="823" y="225"/>
-      <point x="823" y="122" type="curve" smooth="yes"/>
-      <point x="823" y="34"/>
-      <point x="874" y="-16"/>
-      <point x="974" y="-16" type="curve" smooth="yes"/>
-      <point x="1018" y="-16"/>
-      <point x="1064" y="-5"/>
-      <point x="1157" y="52" type="curve" smooth="yes"/>
-      <point x="1220" y="91" type="line"/>
-      <point x="1328" y="158" type="line"/>
-      <point x="1349" y="158" type="line"/>
-      <point x="1374" y="166"/>
-      <point x="1390" y="167"/>
-      <point x="1407" y="167" type="curve" smooth="yes"/>
-      <point x="1442" y="167"/>
-      <point x="1459" y="149"/>
-      <point x="1459" y="114" type="curve" smooth="yes"/>
-      <point x="1459" y="73"/>
-      <point x="1436" y="48"/>
-      <point x="1397" y="48" type="curve" smooth="yes"/>
-      <point x="1364" y="48"/>
-      <point x="1344" y="67"/>
-      <point x="1344" y="99" type="curve" smooth="yes"/>
-      <point x="1344" y="131"/>
-      <point x="1359" y="159"/>
-      <point x="1391" y="185" type="curve"/>
-      <point x="1270" y="162" type="line"/>
-      <point x="1305" y="113" type="line"/>
-      <point x="1316" y="156" type="line"/>
-      <point x="1295" y="135"/>
-      <point x="1284" y="109"/>
-      <point x="1284" y="80" type="curve" smooth="yes"/>
-      <point x="1284" y="22"/>
-      <point x="1327" y="-16"/>
-      <point x="1394" y="-16" type="curve" smooth="yes"/>
-      <point x="1476" y="-16"/>
-      <point x="1526" y="35"/>
-      <point x="1526" y="121" type="curve" smooth="yes"/>
-      <point x="1526" y="189"/>
-      <point x="1484" y="233"/>
-      <point x="1419" y="233" type="curve" smooth="yes"/>
-      <point x="1373" y="233"/>
-      <point x="1328" y="230"/>
-      <point x="1214" y="162" type="curve" smooth="yes"/>
-      <point x="1135" y="115" type="line" smooth="yes"/>
-      <point x="1061" y="71"/>
-      <point x="1019" y="61"/>
-      <point x="978" y="61" type="curve" smooth="yes"/>
-      <point x="927" y="61"/>
-      <point x="903" y="86"/>
-      <point x="903" y="126" type="curve" smooth="yes"/>
-      <point x="903" y="184"/>
-      <point x="949" y="215"/>
-      <point x="1028" y="215" type="curve" smooth="yes"/>
-      <point x="1335" y="215" type="line" smooth="yes"/>
-      <point x="1483" y="215"/>
-      <point x="1587" y="301"/>
-      <point x="1587" y="423" type="curve" smooth="yes"/>
-      <point x="1587" y="529"/>
-      <point x="1522" y="596"/>
-      <point x="1421" y="596" type="curve" smooth="yes"/>
-      <point x="1342" y="596"/>
-      <point x="1283" y="557"/>
-      <point x="1245" y="478" type="curve"/>
-      <point x="1240" y="478" type="line"/>
-      <point x="1229" y="553"/>
-      <point x="1169" y="596"/>
-      <point x="1072" y="596" type="curve" smooth="yes"/>
-      <point x="980" y="596"/>
-      <point x="911" y="560"/>
-      <point x="860" y="459" type="curve" smooth="yes"/>
-      <point x="813" y="366" type="line" smooth="yes"/>
-      <point x="693" y="129"/>
-      <point x="529" y="61"/>
-      <point x="320" y="61" type="curve" smooth="yes"/>
-      <point x="157" y="61"/>
-      <point x="101" y="97"/>
-      <point x="101" y="149" type="curve" smooth="yes"/>
-      <point x="101" y="194"/>
-      <point x="141" y="215"/>
-      <point x="216" y="215" type="curve" smooth="yes"/>
-      <point x="533" y="215" type="line" smooth="yes"/>
-      <point x="681" y="215"/>
-      <point x="785" y="301"/>
-      <point x="785" y="433" type="curve" smooth="yes"/>
-      <point x="785" y="539"/>
-      <point x="720" y="596"/>
-      <point x="622" y="596" type="curve" smooth="yes"/>
-      <point x="548" y="596"/>
-      <point x="485" y="563"/>
-      <point x="451" y="478" type="curve"/>
-      <point x="446" y="478" type="line"/>
-      <point x="431" y="553"/>
-      <point x="378" y="596"/>
-      <point x="282" y="596" type="curve" smooth="yes"/>
-      <point x="159" y="596"/>
-      <point x="69" y="525"/>
-      <point x="69" y="427" type="curve" smooth="yes"/>
-      <point x="69" y="344"/>
-      <point x="123" y="294"/>
-      <point x="212" y="294" type="curve" smooth="yes"/>
-      <point x="294" y="294"/>
-      <point x="347" y="340"/>
-      <point x="347" y="413" type="curve" smooth="yes"/>
-      <point x="347" y="477"/>
-      <point x="309" y="515"/>
-      <point x="246" y="515" type="curve" smooth="yes"/>
-      <point x="225" y="515"/>
-      <point x="203" y="511"/>
-      <point x="185" y="505" type="curve"/>
-      <point x="174" y="528" type="line"/>
-      <point x="175" y="503" type="line"/>
-      <point x="198" y="524"/>
-      <point x="236" y="536"/>
-      <point x="278" y="536" type="curve" smooth="yes"/>
-      <point x="358" y="536"/>
-      <point x="396" y="494"/>
-      <point x="396" y="411" type="curve" smooth="yes"/>
-      <point x="396" y="394"/>
-      <point x="393" y="373"/>
-      <point x="390" y="354" type="curve" smooth="yes"/>
-      <point x="388" y="343" type="line"/>
-      <point x="472" y="343" type="line"/>
-      <point x="480" y="387" type="line" smooth="yes"/>
-      <point x="495" y="470"/>
-      <point x="543" y="518"/>
-      <point x="609" y="518" type="curve" smooth="yes"/>
-      <point x="671" y="518"/>
-      <point x="701" y="486"/>
-      <point x="701" y="433" type="curve" smooth="yes"/>
-      <point x="701" y="336"/>
-      <point x="642" y="287"/>
-      <point x="537" y="287" type="curve" smooth="yes"/>
-      <point x="219" y="287" type="line" smooth="yes"/>
-      <point x="95" y="287"/>
-      <point x="21" y="235"/>
-      <point x="21" y="144" type="curve" smooth="yes"/>
-      <point x="21" y="51"/>
-      <point x="100" y="-16"/>
+      <point x="257" y="-16" type="curve" smooth="yes"/>
+      <point x="553" y="-16"/>
+      <point x="748" y="83"/>
+      <point x="879" y="284" type="curve"/>
+      <point x="902" y="344" type="line"/>
+      <point x="907" y="344" type="line"/>
+      <point x="915" y="304"/>
+      <point x="949" y="273"/>
+      <point x="1012" y="273" type="curve" smooth="yes"/>
+      <point x="1122" y="273"/>
+      <point x="1168" y="357"/>
+      <point x="1168" y="414" type="curve" smooth="yes"/>
+      <point x="1168" y="478"/>
+      <point x="1133" y="515"/>
+      <point x="1069" y="515" type="curve" smooth="yes"/>
+      <point x="1044" y="515"/>
+      <point x="1028" y="512"/>
+      <point x="1007" y="505" type="curve"/>
+      <point x="997" y="523" type="line"/>
+      <point x="982" y="494" type="line"/>
+      <point x="1019" y="522"/>
+      <point x="1058" y="536"/>
+      <point x="1118" y="536" type="curve" smooth="yes"/>
+      <point x="1195" y="536"/>
+      <point x="1234" y="497"/>
+      <point x="1234" y="425" type="curve" smooth="yes"/>
+      <point x="1234" y="409"/>
+      <point x="1232" y="392"/>
+      <point x="1229" y="375" type="curve" smooth="yes"/>
+      <point x="1220" y="324" type="line"/>
+      <point x="1304" y="324" type="line"/>
+      <point x="1313" y="375" type="line" smooth="yes"/>
+      <point x="1328" y="464"/>
+      <point x="1385" y="518"/>
+      <point x="1465" y="518" type="curve" smooth="yes"/>
+      <point x="1531" y="518"/>
+      <point x="1567" y="484"/>
+      <point x="1567" y="422" type="curve" smooth="yes"/>
+      <point x="1567" y="321"/>
+      <point x="1491" y="267"/>
+      <point x="1368" y="267" type="curve" smooth="yes"/>
+      <point x="1025" y="267" type="line" smooth="yes"/>
+      <point x="890" y="267"/>
+      <point x="835" y="181"/>
+      <point x="835" y="114" type="curve" smooth="yes"/>
+      <point x="835" y="39"/>
+      <point x="894" y="-16"/>
+      <point x="978" y="-16" type="curve" smooth="yes"/>
+      <point x="1025" y="-16"/>
+      <point x="1062" y="-4"/>
+      <point x="1148" y="35" type="curve" smooth="yes"/>
+      <point x="1276" y="93" type="line"/>
+      <point x="1351" y="141" type="line"/>
+      <point x="1388" y="153" type="line"/>
+      <point x="1416" y="170"/>
+      <point x="1436" y="176"/>
+      <point x="1465" y="176" type="curve" smooth="yes"/>
+      <point x="1501" y="176"/>
+      <point x="1522" y="155"/>
+      <point x="1522" y="121" type="curve" smooth="yes"/>
+      <point x="1522" y="91"/>
+      <point x="1501" y="54"/>
+      <point x="1449" y="54" type="curve" smooth="yes"/>
+      <point x="1412" y="54"/>
+      <point x="1391" y="74"/>
+      <point x="1391" y="110" type="curve" smooth="yes"/>
+      <point x="1391" y="134"/>
+      <point x="1401" y="159"/>
+      <point x="1422" y="180" type="curve"/>
+      <point x="1330" y="145" type="line"/>
+      <point x="1346" y="131" type="line"/>
+      <point x="1339" y="117"/>
+      <point x="1335" y="101"/>
+      <point x="1335" y="85" type="curve" smooth="yes"/>
+      <point x="1335" y="24"/>
+      <point x="1377" y="-16"/>
+      <point x="1446" y="-16" type="curve" smooth="yes"/>
+      <point x="1550" y="-16"/>
+      <point x="1594" y="67"/>
+      <point x="1594" y="125" type="curve" smooth="yes"/>
+      <point x="1594" y="189"/>
+      <point x="1554" y="236"/>
+      <point x="1480" y="236" type="curve" smooth="yes"/>
+      <point x="1441" y="236"/>
+      <point x="1395" y="221"/>
+      <point x="1315" y="185" type="curve" smooth="yes"/>
+      <point x="1127" y="100" type="line" smooth="yes"/>
+      <point x="1066" y="72"/>
+      <point x="1029" y="60"/>
+      <point x="989" y="60" type="curve" smooth="yes"/>
+      <point x="943" y="60"/>
+      <point x="917" y="85"/>
+      <point x="917" y="120" type="curve" smooth="yes"/>
+      <point x="917" y="158"/>
+      <point x="947" y="195"/>
+      <point x="1021" y="195" type="curve" smooth="yes"/>
+      <point x="1343" y="195" type="line" smooth="yes"/>
+      <point x="1513" y="195"/>
+      <point x="1650" y="283"/>
+      <point x="1650" y="436" type="curve" smooth="yes"/>
+      <point x="1650" y="532"/>
+      <point x="1594" y="596"/>
+      <point x="1486" y="596" type="curve" smooth="yes"/>
+      <point x="1399" y="596"/>
+      <point x="1329" y="552"/>
+      <point x="1292" y="475" type="curve"/>
+      <point x="1287" y="475" type="line"/>
+      <point x="1275" y="552"/>
+      <point x="1215" y="596"/>
+      <point x="1123" y="596" type="curve" smooth="yes"/>
+      <point x="1017" y="596"/>
+      <point x="932" y="546"/>
+      <point x="883" y="447" type="curve" smooth="yes"/>
+      <point x="844" y="369" type="line" smooth="yes"/>
+      <point x="740" y="159"/>
+      <point x="557" y="61"/>
+      <point x="265" y="61" type="curve" smooth="yes"/>
+      <point x="144" y="61"/>
+      <point x="99" y="84"/>
+      <point x="99" y="131" type="curve" smooth="yes"/>
+      <point x="99" y="165"/>
+      <point x="125" y="195"/>
+      <point x="192" y="195" type="curve" smooth="yes"/>
+      <point x="485" y="195" type="line" smooth="yes"/>
+      <point x="655" y="195"/>
+      <point x="789" y="285"/>
+      <point x="789" y="435" type="curve" smooth="yes"/>
+      <point x="789" y="529"/>
+      <point x="743" y="596"/>
+      <point x="648" y="596" type="curve" smooth="yes"/>
+      <point x="569" y="596"/>
+      <point x="504" y="552"/>
+      <point x="472" y="475" type="curve"/>
+      <point x="467" y="475" type="line"/>
+      <point x="455" y="552"/>
+      <point x="395" y="596"/>
+      <point x="303" y="596" type="curve" smooth="yes"/>
+      <point x="142" y="596"/>
+      <point x="64" y="488"/>
+      <point x="64" y="399" type="curve" smooth="yes"/>
+      <point x="64" y="324"/>
+      <point x="114" y="273"/>
+      <point x="192" y="273" type="curve" smooth="yes"/>
+      <point x="302" y="273"/>
+      <point x="348" y="357"/>
+      <point x="348" y="414" type="curve" smooth="yes"/>
+      <point x="348" y="478"/>
+      <point x="313" y="515"/>
+      <point x="249" y="515" type="curve" smooth="yes"/>
+      <point x="224" y="515"/>
+      <point x="208" y="512"/>
+      <point x="187" y="505" type="curve"/>
+      <point x="177" y="523" type="line"/>
+      <point x="162" y="494" type="line"/>
+      <point x="199" y="522"/>
+      <point x="238" y="536"/>
+      <point x="298" y="536" type="curve" smooth="yes"/>
+      <point x="375" y="536"/>
+      <point x="414" y="497"/>
+      <point x="414" y="425" type="curve" smooth="yes"/>
+      <point x="414" y="409"/>
+      <point x="412" y="392"/>
+      <point x="409" y="375" type="curve" smooth="yes"/>
+      <point x="400" y="324" type="line"/>
+      <point x="484" y="324" type="line"/>
+      <point x="493" y="375" type="line" smooth="yes"/>
+      <point x="508" y="464"/>
+      <point x="555" y="518"/>
+      <point x="629" y="518" type="curve" smooth="yes"/>
+      <point x="684" y="518"/>
+      <point x="711" y="488"/>
+      <point x="711" y="431" type="curve" smooth="yes"/>
+      <point x="711" y="329"/>
+      <point x="629" y="267"/>
+      <point x="490" y="267" type="curve" smooth="yes"/>
+      <point x="196" y="267" type="line" smooth="yes"/>
+      <point x="68" y="267"/>
+      <point x="15" y="194"/>
+      <point x="15" y="126" type="curve" smooth="yes"/>
+      <point x="15" y="42"/>
+      <point x="83" y="-16"/>
     </contour>
     <contour>
-      <point x="214" y="357" type="curve" smooth="yes"/>
-      <point x="171" y="357"/>
-      <point x="146" y="383"/>
-      <point x="146" y="427" type="curve" smooth="yes"/>
-      <point x="146" y="449"/>
-      <point x="151" y="467"/>
-      <point x="161" y="481" type="curve"/>
-      <point x="137" y="481" type="line"/>
-      <point x="114" y="431" type="line"/>
-      <point x="144" y="455"/>
-      <point x="176" y="467"/>
-      <point x="210" y="467" type="curve" smooth="yes"/>
-      <point x="253" y="467"/>
-      <point x="275" y="449"/>
-      <point x="275" y="412" type="curve" smooth="yes"/>
-      <point x="275" y="379"/>
-      <point x="251" y="357"/>
+      <point x="196" y="341" type="curve" smooth="yes"/>
+      <point x="158" y="341"/>
+      <point x="132" y="368"/>
+      <point x="132" y="406" type="curve" smooth="yes"/>
+      <point x="132" y="429"/>
+      <point x="137" y="449"/>
+      <point x="150" y="475" type="curve"/>
+      <point x="131" y="475" type="line"/>
+      <point x="116" y="425" type="line"/>
+      <point x="143" y="451"/>
+      <point x="182" y="467"/>
+      <point x="217" y="467" type="curve" smooth="yes"/>
+      <point x="255" y="467"/>
+      <point x="273" y="448"/>
+      <point x="273" y="413" type="curve" smooth="yes"/>
+      <point x="273" y="382"/>
+      <point x="254" y="341"/>
     </contour>
     <contour>
-      <point x="1005" y="357" type="curve" smooth="yes"/>
-      <point x="962" y="357"/>
-      <point x="937" y="383"/>
-      <point x="937" y="427" type="curve" smooth="yes"/>
-      <point x="937" y="449"/>
-      <point x="942" y="467"/>
-      <point x="952" y="481" type="curve"/>
-      <point x="928" y="481" type="line"/>
-      <point x="905" y="431" type="line"/>
-      <point x="935" y="455"/>
-      <point x="967" y="467"/>
-      <point x="1001" y="467" type="curve" smooth="yes"/>
-      <point x="1044" y="467"/>
-      <point x="1066" y="449"/>
-      <point x="1066" y="412" type="curve" smooth="yes"/>
-      <point x="1066" y="379"/>
-      <point x="1042" y="357"/>
+      <point x="1016" y="341" type="curve" smooth="yes"/>
+      <point x="978" y="341"/>
+      <point x="952" y="368"/>
+      <point x="952" y="406" type="curve" smooth="yes"/>
+      <point x="952" y="429"/>
+      <point x="957" y="449"/>
+      <point x="970" y="475" type="curve"/>
+      <point x="951" y="475" type="line"/>
+      <point x="936" y="425" type="line"/>
+      <point x="963" y="451"/>
+      <point x="1002" y="467"/>
+      <point x="1037" y="467" type="curve" smooth="yes"/>
+      <point x="1075" y="467"/>
+      <point x="1093" y="448"/>
+      <point x="1093" y="413" type="curve" smooth="yes"/>
+      <point x="1093" y="382"/>
+      <point x="1074" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/j_nya-malayalam.glif
@@ -1,194 +1,194 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2195"/>
-  <anchor x="1787" y="0" name="bottom"/>
-  <anchor x="1092" y="580" name="top"/>
-  <anchor x="2060" y="580" name="topright"/>
+  <advance width="2228"/>
+  <anchor x="1768" y="0" name="bottom"/>
+  <anchor x="1165" y="580" name="top"/>
+  <anchor x="2143" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="314" y="-16" type="curve" smooth="yes"/>
-      <point x="547" y="-16"/>
-      <point x="673" y="43"/>
-      <point x="787" y="188" type="curve"/>
-      <point x="834" y="188" type="line"/>
-      <point x="798" y="244" type="line"/>
-      <point x="794" y="226"/>
-      <point x="792" y="207"/>
-      <point x="792" y="189" type="curve" smooth="yes"/>
-      <point x="792" y="82"/>
-      <point x="857" y="-16"/>
-      <point x="986" y="-16" type="curve" smooth="yes"/>
-      <point x="1095" y="-16"/>
-      <point x="1171" y="67"/>
-      <point x="1171" y="187" type="curve" smooth="yes"/>
-      <point x="1171" y="277"/>
-      <point x="1110" y="336"/>
-      <point x="1015" y="336" type="curve" smooth="yes"/>
-      <point x="959" y="336"/>
-      <point x="908" y="314"/>
-      <point x="870" y="275" type="curve"/>
-      <point x="840" y="283" type="line"/>
-      <point x="840" y="143" type="line"/>
-      <point x="869" y="219"/>
-      <point x="928" y="267"/>
-      <point x="994" y="267" type="curve" smooth="yes"/>
-      <point x="1053" y="267"/>
-      <point x="1088" y="235"/>
-      <point x="1088" y="181" type="curve" smooth="yes"/>
-      <point x="1088" y="109"/>
-      <point x="1048" y="62"/>
-      <point x="985" y="62" type="curve" smooth="yes"/>
-      <point x="903" y="62"/>
-      <point x="862" y="120"/>
-      <point x="862" y="225" type="curve" smooth="yes"/>
-      <point x="862" y="399"/>
-      <point x="961" y="518"/>
-      <point x="1106" y="518" type="curve" smooth="yes"/>
-      <point x="1219" y="518"/>
-      <point x="1276" y="457"/>
-      <point x="1276" y="360" type="curve" smooth="yes"/>
-      <point x="1276" y="343"/>
-      <point x="1273" y="314"/>
-      <point x="1268" y="285" type="curve" smooth="yes"/>
-      <point x="1218" y="0" type="line"/>
-      <point x="1302" y="0" type="line"/>
-      <point x="1361" y="336" type="line" smooth="yes"/>
-      <point x="1383" y="459"/>
-      <point x="1453" y="518"/>
-      <point x="1569" y="518" type="curve" smooth="yes"/>
-      <point x="1730" y="518"/>
-      <point x="1806" y="430"/>
-      <point x="1806" y="272" type="curve" smooth="yes"/>
-      <point x="1806" y="168"/>
-      <point x="1765" y="64"/>
-      <point x="1670" y="64" type="curve" smooth="yes"/>
-      <point x="1603" y="64"/>
-      <point x="1565" y="105"/>
-      <point x="1565" y="196" type="curve" smooth="yes"/>
-      <point x="1565" y="361"/>
-      <point x="1694" y="518"/>
-      <point x="1881" y="518" type="curve" smooth="yes"/>
-      <point x="2000" y="518"/>
-      <point x="2079" y="458"/>
-      <point x="2079" y="342" type="curve" smooth="yes"/>
-      <point x="2079" y="217"/>
-      <point x="2017" y="131"/>
-      <point x="1921" y="44" type="curve"/>
-      <point x="1982" y="-14" type="line"/>
-      <point x="2093" y="86"/>
-      <point x="2162" y="196"/>
-      <point x="2162" y="336" type="curve" smooth="yes"/>
-      <point x="2162" y="510"/>
-      <point x="2057" y="596"/>
-      <point x="1891" y="596" type="curve" smooth="yes"/>
-      <point x="1662" y="596"/>
-      <point x="1483" y="413"/>
-      <point x="1483" y="191" type="curve" smooth="yes"/>
-      <point x="1483" y="60"/>
-      <point x="1547" y="-16"/>
-      <point x="1666" y="-16" type="curve" smooth="yes"/>
-      <point x="1806" y="-16"/>
-      <point x="1887" y="108"/>
-      <point x="1887" y="273" type="curve" smooth="yes"/>
-      <point x="1887" y="471"/>
-      <point x="1769" y="596"/>
-      <point x="1577" y="596" type="curve" smooth="yes"/>
-      <point x="1463" y="596"/>
-      <point x="1383" y="554"/>
-      <point x="1332" y="470" type="curve"/>
-      <point x="1327" y="470" type="line"/>
-      <point x="1289" y="556"/>
-      <point x="1214" y="596"/>
-      <point x="1107" y="596" type="curve" smooth="yes"/>
-      <point x="978" y="596"/>
-      <point x="879" y="538"/>
-      <point x="802" y="365" type="curve" smooth="yes"/>
-      <point x="690" y="113"/>
-      <point x="540" y="61"/>
-      <point x="317" y="61" type="curve" smooth="yes"/>
-      <point x="157" y="61"/>
-      <point x="101" y="97"/>
-      <point x="101" y="149" type="curve" smooth="yes"/>
-      <point x="101" y="194"/>
-      <point x="141" y="215"/>
-      <point x="216" y="215" type="curve" smooth="yes"/>
-      <point x="521" y="215" type="line" smooth="yes"/>
-      <point x="669" y="215"/>
-      <point x="773" y="301"/>
-      <point x="773" y="433" type="curve" smooth="yes"/>
-      <point x="773" y="539"/>
-      <point x="708" y="596"/>
-      <point x="616" y="596" type="curve" smooth="yes"/>
-      <point x="548" y="596"/>
-      <point x="489" y="562"/>
-      <point x="454" y="478" type="curve"/>
-      <point x="449" y="478" type="line"/>
-      <point x="438" y="553"/>
-      <point x="378" y="596"/>
-      <point x="282" y="596" type="curve" smooth="yes"/>
-      <point x="159" y="596"/>
-      <point x="69" y="525"/>
-      <point x="69" y="427" type="curve" smooth="yes"/>
-      <point x="69" y="344"/>
-      <point x="123" y="294"/>
-      <point x="212" y="294" type="curve" smooth="yes"/>
-      <point x="294" y="294"/>
-      <point x="347" y="340"/>
-      <point x="347" y="413" type="curve" smooth="yes"/>
-      <point x="347" y="477"/>
-      <point x="309" y="515"/>
-      <point x="246" y="515" type="curve" smooth="yes"/>
-      <point x="225" y="515"/>
-      <point x="203" y="511"/>
-      <point x="185" y="505" type="curve"/>
-      <point x="174" y="528" type="line"/>
-      <point x="175" y="503" type="line"/>
-      <point x="198" y="524"/>
-      <point x="236" y="536"/>
-      <point x="278" y="536" type="curve" smooth="yes"/>
-      <point x="358" y="536"/>
-      <point x="396" y="494"/>
-      <point x="396" y="411" type="curve" smooth="yes"/>
-      <point x="396" y="394"/>
-      <point x="393" y="373"/>
-      <point x="390" y="354" type="curve" smooth="yes"/>
-      <point x="388" y="343" type="line"/>
-      <point x="472" y="343" type="line"/>
-      <point x="480" y="387" type="line" smooth="yes"/>
-      <point x="495" y="470"/>
-      <point x="543" y="518"/>
-      <point x="603" y="518" type="curve" smooth="yes"/>
-      <point x="659" y="518"/>
-      <point x="689" y="486"/>
-      <point x="689" y="433" type="curve" smooth="yes"/>
-      <point x="689" y="336"/>
-      <point x="630" y="287"/>
-      <point x="525" y="287" type="curve" smooth="yes"/>
-      <point x="219" y="287" type="line" smooth="yes"/>
-      <point x="95" y="287"/>
-      <point x="21" y="235"/>
-      <point x="21" y="144" type="curve" smooth="yes"/>
-      <point x="21" y="51"/>
-      <point x="100" y="-16"/>
+      <point x="257" y="-16" type="curve" smooth="yes"/>
+      <point x="530" y="-16"/>
+      <point x="696" y="48"/>
+      <point x="817" y="200" type="curve"/>
+      <point x="864" y="200" type="line"/>
+      <point x="830" y="244" type="line"/>
+      <point x="825" y="226"/>
+      <point x="822" y="207"/>
+      <point x="822" y="189" type="curve" smooth="yes"/>
+      <point x="822" y="73"/>
+      <point x="889" y="-16"/>
+      <point x="1004" y="-16" type="curve" smooth="yes"/>
+      <point x="1146" y="-16"/>
+      <point x="1210" y="99"/>
+      <point x="1210" y="195" type="curve" smooth="yes"/>
+      <point x="1210" y="287"/>
+      <point x="1155" y="347"/>
+      <point x="1062" y="347" type="curve" smooth="yes"/>
+      <point x="998" y="347"/>
+      <point x="945" y="321"/>
+      <point x="903" y="275" type="curve"/>
+      <point x="872" y="281" type="line"/>
+      <point x="872" y="126" type="line"/>
+      <point x="904" y="216"/>
+      <point x="969" y="273"/>
+      <point x="1042" y="273" type="curve" smooth="yes"/>
+      <point x="1103" y="273"/>
+      <point x="1128" y="242"/>
+      <point x="1128" y="189" type="curve" smooth="yes"/>
+      <point x="1128" y="132"/>
+      <point x="1093" y="62"/>
+      <point x="1008" y="62" type="curve" smooth="yes"/>
+      <point x="937" y="62"/>
+      <point x="894" y="115"/>
+      <point x="894" y="223" type="curve" smooth="yes"/>
+      <point x="894" y="389"/>
+      <point x="1018" y="518"/>
+      <point x="1147" y="518" type="curve" smooth="yes"/>
+      <point x="1258" y="518"/>
+      <point x="1308" y="460"/>
+      <point x="1308" y="369" type="curve" smooth="yes"/>
+      <point x="1308" y="347"/>
+      <point x="1306" y="317"/>
+      <point x="1300" y="285" type="curve" smooth="yes"/>
+      <point x="1250" y="0" type="line"/>
+      <point x="1334" y="0" type="line"/>
+      <point x="1388" y="306" type="line" smooth="yes"/>
+      <point x="1412" y="443"/>
+      <point x="1484" y="518"/>
+      <point x="1605" y="518" type="curve" smooth="yes"/>
+      <point x="1762" y="518"/>
+      <point x="1836" y="423"/>
+      <point x="1836" y="252" type="curve" smooth="yes"/>
+      <point x="1836" y="172"/>
+      <point x="1808" y="64"/>
+      <point x="1709" y="64" type="curve" smooth="yes"/>
+      <point x="1641" y="64"/>
+      <point x="1598" y="112"/>
+      <point x="1598" y="201" type="curve" smooth="yes"/>
+      <point x="1598" y="347"/>
+      <point x="1728" y="518"/>
+      <point x="1913" y="518" type="curve" smooth="yes"/>
+      <point x="2034" y="518"/>
+      <point x="2106" y="449"/>
+      <point x="2106" y="335" type="curve" smooth="yes"/>
+      <point x="2106" y="233"/>
+      <point x="2059" y="135"/>
+      <point x="1965" y="41" type="curve"/>
+      <point x="2024" y="-16" type="line"/>
+      <point x="2136" y="96"/>
+      <point x="2188" y="208"/>
+      <point x="2188" y="336" type="curve" smooth="yes"/>
+      <point x="2188" y="502"/>
+      <point x="2091" y="596"/>
+      <point x="1922" y="596" type="curve" smooth="yes"/>
+      <point x="1701" y="596"/>
+      <point x="1516" y="402"/>
+      <point x="1516" y="197" type="curve" smooth="yes"/>
+      <point x="1516" y="65"/>
+      <point x="1593" y="-16"/>
+      <point x="1706" y="-16" type="curve" smooth="yes"/>
+      <point x="1864" y="-16"/>
+      <point x="1917" y="135"/>
+      <point x="1917" y="253" type="curve" smooth="yes"/>
+      <point x="1917" y="463"/>
+      <point x="1801" y="596"/>
+      <point x="1613" y="596" type="curve" smooth="yes"/>
+      <point x="1501" y="596"/>
+      <point x="1423" y="549"/>
+      <point x="1371" y="461" type="curve"/>
+      <point x="1366" y="461" type="line"/>
+      <point x="1330" y="548"/>
+      <point x="1263" y="596"/>
+      <point x="1148" y="596" type="curve" smooth="yes"/>
+      <point x="1011" y="596"/>
+      <point x="912" y="516"/>
+      <point x="831" y="349" type="curve" smooth="yes"/>
+      <point x="728" y="136"/>
+      <point x="562" y="61"/>
+      <point x="265" y="61" type="curve" smooth="yes"/>
+      <point x="144" y="61"/>
+      <point x="99" y="84"/>
+      <point x="99" y="132" type="curve" smooth="yes"/>
+      <point x="99" y="165"/>
+      <point x="125" y="195"/>
+      <point x="192" y="195" type="curve" smooth="yes"/>
+      <point x="476" y="195" type="line" smooth="yes"/>
+      <point x="652" y="195"/>
+      <point x="791" y="289"/>
+      <point x="791" y="435" type="curve" smooth="yes"/>
+      <point x="791" y="527"/>
+      <point x="740" y="596"/>
+      <point x="642" y="596" type="curve" smooth="yes"/>
+      <point x="564" y="596"/>
+      <point x="503" y="552"/>
+      <point x="472" y="475" type="curve"/>
+      <point x="467" y="475" type="line"/>
+      <point x="455" y="552"/>
+      <point x="395" y="596"/>
+      <point x="303" y="596" type="curve" smooth="yes"/>
+      <point x="142" y="596"/>
+      <point x="64" y="488"/>
+      <point x="64" y="399" type="curve" smooth="yes"/>
+      <point x="64" y="324"/>
+      <point x="114" y="273"/>
+      <point x="192" y="273" type="curve" smooth="yes"/>
+      <point x="302" y="273"/>
+      <point x="348" y="357"/>
+      <point x="348" y="414" type="curve" smooth="yes"/>
+      <point x="348" y="478"/>
+      <point x="313" y="515"/>
+      <point x="249" y="515" type="curve" smooth="yes"/>
+      <point x="224" y="515"/>
+      <point x="208" y="512"/>
+      <point x="187" y="505" type="curve"/>
+      <point x="177" y="523" type="line"/>
+      <point x="162" y="494" type="line"/>
+      <point x="199" y="522"/>
+      <point x="238" y="536"/>
+      <point x="298" y="536" type="curve" smooth="yes"/>
+      <point x="375" y="536"/>
+      <point x="414" y="497"/>
+      <point x="414" y="425" type="curve" smooth="yes"/>
+      <point x="414" y="409"/>
+      <point x="412" y="392"/>
+      <point x="409" y="375" type="curve" smooth="yes"/>
+      <point x="400" y="324" type="line"/>
+      <point x="484" y="324" type="line"/>
+      <point x="493" y="375" type="line" smooth="yes"/>
+      <point x="508" y="464"/>
+      <point x="553" y="518"/>
+      <point x="625" y="518" type="curve" smooth="yes"/>
+      <point x="678" y="518"/>
+      <point x="707" y="486"/>
+      <point x="707" y="431" type="curve" smooth="yes"/>
+      <point x="707" y="331"/>
+      <point x="621" y="267"/>
+      <point x="481" y="267" type="curve" smooth="yes"/>
+      <point x="196" y="267" type="line" smooth="yes"/>
+      <point x="68" y="267"/>
+      <point x="15" y="195"/>
+      <point x="15" y="128" type="curve" smooth="yes"/>
+      <point x="15" y="43"/>
+      <point x="83" y="-16"/>
     </contour>
     <contour>
-      <point x="214" y="357" type="curve" smooth="yes"/>
-      <point x="171" y="357"/>
-      <point x="146" y="383"/>
-      <point x="146" y="427" type="curve" smooth="yes"/>
-      <point x="146" y="449"/>
-      <point x="151" y="467"/>
-      <point x="161" y="481" type="curve"/>
-      <point x="137" y="481" type="line"/>
-      <point x="114" y="431" type="line"/>
-      <point x="144" y="455"/>
-      <point x="176" y="467"/>
-      <point x="210" y="467" type="curve" smooth="yes"/>
-      <point x="253" y="467"/>
-      <point x="275" y="449"/>
-      <point x="275" y="412" type="curve" smooth="yes"/>
-      <point x="275" y="379"/>
-      <point x="251" y="357"/>
+      <point x="196" y="341" type="curve" smooth="yes"/>
+      <point x="158" y="341"/>
+      <point x="132" y="368"/>
+      <point x="132" y="406" type="curve" smooth="yes"/>
+      <point x="132" y="429"/>
+      <point x="137" y="449"/>
+      <point x="150" y="475" type="curve"/>
+      <point x="131" y="475" type="line"/>
+      <point x="116" y="425" type="line"/>
+      <point x="143" y="451"/>
+      <point x="182" y="467"/>
+      <point x="217" y="467" type="curve" smooth="yes"/>
+      <point x="255" y="467"/>
+      <point x="273" y="448"/>
+      <point x="273" y="413" type="curve" smooth="yes"/>
+      <point x="273" y="382"/>
+      <point x="254" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ja-malayalam.glif
@@ -1,141 +1,138 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <unicode hex="0D1C"/>
-  <guideline x="52" y="133" angle="91.1496"/>
-  <guideline x="770" y="416" angle="269.0789"/>
-  <anchor x="374" y="0" name="bottom"/>
+  <anchor x="389" y="0" name="bottom"/>
   <anchor x="476" y="580" name="top"/>
-  <anchor x="744" y="580" name="topright"/>
+  <anchor x="760" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="150" y="-16" type="curve" smooth="yes"/>
-      <point x="209" y="-16"/>
-      <point x="257" y="0"/>
-      <point x="359" y="54" type="curve" smooth="yes"/>
-      <point x="429" y="91" type="line"/>
-      <point x="536" y="148" type="line"/>
-      <point x="549" y="151" type="line"/>
-      <point x="579" y="164"/>
-      <point x="597" y="167"/>
-      <point x="616" y="167" type="curve" smooth="yes"/>
-      <point x="651" y="167"/>
-      <point x="668" y="149"/>
-      <point x="668" y="114" type="curve" smooth="yes"/>
-      <point x="668" y="73"/>
-      <point x="645" y="48"/>
-      <point x="606" y="48" type="curve" smooth="yes"/>
-      <point x="573" y="48"/>
-      <point x="553" y="67"/>
-      <point x="553" y="99" type="curve" smooth="yes"/>
-      <point x="553" y="131"/>
-      <point x="568" y="159"/>
-      <point x="600" y="185" type="curve"/>
-      <point x="477" y="161" type="line"/>
-      <point x="516" y="102" type="line"/>
-      <point x="525" y="156" type="line"/>
-      <point x="504" y="135"/>
-      <point x="493" y="109"/>
-      <point x="493" y="80" type="curve" smooth="yes"/>
-      <point x="493" y="22"/>
-      <point x="536" y="-16"/>
-      <point x="603" y="-16" type="curve" smooth="yes"/>
-      <point x="685" y="-16"/>
-      <point x="735" y="35"/>
-      <point x="735" y="121" type="curve" smooth="yes"/>
-      <point x="735" y="189"/>
-      <point x="693" y="233"/>
-      <point x="628" y="233" type="curve" smooth="yes"/>
-      <point x="582" y="233"/>
-      <point x="543" y="220"/>
-      <point x="423" y="162" type="curve" smooth="yes"/>
-      <point x="340" y="122" type="line" smooth="yes"/>
-      <point x="229" y="68"/>
-      <point x="208" y="61"/>
-      <point x="165" y="61" type="curve" smooth="yes"/>
-      <point x="125" y="61"/>
-      <point x="101" y="86"/>
-      <point x="101" y="126" type="curve" smooth="yes"/>
-      <point x="101" y="184"/>
-      <point x="141" y="215"/>
-      <point x="216" y="215" type="curve" smooth="yes"/>
-      <point x="544" y="215" type="line" smooth="yes"/>
-      <point x="692" y="215"/>
-      <point x="796" y="301"/>
-      <point x="796" y="423" type="curve" smooth="yes"/>
-      <point x="796" y="529"/>
-      <point x="734" y="596"/>
-      <point x="627" y="596" type="curve" smooth="yes"/>
-      <point x="546" y="596"/>
-      <point x="483" y="559"/>
-      <point x="452" y="478" type="curve"/>
-      <point x="447" y="478" type="line"/>
-      <point x="436" y="553"/>
-      <point x="378" y="596"/>
-      <point x="282" y="596" type="curve" smooth="yes"/>
-      <point x="159" y="596"/>
-      <point x="69" y="525"/>
-      <point x="69" y="427" type="curve" smooth="yes"/>
-      <point x="69" y="344"/>
-      <point x="123" y="294"/>
-      <point x="212" y="294" type="curve" smooth="yes"/>
-      <point x="294" y="294"/>
-      <point x="347" y="340"/>
-      <point x="347" y="413" type="curve" smooth="yes"/>
-      <point x="347" y="477"/>
-      <point x="309" y="515"/>
-      <point x="246" y="515" type="curve" smooth="yes"/>
-      <point x="225" y="515"/>
-      <point x="203" y="511"/>
-      <point x="185" y="505" type="curve"/>
-      <point x="174" y="528" type="line"/>
-      <point x="175" y="503" type="line"/>
-      <point x="198" y="524"/>
-      <point x="236" y="536"/>
-      <point x="278" y="536" type="curve" smooth="yes"/>
-      <point x="358" y="536"/>
-      <point x="399" y="494"/>
-      <point x="399" y="411" type="curve" smooth="yes"/>
-      <point x="399" y="394"/>
-      <point x="396" y="373"/>
-      <point x="393" y="354" type="curve" smooth="yes"/>
-      <point x="391" y="343" type="line"/>
-      <point x="475" y="343" type="line"/>
-      <point x="483" y="387" type="line" smooth="yes"/>
-      <point x="498" y="470"/>
-      <point x="545" y="518"/>
-      <point x="618" y="518" type="curve" smooth="yes"/>
-      <point x="682" y="518"/>
-      <point x="712" y="486"/>
-      <point x="712" y="423" type="curve" smooth="yes"/>
-      <point x="712" y="336"/>
-      <point x="653" y="287"/>
-      <point x="548" y="287" type="curve" smooth="yes"/>
-      <point x="219" y="287" type="line" smooth="yes"/>
-      <point x="95" y="287"/>
-      <point x="21" y="225"/>
-      <point x="21" y="120" type="curve" smooth="yes"/>
-      <point x="21" y="34"/>
-      <point x="69" y="-16"/>
+      <point x="158" y="-16" type="curve" smooth="yes"/>
+      <point x="205" y="-16"/>
+      <point x="242" y="-4"/>
+      <point x="328" y="35" type="curve" smooth="yes"/>
+      <point x="456" y="93" type="line"/>
+      <point x="531" y="141" type="line"/>
+      <point x="568" y="153" type="line"/>
+      <point x="596" y="170"/>
+      <point x="616" y="176"/>
+      <point x="645" y="176" type="curve" smooth="yes"/>
+      <point x="681" y="176"/>
+      <point x="702" y="155"/>
+      <point x="702" y="121" type="curve" smooth="yes"/>
+      <point x="702" y="91"/>
+      <point x="681" y="54"/>
+      <point x="629" y="54" type="curve" smooth="yes"/>
+      <point x="592" y="54"/>
+      <point x="571" y="74"/>
+      <point x="571" y="110" type="curve" smooth="yes"/>
+      <point x="571" y="134"/>
+      <point x="581" y="159"/>
+      <point x="602" y="180" type="curve"/>
+      <point x="510" y="145" type="line"/>
+      <point x="526" y="131" type="line"/>
+      <point x="519" y="117"/>
+      <point x="515" y="101"/>
+      <point x="515" y="85" type="curve" smooth="yes"/>
+      <point x="515" y="24"/>
+      <point x="557" y="-16"/>
+      <point x="626" y="-16" type="curve" smooth="yes"/>
+      <point x="730" y="-16"/>
+      <point x="774" y="67"/>
+      <point x="774" y="125" type="curve" smooth="yes"/>
+      <point x="774" y="189"/>
+      <point x="734" y="236"/>
+      <point x="660" y="236" type="curve" smooth="yes"/>
+      <point x="621" y="236"/>
+      <point x="575" y="221"/>
+      <point x="495" y="185" type="curve" smooth="yes"/>
+      <point x="307" y="100" type="line" smooth="yes"/>
+      <point x="246" y="72"/>
+      <point x="209" y="60"/>
+      <point x="169" y="60" type="curve" smooth="yes"/>
+      <point x="123" y="60"/>
+      <point x="97" y="85"/>
+      <point x="97" y="120" type="curve" smooth="yes"/>
+      <point x="97" y="158"/>
+      <point x="127" y="195"/>
+      <point x="201" y="195" type="curve" smooth="yes"/>
+      <point x="523" y="195" type="line" smooth="yes"/>
+      <point x="693" y="195"/>
+      <point x="830" y="283"/>
+      <point x="830" y="436" type="curve" smooth="yes"/>
+      <point x="830" y="532"/>
+      <point x="774" y="596"/>
+      <point x="666" y="596" type="curve" smooth="yes"/>
+      <point x="579" y="596"/>
+      <point x="509" y="552"/>
+      <point x="472" y="475" type="curve"/>
+      <point x="467" y="475" type="line"/>
+      <point x="455" y="552"/>
+      <point x="395" y="596"/>
+      <point x="303" y="596" type="curve" smooth="yes"/>
+      <point x="142" y="596"/>
+      <point x="64" y="488"/>
+      <point x="64" y="399" type="curve" smooth="yes"/>
+      <point x="64" y="324"/>
+      <point x="114" y="273"/>
+      <point x="192" y="273" type="curve" smooth="yes"/>
+      <point x="302" y="273"/>
+      <point x="348" y="357"/>
+      <point x="348" y="414" type="curve" smooth="yes"/>
+      <point x="348" y="478"/>
+      <point x="313" y="515"/>
+      <point x="249" y="515" type="curve" smooth="yes"/>
+      <point x="224" y="515"/>
+      <point x="208" y="512"/>
+      <point x="187" y="505" type="curve"/>
+      <point x="177" y="523" type="line"/>
+      <point x="162" y="494" type="line"/>
+      <point x="199" y="522"/>
+      <point x="238" y="536"/>
+      <point x="298" y="536" type="curve" smooth="yes"/>
+      <point x="375" y="536"/>
+      <point x="414" y="497"/>
+      <point x="414" y="425" type="curve" smooth="yes"/>
+      <point x="414" y="409"/>
+      <point x="412" y="392"/>
+      <point x="409" y="375" type="curve" smooth="yes"/>
+      <point x="400" y="324" type="line"/>
+      <point x="484" y="324" type="line"/>
+      <point x="493" y="375" type="line" smooth="yes"/>
+      <point x="508" y="464"/>
+      <point x="565" y="518"/>
+      <point x="645" y="518" type="curve" smooth="yes"/>
+      <point x="711" y="518"/>
+      <point x="747" y="484"/>
+      <point x="747" y="422" type="curve" smooth="yes"/>
+      <point x="747" y="321"/>
+      <point x="671" y="267"/>
+      <point x="548" y="267" type="curve" smooth="yes"/>
+      <point x="205" y="267" type="line" smooth="yes"/>
+      <point x="70" y="267"/>
+      <point x="15" y="181"/>
+      <point x="15" y="114" type="curve" smooth="yes"/>
+      <point x="15" y="39"/>
+      <point x="74" y="-16"/>
     </contour>
     <contour>
-      <point x="214" y="357" type="curve" smooth="yes"/>
-      <point x="171" y="357"/>
-      <point x="146" y="383"/>
-      <point x="146" y="427" type="curve" smooth="yes"/>
-      <point x="146" y="449"/>
-      <point x="151" y="467"/>
-      <point x="161" y="481" type="curve"/>
-      <point x="137" y="481" type="line"/>
-      <point x="114" y="431" type="line"/>
-      <point x="144" y="455"/>
-      <point x="176" y="467"/>
-      <point x="210" y="467" type="curve" smooth="yes"/>
-      <point x="253" y="467"/>
-      <point x="275" y="449"/>
-      <point x="275" y="412" type="curve" smooth="yes"/>
-      <point x="275" y="379"/>
-      <point x="251" y="357"/>
+      <point x="196" y="341" type="curve" smooth="yes"/>
+      <point x="158" y="341"/>
+      <point x="132" y="368"/>
+      <point x="132" y="406" type="curve" smooth="yes"/>
+      <point x="132" y="429"/>
+      <point x="137" y="449"/>
+      <point x="150" y="475" type="curve"/>
+      <point x="131" y="475" type="line"/>
+      <point x="116" y="425" type="line"/>
+      <point x="143" y="451"/>
+      <point x="182" y="467"/>
+      <point x="217" y="467" type="curve" smooth="yes"/>
+      <point x="255" y="467"/>
+      <point x="273" y="448"/>
+      <point x="273" y="413" type="curve" smooth="yes"/>
+      <point x="273" y="382"/>
+      <point x="254" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="671"/>
+    <component base="halant-malayalam" xOffset="687"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <guideline x="103" y="133" angle="91.1496"/>
   <guideline x="821" y="416" angle="269.0789"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="420"/>
+    <component base="lVocalicMatra-malayalam" xOffset="435"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <guideline x="88" y="133" angle="91.1496"/>
   <guideline x="806" y="416" angle="269.0789"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="420"/>
+    <component base="llVocalicMatra-malayalam" xOffset="435"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
@@ -2,114 +2,112 @@
 <glyph name="kChillu-malayalam" format="2">
   <advance width="1040"/>
   <unicode hex="0D7F"/>
-  <guideline x="1034"/>
-  <anchor x="667" y="0" name="bottom"/>
-  <anchor x="390" y="580" name="top"/>
+  <anchor x="593" y="0" name="bottom"/>
+  <anchor x="418" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="594" y="-16"/>
-      <point x="639" y="25"/>
-      <point x="670" y="85" type="curve"/>
-      <point x="675" y="85" type="line"/>
-      <point x="690" y="34"/>
-      <point x="732" y="-16"/>
-      <point x="829" y="-16" type="curve" smooth="yes"/>
-      <point x="922" y="-16"/>
-      <point x="995" y="42"/>
-      <point x="995" y="161" type="curve" smooth="yes"/>
-      <point x="995" y="257"/>
-      <point x="943" y="324"/>
-      <point x="795" y="324" type="curve" smooth="yes"/>
-      <point x="778" y="324" type="line"/>
-      <point x="732" y="250" type="line"/>
-      <point x="787" y="250" type="line" smooth="yes"/>
-      <point x="883" y="250"/>
-      <point x="910" y="210"/>
-      <point x="910" y="160" type="curve" smooth="yes"/>
-      <point x="910" y="98"/>
-      <point x="878" y="62"/>
-      <point x="819" y="62" type="curve" smooth="yes"/>
-      <point x="761" y="62"/>
-      <point x="732" y="98"/>
-      <point x="732" y="163" type="curve" smooth="yes"/>
-      <point x="732" y="242"/>
-      <point x="787" y="332"/>
-      <point x="874" y="426" type="curve" smooth="yes"/>
-      <point x="939" y="496"/>
-      <point x="993" y="563"/>
-      <point x="993" y="653" type="curve" smooth="yes"/>
-      <point x="993" y="740"/>
-      <point x="940" y="789"/>
-      <point x="836" y="789" type="curve" smooth="yes"/>
-      <point x="787" y="789"/>
-      <point x="737" y="776"/>
-      <point x="693" y="751" type="curve"/>
-      <point x="720" y="679" type="line"/>
-      <point x="749" y="697"/>
-      <point x="790" y="711"/>
-      <point x="828" y="711" type="curve" smooth="yes"/>
-      <point x="884" y="711"/>
-      <point x="911" y="688"/>
-      <point x="911" y="643" type="curve" smooth="yes"/>
-      <point x="911" y="582"/>
-      <point x="873" y="536"/>
-      <point x="806" y="455" type="curve" smooth="yes"/>
-      <point x="782" y="425"/>
-      <point x="763" y="400"/>
-      <point x="749" y="368" type="curve"/>
-      <point x="703" y="368" type="line"/>
-      <point x="743" y="309" type="line"/>
-      <point x="744" y="325"/>
-      <point x="744" y="340"/>
-      <point x="744" y="356" type="curve" smooth="yes"/>
-      <point x="744" y="477"/>
-      <point x="715" y="596"/>
-      <point x="569" y="596" type="curve" smooth="yes"/>
-      <point x="436" y="596"/>
-      <point x="355" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="721" y="250" type="line"/>
-      <point x="721" y="324" type="line"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="551" y="-16"/>
+      <point x="607" y="19"/>
+      <point x="648" y="82" type="curve"/>
+      <point x="654" y="82" type="line"/>
+      <point x="674" y="24"/>
+      <point x="724" y="-16"/>
+      <point x="800" y="-16" type="curve" smooth="yes"/>
+      <point x="915" y="-16"/>
+      <point x="987" y="68"/>
+      <point x="987" y="174" type="curve" smooth="yes"/>
+      <point x="987" y="278"/>
+      <point x="923" y="344"/>
+      <point x="792" y="344" type="curve" smooth="yes"/>
+      <point x="776" y="344" type="line"/>
+      <point x="728" y="270" type="line"/>
+      <point x="788" y="270" type="line" smooth="yes"/>
+      <point x="865" y="270"/>
+      <point x="903" y="236"/>
+      <point x="903" y="172" type="curve" smooth="yes"/>
+      <point x="903" y="106"/>
+      <point x="859" y="62"/>
+      <point x="802" y="62" type="curve" smooth="yes"/>
+      <point x="745" y="62"/>
+      <point x="713" y="96"/>
+      <point x="713" y="152" type="curve" smooth="yes"/>
+      <point x="713" y="215"/>
+      <point x="756" y="290"/>
+      <point x="870" y="424" type="curve" smooth="yes"/>
+      <point x="931" y="496"/>
+      <point x="987" y="567"/>
+      <point x="987" y="646" type="curve" smooth="yes"/>
+      <point x="987" y="732"/>
+      <point x="935" y="789"/>
+      <point x="838" y="789" type="curve" smooth="yes"/>
+      <point x="784" y="789"/>
+      <point x="736" y="774"/>
+      <point x="679" y="739" type="curve"/>
+      <point x="716" y="670" type="line"/>
+      <point x="758" y="697"/>
+      <point x="796" y="710"/>
+      <point x="834" y="710" type="curve" smooth="yes"/>
+      <point x="881" y="710"/>
+      <point x="904" y="688"/>
+      <point x="904" y="644" type="curve" smooth="yes"/>
+      <point x="904" y="592"/>
+      <point x="872" y="544"/>
+      <point x="805" y="460" type="curve" smooth="yes"/>
+      <point x="769" y="415"/>
+      <point x="756" y="394"/>
+      <point x="743" y="365" type="curve"/>
+      <point x="737" y="365" type="line"/>
+      <point x="738" y="376"/>
+      <point x="739" y="391"/>
+      <point x="739" y="403" type="curve" smooth="yes"/>
+      <point x="739" y="524"/>
+      <point x="682" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="694" y="270" type="line"/>
+      <point x="715" y="344" type="line"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
     </contour>
     <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="644" y="518"/>
+      <point x="671" y="468"/>
+      <point x="671" y="391" type="curve" smooth="yes"/>
+      <point x="671" y="287"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/k_ka-malayalam.glif
@@ -1,99 +1,98 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ka-malayalam" format="2">
   <advance width="1437"/>
-  <guideline x="1400"/>
-  <anchor x="1033" y="0" name="bottom"/>
-  <anchor x="816" y="580" name="top"/>
-  <anchor x="1315" y="580" name="topright"/>
+  <anchor x="976" y="0" name="bottom"/>
+  <anchor x="861" y="580" name="top"/>
+  <anchor x="1360" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="660" y="-16"/>
-      <point x="760" y="140"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="502"/>
-      <point x="705" y="596"/>
-      <point x="574" y="596" type="curve" smooth="yes"/>
-      <point x="436" y="596"/>
-      <point x="355" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="928" y="250" type="line" smooth="yes"/>
-      <point x="1019" y="250"/>
-      <point x="1044" y="207"/>
-      <point x="1044" y="147" type="curve" smooth="yes"/>
-      <point x="1044" y="106"/>
-      <point x="1026" y="62"/>
-      <point x="972" y="62" type="curve" smooth="yes"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="696" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="941" y="270" type="line" smooth="yes"/>
+      <point x="1017" y="270"/>
+      <point x="1053" y="241"/>
+      <point x="1053" y="175" type="curve" smooth="yes"/>
+      <point x="1053" y="124"/>
+      <point x="1024" y="62"/>
+      <point x="963" y="62" type="curve" smooth="yes"/>
       <point x="911" y="62"/>
-      <point x="889" y="116"/>
-      <point x="889" y="202" type="curve" smooth="yes"/>
-      <point x="889" y="361"/>
-      <point x="978" y="517"/>
-      <point x="1148" y="517" type="curve" smooth="yes"/>
-      <point x="1272" y="517"/>
-      <point x="1324" y="441"/>
-      <point x="1324" y="339" type="curve" smooth="yes"/>
-      <point x="1324" y="209"/>
-      <point x="1262" y="120"/>
-      <point x="1182" y="38" type="curve"/>
+      <point x="882" y="100"/>
+      <point x="882" y="173" type="curve" smooth="yes"/>
+      <point x="882" y="304"/>
+      <point x="948" y="517"/>
+      <point x="1150" y="517" type="curve" smooth="yes"/>
+      <point x="1254" y="517"/>
+      <point x="1315" y="450"/>
+      <point x="1315" y="330" type="curve" smooth="yes"/>
+      <point x="1315" y="228"/>
+      <point x="1267" y="124"/>
+      <point x="1184" y="42" type="curve"/>
       <point x="1243" y="-16" type="line"/>
-      <point x="1343" y="83"/>
-      <point x="1407" y="190"/>
-      <point x="1407" y="343" type="curve" smooth="yes"/>
-      <point x="1407" y="498"/>
-      <point x="1314" y="596"/>
-      <point x="1150" y="596" type="curve" smooth="yes"/>
-      <point x="937" y="596"/>
-      <point x="807" y="408"/>
-      <point x="807" y="205" type="curve" smooth="yes"/>
-      <point x="807" y="75"/>
+      <point x="1336" y="74"/>
+      <point x="1397" y="214"/>
+      <point x="1397" y="334" type="curve" smooth="yes"/>
+      <point x="1397" y="495"/>
+      <point x="1310" y="596"/>
+      <point x="1160" y="596" type="curve" smooth="yes"/>
+      <point x="900" y="596"/>
+      <point x="801" y="332"/>
+      <point x="801" y="172" type="curve" smooth="yes"/>
+      <point x="801" y="56"/>
       <point x="858" y="-16"/>
-      <point x="975" y="-16" type="curve" smooth="yes"/>
-      <point x="1069" y="-16"/>
-      <point x="1126" y="49"/>
-      <point x="1126" y="145" type="curve" smooth="yes"/>
-      <point x="1126" y="239"/>
-      <point x="1081" y="324"/>
-      <point x="928" y="324" type="curve" smooth="yes"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
+      <point x="957" y="-16" type="curve" smooth="yes"/>
+      <point x="1071" y="-16"/>
+      <point x="1135" y="86"/>
+      <point x="1135" y="180" type="curve" smooth="yes"/>
+      <point x="1135" y="286"/>
+      <point x="1076" y="344"/>
+      <point x="949" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
     </contour>
     <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/k_la-malayalam.glif
@@ -1,145 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_la-malayalam" format="2">
   <advance width="1035"/>
-  <anchor x="565" y="-351" name="bottom"/>
-  <anchor x="589" y="580" name="top"/>
-  <anchor x="929" y="540" name="topright"/>
+  <anchor x="555" y="-351" name="bottom"/>
+  <anchor x="583" y="580" name="top"/>
+  <anchor x="923" y="540" name="topright"/>
   <outline>
     <contour>
-      <point x="343" y="-367" type="curve" smooth="yes"/>
-      <point x="428" y="-367"/>
-      <point x="480" y="-313"/>
-      <point x="480" y="-228" type="curve" smooth="yes"/>
-      <point x="480" y="-154"/>
-      <point x="440" y="-118"/>
-      <point x="371" y="-118" type="curve" smooth="yes"/>
-      <point x="339" y="-118"/>
-      <point x="301" y="-131"/>
-      <point x="275" y="-164" type="curve"/>
-      <point x="232" y="-154" type="line"/>
-      <point x="265" y="-181" type="line"/>
-      <point x="281" y="-85"/>
-      <point x="340" y="-27"/>
-      <point x="433" y="-27" type="curve" smooth="yes"/>
-      <point x="538" y="-27"/>
-      <point x="565" y="-86"/>
-      <point x="570" y="-174" type="curve" smooth="yes"/>
-      <point x="571" y="-192" type="line" smooth="yes"/>
-      <point x="577" y="-303"/>
-      <point x="627" y="-367"/>
-      <point x="737" y="-367" type="curve" smooth="yes"/>
-      <point x="866" y="-367"/>
-      <point x="921" y="-271"/>
-      <point x="921" y="-131" type="curve" smooth="yes"/>
-      <point x="921" y="-58"/>
-      <point x="902" y="1"/>
-      <point x="872" y="43" type="curve"/>
+      <point x="338" y="-367" type="curve" smooth="yes"/>
+      <point x="426" y="-367"/>
+      <point x="479" y="-301"/>
+      <point x="479" y="-229" type="curve" smooth="yes"/>
+      <point x="479" y="-162"/>
+      <point x="443" y="-118"/>
+      <point x="376" y="-118" type="curve" smooth="yes"/>
+      <point x="328" y="-118"/>
+      <point x="262" y="-150"/>
+      <point x="249" y="-232" type="curve"/>
+      <point x="288" y="-176" type="line"/>
+      <point x="258" y="-163" type="line"/>
+      <point x="264" y="-188" type="line"/>
+      <point x="284" y="-90"/>
+      <point x="360" y="-25"/>
+      <point x="446" y="-25" type="curve" smooth="yes"/>
+      <point x="520" y="-25"/>
+      <point x="554" y="-63"/>
+      <point x="569" y="-157" type="curve" smooth="yes"/>
+      <point x="576" y="-200" type="line" smooth="yes"/>
+      <point x="595" y="-317"/>
+      <point x="646" y="-367"/>
+      <point x="738" y="-367" type="curve" smooth="yes"/>
+      <point x="873" y="-367"/>
+      <point x="921" y="-239"/>
+      <point x="921" y="-140" type="curve" smooth="yes"/>
+      <point x="921" y="-71"/>
+      <point x="905" y="-10"/>
+      <point x="874" y="41" type="curve"/>
       <point x="809" y="5" type="line"/>
-      <point x="831" y="-33"/>
-      <point x="846" y="-82"/>
-      <point x="846" y="-139" type="curve" smooth="yes"/>
-      <point x="846" y="-226"/>
-      <point x="818" y="-297"/>
-      <point x="739" y="-297" type="curve" smooth="yes"/>
-      <point x="679" y="-297"/>
-      <point x="654" y="-265"/>
-      <point x="646" y="-174" type="curve" smooth="yes"/>
-      <point x="644" y="-151" type="line" smooth="yes"/>
-      <point x="638" y="-87"/>
-      <point x="622" y="-36"/>
-      <point x="581" y="-2" type="curve"/>
-      <point x="581" y="3" type="line"/>
-      <point x="710" y="55"/>
-      <point x="760" y="215"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="502"/>
-      <point x="706" y="596"/>
-      <point x="579" y="596" type="curve" smooth="yes"/>
-      <point x="447" y="596"/>
-      <point x="354" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="790" y="250" type="line" smooth="yes"/>
-      <point x="873" y="250"/>
-      <point x="908" y="214"/>
-      <point x="908" y="155" type="curve" smooth="yes"/>
-      <point x="908" y="109"/>
-      <point x="884" y="62"/>
-      <point x="812" y="62" type="curve" smooth="yes"/>
-      <point x="785" y="62"/>
-      <point x="767" y="66"/>
-      <point x="751" y="72" type="curve"/>
-      <point x="719" y="2" type="line"/>
-      <point x="742" y="-9"/>
-      <point x="770" y="-16"/>
-      <point x="807" y="-16" type="curve" smooth="yes"/>
-      <point x="931" y="-16"/>
-      <point x="990" y="65"/>
-      <point x="990" y="159" type="curve" smooth="yes"/>
-      <point x="990" y="256"/>
-      <point x="924" y="324"/>
-      <point x="791" y="324" type="curve" smooth="yes"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="353" y="70"/>
-      <point x="367" y="52"/>
-      <point x="383" y="41" type="curve"/>
-      <point x="382" y="36" type="line"/>
-      <point x="265" y="10"/>
-      <point x="197" y="-86"/>
-      <point x="197" y="-210" type="curve" smooth="yes"/>
-      <point x="197" y="-316"/>
-      <point x="261" y="-367"/>
+      <point x="836" y="-43"/>
+      <point x="848" y="-89"/>
+      <point x="848" y="-142" type="curve" smooth="yes"/>
+      <point x="848" y="-208"/>
+      <point x="825" y="-297"/>
+      <point x="744" y="-297" type="curve" smooth="yes"/>
+      <point x="691" y="-297"/>
+      <point x="663" y="-269"/>
+      <point x="649" y="-185" type="curve" smooth="yes"/>
+      <point x="642" y="-142" type="line" smooth="yes"/>
+      <point x="629" y="-62"/>
+      <point x="610" y="-17"/>
+      <point x="568" y="7" type="curve"/>
+      <point x="569" y="14" type="line"/>
+      <point x="722" y="81"/>
+      <point x="754" y="280"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="789" y="270" type="line" smooth="yes"/>
+      <point x="863" y="270"/>
+      <point x="900" y="238"/>
+      <point x="900" y="175" type="curve" smooth="yes"/>
+      <point x="900" y="108"/>
+      <point x="856" y="62"/>
+      <point x="792" y="62" type="curve" smooth="yes"/>
+      <point x="772" y="62"/>
+      <point x="755" y="64"/>
+      <point x="741" y="69" type="curve"/>
+      <point x="713" y="-4" type="line"/>
+      <point x="736" y="-12"/>
+      <point x="760" y="-16"/>
+      <point x="787" y="-16" type="curve" smooth="yes"/>
+      <point x="901" y="-16"/>
+      <point x="983" y="65"/>
+      <point x="983" y="178" type="curve" smooth="yes"/>
+      <point x="983" y="282"/>
+      <point x="914" y="344"/>
+      <point x="795" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="328" y="90" type="line"/>
+      <point x="337" y="67"/>
+      <point x="352" y="47"/>
+      <point x="371" y="32" type="curve"/>
+      <point x="369" y="23" type="line"/>
+      <point x="257" y="-18"/>
+      <point x="196" y="-121"/>
+      <point x="196" y="-214" type="curve" smooth="yes"/>
+      <point x="196" y="-313"/>
+      <point x="257" y="-367"/>
     </contour>
     <contour>
-      <point x="343" y="-302" type="curve" smooth="yes"/>
-      <point x="288" y="-302"/>
-      <point x="265" y="-264"/>
-      <point x="265" y="-218" type="curve"/>
-      <point x="246" y="-197" type="line"/>
-      <point x="257" y="-253" type="line"/>
-      <point x="265" y="-213"/>
-      <point x="298" y="-178"/>
-      <point x="347" y="-178" type="curve" smooth="yes"/>
-      <point x="389" y="-178"/>
-      <point x="409" y="-199"/>
+      <point x="338" y="-302" type="curve" smooth="yes"/>
+      <point x="290" y="-302"/>
+      <point x="263" y="-269"/>
+      <point x="263" y="-224" type="curve" smooth="yes"/>
+      <point x="263" y="-217"/>
+      <point x="264" y="-208"/>
+      <point x="266" y="-200" type="curve"/>
+      <point x="235" y="-205" type="line"/>
+      <point x="255" y="-265" type="line"/>
+      <point x="263" y="-213"/>
+      <point x="304" y="-178"/>
+      <point x="353" y="-178" type="curve" smooth="yes"/>
+      <point x="392" y="-178"/>
+      <point x="409" y="-201"/>
       <point x="409" y="-233" type="curve" smooth="yes"/>
-      <point x="409" y="-276"/>
-      <point x="385" y="-302"/>
+      <point x="409" y="-272"/>
+      <point x="382" y="-302"/>
     </contour>
     <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
@@ -1,116 +1,115 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam" format="2">
   <advance width="1702"/>
-  <guideline x="1632"/>
-  <anchor x="1214" y="0" name="bottom"/>
-  <anchor x="933" y="580" name="top"/>
-  <anchor x="1638" y="580" name="topright"/>
+  <anchor x="1208" y="0" name="bottom"/>
+  <anchor x="927" y="580" name="top"/>
+  <anchor x="1632" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="660" y="-16"/>
-      <point x="760" y="140"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="515"/>
-      <point x="694" y="596"/>
-      <point x="579" y="596" type="curve" smooth="yes"/>
-      <point x="447" y="596"/>
-      <point x="354" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="127" y="62"/>
-      <point x="90" y="96"/>
-      <point x="90" y="150" type="curve" smooth="yes"/>
-      <point x="90" y="218"/>
-      <point x="136" y="256"/>
-      <point x="219" y="256" type="curve" smooth="yes"/>
-      <point x="801" y="256" type="line" smooth="yes"/>
-      <point x="885" y="256"/>
-      <point x="911" y="224"/>
-      <point x="911" y="173" type="curve" smooth="yes"/>
-      <point x="911" y="122"/>
-      <point x="885" y="93"/>
-      <point x="827" y="56" type="curve"/>
-      <point x="836" y="0" type="line"/>
-      <point x="1580" y="0" type="line"/>
-      <point x="1682" y="580" type="line"/>
-      <point x="1632" y="580" type="line"/>
-      <point x="1537" y="405"/>
-      <point x="1415" y="312"/>
-      <point x="1287" y="312" type="curve" smooth="yes"/>
-      <point x="1187" y="312"/>
-      <point x="1132" y="358"/>
-      <point x="1132" y="430" type="curve" smooth="yes"/>
-      <point x="1132" y="486"/>
-      <point x="1164" y="518"/>
-      <point x="1213" y="518" type="curve" smooth="yes"/>
-      <point x="1264" y="518"/>
-      <point x="1282" y="491"/>
-      <point x="1282" y="447" type="curve" smooth="yes"/>
-      <point x="1282" y="438"/>
-      <point x="1279" y="413"/>
-      <point x="1277" y="400" type="curve" smooth="yes"/>
-      <point x="1218" y="61" type="line"/>
-      <point x="1300" y="61" type="line"/>
-      <point x="1359" y="398" type="line" smooth="yes"/>
-      <point x="1364" y="427"/>
-      <point x="1365" y="446"/>
-      <point x="1365" y="458" type="curve" smooth="yes"/>
-      <point x="1365" y="540"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="696" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="797" y="270" type="line" smooth="yes"/>
+      <point x="871" y="270"/>
+      <point x="906" y="239"/>
+      <point x="906" y="184" type="curve" smooth="yes"/>
+      <point x="906" y="140"/>
+      <point x="880" y="102"/>
+      <point x="826" y="56" type="curve"/>
+      <point x="835" y="0" type="line"/>
+      <point x="1574" y="0" type="line"/>
+      <point x="1676" y="580" type="line"/>
+      <point x="1624" y="580" type="line"/>
+      <point x="1520" y="412"/>
+      <point x="1403" y="312"/>
+      <point x="1259" y="312" type="curve" smooth="yes"/>
+      <point x="1174" y="312"/>
+      <point x="1125" y="355"/>
+      <point x="1125" y="419" type="curve" smooth="yes"/>
+      <point x="1125" y="476"/>
+      <point x="1165" y="518"/>
+      <point x="1220" y="518" type="curve" smooth="yes"/>
+      <point x="1260" y="518"/>
+      <point x="1279" y="495"/>
+      <point x="1279" y="458" type="curve" smooth="yes"/>
+      <point x="1279" y="446"/>
+      <point x="1278" y="433"/>
+      <point x="1275" y="418" type="curve" smooth="yes"/>
+      <point x="1212" y="61" type="line"/>
+      <point x="1294" y="61" type="line"/>
+      <point x="1357" y="420" type="line" smooth="yes"/>
+      <point x="1360" y="437"/>
+      <point x="1362" y="453"/>
+      <point x="1362" y="468" type="curve" smooth="yes"/>
+      <point x="1362" y="542"/>
       <point x="1317" y="596"/>
-      <point x="1220" y="596" type="curve" smooth="yes"/>
-      <point x="1120" y="596"/>
-      <point x="1049" y="533"/>
-      <point x="1049" y="426" type="curve" smooth="yes"/>
-      <point x="1049" y="305"/>
-      <point x="1152" y="234"/>
-      <point x="1281" y="234" type="curve" smooth="yes"/>
-      <point x="1384" y="234"/>
-      <point x="1475" y="277"/>
-      <point x="1554" y="356" type="curve"/>
-      <point x="1559" y="354" type="line"/>
-      <point x="1503" y="40" type="line"/>
-      <point x="1549" y="74" type="line"/>
-      <point x="905" y="74" type="line"/>
-      <point x="905" y="45" type="line"/>
-      <point x="956" y="67"/>
-      <point x="996" y="114"/>
-      <point x="996" y="188" type="curve" smooth="yes"/>
-      <point x="996" y="268"/>
-      <point x="946" y="330"/>
-      <point x="802" y="330" type="curve" smooth="yes"/>
-      <point x="224" y="330" type="line" smooth="yes"/>
-      <point x="89" y="330"/>
-      <point x="8" y="261"/>
-      <point x="8" y="146" type="curve" smooth="yes"/>
-      <point x="8" y="49"/>
-      <point x="76" y="-16"/>
+      <point x="1228" y="596" type="curve" smooth="yes"/>
+      <point x="1119" y="596"/>
+      <point x="1043" y="519"/>
+      <point x="1043" y="415" type="curve" smooth="yes"/>
+      <point x="1043" y="310"/>
+      <point x="1130" y="236"/>
+      <point x="1253" y="236" type="curve" smooth="yes"/>
+      <point x="1363" y="236"/>
+      <point x="1464" y="287"/>
+      <point x="1550" y="380" type="curve"/>
+      <point x="1557" y="380" type="line"/>
+      <point x="1497" y="40" type="line"/>
+      <point x="1543" y="74" type="line"/>
+      <point x="933" y="74" type="line"/>
+      <point x="932" y="79" type="line"/>
+      <point x="967" y="113"/>
+      <point x="989" y="153"/>
+      <point x="989" y="197" type="curve" smooth="yes"/>
+      <point x="989" y="289"/>
+      <point x="924" y="344"/>
+      <point x="803" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
     </contour>
     <contour>
-      <point x="507" y="62" type="curve" smooth="yes"/>
-      <point x="434" y="62"/>
-      <point x="397" y="118"/>
-      <point x="397" y="217" type="curve" smooth="yes"/>
-      <point x="397" y="348"/>
-      <point x="439" y="518"/>
-      <point x="569" y="518" type="curve" smooth="yes"/>
-      <point x="648" y="518"/>
-      <point x="677" y="460"/>
-      <point x="677" y="363" type="curve" smooth="yes"/>
-      <point x="677" y="238"/>
-      <point x="636" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1702"/>
   <outline>
     <component base="k_ssa-malayalam"/>
-    <component base="halant-malayalam" xOffset="1565"/>
+    <component base="halant-malayalam" xOffset="1559"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/k_ta-malayalam.glif
@@ -1,114 +1,114 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ta-malayalam" format="2">
   <advance width="1796"/>
-  <anchor x="1348" y="0" name="bottom"/>
-  <anchor x="872" y="580" name="top"/>
-  <anchor x="1696" y="580" name="topright"/>
+  <anchor x="1336" y="0" name="bottom"/>
+  <anchor x="866" y="580" name="top"/>
+  <anchor x="1684" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="660" y="-16"/>
-      <point x="760" y="140"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="502"/>
-      <point x="705" y="596"/>
-      <point x="574" y="596" type="curve" smooth="yes"/>
-      <point x="436" y="596"/>
-      <point x="355" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="891" y="250" type="line"/>
-      <point x="891" y="324" type="line"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
-    </contour>
-    <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
-    </contour>
-    <contour>
-      <point x="941" y="-16" type="curve"/>
-      <point x="1007" y="33" type="line"/>
-      <point x="964" y="90"/>
-      <point x="943" y="157"/>
-      <point x="943" y="243" type="curve" smooth="yes"/>
-      <point x="943" y="407"/>
-      <point x="1046" y="518"/>
-      <point x="1196" y="518" type="curve" smooth="yes"/>
-      <point x="1339" y="518"/>
-      <point x="1425" y="425"/>
-      <point x="1425" y="271" type="curve" smooth="yes"/>
-      <point x="1425" y="148"/>
-      <point x="1370" y="62"/>
-      <point x="1291" y="62" type="curve" smooth="yes"/>
-      <point x="1225" y="62"/>
-      <point x="1188" y="111"/>
-      <point x="1188" y="197" type="curve" smooth="yes"/>
-      <point x="1188" y="379"/>
-      <point x="1320" y="518"/>
-      <point x="1494" y="518" type="curve" smooth="yes"/>
-      <point x="1616" y="518"/>
-      <point x="1689" y="447"/>
-      <point x="1689" y="326" type="curve" smooth="yes"/>
-      <point x="1689" y="221"/>
-      <point x="1640" y="130"/>
-      <point x="1539" y="46" type="curve"/>
-      <point x="1594" y="-16" type="line"/>
-      <point x="1715" y="84"/>
-      <point x="1773" y="196"/>
-      <point x="1773" y="326" type="curve" smooth="yes"/>
-      <point x="1773" y="495"/>
+      <point x="931" y="-16" type="curve"/>
+      <point x="995" y="31" type="line"/>
+      <point x="954" y="85"/>
+      <point x="931" y="159"/>
+      <point x="931" y="236" type="curve" smooth="yes"/>
+      <point x="931" y="380"/>
+      <point x="1020" y="518"/>
+      <point x="1184" y="518" type="curve" smooth="yes"/>
+      <point x="1337" y="518"/>
+      <point x="1406" y="412"/>
+      <point x="1406" y="273" type="curve" smooth="yes"/>
+      <point x="1406" y="179"/>
+      <point x="1372" y="62"/>
+      <point x="1270" y="62" type="curve" smooth="yes"/>
+      <point x="1204" y="62"/>
+      <point x="1171" y="108"/>
+      <point x="1171" y="189" type="curve" smooth="yes"/>
+      <point x="1171" y="361"/>
+      <point x="1314" y="518"/>
+      <point x="1487" y="518" type="curve" smooth="yes"/>
+      <point x="1614" y="518"/>
+      <point x="1673" y="444"/>
+      <point x="1673" y="330" type="curve" smooth="yes"/>
+      <point x="1673" y="231"/>
+      <point x="1624" y="138"/>
+      <point x="1525" y="46" type="curve"/>
+      <point x="1588" y="-16" type="line"/>
+      <point x="1695" y="87"/>
+      <point x="1757" y="213"/>
+      <point x="1757" y="338" type="curve" smooth="yes"/>
+      <point x="1757" y="493"/>
       <point x="1669" y="596"/>
-      <point x="1494" y="596" type="curve" smooth="yes"/>
-      <point x="1282" y="596"/>
-      <point x="1106" y="415"/>
-      <point x="1106" y="197" type="curve" smooth="yes"/>
-      <point x="1106" y="67"/>
-      <point x="1178" y="-16"/>
-      <point x="1291" y="-16" type="curve" smooth="yes"/>
-      <point x="1424" y="-16"/>
-      <point x="1511" y="97"/>
-      <point x="1511" y="271" type="curve" smooth="yes"/>
-      <point x="1511" y="462"/>
-      <point x="1381" y="596"/>
-      <point x="1196" y="596" type="curve" smooth="yes"/>
-      <point x="1002" y="596"/>
-      <point x="861" y="447"/>
-      <point x="861" y="243" type="curve" smooth="yes"/>
-      <point x="861" y="141"/>
-      <point x="888" y="52"/>
+      <point x="1500" y="596" type="curve" smooth="yes"/>
+      <point x="1269" y="596"/>
+      <point x="1088" y="381"/>
+      <point x="1088" y="186" type="curve" smooth="yes"/>
+      <point x="1088" y="63"/>
+      <point x="1156" y="-16"/>
+      <point x="1264" y="-16" type="curve" smooth="yes"/>
+      <point x="1416" y="-16"/>
+      <point x="1493" y="144"/>
+      <point x="1493" y="271" type="curve" smooth="yes"/>
+      <point x="1493" y="446"/>
+      <point x="1383" y="596"/>
+      <point x="1190" y="596" type="curve" smooth="yes"/>
+      <point x="973" y="596"/>
+      <point x="850" y="412"/>
+      <point x="850" y="234" type="curve" smooth="yes"/>
+      <point x="850" y="137"/>
+      <point x="875" y="59"/>
+    </contour>
+    <contour>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="696" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="902" y="270" type="line"/>
+      <point x="902" y="344" type="line"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
+    </contour>
+    <contour>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/k_tta-malayalam.glif
@@ -1,128 +1,119 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_tta-malayalam" format="2">
   <advance width="1035"/>
-  <anchor x="682" y="-351" name="bottom"/>
-  <anchor x="589" y="580" name="top"/>
-  <anchor x="929" y="540" name="topright"/>
+  <anchor x="727" y="-351" name="bottom"/>
+  <anchor x="583" y="580" name="top"/>
+  <anchor x="923" y="540" name="topright"/>
   <outline>
     <contour>
-      <point x="705" y="-365" type="curve" smooth="yes"/>
-      <point x="833" y="-365"/>
-      <point x="889" y="-312"/>
-      <point x="889" y="-235" type="curve" smooth="yes"/>
-      <point x="889" y="-172"/>
-      <point x="856" y="-131"/>
-      <point x="755" y="-125" type="curve" smooth="yes"/>
-      <point x="702" y="-122" type="line" smooth="yes"/>
-      <point x="644" y="-119"/>
-      <point x="619" y="-100"/>
-      <point x="619" y="-72" type="curve" smooth="yes"/>
-      <point x="619" y="-43"/>
-      <point x="649" y="-20"/>
-      <point x="730" y="-20" type="curve" smooth="yes"/>
-      <point x="791" y="-20"/>
-      <point x="840" y="-32"/>
-      <point x="881" y="-49" type="curve"/>
-      <point x="910" y="10" type="line"/>
-      <point x="867" y="30"/>
-      <point x="806" y="45"/>
-      <point x="736" y="45" type="curve" smooth="yes"/>
-      <point x="707" y="45"/>
-      <point x="680" y="42"/>
-      <point x="655" y="36" type="curve"/>
-      <point x="652" y="41" type="line"/>
-      <point x="728" y="115"/>
-      <point x="760" y="246"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="502"/>
-      <point x="705" y="596"/>
-      <point x="574" y="596" type="curve" smooth="yes"/>
-      <point x="436" y="596"/>
-      <point x="355" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="790" y="250" type="line" smooth="yes"/>
-      <point x="873" y="250"/>
-      <point x="908" y="214"/>
-      <point x="908" y="155" type="curve" smooth="yes"/>
-      <point x="908" y="109"/>
-      <point x="884" y="62"/>
-      <point x="812" y="62" type="curve" smooth="yes"/>
-      <point x="785" y="62"/>
-      <point x="767" y="66"/>
-      <point x="751" y="72" type="curve"/>
-      <point x="719" y="2" type="line"/>
-      <point x="742" y="-9"/>
-      <point x="770" y="-16"/>
-      <point x="807" y="-16" type="curve" smooth="yes"/>
-      <point x="931" y="-16"/>
-      <point x="990" y="65"/>
-      <point x="990" y="159" type="curve" smooth="yes"/>
-      <point x="990" y="256"/>
-      <point x="924" y="324"/>
-      <point x="791" y="324" type="curve" smooth="yes"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="432" y="-16"/>
-      <point x="511" y="-16" type="curve" smooth="yes"/>
-      <point x="529" y="-16"/>
-      <point x="548" y="-14"/>
-      <point x="563" y="-9" type="curve"/>
-      <point x="566" y="-14" type="line"/>
-      <point x="551" y="-34"/>
-      <point x="543" y="-57"/>
-      <point x="543" y="-85" type="curve" smooth="yes"/>
-      <point x="543" y="-141"/>
-      <point x="591" y="-187"/>
-      <point x="684" y="-192" type="curve" smooth="yes"/>
-      <point x="737" y="-195" type="line" smooth="yes"/>
-      <point x="809" y="-199"/>
-      <point x="814" y="-224"/>
-      <point x="814" y="-245" type="curve" smooth="yes"/>
-      <point x="814" y="-278"/>
-      <point x="786" y="-300"/>
-      <point x="705" y="-300" type="curve" smooth="yes"/>
-      <point x="630" y="-300"/>
-      <point x="575" y="-282"/>
-      <point x="534" y="-258" type="curve"/>
-      <point x="497" y="-314" type="line"/>
-      <point x="544" y="-345"/>
-      <point x="610" y="-365"/>
+      <point x="719" y="-367" type="curve" smooth="yes"/>
+      <point x="845" y="-367"/>
+      <point x="922" y="-316"/>
+      <point x="922" y="-236" type="curve" smooth="yes"/>
+      <point x="922" y="-178"/>
+      <point x="886" y="-139"/>
+      <point x="786" y="-127" type="curve" smooth="yes"/>
+      <point x="717" y="-119" type="line" smooth="yes"/>
+      <point x="676" y="-114"/>
+      <point x="656" y="-103"/>
+      <point x="656" y="-77" type="curve" smooth="yes"/>
+      <point x="656" y="-42"/>
+      <point x="701" y="-20"/>
+      <point x="780" y="-20" type="curve" smooth="yes"/>
+      <point x="834" y="-20"/>
+      <point x="876" y="-31"/>
+      <point x="917" y="-52" type="curve"/>
+      <point x="942" y="9" type="line"/>
+      <point x="928" y="16"/>
+      <point x="915" y="21"/>
+      <point x="896" y="26" type="curve"/>
+      <point x="897" y="33" type="line"/>
+      <point x="952" y="62"/>
+      <point x="987" y="116"/>
+      <point x="987" y="179" type="curve" smooth="yes"/>
+      <point x="987" y="281"/>
+      <point x="914" y="344"/>
+      <point x="795" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="690" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="781" y="270" type="line" smooth="yes"/>
+      <point x="863" y="270"/>
+      <point x="904" y="236"/>
+      <point x="904" y="168" type="curve" smooth="yes"/>
+      <point x="904" y="109"/>
+      <point x="867" y="62"/>
+      <point x="803" y="62" type="curve" smooth="yes"/>
+      <point x="782" y="62"/>
+      <point x="764" y="66"/>
+      <point x="746" y="75" type="curve"/>
+      <point x="721" y="19" type="line"/>
+      <point x="757" y="42" type="line"/>
+      <point x="657" y="37"/>
+      <point x="578" y="-15"/>
+      <point x="578" y="-87" type="curve" smooth="yes"/>
+      <point x="578" y="-145"/>
+      <point x="624" y="-179"/>
+      <point x="704" y="-188" type="curve" smooth="yes"/>
+      <point x="773" y="-196" type="line" smooth="yes"/>
+      <point x="832" y="-203"/>
+      <point x="844" y="-219"/>
+      <point x="844" y="-243" type="curve" smooth="yes"/>
+      <point x="844" y="-280"/>
+      <point x="799" y="-302"/>
+      <point x="724" y="-302" type="curve" smooth="yes"/>
+      <point x="664" y="-302"/>
+      <point x="611" y="-288"/>
+      <point x="564" y="-260" type="curve"/>
+      <point x="532" y="-324" type="line"/>
+      <point x="585" y="-353"/>
+      <point x="646" y="-367"/>
     </contour>
     <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ka-malayalam.glif
@@ -2,80 +2,80 @@
 <glyph name="ka-malayalam" format="2">
   <advance width="1035"/>
   <unicode hex="0D15"/>
-  <anchor x="594" y="0" name="bottom"/>
-  <anchor x="589" y="580" name="top"/>
-  <anchor x="929" y="540" name="topright"/>
+  <anchor x="588" y="0" name="bottom"/>
+  <anchor x="583" y="580" name="top"/>
+  <anchor x="923" y="540" name="topright"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="660" y="-16"/>
-      <point x="760" y="140"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="515"/>
-      <point x="694" y="596"/>
-      <point x="579" y="596" type="curve" smooth="yes"/>
-      <point x="447" y="596"/>
-      <point x="354" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="790" y="250" type="line" smooth="yes"/>
-      <point x="868" y="250"/>
-      <point x="908" y="218"/>
-      <point x="908" y="155" type="curve" smooth="yes"/>
-      <point x="908" y="97"/>
-      <point x="872" y="62"/>
-      <point x="812" y="62" type="curve" smooth="yes"/>
-      <point x="788" y="62"/>
-      <point x="769" y="65"/>
-      <point x="751" y="72" type="curve"/>
-      <point x="719" y="2" type="line"/>
-      <point x="744" y="-10"/>
-      <point x="773" y="-16"/>
-      <point x="807" y="-16" type="curve" smooth="yes"/>
-      <point x="918" y="-16"/>
-      <point x="990" y="53"/>
-      <point x="990" y="159" type="curve" smooth="yes"/>
-      <point x="990" y="263"/>
-      <point x="916" y="324"/>
-      <point x="791" y="324" type="curve" smooth="yes"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="696" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="789" y="270" type="line" smooth="yes"/>
+      <point x="863" y="270"/>
+      <point x="900" y="238"/>
+      <point x="900" y="175" type="curve" smooth="yes"/>
+      <point x="900" y="108"/>
+      <point x="856" y="62"/>
+      <point x="792" y="62" type="curve" smooth="yes"/>
+      <point x="772" y="62"/>
+      <point x="755" y="64"/>
+      <point x="741" y="69" type="curve"/>
+      <point x="713" y="-4" type="line"/>
+      <point x="736" y="-12"/>
+      <point x="760" y="-16"/>
+      <point x="787" y="-16" type="curve" smooth="yes"/>
+      <point x="901" y="-16"/>
+      <point x="983" y="65"/>
+      <point x="983" y="178" type="curve" smooth="yes"/>
+      <point x="983" y="282"/>
+      <point x="914" y="344"/>
+      <point x="795" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
     </contour>
     <contour>
-      <point x="511" y="62" type="curve" smooth="yes"/>
-      <point x="436" y="62"/>
-      <point x="396" y="116"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="408"/>
-      <point x="464" y="518"/>
-      <point x="572" y="518" type="curve" smooth="yes"/>
-      <point x="642" y="518"/>
-      <point x="676" y="468"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="186"/>
-      <point x="608" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/m_la-malayalam.glif
@@ -1,53 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="m_la-malayalam" format="2">
   <advance width="668"/>
-  <anchor x="248" y="-351" name="bottom"/>
+  <anchor x="235" y="-351" name="bottom"/>
   <anchor x="394" y="580" name="top"/>
   <anchor x="624" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="26" y="-367" type="curve" smooth="yes"/>
-      <point x="111" y="-367"/>
-      <point x="163" y="-313"/>
-      <point x="163" y="-228" type="curve" smooth="yes"/>
-      <point x="163" y="-154"/>
-      <point x="123" y="-118"/>
-      <point x="54" y="-118" type="curve" smooth="yes"/>
-      <point x="22" y="-118"/>
-      <point x="-16" y="-131"/>
-      <point x="-42" y="-164" type="curve"/>
-      <point x="-48" y="-163" type="line"/>
-      <point x="-28" y="-78"/>
-      <point x="29" y="-27"/>
-      <point x="116" y="-27" type="curve" smooth="yes"/>
-      <point x="221" y="-27"/>
-      <point x="248" y="-86"/>
-      <point x="253" y="-174" type="curve" smooth="yes"/>
-      <point x="254" y="-192" type="line" smooth="yes"/>
-      <point x="260" y="-303"/>
-      <point x="310" y="-367"/>
-      <point x="420" y="-367" type="curve" smooth="yes"/>
-      <point x="549" y="-367"/>
-      <point x="604" y="-271"/>
-      <point x="604" y="-131" type="curve" smooth="yes"/>
-      <point x="604" y="-58"/>
-      <point x="585" y="1"/>
-      <point x="555" y="43" type="curve"/>
-      <point x="492" y="5" type="line"/>
-      <point x="514" y="-33"/>
-      <point x="529" y="-82"/>
-      <point x="529" y="-139" type="curve" smooth="yes"/>
-      <point x="529" y="-226"/>
-      <point x="501" y="-297"/>
-      <point x="422" y="-297" type="curve" smooth="yes"/>
-      <point x="362" y="-297"/>
-      <point x="337" y="-265"/>
-      <point x="329" y="-174" type="curve" smooth="yes"/>
-      <point x="327" y="-151" type="line" smooth="yes"/>
-      <point x="322" y="-88"/>
-      <point x="309" y="-37"/>
-      <point x="268" y="-5" type="curve"/>
-      <point x="269" y="0" type="line"/>
+      <point x="0" y="0" type="line"/>
       <point x="566" y="0" type="line"/>
       <point x="614" y="266" type="line" smooth="yes"/>
       <point x="619" y="292"/>
@@ -59,30 +18,75 @@
       <point x="205" y="596"/>
       <point x="88" y="499"/>
       <point x="59" y="333" type="curve" smooth="yes"/>
-      <point x="0" y="0" type="line"/>
-      <point x="26" y="0" type="line"/>
-      <point x="28" y="27" type="line"/>
-      <point x="-64" y="-8"/>
-      <point x="-120" y="-97"/>
-      <point x="-120" y="-210" type="curve" smooth="yes"/>
-      <point x="-120" y="-316"/>
-      <point x="-56" y="-367"/>
     </contour>
     <contour>
-      <point x="26" y="-302" type="curve" smooth="yes"/>
-      <point x="-29" y="-302"/>
-      <point x="-52" y="-264"/>
-      <point x="-52" y="-218" type="curve"/>
-      <point x="-71" y="-197" type="line"/>
-      <point x="-60" y="-253" type="line"/>
-      <point x="-52" y="-213"/>
-      <point x="-19" y="-178"/>
-      <point x="30" y="-178" type="curve" smooth="yes"/>
-      <point x="72" y="-178"/>
-      <point x="92" y="-199"/>
-      <point x="92" y="-233" type="curve" smooth="yes"/>
-      <point x="92" y="-276"/>
-      <point x="68" y="-302"/>
+      <point x="79" y="-367" type="curve" smooth="yes"/>
+      <point x="179" y="-367"/>
+      <point x="222" y="-288"/>
+      <point x="222" y="-218" type="curve" smooth="yes"/>
+      <point x="222" y="-154"/>
+      <point x="187" y="-109"/>
+      <point x="127" y="-109" type="curve" smooth="yes"/>
+      <point x="65" y="-109"/>
+      <point x="13" y="-154"/>
+      <point x="1" y="-220" type="curve"/>
+      <point x="28" y="-176" type="line"/>
+      <point x="2" y="-170" type="line"/>
+      <point x="9" y="-198" type="line"/>
+      <point x="28" y="-90"/>
+      <point x="87" y="-23"/>
+      <point x="179" y="-23" type="curve" smooth="yes"/>
+      <point x="252" y="-23"/>
+      <point x="279" y="-62"/>
+      <point x="279" y="-146" type="curve" smooth="yes"/>
+      <point x="279" y="-219" type="line" smooth="yes"/>
+      <point x="279" y="-314"/>
+      <point x="328" y="-367"/>
+      <point x="407" y="-367" type="curve" smooth="yes"/>
+      <point x="526" y="-367"/>
+      <point x="557" y="-252"/>
+      <point x="557" y="-163" type="curve" smooth="yes"/>
+      <point x="557" y="-83"/>
+      <point x="534" y="-15"/>
+      <point x="490" y="48" type="curve"/>
+      <point x="432" y="9" type="line"/>
+      <point x="468" y="-43"/>
+      <point x="485" y="-98"/>
+      <point x="485" y="-159" type="curve" smooth="yes"/>
+      <point x="485" y="-219"/>
+      <point x="475" y="-297"/>
+      <point x="410" y="-297" type="curve" smooth="yes"/>
+      <point x="371" y="-297"/>
+      <point x="351" y="-269"/>
+      <point x="351" y="-217" type="curve" smooth="yes"/>
+      <point x="351" y="-144" type="line" smooth="yes"/>
+      <point x="351" y="-30"/>
+      <point x="305" y="37"/>
+      <point x="188" y="37" type="curve" smooth="yes"/>
+      <point x="39" y="37"/>
+      <point x="-55" y="-85"/>
+      <point x="-55" y="-222" type="curve" smooth="yes"/>
+      <point x="-55" y="-307"/>
+      <point x="-1" y="-367"/>
+    </contour>
+    <contour>
+      <point x="81" y="-303" type="curve" smooth="yes"/>
+      <point x="38" y="-303"/>
+      <point x="11" y="-271"/>
+      <point x="11" y="-230" type="curve" smooth="yes"/>
+      <point x="11" y="-220"/>
+      <point x="13" y="-210"/>
+      <point x="16" y="-200" type="curve"/>
+      <point x="-7" y="-205" type="line"/>
+      <point x="4" y="-257" type="line"/>
+      <point x="16" y="-198"/>
+      <point x="56" y="-167"/>
+      <point x="98" y="-167" type="curve" smooth="yes"/>
+      <point x="134" y="-167"/>
+      <point x="152" y="-189"/>
+      <point x="152" y="-224" type="curve" smooth="yes"/>
+      <point x="152" y="-264"/>
+      <point x="128" y="-303"/>
     </contour>
     <contour>
       <point x="58" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
@@ -1,103 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng_ka-malayalam" format="2">
   <advance width="1040"/>
-  <anchor x="610" y="0" name="bottom"/>
-  <anchor x="596" y="580" name="top"/>
-  <anchor x="917" y="580" name="topright"/>
+  <anchor x="604" y="0" name="bottom"/>
+  <anchor x="590" y="580" name="top"/>
+  <anchor x="911" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="181" y="-16" type="curve" smooth="yes"/>
-      <point x="267" y="-16"/>
-      <point x="323" y="30"/>
-      <point x="346" y="91" type="curve"/>
-      <point x="351" y="91" type="line"/>
-      <point x="379" y="18"/>
-      <point x="437" y="-16"/>
-      <point x="515" y="-16" type="curve" smooth="yes"/>
-      <point x="692" y="-16"/>
-      <point x="764" y="182"/>
-      <point x="764" y="376" type="curve" smooth="yes"/>
-      <point x="764" y="502"/>
-      <point x="708" y="596"/>
-      <point x="582" y="596" type="curve" smooth="yes"/>
-      <point x="506" y="596"/>
-      <point x="440" y="560"/>
-      <point x="402" y="486" type="curve"/>
-      <point x="397" y="486" type="line"/>
-      <point x="381" y="549"/>
-      <point x="334" y="596"/>
-      <point x="242" y="596" type="curve" smooth="yes"/>
-      <point x="133" y="596"/>
-      <point x="70" y="524"/>
-      <point x="70" y="434" type="curve" smooth="yes"/>
-      <point x="70" y="376"/>
-      <point x="95" y="328"/>
-      <point x="142" y="303" type="curve"/>
-      <point x="142" y="298" type="line"/>
-      <point x="62" y="283"/>
-      <point x="11" y="224"/>
-      <point x="11" y="140" type="curve" smooth="yes"/>
-      <point x="11" y="40"/>
-      <point x="80" y="-16"/>
+      <point x="164" y="-16" type="curve" smooth="yes"/>
+      <point x="235" y="-16"/>
+      <point x="293" y="20"/>
+      <point x="332" y="90" type="curve"/>
+      <point x="337" y="90" type="line"/>
+      <point x="360" y="23"/>
+      <point x="413" y="-16"/>
+      <point x="489" y="-16" type="curve" smooth="yes"/>
+      <point x="701" y="-16"/>
+      <point x="759" y="247"/>
+      <point x="759" y="389" type="curve" smooth="yes"/>
+      <point x="759" y="517"/>
+      <point x="698" y="596"/>
+      <point x="588" y="596" type="curve" smooth="yes"/>
+      <point x="510" y="596"/>
+      <point x="442" y="557"/>
+      <point x="400" y="481" type="curve"/>
+      <point x="395" y="481" type="line"/>
+      <point x="380" y="551"/>
+      <point x="336" y="596"/>
+      <point x="253" y="596" type="curve" smooth="yes"/>
+      <point x="138" y="596"/>
+      <point x="67" y="518"/>
+      <point x="67" y="432" type="curve" smooth="yes"/>
+      <point x="67" y="378"/>
+      <point x="97" y="336"/>
+      <point x="141" y="314" type="curve"/>
+      <point x="140" y="309" type="line"/>
+      <point x="52" y="279"/>
+      <point x="9" y="207"/>
+      <point x="9" y="134" type="curve" smooth="yes"/>
+      <point x="9" y="45"/>
+      <point x="72" y="-16"/>
     </contour>
     <contour>
-      <point x="510" y="62" type="curve" smooth="yes"/>
-      <point x="437" y="62"/>
-      <point x="400" y="118"/>
-      <point x="400" y="217" type="curve" smooth="yes"/>
-      <point x="400" y="348"/>
-      <point x="442" y="518"/>
-      <point x="570" y="518" type="curve" smooth="yes"/>
-      <point x="651" y="518"/>
-      <point x="680" y="460"/>
-      <point x="680" y="363" type="curve" smooth="yes"/>
-      <point x="680" y="238"/>
-      <point x="639" y="62"/>
+      <point x="792" y="-16" type="curve" smooth="yes"/>
+      <point x="906" y="-16"/>
+      <point x="988" y="65"/>
+      <point x="988" y="178" type="curve" smooth="yes"/>
+      <point x="988" y="282"/>
+      <point x="919" y="344"/>
+      <point x="800" y="344" type="curve" smooth="yes"/>
+      <point x="247" y="344" type="line" smooth="yes"/>
+      <point x="185" y="344"/>
+      <point x="147" y="375"/>
+      <point x="147" y="425" type="curve" smooth="yes"/>
+      <point x="147" y="475"/>
+      <point x="186" y="518"/>
+      <point x="255" y="518" type="curve" smooth="yes"/>
+      <point x="318" y="518"/>
+      <point x="345" y="483"/>
+      <point x="345" y="424" type="curve" smooth="yes"/>
+      <point x="345" y="407"/>
+      <point x="343" y="388"/>
+      <point x="339" y="366" type="curve" smooth="yes"/>
+      <point x="311" y="206" type="line" smooth="yes"/>
+      <point x="295" y="115"/>
+      <point x="249" y="62"/>
+      <point x="179" y="62" type="curve" smooth="yes"/>
+      <point x="121" y="62"/>
+      <point x="91" y="92"/>
+      <point x="91" y="144" type="curve" smooth="yes"/>
+      <point x="91" y="215"/>
+      <point x="147" y="270"/>
+      <point x="239" y="270" type="curve" smooth="yes"/>
+      <point x="794" y="270" type="line" smooth="yes"/>
+      <point x="868" y="270"/>
+      <point x="905" y="238"/>
+      <point x="905" y="175" type="curve" smooth="yes"/>
+      <point x="905" y="108"/>
+      <point x="861" y="62"/>
+      <point x="797" y="62" type="curve" smooth="yes"/>
+      <point x="777" y="62"/>
+      <point x="760" y="64"/>
+      <point x="746" y="69" type="curve"/>
+      <point x="718" y="-4" type="line"/>
+      <point x="741" y="-12"/>
+      <point x="765" y="-16"/>
     </contour>
     <contour>
-      <point x="811" y="-16" type="curve" smooth="yes"/>
-      <point x="935" y="-16"/>
-      <point x="994" y="65"/>
-      <point x="994" y="159" type="curve" smooth="yes"/>
-      <point x="994" y="256"/>
-      <point x="928" y="324"/>
-      <point x="795" y="324" type="curve" smooth="yes"/>
-      <point x="278" y="324" type="line" smooth="yes"/>
-      <point x="188" y="324"/>
-      <point x="151" y="370"/>
-      <point x="151" y="425" type="curve" smooth="yes"/>
-      <point x="151" y="476"/>
-      <point x="185" y="518"/>
-      <point x="251" y="518" type="curve" smooth="yes"/>
-      <point x="315" y="518"/>
-      <point x="348" y="476"/>
-      <point x="348" y="409" type="curve" smooth="yes"/>
-      <point x="348" y="392"/>
-      <point x="346" y="374"/>
-      <point x="343" y="354" type="curve" smooth="yes"/>
-      <point x="317" y="204" type="line" smooth="yes"/>
-      <point x="302" y="116"/>
-      <point x="262" y="62"/>
-      <point x="182" y="62" type="curve" smooth="yes"/>
-      <point x="135" y="62"/>
-      <point x="94" y="89"/>
-      <point x="94" y="149" type="curve" smooth="yes"/>
-      <point x="94" y="210"/>
-      <point x="133" y="250"/>
-      <point x="222" y="250" type="curve" smooth="yes"/>
-      <point x="794" y="250" type="line" smooth="yes"/>
-      <point x="877" y="250"/>
-      <point x="912" y="214"/>
-      <point x="912" y="155" type="curve" smooth="yes"/>
-      <point x="912" y="109"/>
-      <point x="888" y="62"/>
-      <point x="816" y="62" type="curve" smooth="yes"/>
-      <point x="789" y="62"/>
-      <point x="771" y="66"/>
-      <point x="755" y="72" type="curve"/>
-      <point x="723" y="2" type="line"/>
-      <point x="746" y="-9"/>
-      <point x="774" y="-16"/>
+      <point x="495" y="62" type="curve" smooth="yes"/>
+      <point x="428" y="62"/>
+      <point x="395" y="106"/>
+      <point x="395" y="191" type="curve" smooth="yes"/>
+      <point x="395" y="296"/>
+      <point x="431" y="518"/>
+      <point x="580" y="518" type="curve" smooth="yes"/>
+      <point x="644" y="518"/>
+      <point x="676" y="476"/>
+      <point x="676" y="390" type="curve" smooth="yes"/>
+      <point x="676" y="297"/>
+      <point x="634" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,192 +1,193 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1518"/>
-  <anchor x="1084" y="0" name="bottom"/>
-  <anchor x="847" y="580" name="top"/>
-  <anchor x="1454" y="580" name="topright"/>
+  <advance width="1560"/>
+  <anchor x="1099" y="0" name="bottom"/>
+  <anchor x="831" y="580" name="top"/>
+  <anchor x="1470" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="244" y="-16" type="curve" smooth="yes"/>
-      <point x="353" y="-16"/>
-      <point x="429" y="67"/>
+      <point x="232" y="-16" type="curve" smooth="yes"/>
+      <point x="386" y="-16"/>
+      <point x="429" y="111"/>
       <point x="429" y="187" type="curve" smooth="yes"/>
-      <point x="429" y="277"/>
-      <point x="368" y="336"/>
-      <point x="273" y="336" type="curve" smooth="yes"/>
-      <point x="217" y="336"/>
-      <point x="166" y="314"/>
+      <point x="429" y="284"/>
+      <point x="374" y="347"/>
+      <point x="275" y="347" type="curve" smooth="yes"/>
+      <point x="218" y="347"/>
+      <point x="167" y="321"/>
       <point x="128" y="275" type="curve"/>
       <point x="98" y="283" type="line"/>
       <point x="98" y="143" type="line"/>
-      <point x="127" y="219"/>
-      <point x="186" y="267"/>
-      <point x="252" y="267" type="curve" smooth="yes"/>
-      <point x="311" y="267"/>
-      <point x="346" y="235"/>
+      <point x="128" y="223"/>
+      <point x="189" y="273"/>
+      <point x="257" y="273" type="curve" smooth="yes"/>
+      <point x="316" y="273"/>
+      <point x="346" y="239"/>
       <point x="346" y="181" type="curve" smooth="yes"/>
-      <point x="346" y="109"/>
-      <point x="306" y="62"/>
-      <point x="243" y="62" type="curve" smooth="yes"/>
-      <point x="161" y="62"/>
-      <point x="120" y="120"/>
-      <point x="120" y="225" type="curve" smooth="yes"/>
-      <point x="120" y="399"/>
-      <point x="219" y="518"/>
-      <point x="364" y="518" type="curve" smooth="yes"/>
-      <point x="477" y="518"/>
-      <point x="534" y="457"/>
-      <point x="534" y="360" type="curve" smooth="yes"/>
-      <point x="534" y="343"/>
-      <point x="531" y="314"/>
-      <point x="526" y="285" type="curve" smooth="yes"/>
-      <point x="476" y="0" type="line"/>
-      <point x="560" y="0" type="line"/>
-      <point x="619" y="336" type="line" smooth="yes"/>
-      <point x="641" y="459"/>
-      <point x="711" y="529"/>
-      <point x="830" y="529" type="curve" smooth="yes"/>
-      <point x="842" y="529"/>
-      <point x="847" y="529"/>
-      <point x="863" y="527" type="curve"/>
-      <point x="839" y="572" type="line"/>
-      <point x="842" y="523" type="line"/>
-      <point x="804" y="501"/>
-      <point x="779" y="460"/>
-      <point x="779" y="421" type="curve" smooth="yes"/>
-      <point x="779" y="352"/>
-      <point x="831" y="310"/>
-      <point x="915" y="310" type="curve" smooth="yes"/>
-      <point x="995" y="310"/>
-      <point x="1061" y="353"/>
-      <point x="1061" y="433" type="curve" smooth="yes"/>
-      <point x="1061" y="468"/>
-      <point x="1045" y="507"/>
-      <point x="995" y="534" type="curve"/>
-      <point x="1007" y="581" type="line"/>
-      <point x="955" y="538" type="line"/>
-      <point x="970" y="540"/>
-      <point x="975" y="540"/>
-      <point x="982" y="540" type="curve" smooth="yes"/>
-      <point x="1078" y="540"/>
-      <point x="1115" y="494"/>
-      <point x="1115" y="411" type="curve" smooth="yes"/>
-      <point x="1115" y="394"/>
-      <point x="1112" y="373"/>
-      <point x="1109" y="354" type="curve" smooth="yes"/>
-      <point x="1107" y="343" type="line"/>
-      <point x="1191" y="343" type="line"/>
-      <point x="1199" y="387" type="line" smooth="yes"/>
-      <point x="1214" y="470"/>
-      <point x="1261" y="518"/>
-      <point x="1330" y="518" type="curve" smooth="yes"/>
-      <point x="1394" y="518"/>
-      <point x="1424" y="486"/>
-      <point x="1424" y="423" type="curve" smooth="yes"/>
-      <point x="1424" y="336"/>
-      <point x="1365" y="287"/>
-      <point x="1260" y="287" type="curve" smooth="yes"/>
-      <point x="931" y="287" type="line" smooth="yes"/>
-      <point x="807" y="287"/>
-      <point x="733" y="225"/>
-      <point x="733" y="120" type="curve" smooth="yes"/>
-      <point x="733" y="34"/>
-      <point x="781" y="-16"/>
-      <point x="862" y="-16" type="curve" smooth="yes"/>
-      <point x="921" y="-16"/>
-      <point x="969" y="0"/>
-      <point x="1071" y="54" type="curve" smooth="yes"/>
-      <point x="1141" y="91" type="line"/>
-      <point x="1253" y="152" type="line"/>
-      <point x="1262" y="151" type="line"/>
-      <point x="1291" y="164"/>
-      <point x="1309" y="167"/>
-      <point x="1328" y="167" type="curve" smooth="yes"/>
-      <point x="1363" y="167"/>
-      <point x="1380" y="149"/>
-      <point x="1380" y="114" type="curve" smooth="yes"/>
-      <point x="1380" y="73"/>
-      <point x="1357" y="48"/>
-      <point x="1318" y="48" type="curve" smooth="yes"/>
-      <point x="1285" y="48"/>
-      <point x="1265" y="67"/>
-      <point x="1265" y="99" type="curve" smooth="yes"/>
-      <point x="1265" y="131"/>
-      <point x="1280" y="159"/>
-      <point x="1312" y="185" type="curve"/>
-      <point x="1188" y="161" type="line"/>
-      <point x="1229" y="102" type="line"/>
-      <point x="1237" y="156" type="line"/>
-      <point x="1216" y="135"/>
-      <point x="1205" y="109"/>
-      <point x="1205" y="80" type="curve" smooth="yes"/>
-      <point x="1205" y="22"/>
-      <point x="1248" y="-16"/>
-      <point x="1315" y="-16" type="curve" smooth="yes"/>
-      <point x="1397" y="-16"/>
-      <point x="1447" y="35"/>
-      <point x="1447" y="121" type="curve" smooth="yes"/>
-      <point x="1447" y="189"/>
-      <point x="1405" y="233"/>
-      <point x="1340" y="233" type="curve" smooth="yes"/>
-      <point x="1294" y="233"/>
-      <point x="1255" y="220"/>
-      <point x="1135" y="162" type="curve" smooth="yes"/>
-      <point x="1052" y="122" type="line" smooth="yes"/>
-      <point x="941" y="68"/>
-      <point x="920" y="61"/>
-      <point x="877" y="61" type="curve" smooth="yes"/>
-      <point x="837" y="61"/>
-      <point x="813" y="86"/>
-      <point x="813" y="126" type="curve" smooth="yes"/>
-      <point x="813" y="184"/>
-      <point x="853" y="215"/>
-      <point x="928" y="215" type="curve" smooth="yes"/>
-      <point x="1256" y="215" type="line" smooth="yes"/>
-      <point x="1404" y="215"/>
-      <point x="1508" y="301"/>
-      <point x="1508" y="423" type="curve" smooth="yes"/>
-      <point x="1508" y="529"/>
-      <point x="1447" y="596"/>
-      <point x="1341" y="596" type="curve" smooth="yes"/>
-      <point x="1267" y="596"/>
-      <point x="1201" y="563"/>
-      <point x="1170" y="478" type="curve"/>
-      <point x="1165" y="478" type="line"/>
-      <point x="1146" y="560"/>
-      <point x="1094" y="596"/>
-      <point x="998" y="596" type="curve" smooth="yes"/>
-      <point x="934" y="596"/>
-      <point x="890" y="575"/>
-      <point x="873" y="564" type="curve"/>
-      <point x="881" y="528" type="line"/>
-      <point x="960" y="526"/>
-      <point x="986" y="485"/>
-      <point x="986" y="444" type="curve" smooth="yes"/>
-      <point x="986" y="410"/>
-      <point x="963" y="380"/>
-      <point x="918" y="380" type="curve" smooth="yes"/>
-      <point x="882" y="380"/>
-      <point x="854" y="398"/>
-      <point x="854" y="439" type="curve" smooth="yes"/>
-      <point x="854" y="469"/>
-      <point x="880" y="520"/>
-      <point x="953" y="528" type="curve"/>
-      <point x="953" y="571" type="line"/>
-      <point x="921" y="586"/>
-      <point x="883" y="596"/>
+      <point x="346" y="130"/>
+      <point x="318" y="62"/>
+      <point x="238" y="62" type="curve" smooth="yes"/>
+      <point x="162" y="62"/>
+      <point x="119" y="120"/>
+      <point x="119" y="225" type="curve" smooth="yes"/>
+      <point x="119" y="379"/>
+      <point x="200" y="518"/>
+      <point x="370" y="518" type="curve" smooth="yes"/>
+      <point x="472" y="518"/>
+      <point x="528" y="465"/>
+      <point x="528" y="369" type="curve" smooth="yes"/>
+      <point x="528" y="350"/>
+      <point x="525" y="318"/>
+      <point x="519" y="285" type="curve" smooth="yes"/>
+      <point x="469" y="0" type="line"/>
+      <point x="553" y="0" type="line"/>
+      <point x="609" y="319" type="line" smooth="yes"/>
+      <point x="633" y="454"/>
+      <point x="713" y="529"/>
+      <point x="833" y="529" type="curve" smooth="yes"/>
+      <point x="851" y="529"/>
+      <point x="864" y="528"/>
+      <point x="881" y="525" type="curve"/>
+      <point x="839" y="544" type="line"/>
+      <point x="838" y="523" type="line"/>
+      <point x="793" y="498"/>
+      <point x="769" y="456"/>
+      <point x="769" y="408" type="curve" smooth="yes"/>
+      <point x="769" y="338"/>
+      <point x="823" y="287"/>
+      <point x="903" y="287" type="curve" smooth="yes"/>
+      <point x="1020" y="287"/>
+      <point x="1056" y="369"/>
+      <point x="1056" y="424" type="curve" smooth="yes"/>
+      <point x="1056" y="465"/>
+      <point x="1039" y="503"/>
+      <point x="1003" y="530" type="curve"/>
+      <point x="1018" y="564" type="line"/>
+      <point x="979" y="534" type="line"/>
+      <point x="986" y="535"/>
+      <point x="998" y="536"/>
+      <point x="1010" y="536" type="curve" smooth="yes"/>
+      <point x="1085" y="536"/>
+      <point x="1124" y="497"/>
+      <point x="1124" y="425" type="curve" smooth="yes"/>
+      <point x="1124" y="409"/>
+      <point x="1122" y="392"/>
+      <point x="1119" y="375" type="curve" smooth="yes"/>
+      <point x="1110" y="324" type="line"/>
+      <point x="1194" y="324" type="line"/>
+      <point x="1203" y="375" type="line" smooth="yes"/>
+      <point x="1218" y="464"/>
+      <point x="1275" y="518"/>
+      <point x="1355" y="518" type="curve" smooth="yes"/>
+      <point x="1421" y="518"/>
+      <point x="1457" y="484"/>
+      <point x="1457" y="422" type="curve" smooth="yes"/>
+      <point x="1457" y="321"/>
+      <point x="1381" y="267"/>
+      <point x="1258" y="267" type="curve" smooth="yes"/>
+      <point x="915" y="267" type="line" smooth="yes"/>
+      <point x="778" y="267"/>
+      <point x="725" y="184"/>
+      <point x="725" y="115" type="curve" smooth="yes"/>
+      <point x="725" y="39"/>
+      <point x="783" y="-16"/>
+      <point x="868" y="-16" type="curve" smooth="yes"/>
+      <point x="915" y="-16"/>
+      <point x="952" y="-4"/>
+      <point x="1038" y="35" type="curve" smooth="yes"/>
+      <point x="1166" y="93" type="line"/>
+      <point x="1241" y="141" type="line"/>
+      <point x="1278" y="153" type="line"/>
+      <point x="1306" y="170"/>
+      <point x="1326" y="176"/>
+      <point x="1355" y="176" type="curve" smooth="yes"/>
+      <point x="1391" y="176"/>
+      <point x="1412" y="155"/>
+      <point x="1412" y="121" type="curve" smooth="yes"/>
+      <point x="1412" y="91"/>
+      <point x="1391" y="54"/>
+      <point x="1339" y="54" type="curve" smooth="yes"/>
+      <point x="1302" y="54"/>
+      <point x="1281" y="74"/>
+      <point x="1281" y="110" type="curve" smooth="yes"/>
+      <point x="1281" y="134"/>
+      <point x="1291" y="159"/>
+      <point x="1312" y="180" type="curve"/>
+      <point x="1220" y="145" type="line"/>
+      <point x="1236" y="131" type="line"/>
+      <point x="1229" y="117"/>
+      <point x="1225" y="101"/>
+      <point x="1225" y="85" type="curve" smooth="yes"/>
+      <point x="1225" y="24"/>
+      <point x="1267" y="-16"/>
+      <point x="1336" y="-16" type="curve" smooth="yes"/>
+      <point x="1440" y="-16"/>
+      <point x="1484" y="67"/>
+      <point x="1484" y="125" type="curve" smooth="yes"/>
+      <point x="1484" y="189"/>
+      <point x="1444" y="236"/>
+      <point x="1370" y="236" type="curve" smooth="yes"/>
+      <point x="1331" y="236"/>
+      <point x="1285" y="221"/>
+      <point x="1205" y="185" type="curve" smooth="yes"/>
+      <point x="1017" y="100" type="line" smooth="yes"/>
+      <point x="956" y="72"/>
+      <point x="919" y="60"/>
+      <point x="879" y="60" type="curve" smooth="yes"/>
+      <point x="833" y="60"/>
+      <point x="807" y="85"/>
+      <point x="807" y="121" type="curve" smooth="yes"/>
+      <point x="807" y="158"/>
+      <point x="835" y="195"/>
+      <point x="911" y="195" type="curve" smooth="yes"/>
+      <point x="1233" y="195" type="line" smooth="yes"/>
+      <point x="1403" y="195"/>
+      <point x="1540" y="283"/>
+      <point x="1540" y="436" type="curve" smooth="yes"/>
+      <point x="1540" y="532"/>
+      <point x="1484" y="596"/>
+      <point x="1376" y="596" type="curve" smooth="yes"/>
+      <point x="1289" y="596"/>
+      <point x="1219" y="552"/>
+      <point x="1182" y="475" type="curve"/>
+      <point x="1177" y="475" type="line"/>
+      <point x="1165" y="552"/>
+      <point x="1112" y="596"/>
+      <point x="1014" y="596" type="curve" smooth="yes"/>
+      <point x="980" y="596"/>
+      <point x="941" y="589"/>
+      <point x="910" y="575" type="curve"/>
+      <point x="943" y="575" type="line"/>
+      <point x="912" y="589"/>
+      <point x="877" y="596"/>
       <point x="835" y="596" type="curve" smooth="yes"/>
-      <point x="721" y="596"/>
-      <point x="641" y="554"/>
-      <point x="590" y="470" type="curve"/>
-      <point x="585" y="470" type="line"/>
-      <point x="547" y="556"/>
-      <point x="472" y="596"/>
-      <point x="365" y="596" type="curve" smooth="yes"/>
-      <point x="173" y="596"/>
-      <point x="38" y="442"/>
-      <point x="38" y="223" type="curve" smooth="yes"/>
-      <point x="38" y="77"/>
-      <point x="115" y="-16"/>
+      <point x="722" y="596"/>
+      <point x="640" y="547"/>
+      <point x="591" y="464" type="curve"/>
+      <point x="586" y="464" type="line"/>
+      <point x="552" y="549"/>
+      <point x="484" y="596"/>
+      <point x="374" y="596" type="curve" smooth="yes"/>
+      <point x="145" y="596"/>
+      <point x="37" y="402"/>
+      <point x="37" y="223" type="curve" smooth="yes"/>
+      <point x="37" y="77"/>
+      <point x="114" y="-16"/>
+    </contour>
+    <contour>
+      <point x="909" y="357" type="curve" smooth="yes"/>
+      <point x="869" y="357"/>
+      <point x="846" y="380"/>
+      <point x="846" y="418" type="curve" smooth="yes"/>
+      <point x="846" y="473"/>
+      <point x="896" y="519"/>
+      <point x="963" y="536" type="curve"/>
+      <point x="895" y="536" type="line"/>
+      <point x="954" y="517"/>
+      <point x="982" y="483"/>
+      <point x="982" y="433" type="curve" smooth="yes"/>
+      <point x="982" y="394"/>
+      <point x="955" y="357"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/oo-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/oo-malayalam.glif
@@ -4,7 +4,7 @@
   <unicode hex="0D13"/>
   <outline>
     <component base="o-malayalam"/>
-    <component base="aaMatra-malayalam" xOffset="793"/>
+    <component base="aaMatra-malayalam" xOffset="780"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/rr_rra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/rr_rra-malayalam.glif
@@ -1,38 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="rr_rra-malayalam" format="2">
-  <advance width="695"/>
+  <advance width="696"/>
   <anchor x="254" y="-311" name="bottom"/>
   <anchor x="404" y="580" name="top"/>
   <anchor x="612" y="580" name="topright"/>
   <outline>
-    <contour>
-      <point x="149" y="-327" type="curve"/>
-      <point x="206" y="-278" type="line"/>
-      <point x="184" y="-252"/>
-      <point x="160" y="-215"/>
-      <point x="160" y="-144" type="curve" smooth="yes"/>
-      <point x="160" y="-57"/>
-      <point x="207" y="13"/>
-      <point x="306" y="13" type="curve" smooth="yes"/>
-      <point x="384" y="13"/>
-      <point x="431" y="-25"/>
-      <point x="431" y="-106" type="curve" smooth="yes"/>
-      <point x="431" y="-190"/>
-      <point x="385" y="-228"/>
-      <point x="329" y="-275" type="curve"/>
-      <point x="375" y="-327" type="line"/>
-      <point x="456" y="-266"/>
-      <point x="506" y="-198"/>
-      <point x="506" y="-102" type="curve" smooth="yes"/>
-      <point x="506" y="24"/>
-      <point x="429" y="83"/>
-      <point x="308" y="83" type="curve" smooth="yes"/>
-      <point x="163" y="83"/>
-      <point x="84" y="-12"/>
-      <point x="84" y="-148" type="curve" smooth="yes"/>
-      <point x="84" y="-223"/>
-      <point x="108" y="-283"/>
-    </contour>
     <contour>
       <point x="165" y="-16" type="curve"/>
       <point x="222" y="44" type="line"/>
@@ -60,6 +32,34 @@
       <point x="43" y="258" type="curve" smooth="yes"/>
       <point x="43" y="151"/>
       <point x="85" y="56"/>
+    </contour>
+    <contour>
+      <point x="149" y="-327" type="curve"/>
+      <point x="206" y="-278" type="line"/>
+      <point x="184" y="-252"/>
+      <point x="160" y="-215"/>
+      <point x="160" y="-144" type="curve" smooth="yes"/>
+      <point x="160" y="-57"/>
+      <point x="207" y="13"/>
+      <point x="306" y="13" type="curve" smooth="yes"/>
+      <point x="384" y="13"/>
+      <point x="431" y="-25"/>
+      <point x="431" y="-106" type="curve" smooth="yes"/>
+      <point x="431" y="-190"/>
+      <point x="385" y="-228"/>
+      <point x="329" y="-275" type="curve"/>
+      <point x="375" y="-327" type="line"/>
+      <point x="456" y="-266"/>
+      <point x="506" y="-198"/>
+      <point x="506" y="-102" type="curve" smooth="yes"/>
+      <point x="506" y="24"/>
+      <point x="429" y="83"/>
+      <point x="308" y="83" type="curve" smooth="yes"/>
+      <point x="163" y="83"/>
+      <point x="84" y="-12"/>
+      <point x="84" y="-148" type="curve" smooth="yes"/>
+      <point x="84" y="-223"/>
+      <point x="108" y="-283"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/t_la-malayalam.glif
@@ -1,136 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_la-malayalam" format="2">
   <advance width="981"/>
-  <anchor x="509" y="-351" name="bottom"/>
-  <anchor x="551" y="580" name="top"/>
-  <anchor x="875" y="580" name="topright"/>
+  <anchor x="494" y="-351" name="bottom"/>
+  <anchor x="545" y="580" name="top"/>
+  <anchor x="869" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="287" y="-367" type="curve" smooth="yes"/>
-      <point x="372" y="-367"/>
-      <point x="424" y="-313"/>
-      <point x="424" y="-228" type="curve" smooth="yes"/>
-      <point x="424" y="-154"/>
-      <point x="384" y="-118"/>
-      <point x="315" y="-118" type="curve" smooth="yes"/>
-      <point x="283" y="-118"/>
-      <point x="245" y="-131"/>
-      <point x="219" y="-164" type="curve"/>
-      <point x="213" y="-163" type="line"/>
-      <point x="233" y="-78"/>
-      <point x="290" y="-27"/>
-      <point x="377" y="-27" type="curve" smooth="yes"/>
-      <point x="482" y="-27"/>
-      <point x="509" y="-86"/>
-      <point x="514" y="-174" type="curve" smooth="yes"/>
-      <point x="515" y="-192" type="line" smooth="yes"/>
-      <point x="521" y="-303"/>
-      <point x="571" y="-367"/>
-      <point x="681" y="-367" type="curve" smooth="yes"/>
+      <point x="276" y="-367" type="curve" smooth="yes"/>
+      <point x="364" y="-367"/>
+      <point x="417" y="-301"/>
+      <point x="417" y="-229" type="curve" smooth="yes"/>
+      <point x="417" y="-162"/>
+      <point x="381" y="-118"/>
+      <point x="314" y="-118" type="curve" smooth="yes"/>
+      <point x="266" y="-118"/>
+      <point x="200" y="-150"/>
+      <point x="187" y="-232" type="curve"/>
+      <point x="226" y="-176" type="line"/>
+      <point x="196" y="-163" type="line"/>
+      <point x="202" y="-188" type="line"/>
+      <point x="222" y="-91"/>
+      <point x="287" y="-27"/>
+      <point x="384" y="-27" type="curve" smooth="yes"/>
+      <point x="458" y="-27"/>
+      <point x="492" y="-64"/>
+      <point x="507" y="-157" type="curve" smooth="yes"/>
+      <point x="514" y="-200" type="line" smooth="yes"/>
+      <point x="533" y="-317"/>
+      <point x="584" y="-367"/>
+      <point x="676" y="-367" type="curve" smooth="yes"/>
       <point x="810" y="-367"/>
-      <point x="865" y="-271"/>
-      <point x="865" y="-131" type="curve" smooth="yes"/>
-      <point x="865" y="-58"/>
-      <point x="846" y="1"/>
-      <point x="816" y="43" type="curve"/>
-      <point x="773" y="-16" type="line"/>
-      <point x="894" y="84"/>
-      <point x="952" y="196"/>
-      <point x="952" y="326" type="curve" smooth="yes"/>
-      <point x="952" y="495"/>
-      <point x="848" y="596"/>
-      <point x="673" y="596" type="curve" smooth="yes"/>
-      <point x="461" y="596"/>
-      <point x="285" y="415"/>
-      <point x="285" y="197" type="curve" smooth="yes"/>
-      <point x="285" y="136"/>
-      <point x="301" y="86"/>
-      <point x="343" y="46" type="curve"/>
-      <point x="342" y="41" type="line"/>
-      <point x="212" y="16"/>
-      <point x="141" y="-83"/>
-      <point x="141" y="-210" type="curve" smooth="yes"/>
-      <point x="141" y="-316"/>
-      <point x="205" y="-367"/>
+      <point x="858" y="-239"/>
+      <point x="858" y="-140" type="curve" smooth="yes"/>
+      <point x="858" y="-71"/>
+      <point x="842" y="-10"/>
+      <point x="812" y="41" type="curve"/>
+      <point x="804" y="13" type="line"/>
+      <point x="891" y="110"/>
+      <point x="941" y="225"/>
+      <point x="941" y="338" type="curve" smooth="yes"/>
+      <point x="941" y="493"/>
+      <point x="856" y="596"/>
+      <point x="692" y="596" type="curve" smooth="yes"/>
+      <point x="626" y="596"/>
+      <point x="564" y="578"/>
+      <point x="508" y="548" type="curve"/>
+      <point x="554" y="546" type="line"/>
+      <point x="507" y="577"/>
+      <point x="450" y="596"/>
+      <point x="382" y="596" type="curve" smooth="yes"/>
+      <point x="162" y="596"/>
+      <point x="38" y="412"/>
+      <point x="38" y="234" type="curve" smooth="yes"/>
+      <point x="38" y="137"/>
+      <point x="63" y="59"/>
+      <point x="119" y="-16" type="curve"/>
+      <point x="183" y="31" type="line"/>
+      <point x="142" y="85"/>
+      <point x="119" y="159"/>
+      <point x="119" y="236" type="curve" smooth="yes"/>
+      <point x="119" y="380"/>
+      <point x="209" y="518"/>
+      <point x="376" y="518" type="curve" smooth="yes"/>
+      <point x="411" y="518"/>
+      <point x="442" y="512"/>
+      <point x="468" y="502" type="curve"/>
+      <point x="467" y="523" type="line"/>
+      <point x="354" y="443"/>
+      <point x="280" y="311"/>
+      <point x="280" y="186" type="curve" smooth="yes"/>
+      <point x="280" y="126"/>
+      <point x="298" y="77"/>
+      <point x="330" y="42" type="curve"/>
+      <point x="329" y="37" type="line"/>
+      <point x="200" y="-2"/>
+      <point x="134" y="-116"/>
+      <point x="134" y="-214" type="curve" smooth="yes"/>
+      <point x="134" y="-313"/>
+      <point x="195" y="-367"/>
     </contour>
     <contour>
-      <point x="683" y="-297" type="curve" smooth="yes"/>
-      <point x="623" y="-297"/>
-      <point x="598" y="-265"/>
-      <point x="590" y="-174" type="curve" smooth="yes"/>
-      <point x="588" y="-151" type="line" smooth="yes"/>
-      <point x="583" y="-90"/>
-      <point x="567" y="-39"/>
-      <point x="528" y="-4" type="curve"/>
-      <point x="529" y="1" type="line"/>
-      <point x="633" y="27"/>
-      <point x="690" y="130"/>
-      <point x="690" y="271" type="curve" smooth="yes"/>
-      <point x="690" y="390"/>
-      <point x="639" y="487"/>
-      <point x="557" y="543" type="curve"/>
-      <point x="469" y="502" type="line"/>
-      <point x="555" y="469"/>
-      <point x="604" y="387"/>
-      <point x="604" y="271" type="curve" smooth="yes"/>
-      <point x="604" y="148"/>
-      <point x="549" y="62"/>
-      <point x="470" y="62" type="curve" smooth="yes"/>
-      <point x="404" y="62"/>
-      <point x="367" y="111"/>
-      <point x="367" y="197" type="curve" smooth="yes"/>
-      <point x="367" y="379"/>
-      <point x="499" y="518"/>
-      <point x="673" y="518" type="curve" smooth="yes"/>
-      <point x="795" y="518"/>
-      <point x="868" y="447"/>
-      <point x="868" y="326" type="curve" smooth="yes"/>
-      <point x="868" y="221"/>
-      <point x="819" y="130"/>
-      <point x="728" y="46" type="curve"/>
-      <point x="762" y="3"/>
-      <point x="790" y="-61"/>
-      <point x="790" y="-139" type="curve" smooth="yes"/>
-      <point x="790" y="-226"/>
-      <point x="762" y="-297"/>
-    </contour>
-    <contour>
-      <point x="287" y="-302" type="curve" smooth="yes"/>
-      <point x="232" y="-302"/>
-      <point x="209" y="-264"/>
-      <point x="209" y="-218" type="curve"/>
-      <point x="190" y="-197" type="line"/>
-      <point x="201" y="-253" type="line"/>
-      <point x="209" y="-213"/>
+      <point x="276" y="-302" type="curve" smooth="yes"/>
+      <point x="228" y="-302"/>
+      <point x="201" y="-269"/>
+      <point x="201" y="-224" type="curve" smooth="yes"/>
+      <point x="201" y="-217"/>
+      <point x="202" y="-208"/>
+      <point x="204" y="-200" type="curve"/>
+      <point x="173" y="-205" type="line"/>
+      <point x="193" y="-265" type="line"/>
+      <point x="201" y="-213"/>
       <point x="242" y="-178"/>
       <point x="291" y="-178" type="curve" smooth="yes"/>
-      <point x="333" y="-178"/>
-      <point x="353" y="-199"/>
-      <point x="353" y="-233" type="curve" smooth="yes"/>
-      <point x="353" y="-276"/>
-      <point x="329" y="-302"/>
+      <point x="330" y="-178"/>
+      <point x="347" y="-201"/>
+      <point x="347" y="-233" type="curve" smooth="yes"/>
+      <point x="347" y="-272"/>
+      <point x="320" y="-302"/>
     </contour>
     <contour>
-      <point x="120" y="-16" type="curve"/>
-      <point x="186" y="33" type="line"/>
-      <point x="143" y="90"/>
-      <point x="122" y="157"/>
-      <point x="122" y="243" type="curve" smooth="yes"/>
-      <point x="122" y="407"/>
-      <point x="225" y="518"/>
-      <point x="375" y="518" type="curve" smooth="yes"/>
-      <point x="410" y="518"/>
-      <point x="442" y="512"/>
-      <point x="469" y="502" type="curve"/>
-      <point x="557" y="543" type="line"/>
-      <point x="507" y="577"/>
-      <point x="445" y="596"/>
-      <point x="375" y="596" type="curve" smooth="yes"/>
-      <point x="181" y="596"/>
-      <point x="40" y="447"/>
-      <point x="40" y="243" type="curve" smooth="yes"/>
-      <point x="40" y="141"/>
-      <point x="67" y="52"/>
+      <point x="462" y="62" type="curve" smooth="yes"/>
+      <point x="396" y="62"/>
+      <point x="363" y="108"/>
+      <point x="363" y="189" type="curve" smooth="yes"/>
+      <point x="363" y="312"/>
+      <point x="435" y="428"/>
+      <point x="542" y="484" type="curve"/>
+      <point x="503" y="484" type="line"/>
+      <point x="568" y="443"/>
+      <point x="598" y="365"/>
+      <point x="598" y="273" type="curve" smooth="yes"/>
+      <point x="598" y="179"/>
+      <point x="564" y="62"/>
+    </contour>
+    <contour>
+      <point x="682" y="-297" type="curve" smooth="yes"/>
+      <point x="629" y="-297"/>
+      <point x="601" y="-269"/>
+      <point x="587" y="-185" type="curve" smooth="yes"/>
+      <point x="580" y="-142" type="line" smooth="yes"/>
+      <point x="568" y="-67"/>
+      <point x="550" y="-27"/>
+      <point x="516" y="-3" type="curve"/>
+      <point x="517" y="2" type="line"/>
+      <point x="629" y="39"/>
+      <point x="685" y="166"/>
+      <point x="685" y="271" type="curve" smooth="yes"/>
+      <point x="685" y="370"/>
+      <point x="649" y="462"/>
+      <point x="583" y="523" type="curve"/>
+      <point x="579" y="500" type="line"/>
+      <point x="610" y="512"/>
+      <point x="644" y="518"/>
+      <point x="679" y="518" type="curve" smooth="yes"/>
+      <point x="801" y="518"/>
+      <point x="857" y="444"/>
+      <point x="857" y="330" type="curve" smooth="yes"/>
+      <point x="857" y="230"/>
+      <point x="809" y="136"/>
+      <point x="712" y="42" type="curve"/>
+      <point x="763" y="-18"/>
+      <point x="785" y="-75"/>
+      <point x="785" y="-142" type="curve" smooth="yes"/>
+      <point x="785" y="-208"/>
+      <point x="762" y="-297"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ta-malayalam.glif
@@ -2,61 +2,61 @@
 <glyph name="ta-malayalam" format="2">
   <advance width="981"/>
   <unicode hex="0D24"/>
-  <anchor x="527" y="0" name="bottom"/>
-  <anchor x="551" y="580" name="top"/>
-  <anchor x="875" y="580" name="topright"/>
+  <anchor x="521" y="0" name="bottom"/>
+  <anchor x="545" y="580" name="top"/>
+  <anchor x="869" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="120" y="-16" type="curve"/>
-      <point x="186" y="33" type="line"/>
-      <point x="143" y="90"/>
-      <point x="122" y="157"/>
-      <point x="122" y="243" type="curve" smooth="yes"/>
-      <point x="122" y="407"/>
-      <point x="225" y="518"/>
-      <point x="375" y="518" type="curve" smooth="yes"/>
-      <point x="518" y="518"/>
-      <point x="604" y="425"/>
-      <point x="604" y="271" type="curve" smooth="yes"/>
-      <point x="604" y="148"/>
-      <point x="549" y="62"/>
-      <point x="470" y="62" type="curve" smooth="yes"/>
-      <point x="404" y="62"/>
-      <point x="367" y="111"/>
-      <point x="367" y="197" type="curve" smooth="yes"/>
-      <point x="367" y="379"/>
-      <point x="499" y="518"/>
-      <point x="673" y="518" type="curve" smooth="yes"/>
-      <point x="795" y="518"/>
-      <point x="868" y="447"/>
-      <point x="868" y="326" type="curve" smooth="yes"/>
-      <point x="868" y="221"/>
-      <point x="819" y="130"/>
-      <point x="718" y="46" type="curve"/>
-      <point x="773" y="-16" type="line"/>
-      <point x="894" y="84"/>
-      <point x="952" y="196"/>
-      <point x="952" y="326" type="curve" smooth="yes"/>
-      <point x="952" y="495"/>
-      <point x="848" y="596"/>
-      <point x="673" y="596" type="curve" smooth="yes"/>
+      <point x="119" y="-16" type="curve"/>
+      <point x="183" y="31" type="line"/>
+      <point x="142" y="85"/>
+      <point x="119" y="159"/>
+      <point x="119" y="236" type="curve" smooth="yes"/>
+      <point x="119" y="380"/>
+      <point x="209" y="518"/>
+      <point x="376" y="518" type="curve" smooth="yes"/>
+      <point x="529" y="518"/>
+      <point x="598" y="412"/>
+      <point x="598" y="273" type="curve" smooth="yes"/>
+      <point x="598" y="179"/>
+      <point x="564" y="62"/>
+      <point x="462" y="62" type="curve" smooth="yes"/>
+      <point x="396" y="62"/>
+      <point x="363" y="108"/>
+      <point x="363" y="189" type="curve" smooth="yes"/>
+      <point x="363" y="361"/>
+      <point x="506" y="518"/>
+      <point x="679" y="518" type="curve" smooth="yes"/>
+      <point x="801" y="518"/>
+      <point x="857" y="444"/>
+      <point x="857" y="330" type="curve" smooth="yes"/>
+      <point x="857" y="232"/>
+      <point x="811" y="139"/>
+      <point x="716" y="46" type="curve"/>
+      <point x="777" y="-16" type="line"/>
+      <point x="883" y="88"/>
+      <point x="941" y="214"/>
+      <point x="941" y="338" type="curve" smooth="yes"/>
+      <point x="941" y="493"/>
+      <point x="856" y="596"/>
+      <point x="692" y="596" type="curve" smooth="yes"/>
       <point x="461" y="596"/>
-      <point x="285" y="415"/>
-      <point x="285" y="197" type="curve" smooth="yes"/>
-      <point x="285" y="67"/>
-      <point x="357" y="-16"/>
-      <point x="470" y="-16" type="curve" smooth="yes"/>
-      <point x="603" y="-16"/>
-      <point x="690" y="97"/>
-      <point x="690" y="271" type="curve" smooth="yes"/>
-      <point x="690" y="462"/>
-      <point x="560" y="596"/>
-      <point x="375" y="596" type="curve" smooth="yes"/>
-      <point x="181" y="596"/>
-      <point x="40" y="447"/>
-      <point x="40" y="243" type="curve" smooth="yes"/>
-      <point x="40" y="141"/>
-      <point x="67" y="52"/>
+      <point x="280" y="381"/>
+      <point x="280" y="186" type="curve" smooth="yes"/>
+      <point x="280" y="63"/>
+      <point x="348" y="-16"/>
+      <point x="456" y="-16" type="curve" smooth="yes"/>
+      <point x="608" y="-16"/>
+      <point x="685" y="144"/>
+      <point x="685" y="271" type="curve" smooth="yes"/>
+      <point x="685" y="446"/>
+      <point x="575" y="596"/>
+      <point x="382" y="596" type="curve" smooth="yes"/>
+      <point x="162" y="596"/>
+      <point x="38" y="412"/>
+      <point x="38" y="234" type="curve" smooth="yes"/>
+      <point x="38" y="137"/>
+      <point x="63" y="59"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="981"/>
   <outline>
     <component base="ta-malayalam"/>
-    <component base="halant-malayalam" xOffset="802"/>
+    <component base="halant-malayalam" xOffset="796"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="572"/>
-  <anchor x="291" y="0" name="bottom"/>
-  <anchor x="270" y="580" name="top"/>
-  <anchor x="421" y="580" name="topright"/>
+  <anchor x="215" y="-235" name="bottom"/>
+  <anchor x="334" y="580" name="top"/>
+  <anchor x="485" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="235" y="-225" type="curve" smooth="yes"/>
-      <point x="383" y="-225"/>
-      <point x="482" y="-182"/>
-      <point x="482" y="-73" type="curve" smooth="yes"/>
-      <point x="482" y="-26"/>
-      <point x="452" y="16"/>
-      <point x="392" y="32" type="curve"/>
-      <point x="392" y="37" type="line"/>
-      <point x="477" y="59"/>
-      <point x="518" y="112"/>
-      <point x="518" y="193" type="curve" smooth="yes"/>
-      <point x="518" y="288"/>
-      <point x="467" y="340"/>
-      <point x="332" y="347" type="curve" smooth="yes"/>
-      <point x="235" y="352" type="line" smooth="yes"/>
-      <point x="173" y="355"/>
-      <point x="140" y="381"/>
-      <point x="140" y="426" type="curve" smooth="yes"/>
-      <point x="140" y="486"/>
-      <point x="196" y="515"/>
-      <point x="290" y="515" type="curve" smooth="yes"/>
-      <point x="379" y="515"/>
-      <point x="440" y="494"/>
-      <point x="499" y="463" type="curve"/>
-      <point x="541" y="533" type="line"/>
-      <point x="478" y="570"/>
-      <point x="391" y="596"/>
-      <point x="289" y="596" type="curve" smooth="yes"/>
-      <point x="140" y="596"/>
-      <point x="51" y="527"/>
-      <point x="51" y="421" type="curve" smooth="yes"/>
-      <point x="51" y="333"/>
-      <point x="108" y="271"/>
-      <point x="211" y="265" type="curve" smooth="yes"/>
-      <point x="316" y="259" type="line" smooth="yes"/>
-      <point x="408" y="254"/>
-      <point x="432" y="225"/>
-      <point x="432" y="176" type="curve" smooth="yes"/>
-      <point x="432" y="104"/>
-      <point x="374" y="80"/>
-      <point x="293" y="80" type="curve" smooth="yes"/>
-      <point x="37" y="80" type="line"/>
-      <point x="24" y="6" type="line"/>
-      <point x="231" y="6" type="line" smooth="yes"/>
-      <point x="361" y="6"/>
-      <point x="399" y="-26"/>
-      <point x="399" y="-72" type="curve" smooth="yes"/>
-      <point x="399" y="-126"/>
-      <point x="352" y="-147"/>
-      <point x="236" y="-147" type="curve" smooth="yes"/>
-      <point x="133" y="-147"/>
-      <point x="61" y="-124"/>
-      <point x="6" y="-98" type="curve"/>
-      <point x="-40" y="-166" type="line"/>
-      <point x="15" y="-198"/>
-      <point x="114" y="-225"/>
+      <point x="216" y="-251" type="curve" smooth="yes"/>
+      <point x="395" y="-251"/>
+      <point x="472" y="-167"/>
+      <point x="472" y="-69" type="curve" smooth="yes"/>
+      <point x="472" y="-13"/>
+      <point x="443" y="29"/>
+      <point x="385" y="46" type="curve"/>
+      <point x="386" y="52" type="line"/>
+      <point x="469" y="78"/>
+      <point x="510" y="128"/>
+      <point x="510" y="199" type="curve" smooth="yes"/>
+      <point x="510" y="286"/>
+      <point x="452" y="334"/>
+      <point x="334" y="345" type="curve" smooth="yes"/>
+      <point x="228" y="355" type="line" smooth="yes"/>
+      <point x="167" y="361"/>
+      <point x="137" y="382"/>
+      <point x="137" y="426" type="curve" smooth="yes"/>
+      <point x="137" y="478"/>
+      <point x="181" y="516"/>
+      <point x="306" y="516" type="curve" smooth="yes"/>
+      <point x="383" y="516"/>
+      <point x="449" y="500"/>
+      <point x="505" y="468" type="curve"/>
+      <point x="544" y="538" type="line"/>
+      <point x="474" y="579"/>
+      <point x="405" y="596"/>
+      <point x="314" y="596" type="curve" smooth="yes"/>
+      <point x="115" y="596"/>
+      <point x="49" y="499"/>
+      <point x="49" y="414" type="curve" smooth="yes"/>
+      <point x="49" y="329"/>
+      <point x="108" y="277"/>
+      <point x="208" y="268" type="curve" smooth="yes"/>
+      <point x="314" y="258" type="line" smooth="yes"/>
+      <point x="394" y="250"/>
+      <point x="422" y="229"/>
+      <point x="422" y="181" type="curve" smooth="yes"/>
+      <point x="422" y="128"/>
+      <point x="377" y="86"/>
+      <point x="262" y="86" type="curve" smooth="yes"/>
+      <point x="33" y="86" type="line"/>
+      <point x="20" y="12" type="line"/>
+      <point x="274" y="12" type="line" smooth="yes"/>
+      <point x="356" y="12"/>
+      <point x="389" y="-17"/>
+      <point x="389" y="-69" type="curve" smooth="yes"/>
+      <point x="389" y="-126"/>
+      <point x="340" y="-171"/>
+      <point x="226" y="-171" type="curve" smooth="yes"/>
+      <point x="140" y="-171"/>
+      <point x="61" y="-144"/>
+      <point x="7" y="-95" type="curve"/>
+      <point x="-45" y="-156" type="line"/>
+      <point x="24" y="-218"/>
+      <point x="114" y="-251"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/tta-malayalam.glif
@@ -2,51 +2,51 @@
 <glyph name="tta-malayalam" format="2">
   <advance width="574"/>
   <unicode hex="0D1F"/>
-  <anchor x="246" y="0" name="bottom"/>
-  <anchor x="327" y="580" name="top"/>
-  <anchor x="478" y="580" name="topright"/>
+  <anchor x="253" y="0" name="bottom"/>
+  <anchor x="334" y="580" name="top"/>
+  <anchor x="485" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="279" y="-16" type="curve" smooth="yes"/>
-      <point x="427" y="-16"/>
-      <point x="514" y="50"/>
-      <point x="514" y="166" type="curve" smooth="yes"/>
-      <point x="514" y="259"/>
-      <point x="459" y="324"/>
-      <point x="316" y="334" type="curve" smooth="yes"/>
-      <point x="244" y="339" type="line" smooth="yes"/>
-      <point x="170" y="344"/>
-      <point x="137" y="374"/>
-      <point x="137" y="420" type="curve" smooth="yes"/>
-      <point x="137" y="486"/>
-      <point x="193" y="515"/>
-      <point x="287" y="515" type="curve" smooth="yes"/>
-      <point x="376" y="515"/>
-      <point x="437" y="494"/>
-      <point x="496" y="463" type="curve"/>
-      <point x="538" y="533" type="line"/>
-      <point x="475" y="570"/>
-      <point x="388" y="596"/>
-      <point x="286" y="596" type="curve" smooth="yes"/>
-      <point x="137" y="596"/>
-      <point x="49" y="527"/>
-      <point x="49" y="409" type="curve" smooth="yes"/>
-      <point x="49" y="323"/>
-      <point x="105" y="256"/>
-      <point x="223" y="249" type="curve" smooth="yes"/>
-      <point x="309" y="244" type="line" smooth="yes"/>
-      <point x="395" y="239"/>
-      <point x="428" y="205"/>
-      <point x="428" y="161" type="curve" smooth="yes"/>
-      <point x="428" y="96"/>
-      <point x="373" y="65"/>
-      <point x="281" y="65" type="curve" smooth="yes"/>
-      <point x="182" y="65"/>
-      <point x="111" y="99"/>
-      <point x="47" y="147" type="curve"/>
-      <point x="-9" y="76" type="line"/>
-      <point x="63" y="23"/>
-      <point x="148" y="-16"/>
+      <point x="270" y="-16" type="curve" smooth="yes"/>
+      <point x="440" y="-16"/>
+      <point x="516" y="74"/>
+      <point x="516" y="169" type="curve" smooth="yes"/>
+      <point x="516" y="267"/>
+      <point x="458" y="323"/>
+      <point x="344" y="333" type="curve" smooth="yes"/>
+      <point x="240" y="342" type="line" smooth="yes"/>
+      <point x="174" y="348"/>
+      <point x="143" y="372"/>
+      <point x="143" y="418" type="curve" smooth="yes"/>
+      <point x="143" y="473"/>
+      <point x="195" y="516"/>
+      <point x="314" y="516" type="curve" smooth="yes"/>
+      <point x="395" y="516"/>
+      <point x="453" y="502"/>
+      <point x="511" y="470" type="curve"/>
+      <point x="549" y="540" type="line"/>
+      <point x="481" y="578"/>
+      <point x="408" y="596"/>
+      <point x="320" y="596" type="curve" smooth="yes"/>
+      <point x="132" y="596"/>
+      <point x="57" y="500"/>
+      <point x="57" y="409" type="curve" smooth="yes"/>
+      <point x="57" y="318"/>
+      <point x="120" y="262"/>
+      <point x="221" y="253" type="curve" smooth="yes"/>
+      <point x="325" y="244" type="line" smooth="yes"/>
+      <point x="400" y="238"/>
+      <point x="430" y="214"/>
+      <point x="430" y="163" type="curve" smooth="yes"/>
+      <point x="430" y="108"/>
+      <point x="382" y="64"/>
+      <point x="276" y="64" type="curve" smooth="yes"/>
+      <point x="183" y="64"/>
+      <point x="105" y="89"/>
+      <point x="37" y="141" type="curve"/>
+      <point x="-12" y="78" type="line"/>
+      <point x="68" y="15"/>
+      <point x="161" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/tta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/tta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="574"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="halant-malayalam" xOffset="405"/>
+    <component base="halant-malayalam" xOffset="412"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="574"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="292"/>
+    <component base="lVocalicMatra-malayalam" xOffset="299"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="574"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="292"/>
+    <component base="llVocalicMatra-malayalam" xOffset="299"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
@@ -4,65 +4,71 @@
   <unicode hex="0D42"/>
   <outline>
     <contour>
-      <point x="22" y="13" type="curve"/>
-      <point x="112" y="13" type="line"/>
-      <point x="173" y="124"/>
-      <point x="233" y="282"/>
-      <point x="233" y="396" type="curve" smooth="yes"/>
-      <point x="233" y="512"/>
-      <point x="172" y="585"/>
-      <point x="62" y="595" type="curve" smooth="yes"/>
-      <point x="51" y="596" type="line"/>
-      <point x="37" y="518" type="line"/>
-      <point x="113" y="511"/>
-      <point x="151" y="468"/>
-      <point x="151" y="389" type="curve" smooth="yes"/>
-      <point x="151" y="280"/>
-      <point x="88" y="124"/>
+      <point x="41" y="16" type="curve"/>
+      <point x="125" y="16" type="line"/>
+      <point x="194" y="145"/>
+      <point x="243" y="299"/>
+      <point x="243" y="394" type="curve" smooth="yes"/>
+      <point x="243" y="522"/>
+      <point x="183" y="596"/>
+      <point x="67" y="596" type="curve" smooth="yes"/>
+      <point x="59" y="596" type="line"/>
+      <point x="45" y="519" type="line"/>
+      <point x="124" y="519"/>
+      <point x="160" y="475"/>
+      <point x="160" y="388" type="curve" smooth="yes"/>
+      <point x="160" y="290"/>
+      <point x="117" y="155"/>
     </contour>
     <contour>
-      <point x="52" y="-256" type="curve" smooth="yes"/>
-      <point x="148" y="-256"/>
-      <point x="222" y="-187"/>
-      <point x="222" y="-96" type="curve" smooth="yes"/>
-      <point x="222" y="-11"/>
-      <point x="157" y="52"/>
-      <point x="67" y="52" type="curve" smooth="yes"/>
-      <point x="-28" y="52"/>
+      <point x="53" y="-185" type="curve" smooth="yes"/>
+      <point x="0" y="-185"/>
+      <point x="-37" y="-156"/>
+      <point x="-37" y="-112" type="curve" smooth="yes"/>
+      <point x="-37" y="-91"/>
+      <point x="-31" y="-74"/>
+      <point x="-19" y="-60" type="curve"/>
+      <point x="-15" y="-60" type="line"/>
+      <point x="-11" y="-100"/>
+      <point x="15" y="-127"/>
+      <point x="58" y="-127" type="curve" smooth="yes"/>
+      <point x="100" y="-127"/>
+      <point x="129" y="-103"/>
+      <point x="141" y="-60" type="curve"/>
+      <point x="145" y="-60" type="line"/>
+      <point x="148" y="-70"/>
+      <point x="150" y="-80"/>
+      <point x="150" y="-92" type="curve" smooth="yes"/>
+      <point x="150" y="-140"/>
+      <point x="122" y="-185"/>
+    </contour>
+    <contour>
+      <point x="49" y="-256" type="curve" smooth="yes"/>
+      <point x="145" y="-256"/>
+      <point x="217" y="-187"/>
+      <point x="217" y="-96" type="curve" smooth="yes"/>
+      <point x="217" y="-11"/>
+      <point x="153" y="52"/>
+      <point x="64" y="52" type="curve" smooth="yes"/>
+      <point x="-30" y="52"/>
       <point x="-104" y="-20"/>
       <point x="-104" y="-110" type="curve" smooth="yes"/>
       <point x="-104" y="-195"/>
-      <point x="-39" y="-256"/>
+      <point x="-40" y="-256"/>
     </contour>
     <contour>
-      <point x="54" y="-185" type="curve" smooth="yes"/>
-      <point x="4" y="-185"/>
-      <point x="-30" y="-153"/>
-      <point x="-30" y="-106" type="curve" smooth="yes"/>
-      <point x="-30" y="-54"/>
-      <point x="10" y="-15"/>
-      <point x="65" y="-15" type="curve" smooth="yes"/>
-      <point x="114" y="-15"/>
-      <point x="148" y="-46"/>
-      <point x="148" y="-92" type="curve" smooth="yes"/>
-      <point x="148" y="-147"/>
-      <point x="109" y="-185"/>
-    </contour>
-    <contour>
-      <point x="69" y="-125" type="curve" smooth="yes"/>
-      <point x="107" y="-125"/>
-      <point x="141" y="-114"/>
-      <point x="170" y="-93" type="curve"/>
-      <point x="154" y="-51" type="line"/>
-      <point x="130" y="-68"/>
-      <point x="104" y="-76"/>
-      <point x="71" y="-76" type="curve" smooth="yes"/>
-      <point x="25" y="-76"/>
-      <point x="-5" y="-61"/>
-      <point x="-26" y="-35" type="curve"/>
-      <point x="-55" y="-73" type="line"/>
-      <point x="-27" y="-107"/>
-      <point x="13" y="-125"/>
+      <point x="62" y="-63" type="curve" smooth="yes"/>
+      <point x="29" y="-63"/>
+      <point x="6" y="-50"/>
+      <point x="6" y="-31" type="curve" smooth="yes"/>
+      <point x="6" y="-14"/>
+      <point x="24" y="0"/>
+      <point x="76" y="0" type="curve" smooth="yes"/>
+      <point x="115" y="0"/>
+      <point x="133" y="-10"/>
+      <point x="133" y="-26" type="curve" smooth="yes"/>
+      <point x="133" y="-46"/>
+      <point x="111" y="-63"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/y_ya-malayalam.glif
@@ -1,96 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="984"/>
-  <anchor x="528" y="-281" name="bottom"/>
-  <anchor x="562" y="580" name="top"/>
-  <anchor x="868" y="580" name="topright"/>
+  <anchor x="524" y="-268" name="bottom"/>
+  <anchor x="556" y="580" name="top"/>
+  <anchor x="862" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="210" y="-291" type="line"/>
-      <point x="780" y="-291" type="line"/>
-      <point x="844" y="79" type="line"/>
-      <point x="829" y="45" type="line"/>
-      <point x="909" y="107"/>
-      <point x="956" y="213"/>
-      <point x="956" y="349" type="curve" smooth="yes"/>
-      <point x="956" y="450"/>
-      <point x="935" y="530"/>
-      <point x="891" y="596" type="curve"/>
-      <point x="822" y="553" type="line"/>
-      <point x="857" y="499"/>
-      <point x="874" y="432"/>
-      <point x="874" y="349" type="curve" smooth="yes"/>
-      <point x="874" y="173"/>
-      <point x="783" y="62"/>
-      <point x="639" y="62" type="curve" smooth="yes"/>
-      <point x="496" y="62"/>
-      <point x="419" y="152"/>
-      <point x="419" y="320" type="curve" smooth="yes"/>
-      <point x="419" y="435"/>
-      <point x="469" y="518"/>
+      <point x="204" y="-278" type="line"/>
+      <point x="774" y="-278" type="line"/>
+      <point x="844" y="121" type="line"/>
+      <point x="820" y="69" type="line"/>
+      <point x="903" y="137"/>
+      <point x="947" y="245"/>
+      <point x="947" y="349" type="curve" smooth="yes"/>
+      <point x="947" y="438"/>
+      <point x="919" y="526"/>
+      <point x="869" y="596" type="curve"/>
+      <point x="802" y="552" type="line"/>
+      <point x="846" y="489"/>
+      <point x="868" y="421"/>
+      <point x="868" y="350" type="curve" smooth="yes"/>
+      <point x="868" y="197"/>
+      <point x="767" y="62"/>
+      <point x="605" y="62" type="curve" smooth="yes"/>
+      <point x="446" y="62"/>
+      <point x="376" y="165"/>
+      <point x="376" y="303" type="curve" smooth="yes"/>
+      <point x="376" y="386"/>
+      <point x="414" y="518"/>
       <point x="539" y="518" type="curve" smooth="yes"/>
-      <point x="599" y="518"/>
-      <point x="630" y="474"/>
-      <point x="630" y="389" type="curve" smooth="yes"/>
-      <point x="630" y="247"/>
-      <point x="574" y="142"/>
-      <point x="468" y="85" type="curve"/>
-      <point x="519" y="30" type="line"/>
-      <point x="643" y="99"/>
-      <point x="712" y="228"/>
-      <point x="712" y="389" type="curve" smooth="yes"/>
-      <point x="712" y="525"/>
-      <point x="654" y="596"/>
-      <point x="543" y="596" type="curve" smooth="yes"/>
-      <point x="425" y="596"/>
-      <point x="337" y="478"/>
-      <point x="337" y="320" type="curve" smooth="yes"/>
-      <point x="337" y="122"/>
-      <point x="461" y="-16"/>
-      <point x="637" y="-16" type="curve" smooth="yes"/>
-      <point x="642" y="-16"/>
-      <point x="646" y="-16"/>
-      <point x="651" y="-16" type="curve"/>
-      <point x="595" y="30" type="line"/>
-      <point x="604" y="-19" type="line"/>
-      <point x="508" y="-70" type="line"/>
-      <point x="219" y="-235" type="line"/>
+      <point x="609" y="518"/>
+      <point x="644" y="471"/>
+      <point x="644" y="387" type="curve" smooth="yes"/>
+      <point x="644" y="269"/>
+      <point x="572" y="155"/>
+      <point x="456" y="96" type="curve"/>
+      <point x="507" y="49" type="line"/>
+      <point x="653" y="122"/>
+      <point x="726" y="259"/>
+      <point x="726" y="389" type="curve" smooth="yes"/>
+      <point x="726" y="516"/>
+      <point x="663" y="596"/>
+      <point x="547" y="596" type="curve" smooth="yes"/>
+      <point x="388" y="596"/>
+      <point x="294" y="442"/>
+      <point x="294" y="305" type="curve" smooth="yes"/>
+      <point x="294" y="126"/>
+      <point x="418" y="-12"/>
+      <point x="599" y="-12" type="curve" smooth="yes"/>
+      <point x="623" y="-12"/>
+      <point x="647" y="-10"/>
+      <point x="669" y="-5" type="curve"/>
+      <point x="582" y="33" type="line"/>
+      <point x="575" y="-15" type="line"/>
+      <point x="492" y="-57" type="line"/>
+      <point x="214" y="-222" type="line"/>
     </contour>
     <contour>
-      <point x="311" y="-262" type="line"/>
-      <point x="775" y="10" type="line"/>
-      <point x="750" y="10" type="line"/>
-      <point x="706" y="-244" type="line"/>
-      <point x="747" y="-226" type="line"/>
-      <point x="347" y="-226" type="line"/>
+      <point x="315" y="-243" type="line"/>
+      <point x="757" y="19" type="line"/>
+      <point x="744" y="18" type="line"/>
+      <point x="700" y="-231" type="line"/>
+      <point x="742" y="-213" type="line"/>
+      <point x="320" y="-213" type="line"/>
     </contour>
     <contour>
-      <point x="343" y="-16" type="curve" smooth="yes"/>
-      <point x="407" y="-16"/>
-      <point x="459" y="-3"/>
-      <point x="508" y="27" type="curve"/>
-      <point x="438" y="77" type="line"/>
-      <point x="408" y="67"/>
-      <point x="377" y="62"/>
-      <point x="343" y="62" type="curve" smooth="yes"/>
-      <point x="209" y="62"/>
-      <point x="129" y="150"/>
-      <point x="129" y="296" type="curve" smooth="yes"/>
-      <point x="129" y="429"/>
-      <point x="200" y="518"/>
-      <point x="306" y="518" type="curve" smooth="yes"/>
-      <point x="357" y="518"/>
-      <point x="390" y="503"/>
-      <point x="413" y="470" type="curve"/>
-      <point x="464" y="520" type="line"/>
-      <point x="433" y="571"/>
-      <point x="384" y="596"/>
-      <point x="312" y="596" type="curve" smooth="yes"/>
-      <point x="158" y="596"/>
-      <point x="49" y="471"/>
-      <point x="49" y="296" type="curve" smooth="yes"/>
-      <point x="49" y="107"/>
-      <point x="165" y="-16"/>
+      <point x="325" y="-16" type="curve" smooth="yes"/>
+      <point x="382" y="-16"/>
+      <point x="429" y="-3"/>
+      <point x="482" y="30" type="curve"/>
+      <point x="428" y="81" type="line"/>
+      <point x="400" y="69"/>
+      <point x="370" y="62"/>
+      <point x="333" y="62" type="curve" smooth="yes"/>
+      <point x="198" y="62"/>
+      <point x="125" y="146"/>
+      <point x="125" y="279" type="curve" smooth="yes"/>
+      <point x="125" y="385"/>
+      <point x="179" y="518"/>
+      <point x="320" y="518" type="curve" smooth="yes"/>
+      <point x="363" y="518"/>
+      <point x="387" y="505"/>
+      <point x="409" y="479" type="curve"/>
+      <point x="469" y="536" type="line"/>
+      <point x="430" y="575"/>
+      <point x="389" y="596"/>
+      <point x="323" y="596" type="curve" smooth="yes"/>
+      <point x="133" y="596"/>
+      <point x="46" y="416"/>
+      <point x="46" y="281" type="curve" smooth="yes"/>
+      <point x="46" y="105"/>
+      <point x="157" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ya-malayalam.glif
@@ -2,78 +2,78 @@
 <glyph name="ya-malayalam" format="2">
   <advance width="984"/>
   <unicode hex="0D2F"/>
-  <anchor x="531" y="0" name="bottom"/>
-  <anchor x="810" y="0" name="bottomright"/>
-  <anchor x="562" y="580" name="top"/>
-  <anchor x="868" y="580" name="topright"/>
+  <anchor x="525" y="0" name="bottom"/>
+  <anchor x="804" y="0" name="bottomright"/>
+  <anchor x="556" y="580" name="top"/>
+  <anchor x="862" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="639" y="-16" type="curve" smooth="yes"/>
-      <point x="831" y="-16"/>
-      <point x="956" y="127"/>
-      <point x="956" y="349" type="curve" smooth="yes"/>
-      <point x="956" y="450"/>
-      <point x="935" y="530"/>
-      <point x="891" y="596" type="curve"/>
-      <point x="822" y="553" type="line"/>
-      <point x="857" y="499"/>
-      <point x="874" y="432"/>
-      <point x="874" y="349" type="curve" smooth="yes"/>
-      <point x="874" y="173"/>
-      <point x="783" y="62"/>
-      <point x="639" y="62" type="curve" smooth="yes"/>
-      <point x="496" y="62"/>
-      <point x="419" y="152"/>
-      <point x="419" y="320" type="curve" smooth="yes"/>
-      <point x="419" y="435"/>
-      <point x="469" y="518"/>
+      <point x="599" y="-16" type="curve" smooth="yes"/>
+      <point x="815" y="-16"/>
+      <point x="947" y="170"/>
+      <point x="947" y="349" type="curve" smooth="yes"/>
+      <point x="947" y="438"/>
+      <point x="919" y="526"/>
+      <point x="869" y="596" type="curve"/>
+      <point x="802" y="552" type="line"/>
+      <point x="846" y="489"/>
+      <point x="868" y="421"/>
+      <point x="868" y="350" type="curve" smooth="yes"/>
+      <point x="868" y="197"/>
+      <point x="767" y="62"/>
+      <point x="605" y="62" type="curve" smooth="yes"/>
+      <point x="446" y="62"/>
+      <point x="376" y="165"/>
+      <point x="376" y="303" type="curve" smooth="yes"/>
+      <point x="376" y="386"/>
+      <point x="414" y="518"/>
       <point x="539" y="518" type="curve" smooth="yes"/>
-      <point x="599" y="518"/>
-      <point x="630" y="474"/>
-      <point x="630" y="389" type="curve" smooth="yes"/>
-      <point x="630" y="247"/>
-      <point x="574" y="142"/>
-      <point x="468" y="85" type="curve"/>
-      <point x="519" y="30" type="line"/>
-      <point x="643" y="99"/>
-      <point x="712" y="228"/>
-      <point x="712" y="389" type="curve" smooth="yes"/>
-      <point x="712" y="525"/>
-      <point x="654" y="596"/>
-      <point x="543" y="596" type="curve" smooth="yes"/>
-      <point x="425" y="596"/>
-      <point x="337" y="478"/>
-      <point x="337" y="320" type="curve" smooth="yes"/>
-      <point x="337" y="122"/>
-      <point x="462" y="-16"/>
+      <point x="609" y="518"/>
+      <point x="644" y="471"/>
+      <point x="644" y="387" type="curve" smooth="yes"/>
+      <point x="644" y="269"/>
+      <point x="572" y="155"/>
+      <point x="456" y="96" type="curve"/>
+      <point x="507" y="49" type="line"/>
+      <point x="653" y="122"/>
+      <point x="726" y="259"/>
+      <point x="726" y="389" type="curve" smooth="yes"/>
+      <point x="726" y="516"/>
+      <point x="663" y="596"/>
+      <point x="547" y="596" type="curve" smooth="yes"/>
+      <point x="388" y="596"/>
+      <point x="294" y="442"/>
+      <point x="294" y="305" type="curve" smooth="yes"/>
+      <point x="294" y="124"/>
+      <point x="418" y="-16"/>
     </contour>
     <contour>
-      <point x="343" y="-16" type="curve" smooth="yes"/>
-      <point x="407" y="-16"/>
-      <point x="459" y="-3"/>
-      <point x="508" y="27" type="curve"/>
-      <point x="438" y="77" type="line"/>
-      <point x="408" y="67"/>
-      <point x="377" y="62"/>
-      <point x="343" y="62" type="curve" smooth="yes"/>
-      <point x="209" y="62"/>
-      <point x="129" y="150"/>
-      <point x="129" y="296" type="curve" smooth="yes"/>
-      <point x="129" y="429"/>
-      <point x="200" y="518"/>
-      <point x="306" y="518" type="curve" smooth="yes"/>
-      <point x="357" y="518"/>
-      <point x="390" y="503"/>
-      <point x="413" y="470" type="curve"/>
-      <point x="464" y="520" type="line"/>
-      <point x="433" y="571"/>
-      <point x="384" y="596"/>
-      <point x="312" y="596" type="curve" smooth="yes"/>
-      <point x="158" y="596"/>
-      <point x="49" y="471"/>
-      <point x="49" y="296" type="curve" smooth="yes"/>
-      <point x="49" y="107"/>
-      <point x="165" y="-16"/>
+      <point x="325" y="-16" type="curve" smooth="yes"/>
+      <point x="382" y="-16"/>
+      <point x="429" y="-3"/>
+      <point x="482" y="30" type="curve"/>
+      <point x="428" y="81" type="line"/>
+      <point x="400" y="69"/>
+      <point x="370" y="62"/>
+      <point x="333" y="62" type="curve" smooth="yes"/>
+      <point x="198" y="62"/>
+      <point x="125" y="146"/>
+      <point x="125" y="279" type="curve" smooth="yes"/>
+      <point x="125" y="385"/>
+      <point x="179" y="518"/>
+      <point x="320" y="518" type="curve" smooth="yes"/>
+      <point x="363" y="518"/>
+      <point x="387" y="505"/>
+      <point x="409" y="479" type="curve"/>
+      <point x="469" y="536" type="line"/>
+      <point x="430" y="575"/>
+      <point x="389" y="596"/>
+      <point x="323" y="596" type="curve" smooth="yes"/>
+      <point x="133" y="596"/>
+      <point x="46" y="416"/>
+      <point x="46" y="281" type="curve" smooth="yes"/>
+      <point x="46" y="105"/>
+      <point x="157" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ya-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ya-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="984"/>
   <outline>
     <component base="ya-malayalam"/>
-    <component base="halant-malayalam" xOffset="795"/>
+    <component base="halant-malayalam" xOffset="789"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/kerning.plist
@@ -47215,7 +47215,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -47329,7 +47329,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47385,7 +47385,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47440,7 +47440,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>200</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -47487,7 +47487,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -47522,7 +47522,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>110</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -47550,8 +47550,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47586,7 +47584,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47653,7 +47651,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47713,7 +47711,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>130</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47764,7 +47762,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>170</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47822,7 +47820,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47865,7 +47863,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48003,8 +48001,6 @@
       <integer>-10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48090,7 +48086,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48190,8 +48186,6 @@
       <integer>60</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48224,7 +48218,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48304,7 +48298,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48346,8 +48340,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla-malayalam_L</key>
       <integer>-30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48465,8 +48457,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -48580,7 +48570,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48629,7 +48619,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>200</integer>
+      <integer>190</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48679,17 +48669,17 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>70</integer>
-      <key>public.kern2.MAL_braceright.loclMALM_R</key>
       <integer>50</integer>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>40</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
       <integer>40</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
@@ -48699,23 +48689,25 @@
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
       <integer>40</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
-      <integer>-30</integer>
+      <integer>-20</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>70</integer>
+      <key>public.kern2.MAL_tt_tta-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
-      <integer>130</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
-      <integer>90</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_uMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>74</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>220</integer>
+      <integer>210</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
       <integer>170</integer>
     </dict>
@@ -48742,7 +48734,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48791,7 +48783,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>160</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48867,7 +48859,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49078,7 +49070,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49104,8 +49096,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49134,7 +49124,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49188,7 +49178,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -49220,8 +49210,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -49338,7 +49326,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_p_pa-malayalam_L</key>
@@ -49450,7 +49438,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49495,7 +49483,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49591,7 +49579,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -49731,7 +49719,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49784,7 +49772,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49851,7 +49839,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49904,7 +49892,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>290</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>240</integer>
+      <integer>220</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -49991,7 +49979,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>130</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50140,7 +50128,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -50248,7 +50236,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_ng_ka-malayalam_L</key>
@@ -50300,6 +50288,26 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-40</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>110</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>100</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+      <key>public.kern2.MAL_quoteright.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.Man-georgian</key>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/archaicii-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/archaicii-malayalam.glif
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="archaicii-malayalam" format="2">
-  <advance width="1347"/>
+  <advance width="1361"/>
   <unicode hex="0D5F"/>
   <outline>
     <component base="archaicii-malayalam.part"/>
-    <component base="ra-malayalam" xOffset="314"/>
-    <component base="archaicii-malayalam.part" xOffset="1033"/>
+    <component base="ra-malayalam" xOffset="321"/>
+    <component base="archaicii-malayalam.part" xOffset="1040"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/d_da-malayalam.glif
@@ -1,76 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
-  <advance width="665"/>
-  <guideline x="1234" y="-225" angle="0"/>
-  <guideline x="605" y="162" angle="90"/>
-  <guideline x="1428" y="185" angle="90"/>
-  <anchor x="349" y="580" name="top"/>
+  <advance width="655"/>
+  <anchor x="279" y="-263" name="bottom"/>
+  <anchor x="414" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="375" y="-225" type="curve" smooth="yes"/>
-      <point x="503" y="-225"/>
-      <point x="569" y="-175"/>
-      <point x="569" y="-83" type="curve" smooth="yes"/>
-      <point x="569" y="-32"/>
-      <point x="537" y="9"/>
-      <point x="477" y="21" type="curve"/>
-      <point x="477" y="26" type="line"/>
-      <point x="529" y="39"/>
-      <point x="601" y="68"/>
-      <point x="601" y="166" type="curve" smooth="yes"/>
-      <point x="601" y="221"/>
-      <point x="573" y="269"/>
-      <point x="503" y="286" type="curve"/>
-      <point x="504" y="291" type="line"/>
-      <point x="587" y="306"/>
-      <point x="628" y="359"/>
-      <point x="628" y="429" type="curve" smooth="yes"/>
-      <point x="628" y="526"/>
-      <point x="551" y="596"/>
-      <point x="392" y="596" type="curve" smooth="yes"/>
-      <point x="178" y="596"/>
-      <point x="39" y="445"/>
-      <point x="39" y="234" type="curve" smooth="yes"/>
-      <point x="39" y="140"/>
-      <point x="60" y="61"/>
-      <point x="104" y="-16" type="curve"/>
-      <point x="177" y="29" type="line"/>
-      <point x="139" y="91"/>
-      <point x="122" y="156"/>
-      <point x="122" y="237" type="curve" smooth="yes"/>
-      <point x="122" y="399"/>
-      <point x="216" y="518"/>
-      <point x="387" y="518" type="curve" smooth="yes"/>
-      <point x="497" y="518"/>
-      <point x="543" y="478"/>
-      <point x="543" y="425" type="curve" smooth="yes"/>
-      <point x="543" y="365"/>
-      <point x="499" y="329"/>
-      <point x="431" y="329" type="curve" smooth="yes"/>
-      <point x="371" y="329" type="line"/>
-      <point x="358" y="255" type="line"/>
-      <point x="400" y="255" type="line" smooth="yes"/>
+      <point x="319" y="-279" type="curve" smooth="yes"/>
+      <point x="464" y="-279"/>
+      <point x="547" y="-191"/>
+      <point x="547" y="-103" type="curve" smooth="yes"/>
+      <point x="547" y="-44"/>
+      <point x="522" y="-1"/>
+      <point x="471" y="20" type="curve"/>
+      <point x="472" y="26" type="line"/>
+      <point x="547" y="47"/>
+      <point x="596" y="100"/>
+      <point x="596" y="173" type="curve" smooth="yes"/>
+      <point x="596" y="233"/>
+      <point x="564" y="273"/>
+      <point x="499" y="289" type="curve"/>
+      <point x="500" y="295" type="line"/>
+      <point x="576" y="313"/>
+      <point x="624" y="362"/>
+      <point x="624" y="434" type="curve" smooth="yes"/>
+      <point x="624" y="525"/>
+      <point x="549" y="596"/>
+      <point x="404" y="596" type="curve" smooth="yes"/>
+      <point x="137" y="596"/>
+      <point x="39" y="400"/>
+      <point x="39" y="235" type="curve" smooth="yes"/>
+      <point x="39" y="147"/>
+      <point x="62" y="61"/>
+      <point x="107" y="-16" type="curve"/>
+      <point x="179" y="27" type="line"/>
+      <point x="141" y="94"/>
+      <point x="122" y="162"/>
+      <point x="122" y="236" type="curve" smooth="yes"/>
+      <point x="122" y="374"/>
+      <point x="192" y="518"/>
+      <point x="396" y="518" type="curve" smooth="yes"/>
+      <point x="494" y="518"/>
+      <point x="541" y="485"/>
+      <point x="541" y="424" type="curve" smooth="yes"/>
+      <point x="541" y="367"/>
+      <point x="494" y="329"/>
+      <point x="413" y="329" type="curve" smooth="yes"/>
+      <point x="367" y="329" type="line"/>
+      <point x="354" y="255" type="line"/>
+      <point x="408" y="255" type="line" smooth="yes"/>
       <point x="477" y="255"/>
-      <point x="520" y="229"/>
-      <point x="520" y="169" type="curve" smooth="yes"/>
-      <point x="520" y="82"/>
-      <point x="458" y="62"/>
-      <point x="397" y="62" type="curve" smooth="yes"/>
-      <point x="324" y="62" type="line"/>
-      <point x="311" y="-12" type="line"/>
-      <point x="364" y="-12" type="line" smooth="yes"/>
-      <point x="453" y="-12"/>
-      <point x="488" y="-37"/>
-      <point x="488" y="-77" type="curve" smooth="yes"/>
-      <point x="488" y="-125"/>
-      <point x="450" y="-147"/>
-      <point x="388" y="-147" type="curve" smooth="yes"/>
-      <point x="320" y="-147"/>
-      <point x="283" y="-139"/>
-      <point x="255" y="-129" type="curve"/>
-      <point x="214" y="-201" type="line"/>
-      <point x="249" y="-215"/>
-      <point x="309" y="-225"/>
+      <point x="513" y="224"/>
+      <point x="513" y="170" type="curve" smooth="yes"/>
+      <point x="513" y="101"/>
+      <point x="464" y="62"/>
+      <point x="377" y="62" type="curve" smooth="yes"/>
+      <point x="304" y="62" type="line"/>
+      <point x="291" y="-12" type="line"/>
+      <point x="349" y="-12" type="line" smooth="yes"/>
+      <point x="434" y="-12"/>
+      <point x="464" y="-45"/>
+      <point x="464" y="-99" type="curve" smooth="yes"/>
+      <point x="464" y="-152"/>
+      <point x="426" y="-201"/>
+      <point x="325" y="-201" type="curve" smooth="yes"/>
+      <point x="261" y="-201"/>
+      <point x="211" y="-187"/>
+      <point x="160" y="-158" type="curve"/>
+      <point x="121" y="-227" type="line"/>
+      <point x="181" y="-261"/>
+      <point x="249" y="-279"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="963"/>
-  <anchor x="611" y="0" name="bottom"/>
-  <anchor x="531" y="580" name="top"/>
-  <anchor x="903" y="580" name="topright"/>
+  <advance width="956"/>
+  <anchor x="599" y="0" name="bottom"/>
+  <anchor x="526" y="580" name="top"/>
+  <anchor x="891" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="243" y="-16" type="curve" smooth="yes"/>
-      <point x="363" y="-16"/>
-      <point x="440" y="58"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="548" y="451"/>
-      <point x="603" y="516"/>
-      <point x="717" y="516" type="curve" smooth="yes"/>
-      <point x="808" y="516"/>
-      <point x="856" y="487"/>
-      <point x="856" y="423" type="curve" smooth="yes"/>
-      <point x="856" y="365"/>
-      <point x="812" y="329"/>
-      <point x="741" y="329" type="curve" smooth="yes"/>
-      <point x="681" y="329" type="line"/>
-      <point x="668" y="255" type="line"/>
-      <point x="710" y="255" type="line" smooth="yes"/>
-      <point x="788" y="255"/>
-      <point x="829" y="222"/>
-      <point x="829" y="159" type="curve" smooth="yes"/>
-      <point x="829" y="96"/>
-      <point x="790" y="62"/>
-      <point x="718" y="62" type="curve" smooth="yes"/>
-      <point x="677" y="62"/>
-      <point x="642" y="71"/>
-      <point x="608" y="90" type="curve"/>
-      <point x="565" y="20" type="line"/>
-      <point x="604" y="-3"/>
-      <point x="657" y="-16"/>
-      <point x="713" y="-16" type="curve" smooth="yes"/>
-      <point x="834" y="-16"/>
-      <point x="911" y="52"/>
-      <point x="911" y="159" type="curve" smooth="yes"/>
-      <point x="911" y="220"/>
-      <point x="875" y="269"/>
-      <point x="813" y="285" type="curve"/>
-      <point x="813" y="290" type="line"/>
-      <point x="892" y="303"/>
-      <point x="938" y="354"/>
-      <point x="938" y="431" type="curve" smooth="yes"/>
-      <point x="938" y="536"/>
-      <point x="860" y="596"/>
-      <point x="721" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="474" y="508"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="72"/>
-      <point x="115" y="-16"/>
+      <point x="253" y="-16" type="curve" smooth="yes"/>
+      <point x="380" y="-16"/>
+      <point x="468" y="70"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="592" y="516"/>
+      <point x="702" y="516" type="curve" smooth="yes"/>
+      <point x="792" y="516"/>
+      <point x="839" y="482"/>
+      <point x="839" y="422" type="curve" smooth="yes"/>
+      <point x="839" y="365"/>
+      <point x="795" y="329"/>
+      <point x="724" y="329" type="curve" smooth="yes"/>
+      <point x="664" y="329" type="line"/>
+      <point x="651" y="255" type="line"/>
+      <point x="693" y="255" type="line" smooth="yes"/>
+      <point x="771" y="255"/>
+      <point x="812" y="222"/>
+      <point x="812" y="159" type="curve" smooth="yes"/>
+      <point x="812" y="96"/>
+      <point x="773" y="62"/>
+      <point x="701" y="62" type="curve" smooth="yes"/>
+      <point x="660" y="62"/>
+      <point x="625" y="71"/>
+      <point x="591" y="90" type="curve"/>
+      <point x="548" y="20" type="line"/>
+      <point x="587" y="-3"/>
+      <point x="640" y="-16"/>
+      <point x="696" y="-16" type="curve" smooth="yes"/>
+      <point x="817" y="-16"/>
+      <point x="894" y="52"/>
+      <point x="894" y="159" type="curve" smooth="yes"/>
+      <point x="894" y="220"/>
+      <point x="858" y="267"/>
+      <point x="796" y="283" type="curve"/>
+      <point x="796" y="288" type="line"/>
+      <point x="874" y="302"/>
+      <point x="921" y="355"/>
+      <point x="921" y="426" type="curve" smooth="yes"/>
+      <point x="921" y="532"/>
+      <point x="841" y="596"/>
+      <point x="705" y="596" type="curve" smooth="yes"/>
+      <point x="543" y="596"/>
+      <point x="442" y="504"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="75"/>
+      <point x="121" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/g_ga-malayalam.glif
@@ -1,92 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ga-malayalam" format="2">
   <advance width="910"/>
-  <anchor x="416" y="-351" name="bottom"/>
-  <anchor x="515" y="580" name="top"/>
-  <anchor x="819" y="580" name="topright"/>
+  <anchor x="427" y="-351" name="bottom"/>
+  <anchor x="510" y="580" name="top"/>
+  <anchor x="814" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="605" y="-369" type="line"/>
-      <point x="679" y="-303"/>
-      <point x="733" y="-222"/>
-      <point x="733" y="-115" type="curve" smooth="yes"/>
-      <point x="733" y="-14"/>
-      <point x="670" y="43"/>
-      <point x="575" y="43" type="curve" smooth="yes"/>
-      <point x="479" y="43"/>
-      <point x="424" y="-12"/>
-      <point x="394" y="-146" type="curve" smooth="yes"/>
-      <point x="389" y="-168" type="line" smooth="yes"/>
-      <point x="366" y="-269"/>
-      <point x="335" y="-297"/>
-      <point x="281" y="-297" type="curve" smooth="yes"/>
-      <point x="230" y="-297"/>
-      <point x="195" y="-264"/>
-      <point x="195" y="-196" type="curve" smooth="yes"/>
-      <point x="195" y="-124"/>
-      <point x="234" y="-59"/>
-      <point x="292" y="-4" type="curve"/>
-      <point x="269" y="-15" type="line"/>
-      <point x="374" y="-5"/>
-      <point x="443" y="70"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="603" y="516"/>
-      <point x="683" y="516" type="curve" smooth="yes"/>
-      <point x="762" y="516"/>
-      <point x="804" y="465"/>
-      <point x="804" y="369" type="curve" smooth="yes"/>
-      <point x="804" y="244"/>
-      <point x="742" y="127"/>
-      <point x="608" y="24" type="curve"/>
-      <point x="683" y="-16" type="line"/>
-      <point x="812" y="90"/>
-      <point x="886" y="230"/>
-      <point x="886" y="369" type="curve" smooth="yes"/>
-      <point x="886" y="511"/>
-      <point x="811" y="596"/>
-      <point x="685" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="476" y="517"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="93"/>
-      <point x="92" y="12"/>
-      <point x="191" y="-10" type="curve"/>
-      <point x="191" y="-15" type="line"/>
-      <point x="144" y="-75"/>
-      <point x="120" y="-136"/>
-      <point x="120" y="-204" type="curve" smooth="yes"/>
-      <point x="120" y="-306"/>
-      <point x="178" y="-367"/>
-      <point x="283" y="-367" type="curve" smooth="yes"/>
-      <point x="377" y="-367"/>
-      <point x="430" y="-313"/>
-      <point x="460" y="-175" type="curve" smooth="yes"/>
-      <point x="465" y="-152" type="line" smooth="yes"/>
-      <point x="486" y="-53"/>
-      <point x="518" y="-27"/>
-      <point x="570" y="-27" type="curve" smooth="yes"/>
-      <point x="628" y="-27"/>
-      <point x="657" y="-64"/>
-      <point x="657" y="-126" type="curve" smooth="yes"/>
-      <point x="657" y="-201"/>
-      <point x="614" y="-268"/>
-      <point x="556" y="-321" type="curve"/>
+      <point x="253" y="-12" type="curve" smooth="yes"/>
+      <point x="380" y="-12"/>
+      <point x="468" y="73"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="580" y="514"/>
+      <point x="668" y="514" type="curve" smooth="yes"/>
+      <point x="749" y="514"/>
+      <point x="793" y="462"/>
+      <point x="793" y="367" type="curve" smooth="yes"/>
+      <point x="793" y="253"/>
+      <point x="727" y="132"/>
+      <point x="609" y="31" type="curve"/>
+      <point x="681" y="-12" type="line"/>
+      <point x="800" y="90"/>
+      <point x="877" y="239"/>
+      <point x="877" y="369" type="curve" smooth="yes"/>
+      <point x="877" y="511"/>
+      <point x="798" y="596"/>
+      <point x="668" y="596" type="curve" smooth="yes"/>
+      <point x="538" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="77"/>
+      <point x="121" y="-12"/>
+    </contour>
+    <contour>
+      <point x="620" y="-369" type="line"/>
+      <point x="703" y="-303"/>
+      <point x="746" y="-220"/>
+      <point x="746" y="-128" type="curve" smooth="yes"/>
+      <point x="746" y="-27"/>
+      <point x="681" y="43"/>
+      <point x="587" y="43" type="curve" smooth="yes"/>
+      <point x="490" y="43"/>
+      <point x="425" y="-16"/>
+      <point x="410" y="-117" type="curve" smooth="yes"/>
+      <point x="407" y="-139"/>
+      <point x="405" y="-166"/>
+      <point x="402" y="-187" type="curve" smooth="yes"/>
+      <point x="391" y="-260"/>
+      <point x="358" y="-297"/>
+      <point x="303" y="-297" type="curve" smooth="yes"/>
+      <point x="244" y="-297"/>
+      <point x="210" y="-261"/>
+      <point x="210" y="-193" type="curve" smooth="yes"/>
+      <point x="210" y="-115"/>
+      <point x="240" y="-57"/>
+      <point x="310" y="8" type="curve"/>
+      <point x="221" y="8" type="line"/>
+      <point x="167" y="-46"/>
+      <point x="136" y="-122"/>
+      <point x="136" y="-195" type="curve" smooth="yes"/>
+      <point x="136" y="-298"/>
+      <point x="203" y="-367"/>
+      <point x="301" y="-367" type="curve" smooth="yes"/>
+      <point x="395" y="-367"/>
+      <point x="459" y="-306"/>
+      <point x="474" y="-200" type="curve" smooth="yes"/>
+      <point x="477" y="-177"/>
+      <point x="479" y="-153"/>
+      <point x="482" y="-130" type="curve" smooth="yes"/>
+      <point x="492" y="-63"/>
+      <point x="528" y="-27"/>
+      <point x="585" y="-27" type="curve" smooth="yes"/>
+      <point x="641" y="-27"/>
+      <point x="672" y="-63"/>
+      <point x="672" y="-130" type="curve" smooth="yes"/>
+      <point x="672" y="-199"/>
+      <point x="639" y="-263"/>
+      <point x="575" y="-313" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/g_la-malayalam.glif
@@ -1,116 +1,125 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_la-malayalam" format="2">
   <advance width="910"/>
-  <anchor x="428" y="-351" name="bottom"/>
-  <anchor x="515" y="580" name="top"/>
-  <anchor x="819" y="580" name="topright"/>
+  <anchor x="408" y="-351" name="bottom"/>
+  <anchor x="510" y="580" name="top"/>
+  <anchor x="814" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="206" y="-367" type="curve" smooth="yes"/>
-      <point x="291" y="-367"/>
-      <point x="343" y="-313"/>
-      <point x="343" y="-228" type="curve" smooth="yes"/>
-      <point x="343" y="-154"/>
-      <point x="303" y="-118"/>
-      <point x="234" y="-118" type="curve" smooth="yes"/>
-      <point x="202" y="-118"/>
-      <point x="164" y="-131"/>
-      <point x="138" y="-164" type="curve"/>
-      <point x="132" y="-163" type="line"/>
-      <point x="152" y="-78"/>
-      <point x="209" y="-27"/>
-      <point x="296" y="-27" type="curve" smooth="yes"/>
-      <point x="401" y="-27"/>
-      <point x="428" y="-86"/>
-      <point x="433" y="-174" type="curve" smooth="yes"/>
-      <point x="434" y="-192" type="line" smooth="yes"/>
-      <point x="440" y="-303"/>
-      <point x="490" y="-367"/>
-      <point x="600" y="-367" type="curve" smooth="yes"/>
-      <point x="729" y="-367"/>
-      <point x="784" y="-271"/>
-      <point x="784" y="-131" type="curve" smooth="yes"/>
-      <point x="784" y="-62"/>
-      <point x="767" y="-6"/>
-      <point x="729" y="44" type="curve"/>
-      <point x="729" y="26" type="line"/>
-      <point x="829" y="125"/>
-      <point x="886" y="248"/>
-      <point x="886" y="369" type="curve" smooth="yes"/>
-      <point x="886" y="511"/>
-      <point x="811" y="596"/>
-      <point x="685" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="476" y="517"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="68"/>
-      <point x="243" y="68" type="curve" smooth="yes"/>
-      <point x="163" y="68"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="110"/>
-      <point x="75" y="39"/>
-      <point x="165" y="8" type="curve"/>
-      <point x="165" y="3" type="line"/>
-      <point x="96" y="-49"/>
-      <point x="60" y="-125"/>
-      <point x="60" y="-210" type="curve" smooth="yes"/>
-      <point x="60" y="-316"/>
-      <point x="124" y="-367"/>
+      <point x="191" y="-367" type="curve" smooth="yes"/>
+      <point x="282" y="-367"/>
+      <point x="332" y="-297"/>
+      <point x="332" y="-229" type="curve" smooth="yes"/>
+      <point x="332" y="-161"/>
+      <point x="295" y="-118"/>
+      <point x="224" y="-118" type="curve" smooth="yes"/>
+      <point x="171" y="-118"/>
+      <point x="124" y="-149"/>
+      <point x="111" y="-197" type="curve"/>
+      <point x="144" y="-171" type="line"/>
+      <point x="104" y="-155" type="line"/>
+      <point x="117" y="-188" type="line"/>
+      <point x="138" y="-82"/>
+      <point x="198" y="-27"/>
+      <point x="292" y="-27" type="curve" smooth="yes"/>
+      <point x="372" y="-27"/>
+      <point x="406" y="-67"/>
+      <point x="421" y="-157" type="curve" smooth="yes"/>
+      <point x="428" y="-200" type="line" smooth="yes"/>
+      <point x="446" y="-312"/>
+      <point x="503" y="-367"/>
+      <point x="596" y="-367" type="curve" smooth="yes"/>
+      <point x="727" y="-367"/>
+      <point x="774" y="-244"/>
+      <point x="774" y="-148" type="curve" smooth="yes"/>
+      <point x="774" y="-76"/>
+      <point x="758" y="-13"/>
+      <point x="717" y="41" type="curve"/>
+      <point x="719" y="23" type="line"/>
+      <point x="816" y="123"/>
+      <point x="877" y="255"/>
+      <point x="877" y="369" type="curve" smooth="yes"/>
+      <point x="877" y="511"/>
+      <point x="798" y="596"/>
+      <point x="668" y="596" type="curve" smooth="yes"/>
+      <point x="538" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="112"/>
+      <point x="81" y="38"/>
+      <point x="162" y="8" type="curve"/>
+      <point x="162" y="3" type="line"/>
+      <point x="97" y="-35"/>
+      <point x="49" y="-120"/>
+      <point x="49" y="-205" type="curve" smooth="yes"/>
+      <point x="49" y="-310"/>
+      <point x="110" y="-367"/>
     </contour>
     <contour>
-      <point x="206" y="-302" type="curve" smooth="yes"/>
-      <point x="151" y="-302"/>
-      <point x="128" y="-264"/>
-      <point x="128" y="-218" type="curve"/>
-      <point x="109" y="-197" type="line"/>
-      <point x="120" y="-253" type="line"/>
-      <point x="128" y="-213"/>
-      <point x="161" y="-178"/>
-      <point x="210" y="-178" type="curve" smooth="yes"/>
-      <point x="252" y="-178"/>
-      <point x="272" y="-199"/>
-      <point x="272" y="-233" type="curve" smooth="yes"/>
-      <point x="272" y="-276"/>
-      <point x="248" y="-302"/>
+      <point x="192" y="-302" type="curve" smooth="yes"/>
+      <point x="144" y="-302"/>
+      <point x="116" y="-269"/>
+      <point x="116" y="-223" type="curve" smooth="yes"/>
+      <point x="116" y="-216"/>
+      <point x="117" y="-208"/>
+      <point x="119" y="-200" type="curve"/>
+      <point x="98" y="-216" type="line"/>
+      <point x="108" y="-265" type="line"/>
+      <point x="116" y="-213"/>
+      <point x="157" y="-178"/>
+      <point x="206" y="-178" type="curve" smooth="yes"/>
+      <point x="243" y="-178"/>
+      <point x="262" y="-198"/>
+      <point x="262" y="-233" type="curve" smooth="yes"/>
+      <point x="262" y="-268"/>
+      <point x="238" y="-302"/>
     </contour>
     <contour>
-      <point x="602" y="-297" type="curve" smooth="yes"/>
-      <point x="542" y="-297"/>
-      <point x="517" y="-265"/>
-      <point x="509" y="-174" type="curve" smooth="yes"/>
-      <point x="507" y="-151" type="line" smooth="yes"/>
-      <point x="498" y="-52"/>
-      <point x="463" y="8"/>
-      <point x="374" y="34" type="curve"/>
-      <point x="374" y="39" type="line"/>
-      <point x="432" y="71"/>
-      <point x="461" y="137"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="603" y="512"/>
-      <point x="683" y="512" type="curve" smooth="yes"/>
-      <point x="762" y="512"/>
-      <point x="804" y="465"/>
-      <point x="804" y="369" type="curve" smooth="yes"/>
-      <point x="804" y="252"/>
-      <point x="745" y="143"/>
-      <point x="637" y="48" type="curve"/>
-      <point x="681" y="3"/>
-      <point x="709" y="-61"/>
-      <point x="709" y="-149" type="curve" smooth="yes"/>
-      <point x="709" y="-226"/>
-      <point x="681" y="-297"/>
+      <point x="600" y="-297" type="curve" smooth="yes"/>
+      <point x="546" y="-297"/>
+      <point x="514" y="-267"/>
+      <point x="501" y="-185" type="curve" smooth="yes"/>
+      <point x="494" y="-142" type="line" smooth="yes"/>
+      <point x="479" y="-51"/>
+      <point x="445" y="3"/>
+      <point x="378" y="26" type="curve"/>
+      <point x="378" y="31" type="line"/>
+      <point x="436" y="70"/>
+      <point x="477" y="133"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="580" y="514"/>
+      <point x="668" y="514" type="curve" smooth="yes"/>
+      <point x="749" y="514"/>
+      <point x="793" y="462"/>
+      <point x="793" y="367" type="curve" smooth="yes"/>
+      <point x="793" y="251"/>
+      <point x="733" y="138"/>
+      <point x="618" y="42" type="curve"/>
+      <point x="679" y="-20"/>
+      <point x="700" y="-76"/>
+      <point x="700" y="-151" type="curve" smooth="yes"/>
+      <point x="700" y="-214"/>
+      <point x="676" y="-297"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/g_ma-malayalam.glif
@@ -1,99 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ma-malayalam" format="2">
   <advance width="1401"/>
-  <anchor x="1029" y="0" name="bottom"/>
-  <anchor x="746" y="580" name="top"/>
-  <anchor x="1356" y="580" name="topright"/>
+  <anchor x="1024" y="0" name="bottom"/>
+  <anchor x="741" y="580" name="top"/>
+  <anchor x="1351" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="243" y="-16" type="curve" smooth="yes"/>
-      <point x="363" y="-16"/>
-      <point x="440" y="58"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="603" y="512"/>
-      <point x="683" y="512" type="curve" smooth="yes"/>
-      <point x="762" y="512"/>
-      <point x="804" y="465"/>
-      <point x="806" y="384" type="curve" smooth="yes"/>
-      <point x="806" y="365"/>
-      <point x="804" y="345"/>
-      <point x="800" y="323" type="curve" smooth="yes"/>
-      <point x="743" y="0" type="line"/>
-      <point x="1309" y="0" type="line"/>
-      <point x="1357" y="266" type="line" smooth="yes"/>
-      <point x="1363" y="299"/>
-      <point x="1366" y="342"/>
-      <point x="1366" y="362" type="curve" smooth="yes"/>
-      <point x="1366" y="521"/>
-      <point x="1264" y="596"/>
-      <point x="1118" y="596" type="curve" smooth="yes"/>
-      <point x="1005" y="596"/>
-      <point x="923" y="556"/>
-      <point x="868" y="474" type="curve"/>
-      <point x="863" y="474" type="line"/>
-      <point x="831" y="557"/>
-      <point x="769" y="596"/>
-      <point x="679" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="476" y="517"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="72"/>
-      <point x="115" y="-16"/>
+      <point x="253" y="-16" type="curve" smooth="yes"/>
+      <point x="380" y="-16"/>
+      <point x="468" y="70"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="580" y="514"/>
+      <point x="668" y="514" type="curve" smooth="yes"/>
+      <point x="750" y="514"/>
+      <point x="796" y="468"/>
+      <point x="796" y="386" type="curve" smooth="yes"/>
+      <point x="796" y="366"/>
+      <point x="794" y="346"/>
+      <point x="790" y="323" type="curve" smooth="yes"/>
+      <point x="733" y="0" type="line"/>
+      <point x="1299" y="0" type="line"/>
+      <point x="1347" y="271" type="line" smooth="yes"/>
+      <point x="1353" y="305"/>
+      <point x="1357" y="343"/>
+      <point x="1357" y="362" type="curve" smooth="yes"/>
+      <point x="1357" y="510"/>
+      <point x="1270" y="596"/>
+      <point x="1114" y="596" type="curve" smooth="yes"/>
+      <point x="997" y="596"/>
+      <point x="912" y="551"/>
+      <point x="857" y="474" type="curve"/>
+      <point x="852" y="474" type="line"/>
+      <point x="824" y="550"/>
+      <point x="760" y="596"/>
+      <point x="668" y="596" type="curve" smooth="yes"/>
+      <point x="539" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="75"/>
+      <point x="121" y="-16"/>
     </contour>
     <contour>
-      <point x="801" y="45" type="line"/>
-      <point x="833" y="45" type="line"/>
-      <point x="883" y="323" type="line" smooth="yes"/>
-      <point x="902" y="426"/>
-      <point x="943" y="482"/>
-      <point x="1026" y="482" type="curve" smooth="yes"/>
-      <point x="1083" y="482"/>
-      <point x="1112" y="455"/>
-      <point x="1112" y="408" type="curve" smooth="yes"/>
-      <point x="1112" y="336"/>
-      <point x="1088" y="303"/>
-      <point x="930" y="161" type="curve" smooth="yes"/>
+      <point x="790" y="45" type="line"/>
+      <point x="823" y="45" type="line"/>
+      <point x="873" y="328" type="line" smooth="yes"/>
+      <point x="891" y="430"/>
+      <point x="941" y="482"/>
+      <point x="1015" y="482" type="curve" smooth="yes"/>
+      <point x="1070" y="482"/>
+      <point x="1103" y="452"/>
+      <point x="1103" y="402" type="curve" smooth="yes"/>
+      <point x="1103" y="338"/>
+      <point x="1078" y="304"/>
+      <point x="919" y="161" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="913" y="42" type="line"/>
-      <point x="1039" y="155" type="line" smooth="yes"/>
-      <point x="1134" y="240"/>
-      <point x="1194" y="311"/>
-      <point x="1194" y="396" type="curve" smooth="yes"/>
-      <point x="1194" y="467"/>
-      <point x="1147" y="516"/>
-      <point x="1046" y="516" type="curve"/>
-      <point x="1060" y="488" type="line"/>
-      <point x="1060" y="561" type="line"/>
-      <point x="1049" y="519" type="line"/>
-      <point x="1059" y="521"/>
-      <point x="1070" y="522"/>
-      <point x="1083" y="522" type="curve" smooth="yes"/>
-      <point x="1209" y="522"/>
-      <point x="1284" y="476"/>
-      <point x="1284" y="354" type="curve" smooth="yes"/>
-      <point x="1284" y="337"/>
-      <point x="1283" y="313"/>
-      <point x="1275" y="266" type="curve" smooth="yes"/>
-      <point x="1236" y="46" type="line"/>
-      <point x="1278" y="74" type="line"/>
-      <point x="900" y="74" type="line"/>
+      <point x="902" y="42" type="line"/>
+      <point x="1028" y="155" type="line" smooth="yes"/>
+      <point x="1139" y="255"/>
+      <point x="1183" y="321"/>
+      <point x="1183" y="394" type="curve" smooth="yes"/>
+      <point x="1183" y="477"/>
+      <point x="1132" y="528"/>
+      <point x="1043" y="528" type="curve"/>
+      <point x="1049" y="500" type="line"/>
+      <point x="1062" y="573" type="line"/>
+      <point x="1046" y="531" type="line"/>
+      <point x="1062" y="533"/>
+      <point x="1079" y="534"/>
+      <point x="1099" y="534" type="curve" smooth="yes"/>
+      <point x="1216" y="534"/>
+      <point x="1275" y="475"/>
+      <point x="1275" y="358" type="curve" smooth="yes"/>
+      <point x="1275" y="340"/>
+      <point x="1272" y="315"/>
+      <point x="1264" y="267" type="curve" smooth="yes"/>
+      <point x="1225" y="46" type="line"/>
+      <point x="1267" y="74" type="line"/>
+      <point x="889" y="74" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/g_na-malayalam.glif
@@ -1,70 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_na-malayalam" format="2">
   <advance width="1308"/>
-  <anchor x="852" y="0" name="bottom"/>
-  <anchor x="706" y="580" name="top"/>
-  <anchor x="1243" y="580" name="topright"/>
+  <anchor x="847" y="0" name="bottom"/>
+  <anchor x="701" y="580" name="top"/>
+  <anchor x="1238" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="243" y="-16" type="curve" smooth="yes"/>
-      <point x="363" y="-16"/>
-      <point x="439" y="58"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="524" y="362" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="596" y="512"/>
-      <point x="679" y="512" type="curve" smooth="yes"/>
-      <point x="754" y="512"/>
-      <point x="800" y="472"/>
-      <point x="800" y="390" type="curve" smooth="yes"/>
-      <point x="800" y="363"/>
-      <point x="797" y="337"/>
-      <point x="793" y="313" type="curve" smooth="yes"/>
-      <point x="738" y="0" type="line"/>
-      <point x="822" y="0" type="line"/>
-      <point x="881" y="337" type="line" smooth="yes"/>
-      <point x="901" y="451"/>
-      <point x="969" y="518"/>
-      <point x="1058" y="518" type="curve" smooth="yes"/>
-      <point x="1148" y="518"/>
-      <point x="1198" y="461"/>
-      <point x="1198" y="358" type="curve" smooth="yes"/>
-      <point x="1198" y="241"/>
-      <point x="1147" y="147"/>
-      <point x="1029" y="49" type="curve"/>
-      <point x="1082" y="-16" type="line"/>
-      <point x="1217" y="98"/>
-      <point x="1282" y="219"/>
-      <point x="1282" y="358" type="curve" smooth="yes"/>
-      <point x="1282" y="508"/>
-      <point x="1203" y="596"/>
-      <point x="1066" y="596" type="curve" smooth="yes"/>
-      <point x="978" y="596"/>
-      <point x="906" y="555"/>
-      <point x="858" y="479" type="curve"/>
-      <point x="853" y="479" type="line"/>
-      <point x="828" y="555"/>
-      <point x="767" y="596"/>
-      <point x="680" y="596" type="curve" smooth="yes"/>
-      <point x="554" y="596"/>
-      <point x="478" y="526"/>
-      <point x="432" y="354" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="369" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="72"/>
-      <point x="115" y="-16"/>
+      <point x="253" y="-16" type="curve" smooth="yes"/>
+      <point x="380" y="-16"/>
+      <point x="468" y="70"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="454"/>
+      <point x="581" y="518"/>
+      <point x="670" y="518" type="curve" smooth="yes"/>
+      <point x="751" y="518"/>
+      <point x="795" y="469"/>
+      <point x="795" y="390" type="curve" smooth="yes"/>
+      <point x="795" y="363"/>
+      <point x="792" y="337"/>
+      <point x="788" y="313" type="curve" smooth="yes"/>
+      <point x="733" y="0" type="line"/>
+      <point x="817" y="0" type="line"/>
+      <point x="876" y="336" type="line" smooth="yes"/>
+      <point x="896" y="450"/>
+      <point x="961" y="518"/>
+      <point x="1047" y="518" type="curve" smooth="yes"/>
+      <point x="1137" y="518"/>
+      <point x="1187" y="461"/>
+      <point x="1187" y="358" type="curve" smooth="yes"/>
+      <point x="1187" y="241"/>
+      <point x="1136" y="147"/>
+      <point x="1018" y="49" type="curve"/>
+      <point x="1071" y="-16" type="line"/>
+      <point x="1206" y="98"/>
+      <point x="1271" y="219"/>
+      <point x="1271" y="358" type="curve" smooth="yes"/>
+      <point x="1271" y="508"/>
+      <point x="1192" y="596"/>
+      <point x="1055" y="596" type="curve" smooth="yes"/>
+      <point x="971" y="596"/>
+      <point x="897" y="553"/>
+      <point x="853" y="479" type="curve"/>
+      <point x="848" y="479" type="line"/>
+      <point x="822" y="550"/>
+      <point x="764" y="596"/>
+      <point x="666" y="596" type="curve" smooth="yes"/>
+      <point x="538" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="75"/>
+      <point x="121" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ga-malayalam.glif
@@ -2,51 +2,55 @@
 <glyph name="ga-malayalam" format="2">
   <advance width="910"/>
   <unicode hex="0D17"/>
-  <anchor x="456" y="0" name="bottom"/>
-  <anchor x="515" y="580" name="top"/>
-  <anchor x="819" y="580" name="topright"/>
+  <anchor x="451" y="0" name="bottom"/>
+  <anchor x="510" y="580" name="top"/>
+  <anchor x="814" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="243" y="-16" type="curve" smooth="yes"/>
-      <point x="363" y="-16"/>
-      <point x="440" y="58"/>
-      <point x="483" y="215" type="curve" smooth="yes"/>
-      <point x="517" y="338" type="line" smooth="yes"/>
-      <point x="551" y="460"/>
-      <point x="603" y="516"/>
-      <point x="683" y="516" type="curve" smooth="yes"/>
-      <point x="762" y="516"/>
-      <point x="804" y="465"/>
-      <point x="804" y="369" type="curve" smooth="yes"/>
-      <point x="804" y="252"/>
-      <point x="745" y="143"/>
-      <point x="628" y="45" type="curve"/>
-      <point x="683" y="-16" type="line"/>
-      <point x="812" y="90"/>
-      <point x="886" y="230"/>
-      <point x="886" y="369" type="curve" smooth="yes"/>
-      <point x="886" y="511"/>
-      <point x="811" y="596"/>
-      <point x="685" y="596" type="curve" smooth="yes"/>
-      <point x="557" y="596"/>
-      <point x="477" y="517"/>
-      <point x="430" y="345" type="curve" smooth="yes"/>
-      <point x="402" y="241" type="line" smooth="yes"/>
-      <point x="368" y="116"/>
-      <point x="322" y="64"/>
-      <point x="243" y="64" type="curve" smooth="yes"/>
-      <point x="163" y="64"/>
-      <point x="116" y="117"/>
-      <point x="116" y="209" type="curve" smooth="yes"/>
-      <point x="116" y="332"/>
-      <point x="182" y="448"/>
-      <point x="300" y="532" type="curve"/>
-      <point x="250" y="596" type="line"/>
-      <point x="111" y="498"/>
-      <point x="34" y="360"/>
-      <point x="34" y="209" type="curve" smooth="yes"/>
-      <point x="34" y="72"/>
-      <point x="115" y="-16"/>
+      <point x="253" y="-16" type="curve" smooth="yes"/>
+      <point x="380" y="-16"/>
+      <point x="468" y="70"/>
+      <point x="489" y="216" type="curve" smooth="yes"/>
+      <point x="495" y="257"/>
+      <point x="497" y="308"/>
+      <point x="503" y="349" type="curve" smooth="yes"/>
+      <point x="518" y="452"/>
+      <point x="580" y="514"/>
+      <point x="668" y="514" type="curve" smooth="yes"/>
+      <point x="749" y="514"/>
+      <point x="793" y="462"/>
+      <point x="793" y="367" type="curve" smooth="yes"/>
+      <point x="793" y="253"/>
+      <point x="734" y="141"/>
+      <point x="623" y="46" type="curve"/>
+      <point x="678" y="-16" type="line"/>
+      <point x="798" y="87"/>
+      <point x="877" y="239"/>
+      <point x="877" y="369" type="curve" smooth="yes"/>
+      <point x="877" y="511"/>
+      <point x="798" y="596"/>
+      <point x="668" y="596" type="curve" smooth="yes"/>
+      <point x="538" y="596"/>
+      <point x="442" y="506"/>
+      <point x="421" y="363" type="curve" smooth="yes"/>
+      <point x="415" y="322"/>
+      <point x="413" y="271"/>
+      <point x="407" y="230" type="curve" smooth="yes"/>
+      <point x="391" y="122"/>
+      <point x="339" y="66"/>
+      <point x="253" y="66" type="curve" smooth="yes"/>
+      <point x="168" y="66"/>
+      <point x="118" y="120"/>
+      <point x="118" y="213" type="curve" smooth="yes"/>
+      <point x="118" y="325"/>
+      <point x="183" y="438"/>
+      <point x="299" y="531" type="curve"/>
+      <point x="248" y="596" type="line"/>
+      <point x="112" y="490"/>
+      <point x="34" y="348"/>
+      <point x="34" y="211" type="curve" smooth="yes"/>
+      <point x="34" y="75"/>
+      <point x="121" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ga-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="910"/>
   <outline>
     <component base="ga-malayalam"/>
-    <component base="halant-malayalam" xOffset="746"/>
+    <component base="halant-malayalam" xOffset="741"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/j_ja-malayalam.glif
@@ -1,231 +1,230 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1602"/>
-  <anchor x="1163" y="0" name="bottom"/>
-  <anchor x="845" y="580" name="top"/>
-  <anchor x="1533" y="580" name="topright"/>
+  <advance width="1668"/>
+  <anchor x="1207" y="0" name="bottom"/>
+  <anchor x="885" y="580" name="top"/>
+  <anchor x="1578" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="307" y="-16" type="curve" smooth="yes"/>
-      <point x="570" y="-16"/>
-      <point x="745" y="95"/>
-      <point x="859" y="317" type="curve"/>
-      <point x="882" y="374" type="line"/>
-      <point x="887" y="374" type="line"/>
-      <point x="896" y="328"/>
-      <point x="935" y="294"/>
-      <point x="1003" y="294" type="curve" smooth="yes"/>
-      <point x="1085" y="294"/>
-      <point x="1138" y="340"/>
-      <point x="1138" y="413" type="curve" smooth="yes"/>
-      <point x="1138" y="477"/>
-      <point x="1100" y="515"/>
-      <point x="1037" y="515" type="curve" smooth="yes"/>
-      <point x="1016" y="515"/>
-      <point x="994" y="511"/>
-      <point x="976" y="505" type="curve"/>
-      <point x="965" y="528" type="line"/>
-      <point x="966" y="503" type="line"/>
-      <point x="989" y="524"/>
-      <point x="1027" y="536"/>
-      <point x="1069" y="536" type="curve" smooth="yes"/>
-      <point x="1149" y="536"/>
-      <point x="1190" y="494"/>
-      <point x="1190" y="411" type="curve" smooth="yes"/>
-      <point x="1190" y="394"/>
-      <point x="1187" y="373"/>
-      <point x="1184" y="354" type="curve" smooth="yes"/>
-      <point x="1182" y="343" type="line"/>
-      <point x="1266" y="343" type="line"/>
-      <point x="1274" y="387" type="line" smooth="yes"/>
-      <point x="1289" y="470"/>
-      <point x="1341" y="518"/>
-      <point x="1415" y="518" type="curve" smooth="yes"/>
-      <point x="1473" y="518"/>
-      <point x="1503" y="486"/>
-      <point x="1503" y="423" type="curve" smooth="yes"/>
-      <point x="1503" y="336"/>
-      <point x="1444" y="287"/>
-      <point x="1339" y="287" type="curve" smooth="yes"/>
-      <point x="1031" y="287" type="line" smooth="yes"/>
-      <point x="903" y="287"/>
-      <point x="823" y="225"/>
-      <point x="823" y="122" type="curve" smooth="yes"/>
-      <point x="823" y="34"/>
-      <point x="874" y="-16"/>
-      <point x="974" y="-16" type="curve" smooth="yes"/>
-      <point x="1018" y="-16"/>
-      <point x="1064" y="-5"/>
-      <point x="1157" y="52" type="curve" smooth="yes"/>
-      <point x="1220" y="91" type="line"/>
-      <point x="1328" y="158" type="line"/>
-      <point x="1349" y="158" type="line"/>
-      <point x="1374" y="166"/>
-      <point x="1390" y="167"/>
-      <point x="1407" y="167" type="curve" smooth="yes"/>
-      <point x="1442" y="167"/>
-      <point x="1459" y="149"/>
-      <point x="1459" y="114" type="curve" smooth="yes"/>
-      <point x="1459" y="73"/>
-      <point x="1436" y="48"/>
-      <point x="1397" y="48" type="curve" smooth="yes"/>
-      <point x="1364" y="48"/>
-      <point x="1344" y="67"/>
-      <point x="1344" y="99" type="curve" smooth="yes"/>
-      <point x="1344" y="131"/>
-      <point x="1359" y="159"/>
-      <point x="1391" y="185" type="curve"/>
-      <point x="1270" y="162" type="line"/>
-      <point x="1305" y="113" type="line"/>
-      <point x="1316" y="156" type="line"/>
-      <point x="1295" y="135"/>
-      <point x="1284" y="109"/>
-      <point x="1284" y="80" type="curve" smooth="yes"/>
-      <point x="1284" y="22"/>
-      <point x="1327" y="-16"/>
-      <point x="1394" y="-16" type="curve" smooth="yes"/>
-      <point x="1476" y="-16"/>
-      <point x="1526" y="35"/>
-      <point x="1526" y="121" type="curve" smooth="yes"/>
-      <point x="1526" y="189"/>
-      <point x="1484" y="233"/>
-      <point x="1419" y="233" type="curve" smooth="yes"/>
-      <point x="1373" y="233"/>
-      <point x="1328" y="230"/>
-      <point x="1214" y="162" type="curve" smooth="yes"/>
-      <point x="1135" y="115" type="line" smooth="yes"/>
-      <point x="1061" y="71"/>
-      <point x="1019" y="61"/>
-      <point x="978" y="61" type="curve" smooth="yes"/>
-      <point x="927" y="61"/>
-      <point x="903" y="86"/>
-      <point x="903" y="126" type="curve" smooth="yes"/>
-      <point x="903" y="184"/>
-      <point x="949" y="215"/>
-      <point x="1028" y="215" type="curve" smooth="yes"/>
-      <point x="1335" y="215" type="line" smooth="yes"/>
-      <point x="1483" y="215"/>
-      <point x="1587" y="301"/>
-      <point x="1587" y="423" type="curve" smooth="yes"/>
-      <point x="1587" y="529"/>
-      <point x="1522" y="596"/>
-      <point x="1421" y="596" type="curve" smooth="yes"/>
-      <point x="1342" y="596"/>
-      <point x="1283" y="557"/>
-      <point x="1245" y="478" type="curve"/>
-      <point x="1240" y="478" type="line"/>
-      <point x="1229" y="553"/>
-      <point x="1169" y="596"/>
-      <point x="1072" y="596" type="curve" smooth="yes"/>
-      <point x="980" y="596"/>
-      <point x="911" y="560"/>
-      <point x="860" y="459" type="curve" smooth="yes"/>
-      <point x="813" y="366" type="line" smooth="yes"/>
-      <point x="693" y="129"/>
-      <point x="529" y="61"/>
-      <point x="320" y="61" type="curve" smooth="yes"/>
-      <point x="157" y="61"/>
-      <point x="101" y="97"/>
-      <point x="101" y="149" type="curve" smooth="yes"/>
-      <point x="101" y="194"/>
-      <point x="141" y="215"/>
-      <point x="216" y="215" type="curve" smooth="yes"/>
-      <point x="533" y="215" type="line" smooth="yes"/>
-      <point x="681" y="215"/>
-      <point x="785" y="301"/>
-      <point x="785" y="433" type="curve" smooth="yes"/>
-      <point x="785" y="539"/>
-      <point x="720" y="596"/>
-      <point x="622" y="596" type="curve" smooth="yes"/>
-      <point x="548" y="596"/>
-      <point x="485" y="563"/>
-      <point x="451" y="478" type="curve"/>
-      <point x="446" y="478" type="line"/>
-      <point x="431" y="553"/>
-      <point x="378" y="596"/>
-      <point x="282" y="596" type="curve" smooth="yes"/>
-      <point x="159" y="596"/>
-      <point x="69" y="525"/>
-      <point x="69" y="427" type="curve" smooth="yes"/>
-      <point x="69" y="344"/>
-      <point x="123" y="294"/>
-      <point x="212" y="294" type="curve" smooth="yes"/>
-      <point x="294" y="294"/>
-      <point x="347" y="340"/>
-      <point x="347" y="413" type="curve" smooth="yes"/>
-      <point x="347" y="477"/>
-      <point x="309" y="515"/>
-      <point x="246" y="515" type="curve" smooth="yes"/>
-      <point x="225" y="515"/>
-      <point x="203" y="511"/>
-      <point x="185" y="505" type="curve"/>
-      <point x="174" y="528" type="line"/>
-      <point x="175" y="503" type="line"/>
-      <point x="198" y="524"/>
-      <point x="236" y="536"/>
-      <point x="278" y="536" type="curve" smooth="yes"/>
-      <point x="358" y="536"/>
-      <point x="396" y="494"/>
-      <point x="396" y="411" type="curve" smooth="yes"/>
-      <point x="396" y="394"/>
-      <point x="393" y="373"/>
-      <point x="390" y="354" type="curve" smooth="yes"/>
-      <point x="388" y="343" type="line"/>
-      <point x="472" y="343" type="line"/>
-      <point x="480" y="387" type="line" smooth="yes"/>
-      <point x="495" y="470"/>
-      <point x="543" y="518"/>
-      <point x="609" y="518" type="curve" smooth="yes"/>
-      <point x="671" y="518"/>
-      <point x="701" y="486"/>
-      <point x="701" y="433" type="curve" smooth="yes"/>
-      <point x="701" y="336"/>
-      <point x="642" y="287"/>
-      <point x="537" y="287" type="curve" smooth="yes"/>
-      <point x="219" y="287" type="line" smooth="yes"/>
-      <point x="95" y="287"/>
-      <point x="21" y="235"/>
-      <point x="21" y="144" type="curve" smooth="yes"/>
-      <point x="21" y="51"/>
-      <point x="100" y="-16"/>
+      <point x="257" y="-16" type="curve" smooth="yes"/>
+      <point x="553" y="-16"/>
+      <point x="748" y="83"/>
+      <point x="879" y="284" type="curve"/>
+      <point x="902" y="344" type="line"/>
+      <point x="907" y="344" type="line"/>
+      <point x="915" y="304"/>
+      <point x="949" y="273"/>
+      <point x="1012" y="273" type="curve" smooth="yes"/>
+      <point x="1122" y="273"/>
+      <point x="1168" y="357"/>
+      <point x="1168" y="414" type="curve" smooth="yes"/>
+      <point x="1168" y="478"/>
+      <point x="1133" y="515"/>
+      <point x="1069" y="515" type="curve" smooth="yes"/>
+      <point x="1044" y="515"/>
+      <point x="1028" y="512"/>
+      <point x="1007" y="505" type="curve"/>
+      <point x="997" y="523" type="line"/>
+      <point x="982" y="494" type="line"/>
+      <point x="1019" y="522"/>
+      <point x="1058" y="536"/>
+      <point x="1118" y="536" type="curve" smooth="yes"/>
+      <point x="1195" y="536"/>
+      <point x="1234" y="497"/>
+      <point x="1234" y="425" type="curve" smooth="yes"/>
+      <point x="1234" y="409"/>
+      <point x="1232" y="392"/>
+      <point x="1229" y="375" type="curve" smooth="yes"/>
+      <point x="1220" y="324" type="line"/>
+      <point x="1304" y="324" type="line"/>
+      <point x="1313" y="375" type="line" smooth="yes"/>
+      <point x="1328" y="464"/>
+      <point x="1385" y="518"/>
+      <point x="1465" y="518" type="curve" smooth="yes"/>
+      <point x="1531" y="518"/>
+      <point x="1567" y="484"/>
+      <point x="1567" y="422" type="curve" smooth="yes"/>
+      <point x="1567" y="321"/>
+      <point x="1491" y="267"/>
+      <point x="1368" y="267" type="curve" smooth="yes"/>
+      <point x="1025" y="267" type="line" smooth="yes"/>
+      <point x="890" y="267"/>
+      <point x="835" y="181"/>
+      <point x="835" y="114" type="curve" smooth="yes"/>
+      <point x="835" y="39"/>
+      <point x="894" y="-16"/>
+      <point x="978" y="-16" type="curve" smooth="yes"/>
+      <point x="1025" y="-16"/>
+      <point x="1062" y="-4"/>
+      <point x="1148" y="35" type="curve" smooth="yes"/>
+      <point x="1276" y="93" type="line"/>
+      <point x="1351" y="141" type="line"/>
+      <point x="1388" y="153" type="line"/>
+      <point x="1416" y="170"/>
+      <point x="1436" y="176"/>
+      <point x="1465" y="176" type="curve" smooth="yes"/>
+      <point x="1501" y="176"/>
+      <point x="1522" y="155"/>
+      <point x="1522" y="121" type="curve" smooth="yes"/>
+      <point x="1522" y="91"/>
+      <point x="1501" y="54"/>
+      <point x="1449" y="54" type="curve" smooth="yes"/>
+      <point x="1412" y="54"/>
+      <point x="1391" y="74"/>
+      <point x="1391" y="110" type="curve" smooth="yes"/>
+      <point x="1391" y="134"/>
+      <point x="1401" y="159"/>
+      <point x="1422" y="180" type="curve"/>
+      <point x="1330" y="145" type="line"/>
+      <point x="1346" y="131" type="line"/>
+      <point x="1339" y="117"/>
+      <point x="1335" y="101"/>
+      <point x="1335" y="85" type="curve" smooth="yes"/>
+      <point x="1335" y="24"/>
+      <point x="1377" y="-16"/>
+      <point x="1446" y="-16" type="curve" smooth="yes"/>
+      <point x="1550" y="-16"/>
+      <point x="1594" y="67"/>
+      <point x="1594" y="125" type="curve" smooth="yes"/>
+      <point x="1594" y="189"/>
+      <point x="1554" y="236"/>
+      <point x="1480" y="236" type="curve" smooth="yes"/>
+      <point x="1441" y="236"/>
+      <point x="1395" y="221"/>
+      <point x="1315" y="185" type="curve" smooth="yes"/>
+      <point x="1127" y="100" type="line" smooth="yes"/>
+      <point x="1066" y="72"/>
+      <point x="1029" y="60"/>
+      <point x="989" y="60" type="curve" smooth="yes"/>
+      <point x="943" y="60"/>
+      <point x="917" y="85"/>
+      <point x="917" y="120" type="curve" smooth="yes"/>
+      <point x="917" y="158"/>
+      <point x="947" y="195"/>
+      <point x="1021" y="195" type="curve" smooth="yes"/>
+      <point x="1343" y="195" type="line" smooth="yes"/>
+      <point x="1513" y="195"/>
+      <point x="1650" y="283"/>
+      <point x="1650" y="436" type="curve" smooth="yes"/>
+      <point x="1650" y="532"/>
+      <point x="1594" y="596"/>
+      <point x="1486" y="596" type="curve" smooth="yes"/>
+      <point x="1399" y="596"/>
+      <point x="1329" y="552"/>
+      <point x="1292" y="475" type="curve"/>
+      <point x="1287" y="475" type="line"/>
+      <point x="1275" y="552"/>
+      <point x="1215" y="596"/>
+      <point x="1123" y="596" type="curve" smooth="yes"/>
+      <point x="1017" y="596"/>
+      <point x="932" y="546"/>
+      <point x="883" y="447" type="curve" smooth="yes"/>
+      <point x="844" y="369" type="line" smooth="yes"/>
+      <point x="740" y="159"/>
+      <point x="557" y="61"/>
+      <point x="265" y="61" type="curve" smooth="yes"/>
+      <point x="144" y="61"/>
+      <point x="99" y="84"/>
+      <point x="99" y="131" type="curve" smooth="yes"/>
+      <point x="99" y="165"/>
+      <point x="125" y="195"/>
+      <point x="192" y="195" type="curve" smooth="yes"/>
+      <point x="485" y="195" type="line" smooth="yes"/>
+      <point x="655" y="195"/>
+      <point x="789" y="285"/>
+      <point x="789" y="435" type="curve" smooth="yes"/>
+      <point x="789" y="529"/>
+      <point x="743" y="596"/>
+      <point x="648" y="596" type="curve" smooth="yes"/>
+      <point x="569" y="596"/>
+      <point x="504" y="552"/>
+      <point x="472" y="475" type="curve"/>
+      <point x="467" y="475" type="line"/>
+      <point x="455" y="552"/>
+      <point x="395" y="596"/>
+      <point x="303" y="596" type="curve" smooth="yes"/>
+      <point x="142" y="596"/>
+      <point x="64" y="488"/>
+      <point x="64" y="399" type="curve" smooth="yes"/>
+      <point x="64" y="324"/>
+      <point x="114" y="273"/>
+      <point x="192" y="273" type="curve" smooth="yes"/>
+      <point x="302" y="273"/>
+      <point x="348" y="357"/>
+      <point x="348" y="414" type="curve" smooth="yes"/>
+      <point x="348" y="478"/>
+      <point x="313" y="515"/>
+      <point x="249" y="515" type="curve" smooth="yes"/>
+      <point x="224" y="515"/>
+      <point x="208" y="512"/>
+      <point x="187" y="505" type="curve"/>
+      <point x="177" y="523" type="line"/>
+      <point x="162" y="494" type="line"/>
+      <point x="199" y="522"/>
+      <point x="238" y="536"/>
+      <point x="298" y="536" type="curve" smooth="yes"/>
+      <point x="375" y="536"/>
+      <point x="414" y="497"/>
+      <point x="414" y="425" type="curve" smooth="yes"/>
+      <point x="414" y="409"/>
+      <point x="412" y="392"/>
+      <point x="409" y="375" type="curve" smooth="yes"/>
+      <point x="400" y="324" type="line"/>
+      <point x="484" y="324" type="line"/>
+      <point x="493" y="375" type="line" smooth="yes"/>
+      <point x="508" y="464"/>
+      <point x="555" y="518"/>
+      <point x="629" y="518" type="curve" smooth="yes"/>
+      <point x="684" y="518"/>
+      <point x="711" y="488"/>
+      <point x="711" y="431" type="curve" smooth="yes"/>
+      <point x="711" y="329"/>
+      <point x="629" y="267"/>
+      <point x="490" y="267" type="curve" smooth="yes"/>
+      <point x="196" y="267" type="line" smooth="yes"/>
+      <point x="68" y="267"/>
+      <point x="15" y="194"/>
+      <point x="15" y="126" type="curve" smooth="yes"/>
+      <point x="15" y="42"/>
+      <point x="83" y="-16"/>
     </contour>
     <contour>
-      <point x="214" y="357" type="curve" smooth="yes"/>
-      <point x="171" y="357"/>
-      <point x="146" y="383"/>
-      <point x="146" y="427" type="curve" smooth="yes"/>
-      <point x="146" y="449"/>
-      <point x="151" y="467"/>
-      <point x="161" y="481" type="curve"/>
-      <point x="137" y="481" type="line"/>
-      <point x="114" y="431" type="line"/>
-      <point x="144" y="455"/>
-      <point x="176" y="467"/>
-      <point x="210" y="467" type="curve" smooth="yes"/>
-      <point x="253" y="467"/>
-      <point x="275" y="449"/>
-      <point x="275" y="412" type="curve" smooth="yes"/>
-      <point x="275" y="379"/>
-      <point x="251" y="357"/>
+      <point x="196" y="341" type="curve" smooth="yes"/>
+      <point x="158" y="341"/>
+      <point x="132" y="368"/>
+      <point x="132" y="406" type="curve" smooth="yes"/>
+      <point x="132" y="429"/>
+      <point x="137" y="449"/>
+      <point x="150" y="475" type="curve"/>
+      <point x="131" y="475" type="line"/>
+      <point x="116" y="425" type="line"/>
+      <point x="143" y="451"/>
+      <point x="182" y="467"/>
+      <point x="217" y="467" type="curve" smooth="yes"/>
+      <point x="255" y="467"/>
+      <point x="273" y="448"/>
+      <point x="273" y="413" type="curve" smooth="yes"/>
+      <point x="273" y="382"/>
+      <point x="254" y="341"/>
     </contour>
     <contour>
-      <point x="1005" y="357" type="curve" smooth="yes"/>
-      <point x="962" y="357"/>
-      <point x="937" y="383"/>
-      <point x="937" y="427" type="curve" smooth="yes"/>
-      <point x="937" y="449"/>
-      <point x="942" y="467"/>
-      <point x="952" y="481" type="curve"/>
-      <point x="928" y="481" type="line"/>
-      <point x="905" y="431" type="line"/>
-      <point x="935" y="455"/>
-      <point x="967" y="467"/>
-      <point x="1001" y="467" type="curve" smooth="yes"/>
-      <point x="1044" y="467"/>
-      <point x="1066" y="449"/>
-      <point x="1066" y="412" type="curve" smooth="yes"/>
-      <point x="1066" y="379"/>
-      <point x="1042" y="357"/>
+      <point x="1016" y="341" type="curve" smooth="yes"/>
+      <point x="978" y="341"/>
+      <point x="952" y="368"/>
+      <point x="952" y="406" type="curve" smooth="yes"/>
+      <point x="952" y="429"/>
+      <point x="957" y="449"/>
+      <point x="970" y="475" type="curve"/>
+      <point x="951" y="475" type="line"/>
+      <point x="936" y="425" type="line"/>
+      <point x="963" y="451"/>
+      <point x="1002" y="467"/>
+      <point x="1037" y="467" type="curve" smooth="yes"/>
+      <point x="1075" y="467"/>
+      <point x="1093" y="448"/>
+      <point x="1093" y="413" type="curve" smooth="yes"/>
+      <point x="1093" y="382"/>
+      <point x="1074" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/j_nya-malayalam.glif
@@ -1,194 +1,194 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2195"/>
-  <anchor x="1787" y="0" name="bottom"/>
-  <anchor x="1092" y="580" name="top"/>
-  <anchor x="2060" y="580" name="topright"/>
+  <advance width="2228"/>
+  <anchor x="1768" y="0" name="bottom"/>
+  <anchor x="1165" y="580" name="top"/>
+  <anchor x="2143" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="314" y="-16" type="curve" smooth="yes"/>
-      <point x="547" y="-16"/>
-      <point x="673" y="43"/>
-      <point x="787" y="188" type="curve"/>
-      <point x="834" y="188" type="line"/>
-      <point x="798" y="244" type="line"/>
-      <point x="794" y="226"/>
-      <point x="792" y="207"/>
-      <point x="792" y="189" type="curve" smooth="yes"/>
-      <point x="792" y="82"/>
-      <point x="857" y="-16"/>
-      <point x="986" y="-16" type="curve" smooth="yes"/>
-      <point x="1095" y="-16"/>
-      <point x="1171" y="67"/>
-      <point x="1171" y="187" type="curve" smooth="yes"/>
-      <point x="1171" y="277"/>
-      <point x="1110" y="336"/>
-      <point x="1015" y="336" type="curve" smooth="yes"/>
-      <point x="959" y="336"/>
-      <point x="908" y="314"/>
-      <point x="870" y="275" type="curve"/>
-      <point x="840" y="283" type="line"/>
-      <point x="840" y="143" type="line"/>
-      <point x="869" y="219"/>
-      <point x="928" y="267"/>
-      <point x="994" y="267" type="curve" smooth="yes"/>
-      <point x="1053" y="267"/>
-      <point x="1088" y="235"/>
-      <point x="1088" y="181" type="curve" smooth="yes"/>
-      <point x="1088" y="109"/>
-      <point x="1048" y="62"/>
-      <point x="985" y="62" type="curve" smooth="yes"/>
-      <point x="903" y="62"/>
-      <point x="862" y="120"/>
-      <point x="862" y="225" type="curve" smooth="yes"/>
-      <point x="862" y="399"/>
-      <point x="961" y="518"/>
-      <point x="1106" y="518" type="curve" smooth="yes"/>
-      <point x="1219" y="518"/>
-      <point x="1276" y="457"/>
-      <point x="1276" y="360" type="curve" smooth="yes"/>
-      <point x="1276" y="343"/>
-      <point x="1273" y="314"/>
-      <point x="1268" y="285" type="curve" smooth="yes"/>
-      <point x="1218" y="0" type="line"/>
-      <point x="1302" y="0" type="line"/>
-      <point x="1361" y="336" type="line" smooth="yes"/>
-      <point x="1383" y="459"/>
-      <point x="1453" y="518"/>
-      <point x="1569" y="518" type="curve" smooth="yes"/>
-      <point x="1730" y="518"/>
-      <point x="1806" y="430"/>
-      <point x="1806" y="272" type="curve" smooth="yes"/>
-      <point x="1806" y="168"/>
-      <point x="1765" y="64"/>
-      <point x="1670" y="64" type="curve" smooth="yes"/>
-      <point x="1603" y="64"/>
-      <point x="1565" y="105"/>
-      <point x="1565" y="196" type="curve" smooth="yes"/>
-      <point x="1565" y="361"/>
-      <point x="1694" y="518"/>
-      <point x="1881" y="518" type="curve" smooth="yes"/>
-      <point x="2000" y="518"/>
-      <point x="2079" y="458"/>
-      <point x="2079" y="342" type="curve" smooth="yes"/>
-      <point x="2079" y="217"/>
-      <point x="2017" y="131"/>
-      <point x="1921" y="44" type="curve"/>
-      <point x="1982" y="-14" type="line"/>
-      <point x="2093" y="86"/>
-      <point x="2162" y="196"/>
-      <point x="2162" y="336" type="curve" smooth="yes"/>
-      <point x="2162" y="510"/>
-      <point x="2057" y="596"/>
-      <point x="1891" y="596" type="curve" smooth="yes"/>
-      <point x="1662" y="596"/>
-      <point x="1483" y="413"/>
-      <point x="1483" y="191" type="curve" smooth="yes"/>
-      <point x="1483" y="60"/>
-      <point x="1547" y="-16"/>
-      <point x="1666" y="-16" type="curve" smooth="yes"/>
-      <point x="1806" y="-16"/>
-      <point x="1887" y="108"/>
-      <point x="1887" y="273" type="curve" smooth="yes"/>
-      <point x="1887" y="471"/>
-      <point x="1769" y="596"/>
-      <point x="1577" y="596" type="curve" smooth="yes"/>
-      <point x="1463" y="596"/>
-      <point x="1383" y="554"/>
-      <point x="1332" y="470" type="curve"/>
-      <point x="1327" y="470" type="line"/>
-      <point x="1289" y="556"/>
-      <point x="1214" y="596"/>
-      <point x="1107" y="596" type="curve" smooth="yes"/>
-      <point x="978" y="596"/>
-      <point x="879" y="538"/>
-      <point x="802" y="365" type="curve" smooth="yes"/>
-      <point x="690" y="113"/>
-      <point x="540" y="61"/>
-      <point x="317" y="61" type="curve" smooth="yes"/>
-      <point x="157" y="61"/>
-      <point x="101" y="97"/>
-      <point x="101" y="149" type="curve" smooth="yes"/>
-      <point x="101" y="194"/>
-      <point x="141" y="215"/>
-      <point x="216" y="215" type="curve" smooth="yes"/>
-      <point x="521" y="215" type="line" smooth="yes"/>
-      <point x="669" y="215"/>
-      <point x="773" y="301"/>
-      <point x="773" y="433" type="curve" smooth="yes"/>
-      <point x="773" y="539"/>
-      <point x="708" y="596"/>
-      <point x="616" y="596" type="curve" smooth="yes"/>
-      <point x="548" y="596"/>
-      <point x="489" y="562"/>
-      <point x="454" y="478" type="curve"/>
-      <point x="449" y="478" type="line"/>
-      <point x="438" y="553"/>
-      <point x="378" y="596"/>
-      <point x="282" y="596" type="curve" smooth="yes"/>
-      <point x="159" y="596"/>
-      <point x="69" y="525"/>
-      <point x="69" y="427" type="curve" smooth="yes"/>
-      <point x="69" y="344"/>
-      <point x="123" y="294"/>
-      <point x="212" y="294" type="curve" smooth="yes"/>
-      <point x="294" y="294"/>
-      <point x="347" y="340"/>
-      <point x="347" y="413" type="curve" smooth="yes"/>
-      <point x="347" y="477"/>
-      <point x="309" y="515"/>
-      <point x="246" y="515" type="curve" smooth="yes"/>
-      <point x="225" y="515"/>
-      <point x="203" y="511"/>
-      <point x="185" y="505" type="curve"/>
-      <point x="174" y="528" type="line"/>
-      <point x="175" y="503" type="line"/>
-      <point x="198" y="524"/>
-      <point x="236" y="536"/>
-      <point x="278" y="536" type="curve" smooth="yes"/>
-      <point x="358" y="536"/>
-      <point x="396" y="494"/>
-      <point x="396" y="411" type="curve" smooth="yes"/>
-      <point x="396" y="394"/>
-      <point x="393" y="373"/>
-      <point x="390" y="354" type="curve" smooth="yes"/>
-      <point x="388" y="343" type="line"/>
-      <point x="472" y="343" type="line"/>
-      <point x="480" y="387" type="line" smooth="yes"/>
-      <point x="495" y="470"/>
-      <point x="543" y="518"/>
-      <point x="603" y="518" type="curve" smooth="yes"/>
-      <point x="659" y="518"/>
-      <point x="689" y="486"/>
-      <point x="689" y="433" type="curve" smooth="yes"/>
-      <point x="689" y="336"/>
-      <point x="630" y="287"/>
-      <point x="525" y="287" type="curve" smooth="yes"/>
-      <point x="219" y="287" type="line" smooth="yes"/>
-      <point x="95" y="287"/>
-      <point x="21" y="235"/>
-      <point x="21" y="144" type="curve" smooth="yes"/>
-      <point x="21" y="51"/>
-      <point x="100" y="-16"/>
+      <point x="257" y="-16" type="curve" smooth="yes"/>
+      <point x="530" y="-16"/>
+      <point x="696" y="48"/>
+      <point x="817" y="200" type="curve"/>
+      <point x="864" y="200" type="line"/>
+      <point x="830" y="244" type="line"/>
+      <point x="825" y="226"/>
+      <point x="822" y="207"/>
+      <point x="822" y="189" type="curve" smooth="yes"/>
+      <point x="822" y="73"/>
+      <point x="889" y="-16"/>
+      <point x="1004" y="-16" type="curve" smooth="yes"/>
+      <point x="1146" y="-16"/>
+      <point x="1210" y="99"/>
+      <point x="1210" y="195" type="curve" smooth="yes"/>
+      <point x="1210" y="287"/>
+      <point x="1155" y="347"/>
+      <point x="1062" y="347" type="curve" smooth="yes"/>
+      <point x="998" y="347"/>
+      <point x="945" y="321"/>
+      <point x="903" y="275" type="curve"/>
+      <point x="872" y="281" type="line"/>
+      <point x="872" y="126" type="line"/>
+      <point x="904" y="216"/>
+      <point x="969" y="273"/>
+      <point x="1042" y="273" type="curve" smooth="yes"/>
+      <point x="1103" y="273"/>
+      <point x="1128" y="242"/>
+      <point x="1128" y="189" type="curve" smooth="yes"/>
+      <point x="1128" y="132"/>
+      <point x="1093" y="62"/>
+      <point x="1008" y="62" type="curve" smooth="yes"/>
+      <point x="937" y="62"/>
+      <point x="894" y="115"/>
+      <point x="894" y="223" type="curve" smooth="yes"/>
+      <point x="894" y="389"/>
+      <point x="1018" y="518"/>
+      <point x="1147" y="518" type="curve" smooth="yes"/>
+      <point x="1258" y="518"/>
+      <point x="1308" y="460"/>
+      <point x="1308" y="369" type="curve" smooth="yes"/>
+      <point x="1308" y="347"/>
+      <point x="1306" y="317"/>
+      <point x="1300" y="285" type="curve" smooth="yes"/>
+      <point x="1250" y="0" type="line"/>
+      <point x="1334" y="0" type="line"/>
+      <point x="1388" y="306" type="line" smooth="yes"/>
+      <point x="1412" y="443"/>
+      <point x="1484" y="518"/>
+      <point x="1605" y="518" type="curve" smooth="yes"/>
+      <point x="1762" y="518"/>
+      <point x="1836" y="423"/>
+      <point x="1836" y="252" type="curve" smooth="yes"/>
+      <point x="1836" y="172"/>
+      <point x="1808" y="64"/>
+      <point x="1709" y="64" type="curve" smooth="yes"/>
+      <point x="1641" y="64"/>
+      <point x="1598" y="112"/>
+      <point x="1598" y="201" type="curve" smooth="yes"/>
+      <point x="1598" y="347"/>
+      <point x="1728" y="518"/>
+      <point x="1913" y="518" type="curve" smooth="yes"/>
+      <point x="2034" y="518"/>
+      <point x="2106" y="449"/>
+      <point x="2106" y="335" type="curve" smooth="yes"/>
+      <point x="2106" y="233"/>
+      <point x="2059" y="135"/>
+      <point x="1965" y="41" type="curve"/>
+      <point x="2024" y="-16" type="line"/>
+      <point x="2136" y="96"/>
+      <point x="2188" y="208"/>
+      <point x="2188" y="336" type="curve" smooth="yes"/>
+      <point x="2188" y="502"/>
+      <point x="2091" y="596"/>
+      <point x="1922" y="596" type="curve" smooth="yes"/>
+      <point x="1701" y="596"/>
+      <point x="1516" y="402"/>
+      <point x="1516" y="197" type="curve" smooth="yes"/>
+      <point x="1516" y="65"/>
+      <point x="1593" y="-16"/>
+      <point x="1706" y="-16" type="curve" smooth="yes"/>
+      <point x="1864" y="-16"/>
+      <point x="1917" y="135"/>
+      <point x="1917" y="253" type="curve" smooth="yes"/>
+      <point x="1917" y="463"/>
+      <point x="1801" y="596"/>
+      <point x="1613" y="596" type="curve" smooth="yes"/>
+      <point x="1501" y="596"/>
+      <point x="1423" y="549"/>
+      <point x="1371" y="461" type="curve"/>
+      <point x="1366" y="461" type="line"/>
+      <point x="1330" y="548"/>
+      <point x="1263" y="596"/>
+      <point x="1148" y="596" type="curve" smooth="yes"/>
+      <point x="1011" y="596"/>
+      <point x="912" y="516"/>
+      <point x="831" y="349" type="curve" smooth="yes"/>
+      <point x="728" y="136"/>
+      <point x="562" y="61"/>
+      <point x="265" y="61" type="curve" smooth="yes"/>
+      <point x="144" y="61"/>
+      <point x="99" y="84"/>
+      <point x="99" y="132" type="curve" smooth="yes"/>
+      <point x="99" y="165"/>
+      <point x="125" y="195"/>
+      <point x="192" y="195" type="curve" smooth="yes"/>
+      <point x="476" y="195" type="line" smooth="yes"/>
+      <point x="652" y="195"/>
+      <point x="791" y="289"/>
+      <point x="791" y="435" type="curve" smooth="yes"/>
+      <point x="791" y="527"/>
+      <point x="740" y="596"/>
+      <point x="642" y="596" type="curve" smooth="yes"/>
+      <point x="564" y="596"/>
+      <point x="503" y="552"/>
+      <point x="472" y="475" type="curve"/>
+      <point x="467" y="475" type="line"/>
+      <point x="455" y="552"/>
+      <point x="395" y="596"/>
+      <point x="303" y="596" type="curve" smooth="yes"/>
+      <point x="142" y="596"/>
+      <point x="64" y="488"/>
+      <point x="64" y="399" type="curve" smooth="yes"/>
+      <point x="64" y="324"/>
+      <point x="114" y="273"/>
+      <point x="192" y="273" type="curve" smooth="yes"/>
+      <point x="302" y="273"/>
+      <point x="348" y="357"/>
+      <point x="348" y="414" type="curve" smooth="yes"/>
+      <point x="348" y="478"/>
+      <point x="313" y="515"/>
+      <point x="249" y="515" type="curve" smooth="yes"/>
+      <point x="224" y="515"/>
+      <point x="208" y="512"/>
+      <point x="187" y="505" type="curve"/>
+      <point x="177" y="523" type="line"/>
+      <point x="162" y="494" type="line"/>
+      <point x="199" y="522"/>
+      <point x="238" y="536"/>
+      <point x="298" y="536" type="curve" smooth="yes"/>
+      <point x="375" y="536"/>
+      <point x="414" y="497"/>
+      <point x="414" y="425" type="curve" smooth="yes"/>
+      <point x="414" y="409"/>
+      <point x="412" y="392"/>
+      <point x="409" y="375" type="curve" smooth="yes"/>
+      <point x="400" y="324" type="line"/>
+      <point x="484" y="324" type="line"/>
+      <point x="493" y="375" type="line" smooth="yes"/>
+      <point x="508" y="464"/>
+      <point x="553" y="518"/>
+      <point x="625" y="518" type="curve" smooth="yes"/>
+      <point x="678" y="518"/>
+      <point x="707" y="486"/>
+      <point x="707" y="431" type="curve" smooth="yes"/>
+      <point x="707" y="331"/>
+      <point x="621" y="267"/>
+      <point x="481" y="267" type="curve" smooth="yes"/>
+      <point x="196" y="267" type="line" smooth="yes"/>
+      <point x="68" y="267"/>
+      <point x="15" y="195"/>
+      <point x="15" y="128" type="curve" smooth="yes"/>
+      <point x="15" y="43"/>
+      <point x="83" y="-16"/>
     </contour>
     <contour>
-      <point x="214" y="357" type="curve" smooth="yes"/>
-      <point x="171" y="357"/>
-      <point x="146" y="383"/>
-      <point x="146" y="427" type="curve" smooth="yes"/>
-      <point x="146" y="449"/>
-      <point x="151" y="467"/>
-      <point x="161" y="481" type="curve"/>
-      <point x="137" y="481" type="line"/>
-      <point x="114" y="431" type="line"/>
-      <point x="144" y="455"/>
-      <point x="176" y="467"/>
-      <point x="210" y="467" type="curve" smooth="yes"/>
-      <point x="253" y="467"/>
-      <point x="275" y="449"/>
-      <point x="275" y="412" type="curve" smooth="yes"/>
-      <point x="275" y="379"/>
-      <point x="251" y="357"/>
+      <point x="196" y="341" type="curve" smooth="yes"/>
+      <point x="158" y="341"/>
+      <point x="132" y="368"/>
+      <point x="132" y="406" type="curve" smooth="yes"/>
+      <point x="132" y="429"/>
+      <point x="137" y="449"/>
+      <point x="150" y="475" type="curve"/>
+      <point x="131" y="475" type="line"/>
+      <point x="116" y="425" type="line"/>
+      <point x="143" y="451"/>
+      <point x="182" y="467"/>
+      <point x="217" y="467" type="curve" smooth="yes"/>
+      <point x="255" y="467"/>
+      <point x="273" y="448"/>
+      <point x="273" y="413" type="curve" smooth="yes"/>
+      <point x="273" y="382"/>
+      <point x="254" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ja-malayalam.glif
@@ -1,141 +1,138 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <unicode hex="0D1C"/>
-  <guideline x="52" y="133" angle="91.1496"/>
-  <guideline x="770" y="416" angle="269.0789"/>
-  <anchor x="374" y="0" name="bottom"/>
+  <anchor x="389" y="0" name="bottom"/>
   <anchor x="476" y="580" name="top"/>
-  <anchor x="744" y="580" name="topright"/>
+  <anchor x="760" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="150" y="-16" type="curve" smooth="yes"/>
-      <point x="209" y="-16"/>
-      <point x="257" y="0"/>
-      <point x="359" y="54" type="curve" smooth="yes"/>
-      <point x="429" y="91" type="line"/>
-      <point x="536" y="148" type="line"/>
-      <point x="549" y="151" type="line"/>
-      <point x="579" y="164"/>
-      <point x="597" y="167"/>
-      <point x="616" y="167" type="curve" smooth="yes"/>
-      <point x="651" y="167"/>
-      <point x="668" y="149"/>
-      <point x="668" y="114" type="curve" smooth="yes"/>
-      <point x="668" y="73"/>
-      <point x="645" y="48"/>
-      <point x="606" y="48" type="curve" smooth="yes"/>
-      <point x="573" y="48"/>
-      <point x="553" y="67"/>
-      <point x="553" y="99" type="curve" smooth="yes"/>
-      <point x="553" y="131"/>
-      <point x="568" y="159"/>
-      <point x="600" y="185" type="curve"/>
-      <point x="477" y="161" type="line"/>
-      <point x="516" y="102" type="line"/>
-      <point x="525" y="156" type="line"/>
-      <point x="504" y="135"/>
-      <point x="493" y="109"/>
-      <point x="493" y="80" type="curve" smooth="yes"/>
-      <point x="493" y="22"/>
-      <point x="536" y="-16"/>
-      <point x="603" y="-16" type="curve" smooth="yes"/>
-      <point x="685" y="-16"/>
-      <point x="735" y="35"/>
-      <point x="735" y="121" type="curve" smooth="yes"/>
-      <point x="735" y="189"/>
-      <point x="693" y="233"/>
-      <point x="628" y="233" type="curve" smooth="yes"/>
-      <point x="582" y="233"/>
-      <point x="543" y="220"/>
-      <point x="423" y="162" type="curve" smooth="yes"/>
-      <point x="340" y="122" type="line" smooth="yes"/>
-      <point x="229" y="68"/>
-      <point x="208" y="61"/>
-      <point x="165" y="61" type="curve" smooth="yes"/>
-      <point x="125" y="61"/>
-      <point x="101" y="86"/>
-      <point x="101" y="126" type="curve" smooth="yes"/>
-      <point x="101" y="184"/>
-      <point x="141" y="215"/>
-      <point x="216" y="215" type="curve" smooth="yes"/>
-      <point x="544" y="215" type="line" smooth="yes"/>
-      <point x="692" y="215"/>
-      <point x="796" y="301"/>
-      <point x="796" y="423" type="curve" smooth="yes"/>
-      <point x="796" y="529"/>
-      <point x="734" y="596"/>
-      <point x="627" y="596" type="curve" smooth="yes"/>
-      <point x="546" y="596"/>
-      <point x="483" y="559"/>
-      <point x="452" y="478" type="curve"/>
-      <point x="447" y="478" type="line"/>
-      <point x="436" y="553"/>
-      <point x="378" y="596"/>
-      <point x="282" y="596" type="curve" smooth="yes"/>
-      <point x="159" y="596"/>
-      <point x="69" y="525"/>
-      <point x="69" y="427" type="curve" smooth="yes"/>
-      <point x="69" y="344"/>
-      <point x="123" y="294"/>
-      <point x="212" y="294" type="curve" smooth="yes"/>
-      <point x="294" y="294"/>
-      <point x="347" y="340"/>
-      <point x="347" y="413" type="curve" smooth="yes"/>
-      <point x="347" y="477"/>
-      <point x="309" y="515"/>
-      <point x="246" y="515" type="curve" smooth="yes"/>
-      <point x="225" y="515"/>
-      <point x="203" y="511"/>
-      <point x="185" y="505" type="curve"/>
-      <point x="174" y="528" type="line"/>
-      <point x="175" y="503" type="line"/>
-      <point x="198" y="524"/>
-      <point x="236" y="536"/>
-      <point x="278" y="536" type="curve" smooth="yes"/>
-      <point x="358" y="536"/>
-      <point x="399" y="494"/>
-      <point x="399" y="411" type="curve" smooth="yes"/>
-      <point x="399" y="394"/>
-      <point x="396" y="373"/>
-      <point x="393" y="354" type="curve" smooth="yes"/>
-      <point x="391" y="343" type="line"/>
-      <point x="475" y="343" type="line"/>
-      <point x="483" y="387" type="line" smooth="yes"/>
-      <point x="498" y="470"/>
-      <point x="545" y="518"/>
-      <point x="618" y="518" type="curve" smooth="yes"/>
-      <point x="682" y="518"/>
-      <point x="712" y="486"/>
-      <point x="712" y="423" type="curve" smooth="yes"/>
-      <point x="712" y="336"/>
-      <point x="653" y="287"/>
-      <point x="548" y="287" type="curve" smooth="yes"/>
-      <point x="219" y="287" type="line" smooth="yes"/>
-      <point x="95" y="287"/>
-      <point x="21" y="225"/>
-      <point x="21" y="120" type="curve" smooth="yes"/>
-      <point x="21" y="34"/>
-      <point x="69" y="-16"/>
+      <point x="158" y="-16" type="curve" smooth="yes"/>
+      <point x="205" y="-16"/>
+      <point x="242" y="-4"/>
+      <point x="328" y="35" type="curve" smooth="yes"/>
+      <point x="456" y="93" type="line"/>
+      <point x="531" y="141" type="line"/>
+      <point x="568" y="153" type="line"/>
+      <point x="596" y="170"/>
+      <point x="616" y="176"/>
+      <point x="645" y="176" type="curve" smooth="yes"/>
+      <point x="681" y="176"/>
+      <point x="702" y="155"/>
+      <point x="702" y="121" type="curve" smooth="yes"/>
+      <point x="702" y="91"/>
+      <point x="681" y="54"/>
+      <point x="629" y="54" type="curve" smooth="yes"/>
+      <point x="592" y="54"/>
+      <point x="571" y="74"/>
+      <point x="571" y="110" type="curve" smooth="yes"/>
+      <point x="571" y="134"/>
+      <point x="581" y="159"/>
+      <point x="602" y="180" type="curve"/>
+      <point x="510" y="145" type="line"/>
+      <point x="526" y="131" type="line"/>
+      <point x="519" y="117"/>
+      <point x="515" y="101"/>
+      <point x="515" y="85" type="curve" smooth="yes"/>
+      <point x="515" y="24"/>
+      <point x="557" y="-16"/>
+      <point x="626" y="-16" type="curve" smooth="yes"/>
+      <point x="730" y="-16"/>
+      <point x="774" y="67"/>
+      <point x="774" y="125" type="curve" smooth="yes"/>
+      <point x="774" y="189"/>
+      <point x="734" y="236"/>
+      <point x="660" y="236" type="curve" smooth="yes"/>
+      <point x="621" y="236"/>
+      <point x="575" y="221"/>
+      <point x="495" y="185" type="curve" smooth="yes"/>
+      <point x="307" y="100" type="line" smooth="yes"/>
+      <point x="246" y="72"/>
+      <point x="209" y="60"/>
+      <point x="169" y="60" type="curve" smooth="yes"/>
+      <point x="123" y="60"/>
+      <point x="97" y="85"/>
+      <point x="97" y="120" type="curve" smooth="yes"/>
+      <point x="97" y="158"/>
+      <point x="127" y="195"/>
+      <point x="201" y="195" type="curve" smooth="yes"/>
+      <point x="523" y="195" type="line" smooth="yes"/>
+      <point x="693" y="195"/>
+      <point x="830" y="283"/>
+      <point x="830" y="436" type="curve" smooth="yes"/>
+      <point x="830" y="532"/>
+      <point x="774" y="596"/>
+      <point x="666" y="596" type="curve" smooth="yes"/>
+      <point x="579" y="596"/>
+      <point x="509" y="552"/>
+      <point x="472" y="475" type="curve"/>
+      <point x="467" y="475" type="line"/>
+      <point x="455" y="552"/>
+      <point x="395" y="596"/>
+      <point x="303" y="596" type="curve" smooth="yes"/>
+      <point x="142" y="596"/>
+      <point x="64" y="488"/>
+      <point x="64" y="399" type="curve" smooth="yes"/>
+      <point x="64" y="324"/>
+      <point x="114" y="273"/>
+      <point x="192" y="273" type="curve" smooth="yes"/>
+      <point x="302" y="273"/>
+      <point x="348" y="357"/>
+      <point x="348" y="414" type="curve" smooth="yes"/>
+      <point x="348" y="478"/>
+      <point x="313" y="515"/>
+      <point x="249" y="515" type="curve" smooth="yes"/>
+      <point x="224" y="515"/>
+      <point x="208" y="512"/>
+      <point x="187" y="505" type="curve"/>
+      <point x="177" y="523" type="line"/>
+      <point x="162" y="494" type="line"/>
+      <point x="199" y="522"/>
+      <point x="238" y="536"/>
+      <point x="298" y="536" type="curve" smooth="yes"/>
+      <point x="375" y="536"/>
+      <point x="414" y="497"/>
+      <point x="414" y="425" type="curve" smooth="yes"/>
+      <point x="414" y="409"/>
+      <point x="412" y="392"/>
+      <point x="409" y="375" type="curve" smooth="yes"/>
+      <point x="400" y="324" type="line"/>
+      <point x="484" y="324" type="line"/>
+      <point x="493" y="375" type="line" smooth="yes"/>
+      <point x="508" y="464"/>
+      <point x="565" y="518"/>
+      <point x="645" y="518" type="curve" smooth="yes"/>
+      <point x="711" y="518"/>
+      <point x="747" y="484"/>
+      <point x="747" y="422" type="curve" smooth="yes"/>
+      <point x="747" y="321"/>
+      <point x="671" y="267"/>
+      <point x="548" y="267" type="curve" smooth="yes"/>
+      <point x="205" y="267" type="line" smooth="yes"/>
+      <point x="70" y="267"/>
+      <point x="15" y="181"/>
+      <point x="15" y="114" type="curve" smooth="yes"/>
+      <point x="15" y="39"/>
+      <point x="74" y="-16"/>
     </contour>
     <contour>
-      <point x="214" y="357" type="curve" smooth="yes"/>
-      <point x="171" y="357"/>
-      <point x="146" y="383"/>
-      <point x="146" y="427" type="curve" smooth="yes"/>
-      <point x="146" y="449"/>
-      <point x="151" y="467"/>
-      <point x="161" y="481" type="curve"/>
-      <point x="137" y="481" type="line"/>
-      <point x="114" y="431" type="line"/>
-      <point x="144" y="455"/>
-      <point x="176" y="467"/>
-      <point x="210" y="467" type="curve" smooth="yes"/>
-      <point x="253" y="467"/>
-      <point x="275" y="449"/>
-      <point x="275" y="412" type="curve" smooth="yes"/>
-      <point x="275" y="379"/>
-      <point x="251" y="357"/>
+      <point x="196" y="341" type="curve" smooth="yes"/>
+      <point x="158" y="341"/>
+      <point x="132" y="368"/>
+      <point x="132" y="406" type="curve" smooth="yes"/>
+      <point x="132" y="429"/>
+      <point x="137" y="449"/>
+      <point x="150" y="475" type="curve"/>
+      <point x="131" y="475" type="line"/>
+      <point x="116" y="425" type="line"/>
+      <point x="143" y="451"/>
+      <point x="182" y="467"/>
+      <point x="217" y="467" type="curve" smooth="yes"/>
+      <point x="255" y="467"/>
+      <point x="273" y="448"/>
+      <point x="273" y="413" type="curve" smooth="yes"/>
+      <point x="273" y="382"/>
+      <point x="254" y="341"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="671"/>
+    <component base="halant-malayalam" xOffset="687"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <guideline x="103" y="133" angle="91.1496"/>
   <guideline x="821" y="416" angle="269.0789"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="420"/>
+    <component base="lVocalicMatra-malayalam" xOffset="435"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="808"/>
+  <advance width="850"/>
   <guideline x="88" y="133" angle="91.1496"/>
   <guideline x="806" y="416" angle="269.0789"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="420"/>
+    <component base="llVocalicMatra-malayalam" xOffset="435"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/kC_hillu-malayalam.glif
@@ -2,114 +2,112 @@
 <glyph name="kChillu-malayalam" format="2">
   <advance width="1040"/>
   <unicode hex="0D7F"/>
-  <guideline x="1034"/>
-  <anchor x="667" y="0" name="bottom"/>
-  <anchor x="390" y="580" name="top"/>
+  <anchor x="593" y="0" name="bottom"/>
+  <anchor x="418" y="580" name="top"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="594" y="-16"/>
-      <point x="639" y="25"/>
-      <point x="670" y="85" type="curve"/>
-      <point x="675" y="85" type="line"/>
-      <point x="690" y="34"/>
-      <point x="732" y="-16"/>
-      <point x="829" y="-16" type="curve" smooth="yes"/>
-      <point x="922" y="-16"/>
-      <point x="995" y="42"/>
-      <point x="995" y="161" type="curve" smooth="yes"/>
-      <point x="995" y="257"/>
-      <point x="943" y="324"/>
-      <point x="795" y="324" type="curve" smooth="yes"/>
-      <point x="778" y="324" type="line"/>
-      <point x="732" y="250" type="line"/>
-      <point x="787" y="250" type="line" smooth="yes"/>
-      <point x="883" y="250"/>
-      <point x="910" y="210"/>
-      <point x="910" y="160" type="curve" smooth="yes"/>
-      <point x="910" y="98"/>
-      <point x="878" y="62"/>
-      <point x="819" y="62" type="curve" smooth="yes"/>
-      <point x="761" y="62"/>
-      <point x="732" y="98"/>
-      <point x="732" y="163" type="curve" smooth="yes"/>
-      <point x="732" y="242"/>
-      <point x="787" y="332"/>
-      <point x="874" y="426" type="curve" smooth="yes"/>
-      <point x="939" y="496"/>
-      <point x="993" y="563"/>
-      <point x="993" y="653" type="curve" smooth="yes"/>
-      <point x="993" y="740"/>
-      <point x="940" y="789"/>
-      <point x="836" y="789" type="curve" smooth="yes"/>
-      <point x="787" y="789"/>
-      <point x="737" y="776"/>
-      <point x="693" y="751" type="curve"/>
-      <point x="720" y="679" type="line"/>
-      <point x="749" y="697"/>
-      <point x="790" y="711"/>
-      <point x="828" y="711" type="curve" smooth="yes"/>
-      <point x="884" y="711"/>
-      <point x="911" y="688"/>
-      <point x="911" y="643" type="curve" smooth="yes"/>
-      <point x="911" y="582"/>
-      <point x="873" y="536"/>
-      <point x="806" y="455" type="curve" smooth="yes"/>
-      <point x="782" y="425"/>
-      <point x="763" y="400"/>
-      <point x="749" y="368" type="curve"/>
-      <point x="703" y="368" type="line"/>
-      <point x="743" y="309" type="line"/>
-      <point x="744" y="325"/>
-      <point x="744" y="340"/>
-      <point x="744" y="356" type="curve" smooth="yes"/>
-      <point x="744" y="477"/>
-      <point x="715" y="596"/>
-      <point x="569" y="596" type="curve" smooth="yes"/>
-      <point x="436" y="596"/>
-      <point x="355" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="721" y="250" type="line"/>
-      <point x="721" y="324" type="line"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="551" y="-16"/>
+      <point x="607" y="19"/>
+      <point x="648" y="82" type="curve"/>
+      <point x="654" y="82" type="line"/>
+      <point x="674" y="24"/>
+      <point x="724" y="-16"/>
+      <point x="800" y="-16" type="curve" smooth="yes"/>
+      <point x="915" y="-16"/>
+      <point x="987" y="68"/>
+      <point x="987" y="174" type="curve" smooth="yes"/>
+      <point x="987" y="278"/>
+      <point x="923" y="344"/>
+      <point x="792" y="344" type="curve" smooth="yes"/>
+      <point x="776" y="344" type="line"/>
+      <point x="728" y="270" type="line"/>
+      <point x="788" y="270" type="line" smooth="yes"/>
+      <point x="865" y="270"/>
+      <point x="903" y="236"/>
+      <point x="903" y="172" type="curve" smooth="yes"/>
+      <point x="903" y="106"/>
+      <point x="859" y="62"/>
+      <point x="802" y="62" type="curve" smooth="yes"/>
+      <point x="745" y="62"/>
+      <point x="713" y="96"/>
+      <point x="713" y="152" type="curve" smooth="yes"/>
+      <point x="713" y="215"/>
+      <point x="756" y="290"/>
+      <point x="870" y="424" type="curve" smooth="yes"/>
+      <point x="931" y="496"/>
+      <point x="987" y="567"/>
+      <point x="987" y="646" type="curve" smooth="yes"/>
+      <point x="987" y="732"/>
+      <point x="935" y="789"/>
+      <point x="838" y="789" type="curve" smooth="yes"/>
+      <point x="784" y="789"/>
+      <point x="736" y="774"/>
+      <point x="679" y="739" type="curve"/>
+      <point x="716" y="670" type="line"/>
+      <point x="758" y="697"/>
+      <point x="796" y="710"/>
+      <point x="834" y="710" type="curve" smooth="yes"/>
+      <point x="881" y="710"/>
+      <point x="904" y="688"/>
+      <point x="904" y="644" type="curve" smooth="yes"/>
+      <point x="904" y="592"/>
+      <point x="872" y="544"/>
+      <point x="805" y="460" type="curve" smooth="yes"/>
+      <point x="769" y="415"/>
+      <point x="756" y="394"/>
+      <point x="743" y="365" type="curve"/>
+      <point x="737" y="365" type="line"/>
+      <point x="738" y="376"/>
+      <point x="739" y="391"/>
+      <point x="739" y="403" type="curve" smooth="yes"/>
+      <point x="739" y="524"/>
+      <point x="682" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="694" y="270" type="line"/>
+      <point x="715" y="344" type="line"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
     </contour>
     <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="644" y="518"/>
+      <point x="671" y="468"/>
+      <point x="671" y="391" type="curve" smooth="yes"/>
+      <point x="671" y="287"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/k_ka-malayalam.glif
@@ -1,99 +1,98 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ka-malayalam" format="2">
   <advance width="1437"/>
-  <guideline x="1400"/>
-  <anchor x="1033" y="0" name="bottom"/>
-  <anchor x="816" y="580" name="top"/>
-  <anchor x="1315" y="580" name="topright"/>
+  <anchor x="976" y="0" name="bottom"/>
+  <anchor x="861" y="580" name="top"/>
+  <anchor x="1360" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="660" y="-16"/>
-      <point x="760" y="140"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="502"/>
-      <point x="705" y="596"/>
-      <point x="574" y="596" type="curve" smooth="yes"/>
-      <point x="436" y="596"/>
-      <point x="355" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="928" y="250" type="line" smooth="yes"/>
-      <point x="1019" y="250"/>
-      <point x="1044" y="207"/>
-      <point x="1044" y="147" type="curve" smooth="yes"/>
-      <point x="1044" y="106"/>
-      <point x="1026" y="62"/>
-      <point x="972" y="62" type="curve" smooth="yes"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="696" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="941" y="270" type="line" smooth="yes"/>
+      <point x="1017" y="270"/>
+      <point x="1053" y="241"/>
+      <point x="1053" y="175" type="curve" smooth="yes"/>
+      <point x="1053" y="124"/>
+      <point x="1024" y="62"/>
+      <point x="963" y="62" type="curve" smooth="yes"/>
       <point x="911" y="62"/>
-      <point x="889" y="116"/>
-      <point x="889" y="202" type="curve" smooth="yes"/>
-      <point x="889" y="361"/>
-      <point x="978" y="517"/>
-      <point x="1148" y="517" type="curve" smooth="yes"/>
-      <point x="1272" y="517"/>
-      <point x="1324" y="441"/>
-      <point x="1324" y="339" type="curve" smooth="yes"/>
-      <point x="1324" y="209"/>
-      <point x="1262" y="120"/>
-      <point x="1182" y="38" type="curve"/>
+      <point x="882" y="100"/>
+      <point x="882" y="173" type="curve" smooth="yes"/>
+      <point x="882" y="304"/>
+      <point x="948" y="517"/>
+      <point x="1150" y="517" type="curve" smooth="yes"/>
+      <point x="1254" y="517"/>
+      <point x="1315" y="450"/>
+      <point x="1315" y="330" type="curve" smooth="yes"/>
+      <point x="1315" y="228"/>
+      <point x="1267" y="124"/>
+      <point x="1184" y="42" type="curve"/>
       <point x="1243" y="-16" type="line"/>
-      <point x="1343" y="83"/>
-      <point x="1407" y="190"/>
-      <point x="1407" y="343" type="curve" smooth="yes"/>
-      <point x="1407" y="498"/>
-      <point x="1314" y="596"/>
-      <point x="1150" y="596" type="curve" smooth="yes"/>
-      <point x="937" y="596"/>
-      <point x="807" y="408"/>
-      <point x="807" y="205" type="curve" smooth="yes"/>
-      <point x="807" y="75"/>
+      <point x="1336" y="74"/>
+      <point x="1397" y="214"/>
+      <point x="1397" y="334" type="curve" smooth="yes"/>
+      <point x="1397" y="495"/>
+      <point x="1310" y="596"/>
+      <point x="1160" y="596" type="curve" smooth="yes"/>
+      <point x="900" y="596"/>
+      <point x="801" y="332"/>
+      <point x="801" y="172" type="curve" smooth="yes"/>
+      <point x="801" y="56"/>
       <point x="858" y="-16"/>
-      <point x="975" y="-16" type="curve" smooth="yes"/>
-      <point x="1069" y="-16"/>
-      <point x="1126" y="49"/>
-      <point x="1126" y="145" type="curve" smooth="yes"/>
-      <point x="1126" y="239"/>
-      <point x="1081" y="324"/>
-      <point x="928" y="324" type="curve" smooth="yes"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
+      <point x="957" y="-16" type="curve" smooth="yes"/>
+      <point x="1071" y="-16"/>
+      <point x="1135" y="86"/>
+      <point x="1135" y="180" type="curve" smooth="yes"/>
+      <point x="1135" y="286"/>
+      <point x="1076" y="344"/>
+      <point x="949" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
     </contour>
     <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/k_la-malayalam.glif
@@ -1,145 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_la-malayalam" format="2">
   <advance width="1035"/>
-  <anchor x="565" y="-351" name="bottom"/>
-  <anchor x="589" y="580" name="top"/>
-  <anchor x="929" y="540" name="topright"/>
+  <anchor x="555" y="-351" name="bottom"/>
+  <anchor x="583" y="580" name="top"/>
+  <anchor x="923" y="540" name="topright"/>
   <outline>
     <contour>
-      <point x="343" y="-367" type="curve" smooth="yes"/>
-      <point x="428" y="-367"/>
-      <point x="480" y="-313"/>
-      <point x="480" y="-228" type="curve" smooth="yes"/>
-      <point x="480" y="-154"/>
-      <point x="440" y="-118"/>
-      <point x="371" y="-118" type="curve" smooth="yes"/>
-      <point x="339" y="-118"/>
-      <point x="301" y="-131"/>
-      <point x="275" y="-164" type="curve"/>
-      <point x="232" y="-154" type="line"/>
-      <point x="265" y="-181" type="line"/>
-      <point x="281" y="-85"/>
-      <point x="340" y="-27"/>
-      <point x="433" y="-27" type="curve" smooth="yes"/>
-      <point x="538" y="-27"/>
-      <point x="565" y="-86"/>
-      <point x="570" y="-174" type="curve" smooth="yes"/>
-      <point x="571" y="-192" type="line" smooth="yes"/>
-      <point x="577" y="-303"/>
-      <point x="627" y="-367"/>
-      <point x="737" y="-367" type="curve" smooth="yes"/>
-      <point x="866" y="-367"/>
-      <point x="921" y="-271"/>
-      <point x="921" y="-131" type="curve" smooth="yes"/>
-      <point x="921" y="-58"/>
-      <point x="902" y="1"/>
-      <point x="872" y="43" type="curve"/>
+      <point x="338" y="-367" type="curve" smooth="yes"/>
+      <point x="426" y="-367"/>
+      <point x="479" y="-301"/>
+      <point x="479" y="-229" type="curve" smooth="yes"/>
+      <point x="479" y="-162"/>
+      <point x="443" y="-118"/>
+      <point x="376" y="-118" type="curve" smooth="yes"/>
+      <point x="328" y="-118"/>
+      <point x="262" y="-150"/>
+      <point x="249" y="-232" type="curve"/>
+      <point x="288" y="-176" type="line"/>
+      <point x="258" y="-163" type="line"/>
+      <point x="264" y="-188" type="line"/>
+      <point x="284" y="-90"/>
+      <point x="360" y="-25"/>
+      <point x="446" y="-25" type="curve" smooth="yes"/>
+      <point x="520" y="-25"/>
+      <point x="554" y="-63"/>
+      <point x="569" y="-157" type="curve" smooth="yes"/>
+      <point x="576" y="-200" type="line" smooth="yes"/>
+      <point x="595" y="-317"/>
+      <point x="646" y="-367"/>
+      <point x="738" y="-367" type="curve" smooth="yes"/>
+      <point x="873" y="-367"/>
+      <point x="921" y="-239"/>
+      <point x="921" y="-140" type="curve" smooth="yes"/>
+      <point x="921" y="-71"/>
+      <point x="905" y="-10"/>
+      <point x="874" y="41" type="curve"/>
       <point x="809" y="5" type="line"/>
-      <point x="831" y="-33"/>
-      <point x="846" y="-82"/>
-      <point x="846" y="-139" type="curve" smooth="yes"/>
-      <point x="846" y="-226"/>
-      <point x="818" y="-297"/>
-      <point x="739" y="-297" type="curve" smooth="yes"/>
-      <point x="679" y="-297"/>
-      <point x="654" y="-265"/>
-      <point x="646" y="-174" type="curve" smooth="yes"/>
-      <point x="644" y="-151" type="line" smooth="yes"/>
-      <point x="638" y="-87"/>
-      <point x="622" y="-36"/>
-      <point x="581" y="-2" type="curve"/>
-      <point x="581" y="3" type="line"/>
-      <point x="710" y="55"/>
-      <point x="760" y="215"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="502"/>
-      <point x="706" y="596"/>
-      <point x="579" y="596" type="curve" smooth="yes"/>
-      <point x="447" y="596"/>
-      <point x="354" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="790" y="250" type="line" smooth="yes"/>
-      <point x="873" y="250"/>
-      <point x="908" y="214"/>
-      <point x="908" y="155" type="curve" smooth="yes"/>
-      <point x="908" y="109"/>
-      <point x="884" y="62"/>
-      <point x="812" y="62" type="curve" smooth="yes"/>
-      <point x="785" y="62"/>
-      <point x="767" y="66"/>
-      <point x="751" y="72" type="curve"/>
-      <point x="719" y="2" type="line"/>
-      <point x="742" y="-9"/>
-      <point x="770" y="-16"/>
-      <point x="807" y="-16" type="curve" smooth="yes"/>
-      <point x="931" y="-16"/>
-      <point x="990" y="65"/>
-      <point x="990" y="159" type="curve" smooth="yes"/>
-      <point x="990" y="256"/>
-      <point x="924" y="324"/>
-      <point x="791" y="324" type="curve" smooth="yes"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="353" y="70"/>
-      <point x="367" y="52"/>
-      <point x="383" y="41" type="curve"/>
-      <point x="382" y="36" type="line"/>
-      <point x="265" y="10"/>
-      <point x="197" y="-86"/>
-      <point x="197" y="-210" type="curve" smooth="yes"/>
-      <point x="197" y="-316"/>
-      <point x="261" y="-367"/>
+      <point x="836" y="-43"/>
+      <point x="848" y="-89"/>
+      <point x="848" y="-142" type="curve" smooth="yes"/>
+      <point x="848" y="-208"/>
+      <point x="825" y="-297"/>
+      <point x="744" y="-297" type="curve" smooth="yes"/>
+      <point x="691" y="-297"/>
+      <point x="663" y="-269"/>
+      <point x="649" y="-185" type="curve" smooth="yes"/>
+      <point x="642" y="-142" type="line" smooth="yes"/>
+      <point x="629" y="-62"/>
+      <point x="610" y="-17"/>
+      <point x="568" y="7" type="curve"/>
+      <point x="569" y="14" type="line"/>
+      <point x="722" y="81"/>
+      <point x="754" y="280"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="789" y="270" type="line" smooth="yes"/>
+      <point x="863" y="270"/>
+      <point x="900" y="238"/>
+      <point x="900" y="175" type="curve" smooth="yes"/>
+      <point x="900" y="108"/>
+      <point x="856" y="62"/>
+      <point x="792" y="62" type="curve" smooth="yes"/>
+      <point x="772" y="62"/>
+      <point x="755" y="64"/>
+      <point x="741" y="69" type="curve"/>
+      <point x="713" y="-4" type="line"/>
+      <point x="736" y="-12"/>
+      <point x="760" y="-16"/>
+      <point x="787" y="-16" type="curve" smooth="yes"/>
+      <point x="901" y="-16"/>
+      <point x="983" y="65"/>
+      <point x="983" y="178" type="curve" smooth="yes"/>
+      <point x="983" y="282"/>
+      <point x="914" y="344"/>
+      <point x="795" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="328" y="90" type="line"/>
+      <point x="337" y="67"/>
+      <point x="352" y="47"/>
+      <point x="371" y="32" type="curve"/>
+      <point x="369" y="23" type="line"/>
+      <point x="257" y="-18"/>
+      <point x="196" y="-121"/>
+      <point x="196" y="-214" type="curve" smooth="yes"/>
+      <point x="196" y="-313"/>
+      <point x="257" y="-367"/>
     </contour>
     <contour>
-      <point x="343" y="-302" type="curve" smooth="yes"/>
-      <point x="288" y="-302"/>
-      <point x="265" y="-264"/>
-      <point x="265" y="-218" type="curve"/>
-      <point x="246" y="-197" type="line"/>
-      <point x="257" y="-253" type="line"/>
-      <point x="265" y="-213"/>
-      <point x="298" y="-178"/>
-      <point x="347" y="-178" type="curve" smooth="yes"/>
-      <point x="389" y="-178"/>
-      <point x="409" y="-199"/>
+      <point x="338" y="-302" type="curve" smooth="yes"/>
+      <point x="290" y="-302"/>
+      <point x="263" y="-269"/>
+      <point x="263" y="-224" type="curve" smooth="yes"/>
+      <point x="263" y="-217"/>
+      <point x="264" y="-208"/>
+      <point x="266" y="-200" type="curve"/>
+      <point x="235" y="-205" type="line"/>
+      <point x="255" y="-265" type="line"/>
+      <point x="263" y="-213"/>
+      <point x="304" y="-178"/>
+      <point x="353" y="-178" type="curve" smooth="yes"/>
+      <point x="392" y="-178"/>
+      <point x="409" y="-201"/>
       <point x="409" y="-233" type="curve" smooth="yes"/>
-      <point x="409" y="-276"/>
-      <point x="385" y="-302"/>
+      <point x="409" y="-272"/>
+      <point x="382" y="-302"/>
     </contour>
     <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.glif
@@ -1,116 +1,115 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam" format="2">
   <advance width="1702"/>
-  <guideline x="1632"/>
-  <anchor x="1214" y="0" name="bottom"/>
-  <anchor x="933" y="580" name="top"/>
-  <anchor x="1638" y="580" name="topright"/>
+  <anchor x="1208" y="0" name="bottom"/>
+  <anchor x="927" y="580" name="top"/>
+  <anchor x="1632" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="660" y="-16"/>
-      <point x="760" y="140"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="515"/>
-      <point x="694" y="596"/>
-      <point x="579" y="596" type="curve" smooth="yes"/>
-      <point x="447" y="596"/>
-      <point x="354" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="127" y="62"/>
-      <point x="90" y="96"/>
-      <point x="90" y="150" type="curve" smooth="yes"/>
-      <point x="90" y="218"/>
-      <point x="136" y="256"/>
-      <point x="219" y="256" type="curve" smooth="yes"/>
-      <point x="801" y="256" type="line" smooth="yes"/>
-      <point x="885" y="256"/>
-      <point x="911" y="224"/>
-      <point x="911" y="173" type="curve" smooth="yes"/>
-      <point x="911" y="122"/>
-      <point x="885" y="93"/>
-      <point x="827" y="56" type="curve"/>
-      <point x="836" y="0" type="line"/>
-      <point x="1580" y="0" type="line"/>
-      <point x="1682" y="580" type="line"/>
-      <point x="1632" y="580" type="line"/>
-      <point x="1537" y="405"/>
-      <point x="1415" y="312"/>
-      <point x="1287" y="312" type="curve" smooth="yes"/>
-      <point x="1187" y="312"/>
-      <point x="1132" y="358"/>
-      <point x="1132" y="430" type="curve" smooth="yes"/>
-      <point x="1132" y="486"/>
-      <point x="1164" y="518"/>
-      <point x="1213" y="518" type="curve" smooth="yes"/>
-      <point x="1264" y="518"/>
-      <point x="1282" y="491"/>
-      <point x="1282" y="447" type="curve" smooth="yes"/>
-      <point x="1282" y="438"/>
-      <point x="1279" y="413"/>
-      <point x="1277" y="400" type="curve" smooth="yes"/>
-      <point x="1218" y="61" type="line"/>
-      <point x="1300" y="61" type="line"/>
-      <point x="1359" y="398" type="line" smooth="yes"/>
-      <point x="1364" y="427"/>
-      <point x="1365" y="446"/>
-      <point x="1365" y="458" type="curve" smooth="yes"/>
-      <point x="1365" y="540"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="696" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="797" y="270" type="line" smooth="yes"/>
+      <point x="871" y="270"/>
+      <point x="906" y="239"/>
+      <point x="906" y="184" type="curve" smooth="yes"/>
+      <point x="906" y="140"/>
+      <point x="880" y="102"/>
+      <point x="826" y="56" type="curve"/>
+      <point x="835" y="0" type="line"/>
+      <point x="1574" y="0" type="line"/>
+      <point x="1676" y="580" type="line"/>
+      <point x="1624" y="580" type="line"/>
+      <point x="1520" y="412"/>
+      <point x="1403" y="312"/>
+      <point x="1259" y="312" type="curve" smooth="yes"/>
+      <point x="1174" y="312"/>
+      <point x="1125" y="355"/>
+      <point x="1125" y="419" type="curve" smooth="yes"/>
+      <point x="1125" y="476"/>
+      <point x="1165" y="518"/>
+      <point x="1220" y="518" type="curve" smooth="yes"/>
+      <point x="1260" y="518"/>
+      <point x="1279" y="495"/>
+      <point x="1279" y="458" type="curve" smooth="yes"/>
+      <point x="1279" y="446"/>
+      <point x="1278" y="433"/>
+      <point x="1275" y="418" type="curve" smooth="yes"/>
+      <point x="1212" y="61" type="line"/>
+      <point x="1294" y="61" type="line"/>
+      <point x="1357" y="420" type="line" smooth="yes"/>
+      <point x="1360" y="437"/>
+      <point x="1362" y="453"/>
+      <point x="1362" y="468" type="curve" smooth="yes"/>
+      <point x="1362" y="542"/>
       <point x="1317" y="596"/>
-      <point x="1220" y="596" type="curve" smooth="yes"/>
-      <point x="1120" y="596"/>
-      <point x="1049" y="533"/>
-      <point x="1049" y="426" type="curve" smooth="yes"/>
-      <point x="1049" y="305"/>
-      <point x="1152" y="234"/>
-      <point x="1281" y="234" type="curve" smooth="yes"/>
-      <point x="1384" y="234"/>
-      <point x="1475" y="277"/>
-      <point x="1554" y="356" type="curve"/>
-      <point x="1559" y="354" type="line"/>
-      <point x="1503" y="40" type="line"/>
-      <point x="1549" y="74" type="line"/>
-      <point x="905" y="74" type="line"/>
-      <point x="905" y="45" type="line"/>
-      <point x="956" y="67"/>
-      <point x="996" y="114"/>
-      <point x="996" y="188" type="curve" smooth="yes"/>
-      <point x="996" y="268"/>
-      <point x="946" y="330"/>
-      <point x="802" y="330" type="curve" smooth="yes"/>
-      <point x="224" y="330" type="line" smooth="yes"/>
-      <point x="89" y="330"/>
-      <point x="8" y="261"/>
-      <point x="8" y="146" type="curve" smooth="yes"/>
-      <point x="8" y="49"/>
-      <point x="76" y="-16"/>
+      <point x="1228" y="596" type="curve" smooth="yes"/>
+      <point x="1119" y="596"/>
+      <point x="1043" y="519"/>
+      <point x="1043" y="415" type="curve" smooth="yes"/>
+      <point x="1043" y="310"/>
+      <point x="1130" y="236"/>
+      <point x="1253" y="236" type="curve" smooth="yes"/>
+      <point x="1363" y="236"/>
+      <point x="1464" y="287"/>
+      <point x="1550" y="380" type="curve"/>
+      <point x="1557" y="380" type="line"/>
+      <point x="1497" y="40" type="line"/>
+      <point x="1543" y="74" type="line"/>
+      <point x="933" y="74" type="line"/>
+      <point x="932" y="79" type="line"/>
+      <point x="967" y="113"/>
+      <point x="989" y="153"/>
+      <point x="989" y="197" type="curve" smooth="yes"/>
+      <point x="989" y="289"/>
+      <point x="924" y="344"/>
+      <point x="803" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
     </contour>
     <contour>
-      <point x="507" y="62" type="curve" smooth="yes"/>
-      <point x="434" y="62"/>
-      <point x="397" y="118"/>
-      <point x="397" y="217" type="curve" smooth="yes"/>
-      <point x="397" y="348"/>
-      <point x="439" y="518"/>
-      <point x="569" y="518" type="curve" smooth="yes"/>
-      <point x="648" y="518"/>
-      <point x="677" y="460"/>
-      <point x="677" y="363" type="curve" smooth="yes"/>
-      <point x="677" y="238"/>
-      <point x="636" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1702"/>
   <outline>
     <component base="k_ssa-malayalam"/>
-    <component base="halant-malayalam" xOffset="1565"/>
+    <component base="halant-malayalam" xOffset="1559"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/k_ta-malayalam.glif
@@ -1,114 +1,114 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ta-malayalam" format="2">
   <advance width="1796"/>
-  <anchor x="1348" y="0" name="bottom"/>
-  <anchor x="872" y="580" name="top"/>
-  <anchor x="1696" y="580" name="topright"/>
+  <anchor x="1336" y="0" name="bottom"/>
+  <anchor x="866" y="580" name="top"/>
+  <anchor x="1684" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="660" y="-16"/>
-      <point x="760" y="140"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="502"/>
-      <point x="705" y="596"/>
-      <point x="574" y="596" type="curve" smooth="yes"/>
-      <point x="436" y="596"/>
-      <point x="355" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="891" y="250" type="line"/>
-      <point x="891" y="324" type="line"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
-    </contour>
-    <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
-    </contour>
-    <contour>
-      <point x="941" y="-16" type="curve"/>
-      <point x="1007" y="33" type="line"/>
-      <point x="964" y="90"/>
-      <point x="943" y="157"/>
-      <point x="943" y="243" type="curve" smooth="yes"/>
-      <point x="943" y="407"/>
-      <point x="1046" y="518"/>
-      <point x="1196" y="518" type="curve" smooth="yes"/>
-      <point x="1339" y="518"/>
-      <point x="1425" y="425"/>
-      <point x="1425" y="271" type="curve" smooth="yes"/>
-      <point x="1425" y="148"/>
-      <point x="1370" y="62"/>
-      <point x="1291" y="62" type="curve" smooth="yes"/>
-      <point x="1225" y="62"/>
-      <point x="1188" y="111"/>
-      <point x="1188" y="197" type="curve" smooth="yes"/>
-      <point x="1188" y="379"/>
-      <point x="1320" y="518"/>
-      <point x="1494" y="518" type="curve" smooth="yes"/>
-      <point x="1616" y="518"/>
-      <point x="1689" y="447"/>
-      <point x="1689" y="326" type="curve" smooth="yes"/>
-      <point x="1689" y="221"/>
-      <point x="1640" y="130"/>
-      <point x="1539" y="46" type="curve"/>
-      <point x="1594" y="-16" type="line"/>
-      <point x="1715" y="84"/>
-      <point x="1773" y="196"/>
-      <point x="1773" y="326" type="curve" smooth="yes"/>
-      <point x="1773" y="495"/>
+      <point x="931" y="-16" type="curve"/>
+      <point x="995" y="31" type="line"/>
+      <point x="954" y="85"/>
+      <point x="931" y="159"/>
+      <point x="931" y="236" type="curve" smooth="yes"/>
+      <point x="931" y="380"/>
+      <point x="1020" y="518"/>
+      <point x="1184" y="518" type="curve" smooth="yes"/>
+      <point x="1337" y="518"/>
+      <point x="1406" y="412"/>
+      <point x="1406" y="273" type="curve" smooth="yes"/>
+      <point x="1406" y="179"/>
+      <point x="1372" y="62"/>
+      <point x="1270" y="62" type="curve" smooth="yes"/>
+      <point x="1204" y="62"/>
+      <point x="1171" y="108"/>
+      <point x="1171" y="189" type="curve" smooth="yes"/>
+      <point x="1171" y="361"/>
+      <point x="1314" y="518"/>
+      <point x="1487" y="518" type="curve" smooth="yes"/>
+      <point x="1614" y="518"/>
+      <point x="1673" y="444"/>
+      <point x="1673" y="330" type="curve" smooth="yes"/>
+      <point x="1673" y="231"/>
+      <point x="1624" y="138"/>
+      <point x="1525" y="46" type="curve"/>
+      <point x="1588" y="-16" type="line"/>
+      <point x="1695" y="87"/>
+      <point x="1757" y="213"/>
+      <point x="1757" y="338" type="curve" smooth="yes"/>
+      <point x="1757" y="493"/>
       <point x="1669" y="596"/>
-      <point x="1494" y="596" type="curve" smooth="yes"/>
-      <point x="1282" y="596"/>
-      <point x="1106" y="415"/>
-      <point x="1106" y="197" type="curve" smooth="yes"/>
-      <point x="1106" y="67"/>
-      <point x="1178" y="-16"/>
-      <point x="1291" y="-16" type="curve" smooth="yes"/>
-      <point x="1424" y="-16"/>
-      <point x="1511" y="97"/>
-      <point x="1511" y="271" type="curve" smooth="yes"/>
-      <point x="1511" y="462"/>
-      <point x="1381" y="596"/>
-      <point x="1196" y="596" type="curve" smooth="yes"/>
-      <point x="1002" y="596"/>
-      <point x="861" y="447"/>
-      <point x="861" y="243" type="curve" smooth="yes"/>
-      <point x="861" y="141"/>
-      <point x="888" y="52"/>
+      <point x="1500" y="596" type="curve" smooth="yes"/>
+      <point x="1269" y="596"/>
+      <point x="1088" y="381"/>
+      <point x="1088" y="186" type="curve" smooth="yes"/>
+      <point x="1088" y="63"/>
+      <point x="1156" y="-16"/>
+      <point x="1264" y="-16" type="curve" smooth="yes"/>
+      <point x="1416" y="-16"/>
+      <point x="1493" y="144"/>
+      <point x="1493" y="271" type="curve" smooth="yes"/>
+      <point x="1493" y="446"/>
+      <point x="1383" y="596"/>
+      <point x="1190" y="596" type="curve" smooth="yes"/>
+      <point x="973" y="596"/>
+      <point x="850" y="412"/>
+      <point x="850" y="234" type="curve" smooth="yes"/>
+      <point x="850" y="137"/>
+      <point x="875" y="59"/>
+    </contour>
+    <contour>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="696" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="902" y="270" type="line"/>
+      <point x="902" y="344" type="line"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
+    </contour>
+    <contour>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/k_tta-malayalam.glif
@@ -1,128 +1,119 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_tta-malayalam" format="2">
   <advance width="1035"/>
-  <anchor x="682" y="-351" name="bottom"/>
-  <anchor x="589" y="580" name="top"/>
-  <anchor x="929" y="540" name="topright"/>
+  <anchor x="727" y="-351" name="bottom"/>
+  <anchor x="583" y="580" name="top"/>
+  <anchor x="923" y="540" name="topright"/>
   <outline>
     <contour>
-      <point x="705" y="-365" type="curve" smooth="yes"/>
-      <point x="833" y="-365"/>
-      <point x="889" y="-312"/>
-      <point x="889" y="-235" type="curve" smooth="yes"/>
-      <point x="889" y="-172"/>
-      <point x="856" y="-131"/>
-      <point x="755" y="-125" type="curve" smooth="yes"/>
-      <point x="702" y="-122" type="line" smooth="yes"/>
-      <point x="644" y="-119"/>
-      <point x="619" y="-100"/>
-      <point x="619" y="-72" type="curve" smooth="yes"/>
-      <point x="619" y="-43"/>
-      <point x="649" y="-20"/>
-      <point x="730" y="-20" type="curve" smooth="yes"/>
-      <point x="791" y="-20"/>
-      <point x="840" y="-32"/>
-      <point x="881" y="-49" type="curve"/>
-      <point x="910" y="10" type="line"/>
-      <point x="867" y="30"/>
-      <point x="806" y="45"/>
-      <point x="736" y="45" type="curve" smooth="yes"/>
-      <point x="707" y="45"/>
-      <point x="680" y="42"/>
-      <point x="655" y="36" type="curve"/>
-      <point x="652" y="41" type="line"/>
-      <point x="728" y="115"/>
-      <point x="760" y="246"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="502"/>
-      <point x="705" y="596"/>
-      <point x="574" y="596" type="curve" smooth="yes"/>
-      <point x="436" y="596"/>
-      <point x="355" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="790" y="250" type="line" smooth="yes"/>
-      <point x="873" y="250"/>
-      <point x="908" y="214"/>
-      <point x="908" y="155" type="curve" smooth="yes"/>
-      <point x="908" y="109"/>
-      <point x="884" y="62"/>
-      <point x="812" y="62" type="curve" smooth="yes"/>
-      <point x="785" y="62"/>
-      <point x="767" y="66"/>
-      <point x="751" y="72" type="curve"/>
-      <point x="719" y="2" type="line"/>
-      <point x="742" y="-9"/>
-      <point x="770" y="-16"/>
-      <point x="807" y="-16" type="curve" smooth="yes"/>
-      <point x="931" y="-16"/>
-      <point x="990" y="65"/>
-      <point x="990" y="159" type="curve" smooth="yes"/>
-      <point x="990" y="256"/>
-      <point x="924" y="324"/>
-      <point x="791" y="324" type="curve" smooth="yes"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="432" y="-16"/>
-      <point x="511" y="-16" type="curve" smooth="yes"/>
-      <point x="529" y="-16"/>
-      <point x="548" y="-14"/>
-      <point x="563" y="-9" type="curve"/>
-      <point x="566" y="-14" type="line"/>
-      <point x="551" y="-34"/>
-      <point x="543" y="-57"/>
-      <point x="543" y="-85" type="curve" smooth="yes"/>
-      <point x="543" y="-141"/>
-      <point x="591" y="-187"/>
-      <point x="684" y="-192" type="curve" smooth="yes"/>
-      <point x="737" y="-195" type="line" smooth="yes"/>
-      <point x="809" y="-199"/>
-      <point x="814" y="-224"/>
-      <point x="814" y="-245" type="curve" smooth="yes"/>
-      <point x="814" y="-278"/>
-      <point x="786" y="-300"/>
-      <point x="705" y="-300" type="curve" smooth="yes"/>
-      <point x="630" y="-300"/>
-      <point x="575" y="-282"/>
-      <point x="534" y="-258" type="curve"/>
-      <point x="497" y="-314" type="line"/>
-      <point x="544" y="-345"/>
-      <point x="610" y="-365"/>
+      <point x="719" y="-367" type="curve" smooth="yes"/>
+      <point x="845" y="-367"/>
+      <point x="922" y="-316"/>
+      <point x="922" y="-236" type="curve" smooth="yes"/>
+      <point x="922" y="-178"/>
+      <point x="886" y="-139"/>
+      <point x="786" y="-127" type="curve" smooth="yes"/>
+      <point x="717" y="-119" type="line" smooth="yes"/>
+      <point x="676" y="-114"/>
+      <point x="656" y="-103"/>
+      <point x="656" y="-77" type="curve" smooth="yes"/>
+      <point x="656" y="-42"/>
+      <point x="701" y="-20"/>
+      <point x="780" y="-20" type="curve" smooth="yes"/>
+      <point x="834" y="-20"/>
+      <point x="876" y="-31"/>
+      <point x="917" y="-52" type="curve"/>
+      <point x="942" y="9" type="line"/>
+      <point x="928" y="16"/>
+      <point x="915" y="21"/>
+      <point x="896" y="26" type="curve"/>
+      <point x="897" y="33" type="line"/>
+      <point x="952" y="62"/>
+      <point x="987" y="116"/>
+      <point x="987" y="179" type="curve" smooth="yes"/>
+      <point x="987" y="281"/>
+      <point x="914" y="344"/>
+      <point x="795" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="690" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="781" y="270" type="line" smooth="yes"/>
+      <point x="863" y="270"/>
+      <point x="904" y="236"/>
+      <point x="904" y="168" type="curve" smooth="yes"/>
+      <point x="904" y="109"/>
+      <point x="867" y="62"/>
+      <point x="803" y="62" type="curve" smooth="yes"/>
+      <point x="782" y="62"/>
+      <point x="764" y="66"/>
+      <point x="746" y="75" type="curve"/>
+      <point x="721" y="19" type="line"/>
+      <point x="757" y="42" type="line"/>
+      <point x="657" y="37"/>
+      <point x="578" y="-15"/>
+      <point x="578" y="-87" type="curve" smooth="yes"/>
+      <point x="578" y="-145"/>
+      <point x="624" y="-179"/>
+      <point x="704" y="-188" type="curve" smooth="yes"/>
+      <point x="773" y="-196" type="line" smooth="yes"/>
+      <point x="832" y="-203"/>
+      <point x="844" y="-219"/>
+      <point x="844" y="-243" type="curve" smooth="yes"/>
+      <point x="844" y="-280"/>
+      <point x="799" y="-302"/>
+      <point x="724" y="-302" type="curve" smooth="yes"/>
+      <point x="664" y="-302"/>
+      <point x="611" y="-288"/>
+      <point x="564" y="-260" type="curve"/>
+      <point x="532" y="-324" type="line"/>
+      <point x="585" y="-353"/>
+      <point x="646" y="-367"/>
     </contour>
     <contour>
-      <point x="506" y="62" type="curve" smooth="yes"/>
-      <point x="433" y="62"/>
-      <point x="396" y="118"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="348"/>
-      <point x="438" y="518"/>
-      <point x="568" y="518" type="curve" smooth="yes"/>
-      <point x="647" y="518"/>
-      <point x="676" y="460"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="238"/>
-      <point x="635" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ka-malayalam.glif
@@ -2,80 +2,80 @@
 <glyph name="ka-malayalam" format="2">
   <advance width="1035"/>
   <unicode hex="0D15"/>
-  <anchor x="594" y="0" name="bottom"/>
-  <anchor x="589" y="580" name="top"/>
-  <anchor x="929" y="540" name="topright"/>
+  <anchor x="588" y="0" name="bottom"/>
+  <anchor x="583" y="580" name="top"/>
+  <anchor x="923" y="540" name="topright"/>
   <outline>
     <contour>
-      <point x="174" y="-16" type="curve" smooth="yes"/>
-      <point x="254" y="-16"/>
-      <point x="317" y="24"/>
-      <point x="342" y="91" type="curve"/>
-      <point x="347" y="91" type="line"/>
-      <point x="374" y="22"/>
-      <point x="431" y="-16"/>
-      <point x="509" y="-16" type="curve" smooth="yes"/>
-      <point x="660" y="-16"/>
-      <point x="760" y="140"/>
-      <point x="760" y="376" type="curve" smooth="yes"/>
-      <point x="760" y="515"/>
-      <point x="694" y="596"/>
-      <point x="579" y="596" type="curve" smooth="yes"/>
-      <point x="447" y="596"/>
-      <point x="354" y="496"/>
-      <point x="327" y="323" type="curve" smooth="yes"/>
-      <point x="318" y="267"/>
-      <point x="316" y="227"/>
-      <point x="312" y="204" type="curve" smooth="yes"/>
-      <point x="296" y="108"/>
-      <point x="254" y="62"/>
-      <point x="183" y="62" type="curve" smooth="yes"/>
-      <point x="126" y="62"/>
-      <point x="89" y="95"/>
-      <point x="89" y="147" type="curve" smooth="yes"/>
-      <point x="89" y="213"/>
-      <point x="135" y="250"/>
-      <point x="218" y="250" type="curve" smooth="yes"/>
-      <point x="790" y="250" type="line" smooth="yes"/>
-      <point x="868" y="250"/>
-      <point x="908" y="218"/>
-      <point x="908" y="155" type="curve" smooth="yes"/>
-      <point x="908" y="97"/>
-      <point x="872" y="62"/>
-      <point x="812" y="62" type="curve" smooth="yes"/>
-      <point x="788" y="62"/>
-      <point x="769" y="65"/>
-      <point x="751" y="72" type="curve"/>
-      <point x="719" y="2" type="line"/>
-      <point x="744" y="-10"/>
-      <point x="773" y="-16"/>
-      <point x="807" y="-16" type="curve" smooth="yes"/>
-      <point x="918" y="-16"/>
-      <point x="990" y="53"/>
-      <point x="990" y="159" type="curve" smooth="yes"/>
-      <point x="990" y="263"/>
-      <point x="916" y="324"/>
-      <point x="791" y="324" type="curve" smooth="yes"/>
-      <point x="223" y="324" type="line" smooth="yes"/>
-      <point x="88" y="324"/>
-      <point x="7" y="256"/>
-      <point x="7" y="143" type="curve" smooth="yes"/>
-      <point x="7" y="48"/>
-      <point x="75" y="-16"/>
+      <point x="160" y="-16" type="curve" smooth="yes"/>
+      <point x="227" y="-16"/>
+      <point x="286" y="22"/>
+      <point x="323" y="90" type="curve"/>
+      <point x="330" y="90" type="line"/>
+      <point x="354" y="24"/>
+      <point x="408" y="-16"/>
+      <point x="484" y="-16" type="curve" smooth="yes"/>
+      <point x="696" y="-16"/>
+      <point x="754" y="247"/>
+      <point x="754" y="389" type="curve" smooth="yes"/>
+      <point x="754" y="517"/>
+      <point x="693" y="596"/>
+      <point x="583" y="596" type="curve" smooth="yes"/>
+      <point x="446" y="596"/>
+      <point x="353" y="488"/>
+      <point x="321" y="305" type="curve" smooth="yes"/>
+      <point x="316" y="279"/>
+      <point x="312" y="233"/>
+      <point x="307" y="206" type="curve" smooth="yes"/>
+      <point x="291" y="113"/>
+      <point x="242" y="62"/>
+      <point x="173" y="62" type="curve" smooth="yes"/>
+      <point x="119" y="62"/>
+      <point x="88" y="91"/>
+      <point x="88" y="142" type="curve" smooth="yes"/>
+      <point x="88" y="217"/>
+      <point x="144" y="270"/>
+      <point x="245" y="270" type="curve" smooth="yes"/>
+      <point x="789" y="270" type="line" smooth="yes"/>
+      <point x="863" y="270"/>
+      <point x="900" y="238"/>
+      <point x="900" y="175" type="curve" smooth="yes"/>
+      <point x="900" y="108"/>
+      <point x="856" y="62"/>
+      <point x="792" y="62" type="curve" smooth="yes"/>
+      <point x="772" y="62"/>
+      <point x="755" y="64"/>
+      <point x="741" y="69" type="curve"/>
+      <point x="713" y="-4" type="line"/>
+      <point x="736" y="-12"/>
+      <point x="760" y="-16"/>
+      <point x="787" y="-16" type="curve" smooth="yes"/>
+      <point x="901" y="-16"/>
+      <point x="983" y="65"/>
+      <point x="983" y="178" type="curve" smooth="yes"/>
+      <point x="983" y="282"/>
+      <point x="914" y="344"/>
+      <point x="795" y="344" type="curve" smooth="yes"/>
+      <point x="249" y="344" type="line" smooth="yes"/>
+      <point x="85" y="344"/>
+      <point x="5" y="250"/>
+      <point x="5" y="134" type="curve" smooth="yes"/>
+      <point x="5" y="46"/>
+      <point x="65" y="-16"/>
     </contour>
     <contour>
-      <point x="511" y="62" type="curve" smooth="yes"/>
-      <point x="436" y="62"/>
-      <point x="396" y="116"/>
-      <point x="396" y="217" type="curve" smooth="yes"/>
-      <point x="396" y="408"/>
-      <point x="464" y="518"/>
-      <point x="572" y="518" type="curve" smooth="yes"/>
-      <point x="642" y="518"/>
-      <point x="676" y="468"/>
-      <point x="676" y="363" type="curve" smooth="yes"/>
-      <point x="676" y="186"/>
-      <point x="608" y="62"/>
+      <point x="490" y="62" type="curve" smooth="yes"/>
+      <point x="423" y="62"/>
+      <point x="390" y="106"/>
+      <point x="390" y="191" type="curve" smooth="yes"/>
+      <point x="390" y="296"/>
+      <point x="426" y="518"/>
+      <point x="575" y="518" type="curve" smooth="yes"/>
+      <point x="639" y="518"/>
+      <point x="671" y="476"/>
+      <point x="671" y="390" type="curve" smooth="yes"/>
+      <point x="671" y="297"/>
+      <point x="629" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/m_la-malayalam.glif
@@ -1,53 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="m_la-malayalam" format="2">
   <advance width="668"/>
-  <anchor x="248" y="-351" name="bottom"/>
+  <anchor x="235" y="-351" name="bottom"/>
   <anchor x="394" y="580" name="top"/>
   <anchor x="624" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="26" y="-367" type="curve" smooth="yes"/>
-      <point x="111" y="-367"/>
-      <point x="163" y="-313"/>
-      <point x="163" y="-228" type="curve" smooth="yes"/>
-      <point x="163" y="-154"/>
-      <point x="123" y="-118"/>
-      <point x="54" y="-118" type="curve" smooth="yes"/>
-      <point x="22" y="-118"/>
-      <point x="-16" y="-131"/>
-      <point x="-42" y="-164" type="curve"/>
-      <point x="-48" y="-163" type="line"/>
-      <point x="-28" y="-78"/>
-      <point x="29" y="-27"/>
-      <point x="116" y="-27" type="curve" smooth="yes"/>
-      <point x="221" y="-27"/>
-      <point x="248" y="-86"/>
-      <point x="253" y="-174" type="curve" smooth="yes"/>
-      <point x="254" y="-192" type="line" smooth="yes"/>
-      <point x="260" y="-303"/>
-      <point x="310" y="-367"/>
-      <point x="420" y="-367" type="curve" smooth="yes"/>
-      <point x="549" y="-367"/>
-      <point x="604" y="-271"/>
-      <point x="604" y="-131" type="curve" smooth="yes"/>
-      <point x="604" y="-58"/>
-      <point x="585" y="1"/>
-      <point x="555" y="43" type="curve"/>
-      <point x="492" y="5" type="line"/>
-      <point x="514" y="-33"/>
-      <point x="529" y="-82"/>
-      <point x="529" y="-139" type="curve" smooth="yes"/>
-      <point x="529" y="-226"/>
-      <point x="501" y="-297"/>
-      <point x="422" y="-297" type="curve" smooth="yes"/>
-      <point x="362" y="-297"/>
-      <point x="337" y="-265"/>
-      <point x="329" y="-174" type="curve" smooth="yes"/>
-      <point x="327" y="-151" type="line" smooth="yes"/>
-      <point x="322" y="-88"/>
-      <point x="309" y="-37"/>
-      <point x="268" y="-5" type="curve"/>
-      <point x="269" y="0" type="line"/>
+      <point x="0" y="0" type="line"/>
       <point x="566" y="0" type="line"/>
       <point x="614" y="266" type="line" smooth="yes"/>
       <point x="619" y="292"/>
@@ -59,30 +18,75 @@
       <point x="205" y="596"/>
       <point x="88" y="499"/>
       <point x="59" y="333" type="curve" smooth="yes"/>
-      <point x="0" y="0" type="line"/>
-      <point x="26" y="0" type="line"/>
-      <point x="28" y="27" type="line"/>
-      <point x="-64" y="-8"/>
-      <point x="-120" y="-97"/>
-      <point x="-120" y="-210" type="curve" smooth="yes"/>
-      <point x="-120" y="-316"/>
-      <point x="-56" y="-367"/>
     </contour>
     <contour>
-      <point x="26" y="-302" type="curve" smooth="yes"/>
-      <point x="-29" y="-302"/>
-      <point x="-52" y="-264"/>
-      <point x="-52" y="-218" type="curve"/>
-      <point x="-71" y="-197" type="line"/>
-      <point x="-60" y="-253" type="line"/>
-      <point x="-52" y="-213"/>
-      <point x="-19" y="-178"/>
-      <point x="30" y="-178" type="curve" smooth="yes"/>
-      <point x="72" y="-178"/>
-      <point x="92" y="-199"/>
-      <point x="92" y="-233" type="curve" smooth="yes"/>
-      <point x="92" y="-276"/>
-      <point x="68" y="-302"/>
+      <point x="79" y="-367" type="curve" smooth="yes"/>
+      <point x="179" y="-367"/>
+      <point x="222" y="-288"/>
+      <point x="222" y="-218" type="curve" smooth="yes"/>
+      <point x="222" y="-154"/>
+      <point x="187" y="-109"/>
+      <point x="127" y="-109" type="curve" smooth="yes"/>
+      <point x="65" y="-109"/>
+      <point x="13" y="-154"/>
+      <point x="1" y="-220" type="curve"/>
+      <point x="28" y="-176" type="line"/>
+      <point x="2" y="-170" type="line"/>
+      <point x="9" y="-198" type="line"/>
+      <point x="28" y="-90"/>
+      <point x="87" y="-23"/>
+      <point x="179" y="-23" type="curve" smooth="yes"/>
+      <point x="252" y="-23"/>
+      <point x="279" y="-62"/>
+      <point x="279" y="-146" type="curve" smooth="yes"/>
+      <point x="279" y="-219" type="line" smooth="yes"/>
+      <point x="279" y="-314"/>
+      <point x="328" y="-367"/>
+      <point x="407" y="-367" type="curve" smooth="yes"/>
+      <point x="526" y="-367"/>
+      <point x="557" y="-252"/>
+      <point x="557" y="-163" type="curve" smooth="yes"/>
+      <point x="557" y="-83"/>
+      <point x="534" y="-15"/>
+      <point x="490" y="48" type="curve"/>
+      <point x="432" y="9" type="line"/>
+      <point x="468" y="-43"/>
+      <point x="485" y="-98"/>
+      <point x="485" y="-159" type="curve" smooth="yes"/>
+      <point x="485" y="-219"/>
+      <point x="475" y="-297"/>
+      <point x="410" y="-297" type="curve" smooth="yes"/>
+      <point x="371" y="-297"/>
+      <point x="351" y="-269"/>
+      <point x="351" y="-217" type="curve" smooth="yes"/>
+      <point x="351" y="-144" type="line" smooth="yes"/>
+      <point x="351" y="-30"/>
+      <point x="305" y="37"/>
+      <point x="188" y="37" type="curve" smooth="yes"/>
+      <point x="39" y="37"/>
+      <point x="-55" y="-85"/>
+      <point x="-55" y="-222" type="curve" smooth="yes"/>
+      <point x="-55" y="-307"/>
+      <point x="-1" y="-367"/>
+    </contour>
+    <contour>
+      <point x="81" y="-303" type="curve" smooth="yes"/>
+      <point x="38" y="-303"/>
+      <point x="11" y="-271"/>
+      <point x="11" y="-230" type="curve" smooth="yes"/>
+      <point x="11" y="-220"/>
+      <point x="13" y="-210"/>
+      <point x="16" y="-200" type="curve"/>
+      <point x="-7" y="-205" type="line"/>
+      <point x="4" y="-257" type="line"/>
+      <point x="16" y="-198"/>
+      <point x="56" y="-167"/>
+      <point x="98" y="-167" type="curve" smooth="yes"/>
+      <point x="134" y="-167"/>
+      <point x="152" y="-189"/>
+      <point x="152" y="-224" type="curve" smooth="yes"/>
+      <point x="152" y="-264"/>
+      <point x="128" y="-303"/>
     </contour>
     <contour>
       <point x="58" y="45" type="line"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ng_ka-malayalam.glif
@@ -1,103 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng_ka-malayalam" format="2">
   <advance width="1040"/>
-  <anchor x="610" y="0" name="bottom"/>
-  <anchor x="596" y="580" name="top"/>
-  <anchor x="917" y="580" name="topright"/>
+  <anchor x="604" y="0" name="bottom"/>
+  <anchor x="590" y="580" name="top"/>
+  <anchor x="911" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="181" y="-16" type="curve" smooth="yes"/>
-      <point x="267" y="-16"/>
-      <point x="323" y="30"/>
-      <point x="346" y="91" type="curve"/>
-      <point x="351" y="91" type="line"/>
-      <point x="379" y="18"/>
-      <point x="437" y="-16"/>
-      <point x="515" y="-16" type="curve" smooth="yes"/>
-      <point x="692" y="-16"/>
-      <point x="764" y="182"/>
-      <point x="764" y="376" type="curve" smooth="yes"/>
-      <point x="764" y="502"/>
-      <point x="708" y="596"/>
-      <point x="582" y="596" type="curve" smooth="yes"/>
-      <point x="506" y="596"/>
-      <point x="440" y="560"/>
-      <point x="402" y="486" type="curve"/>
-      <point x="397" y="486" type="line"/>
-      <point x="381" y="549"/>
-      <point x="334" y="596"/>
-      <point x="242" y="596" type="curve" smooth="yes"/>
-      <point x="133" y="596"/>
-      <point x="70" y="524"/>
-      <point x="70" y="434" type="curve" smooth="yes"/>
-      <point x="70" y="376"/>
-      <point x="95" y="328"/>
-      <point x="142" y="303" type="curve"/>
-      <point x="142" y="298" type="line"/>
-      <point x="62" y="283"/>
-      <point x="11" y="224"/>
-      <point x="11" y="140" type="curve" smooth="yes"/>
-      <point x="11" y="40"/>
-      <point x="80" y="-16"/>
+      <point x="164" y="-16" type="curve" smooth="yes"/>
+      <point x="235" y="-16"/>
+      <point x="293" y="20"/>
+      <point x="332" y="90" type="curve"/>
+      <point x="337" y="90" type="line"/>
+      <point x="360" y="23"/>
+      <point x="413" y="-16"/>
+      <point x="489" y="-16" type="curve" smooth="yes"/>
+      <point x="701" y="-16"/>
+      <point x="759" y="247"/>
+      <point x="759" y="389" type="curve" smooth="yes"/>
+      <point x="759" y="517"/>
+      <point x="698" y="596"/>
+      <point x="588" y="596" type="curve" smooth="yes"/>
+      <point x="510" y="596"/>
+      <point x="442" y="557"/>
+      <point x="400" y="481" type="curve"/>
+      <point x="395" y="481" type="line"/>
+      <point x="380" y="551"/>
+      <point x="336" y="596"/>
+      <point x="253" y="596" type="curve" smooth="yes"/>
+      <point x="138" y="596"/>
+      <point x="67" y="518"/>
+      <point x="67" y="432" type="curve" smooth="yes"/>
+      <point x="67" y="378"/>
+      <point x="97" y="336"/>
+      <point x="141" y="314" type="curve"/>
+      <point x="140" y="309" type="line"/>
+      <point x="52" y="279"/>
+      <point x="9" y="207"/>
+      <point x="9" y="134" type="curve" smooth="yes"/>
+      <point x="9" y="45"/>
+      <point x="72" y="-16"/>
     </contour>
     <contour>
-      <point x="510" y="62" type="curve" smooth="yes"/>
-      <point x="437" y="62"/>
-      <point x="400" y="118"/>
-      <point x="400" y="217" type="curve" smooth="yes"/>
-      <point x="400" y="348"/>
-      <point x="442" y="518"/>
-      <point x="570" y="518" type="curve" smooth="yes"/>
-      <point x="651" y="518"/>
-      <point x="680" y="460"/>
-      <point x="680" y="363" type="curve" smooth="yes"/>
-      <point x="680" y="238"/>
-      <point x="639" y="62"/>
+      <point x="792" y="-16" type="curve" smooth="yes"/>
+      <point x="906" y="-16"/>
+      <point x="988" y="65"/>
+      <point x="988" y="178" type="curve" smooth="yes"/>
+      <point x="988" y="282"/>
+      <point x="919" y="344"/>
+      <point x="800" y="344" type="curve" smooth="yes"/>
+      <point x="247" y="344" type="line" smooth="yes"/>
+      <point x="185" y="344"/>
+      <point x="147" y="375"/>
+      <point x="147" y="425" type="curve" smooth="yes"/>
+      <point x="147" y="475"/>
+      <point x="186" y="518"/>
+      <point x="255" y="518" type="curve" smooth="yes"/>
+      <point x="318" y="518"/>
+      <point x="345" y="483"/>
+      <point x="345" y="424" type="curve" smooth="yes"/>
+      <point x="345" y="407"/>
+      <point x="343" y="388"/>
+      <point x="339" y="366" type="curve" smooth="yes"/>
+      <point x="311" y="206" type="line" smooth="yes"/>
+      <point x="295" y="115"/>
+      <point x="249" y="62"/>
+      <point x="179" y="62" type="curve" smooth="yes"/>
+      <point x="121" y="62"/>
+      <point x="91" y="92"/>
+      <point x="91" y="144" type="curve" smooth="yes"/>
+      <point x="91" y="215"/>
+      <point x="147" y="270"/>
+      <point x="239" y="270" type="curve" smooth="yes"/>
+      <point x="794" y="270" type="line" smooth="yes"/>
+      <point x="868" y="270"/>
+      <point x="905" y="238"/>
+      <point x="905" y="175" type="curve" smooth="yes"/>
+      <point x="905" y="108"/>
+      <point x="861" y="62"/>
+      <point x="797" y="62" type="curve" smooth="yes"/>
+      <point x="777" y="62"/>
+      <point x="760" y="64"/>
+      <point x="746" y="69" type="curve"/>
+      <point x="718" y="-4" type="line"/>
+      <point x="741" y="-12"/>
+      <point x="765" y="-16"/>
     </contour>
     <contour>
-      <point x="811" y="-16" type="curve" smooth="yes"/>
-      <point x="935" y="-16"/>
-      <point x="994" y="65"/>
-      <point x="994" y="159" type="curve" smooth="yes"/>
-      <point x="994" y="256"/>
-      <point x="928" y="324"/>
-      <point x="795" y="324" type="curve" smooth="yes"/>
-      <point x="278" y="324" type="line" smooth="yes"/>
-      <point x="188" y="324"/>
-      <point x="151" y="370"/>
-      <point x="151" y="425" type="curve" smooth="yes"/>
-      <point x="151" y="476"/>
-      <point x="185" y="518"/>
-      <point x="251" y="518" type="curve" smooth="yes"/>
-      <point x="315" y="518"/>
-      <point x="348" y="476"/>
-      <point x="348" y="409" type="curve" smooth="yes"/>
-      <point x="348" y="392"/>
-      <point x="346" y="374"/>
-      <point x="343" y="354" type="curve" smooth="yes"/>
-      <point x="317" y="204" type="line" smooth="yes"/>
-      <point x="302" y="116"/>
-      <point x="262" y="62"/>
-      <point x="182" y="62" type="curve" smooth="yes"/>
-      <point x="135" y="62"/>
-      <point x="94" y="89"/>
-      <point x="94" y="149" type="curve" smooth="yes"/>
-      <point x="94" y="210"/>
-      <point x="133" y="250"/>
-      <point x="222" y="250" type="curve" smooth="yes"/>
-      <point x="794" y="250" type="line" smooth="yes"/>
-      <point x="877" y="250"/>
-      <point x="912" y="214"/>
-      <point x="912" y="155" type="curve" smooth="yes"/>
-      <point x="912" y="109"/>
-      <point x="888" y="62"/>
-      <point x="816" y="62" type="curve" smooth="yes"/>
-      <point x="789" y="62"/>
-      <point x="771" y="66"/>
-      <point x="755" y="72" type="curve"/>
-      <point x="723" y="2" type="line"/>
-      <point x="746" y="-9"/>
-      <point x="774" y="-16"/>
+      <point x="495" y="62" type="curve" smooth="yes"/>
+      <point x="428" y="62"/>
+      <point x="395" y="106"/>
+      <point x="395" y="191" type="curve" smooth="yes"/>
+      <point x="395" y="296"/>
+      <point x="431" y="518"/>
+      <point x="580" y="518" type="curve" smooth="yes"/>
+      <point x="644" y="518"/>
+      <point x="676" y="476"/>
+      <point x="676" y="390" type="curve" smooth="yes"/>
+      <point x="676" y="297"/>
+      <point x="634" y="62"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,192 +1,193 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1518"/>
-  <anchor x="1084" y="0" name="bottom"/>
-  <anchor x="847" y="580" name="top"/>
-  <anchor x="1454" y="580" name="topright"/>
+  <advance width="1560"/>
+  <anchor x="1099" y="0" name="bottom"/>
+  <anchor x="831" y="580" name="top"/>
+  <anchor x="1470" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="244" y="-16" type="curve" smooth="yes"/>
-      <point x="353" y="-16"/>
-      <point x="429" y="67"/>
+      <point x="232" y="-16" type="curve" smooth="yes"/>
+      <point x="386" y="-16"/>
+      <point x="429" y="111"/>
       <point x="429" y="187" type="curve" smooth="yes"/>
-      <point x="429" y="277"/>
-      <point x="368" y="336"/>
-      <point x="273" y="336" type="curve" smooth="yes"/>
-      <point x="217" y="336"/>
-      <point x="166" y="314"/>
+      <point x="429" y="284"/>
+      <point x="374" y="347"/>
+      <point x="275" y="347" type="curve" smooth="yes"/>
+      <point x="218" y="347"/>
+      <point x="167" y="321"/>
       <point x="128" y="275" type="curve"/>
       <point x="98" y="283" type="line"/>
       <point x="98" y="143" type="line"/>
-      <point x="127" y="219"/>
-      <point x="186" y="267"/>
-      <point x="252" y="267" type="curve" smooth="yes"/>
-      <point x="311" y="267"/>
-      <point x="346" y="235"/>
+      <point x="128" y="223"/>
+      <point x="189" y="273"/>
+      <point x="257" y="273" type="curve" smooth="yes"/>
+      <point x="316" y="273"/>
+      <point x="346" y="239"/>
       <point x="346" y="181" type="curve" smooth="yes"/>
-      <point x="346" y="109"/>
-      <point x="306" y="62"/>
-      <point x="243" y="62" type="curve" smooth="yes"/>
-      <point x="161" y="62"/>
-      <point x="120" y="120"/>
-      <point x="120" y="225" type="curve" smooth="yes"/>
-      <point x="120" y="399"/>
-      <point x="219" y="518"/>
-      <point x="364" y="518" type="curve" smooth="yes"/>
-      <point x="477" y="518"/>
-      <point x="534" y="457"/>
-      <point x="534" y="360" type="curve" smooth="yes"/>
-      <point x="534" y="343"/>
-      <point x="531" y="314"/>
-      <point x="526" y="285" type="curve" smooth="yes"/>
-      <point x="476" y="0" type="line"/>
-      <point x="560" y="0" type="line"/>
-      <point x="619" y="336" type="line" smooth="yes"/>
-      <point x="641" y="459"/>
-      <point x="711" y="529"/>
-      <point x="830" y="529" type="curve" smooth="yes"/>
-      <point x="842" y="529"/>
-      <point x="847" y="529"/>
-      <point x="863" y="527" type="curve"/>
-      <point x="839" y="572" type="line"/>
-      <point x="842" y="523" type="line"/>
-      <point x="804" y="501"/>
-      <point x="779" y="460"/>
-      <point x="779" y="421" type="curve" smooth="yes"/>
-      <point x="779" y="352"/>
-      <point x="831" y="310"/>
-      <point x="915" y="310" type="curve" smooth="yes"/>
-      <point x="995" y="310"/>
-      <point x="1061" y="353"/>
-      <point x="1061" y="433" type="curve" smooth="yes"/>
-      <point x="1061" y="468"/>
-      <point x="1045" y="507"/>
-      <point x="995" y="534" type="curve"/>
-      <point x="1007" y="581" type="line"/>
-      <point x="955" y="538" type="line"/>
-      <point x="970" y="540"/>
-      <point x="975" y="540"/>
-      <point x="982" y="540" type="curve" smooth="yes"/>
-      <point x="1078" y="540"/>
-      <point x="1115" y="494"/>
-      <point x="1115" y="411" type="curve" smooth="yes"/>
-      <point x="1115" y="394"/>
-      <point x="1112" y="373"/>
-      <point x="1109" y="354" type="curve" smooth="yes"/>
-      <point x="1107" y="343" type="line"/>
-      <point x="1191" y="343" type="line"/>
-      <point x="1199" y="387" type="line" smooth="yes"/>
-      <point x="1214" y="470"/>
-      <point x="1261" y="518"/>
-      <point x="1330" y="518" type="curve" smooth="yes"/>
-      <point x="1394" y="518"/>
-      <point x="1424" y="486"/>
-      <point x="1424" y="423" type="curve" smooth="yes"/>
-      <point x="1424" y="336"/>
-      <point x="1365" y="287"/>
-      <point x="1260" y="287" type="curve" smooth="yes"/>
-      <point x="931" y="287" type="line" smooth="yes"/>
-      <point x="807" y="287"/>
-      <point x="733" y="225"/>
-      <point x="733" y="120" type="curve" smooth="yes"/>
-      <point x="733" y="34"/>
-      <point x="781" y="-16"/>
-      <point x="862" y="-16" type="curve" smooth="yes"/>
-      <point x="921" y="-16"/>
-      <point x="969" y="0"/>
-      <point x="1071" y="54" type="curve" smooth="yes"/>
-      <point x="1141" y="91" type="line"/>
-      <point x="1253" y="152" type="line"/>
-      <point x="1262" y="151" type="line"/>
-      <point x="1291" y="164"/>
-      <point x="1309" y="167"/>
-      <point x="1328" y="167" type="curve" smooth="yes"/>
-      <point x="1363" y="167"/>
-      <point x="1380" y="149"/>
-      <point x="1380" y="114" type="curve" smooth="yes"/>
-      <point x="1380" y="73"/>
-      <point x="1357" y="48"/>
-      <point x="1318" y="48" type="curve" smooth="yes"/>
-      <point x="1285" y="48"/>
-      <point x="1265" y="67"/>
-      <point x="1265" y="99" type="curve" smooth="yes"/>
-      <point x="1265" y="131"/>
-      <point x="1280" y="159"/>
-      <point x="1312" y="185" type="curve"/>
-      <point x="1188" y="161" type="line"/>
-      <point x="1229" y="102" type="line"/>
-      <point x="1237" y="156" type="line"/>
-      <point x="1216" y="135"/>
-      <point x="1205" y="109"/>
-      <point x="1205" y="80" type="curve" smooth="yes"/>
-      <point x="1205" y="22"/>
-      <point x="1248" y="-16"/>
-      <point x="1315" y="-16" type="curve" smooth="yes"/>
-      <point x="1397" y="-16"/>
-      <point x="1447" y="35"/>
-      <point x="1447" y="121" type="curve" smooth="yes"/>
-      <point x="1447" y="189"/>
-      <point x="1405" y="233"/>
-      <point x="1340" y="233" type="curve" smooth="yes"/>
-      <point x="1294" y="233"/>
-      <point x="1255" y="220"/>
-      <point x="1135" y="162" type="curve" smooth="yes"/>
-      <point x="1052" y="122" type="line" smooth="yes"/>
-      <point x="941" y="68"/>
-      <point x="920" y="61"/>
-      <point x="877" y="61" type="curve" smooth="yes"/>
-      <point x="837" y="61"/>
-      <point x="813" y="86"/>
-      <point x="813" y="126" type="curve" smooth="yes"/>
-      <point x="813" y="184"/>
-      <point x="853" y="215"/>
-      <point x="928" y="215" type="curve" smooth="yes"/>
-      <point x="1256" y="215" type="line" smooth="yes"/>
-      <point x="1404" y="215"/>
-      <point x="1508" y="301"/>
-      <point x="1508" y="423" type="curve" smooth="yes"/>
-      <point x="1508" y="529"/>
-      <point x="1447" y="596"/>
-      <point x="1341" y="596" type="curve" smooth="yes"/>
-      <point x="1267" y="596"/>
-      <point x="1201" y="563"/>
-      <point x="1170" y="478" type="curve"/>
-      <point x="1165" y="478" type="line"/>
-      <point x="1146" y="560"/>
-      <point x="1094" y="596"/>
-      <point x="998" y="596" type="curve" smooth="yes"/>
-      <point x="934" y="596"/>
-      <point x="890" y="575"/>
-      <point x="873" y="564" type="curve"/>
-      <point x="881" y="528" type="line"/>
-      <point x="960" y="526"/>
-      <point x="986" y="485"/>
-      <point x="986" y="444" type="curve" smooth="yes"/>
-      <point x="986" y="410"/>
-      <point x="963" y="380"/>
-      <point x="918" y="380" type="curve" smooth="yes"/>
-      <point x="882" y="380"/>
-      <point x="854" y="398"/>
-      <point x="854" y="439" type="curve" smooth="yes"/>
-      <point x="854" y="469"/>
-      <point x="880" y="520"/>
-      <point x="953" y="528" type="curve"/>
-      <point x="953" y="571" type="line"/>
-      <point x="921" y="586"/>
-      <point x="883" y="596"/>
+      <point x="346" y="130"/>
+      <point x="318" y="62"/>
+      <point x="238" y="62" type="curve" smooth="yes"/>
+      <point x="162" y="62"/>
+      <point x="119" y="120"/>
+      <point x="119" y="225" type="curve" smooth="yes"/>
+      <point x="119" y="379"/>
+      <point x="200" y="518"/>
+      <point x="370" y="518" type="curve" smooth="yes"/>
+      <point x="472" y="518"/>
+      <point x="528" y="465"/>
+      <point x="528" y="369" type="curve" smooth="yes"/>
+      <point x="528" y="350"/>
+      <point x="525" y="318"/>
+      <point x="519" y="285" type="curve" smooth="yes"/>
+      <point x="469" y="0" type="line"/>
+      <point x="553" y="0" type="line"/>
+      <point x="609" y="319" type="line" smooth="yes"/>
+      <point x="633" y="454"/>
+      <point x="713" y="529"/>
+      <point x="833" y="529" type="curve" smooth="yes"/>
+      <point x="851" y="529"/>
+      <point x="864" y="528"/>
+      <point x="881" y="525" type="curve"/>
+      <point x="839" y="544" type="line"/>
+      <point x="838" y="523" type="line"/>
+      <point x="793" y="498"/>
+      <point x="769" y="456"/>
+      <point x="769" y="408" type="curve" smooth="yes"/>
+      <point x="769" y="338"/>
+      <point x="823" y="287"/>
+      <point x="903" y="287" type="curve" smooth="yes"/>
+      <point x="1020" y="287"/>
+      <point x="1056" y="369"/>
+      <point x="1056" y="424" type="curve" smooth="yes"/>
+      <point x="1056" y="465"/>
+      <point x="1039" y="503"/>
+      <point x="1003" y="530" type="curve"/>
+      <point x="1018" y="564" type="line"/>
+      <point x="979" y="534" type="line"/>
+      <point x="986" y="535"/>
+      <point x="998" y="536"/>
+      <point x="1010" y="536" type="curve" smooth="yes"/>
+      <point x="1085" y="536"/>
+      <point x="1124" y="497"/>
+      <point x="1124" y="425" type="curve" smooth="yes"/>
+      <point x="1124" y="409"/>
+      <point x="1122" y="392"/>
+      <point x="1119" y="375" type="curve" smooth="yes"/>
+      <point x="1110" y="324" type="line"/>
+      <point x="1194" y="324" type="line"/>
+      <point x="1203" y="375" type="line" smooth="yes"/>
+      <point x="1218" y="464"/>
+      <point x="1275" y="518"/>
+      <point x="1355" y="518" type="curve" smooth="yes"/>
+      <point x="1421" y="518"/>
+      <point x="1457" y="484"/>
+      <point x="1457" y="422" type="curve" smooth="yes"/>
+      <point x="1457" y="321"/>
+      <point x="1381" y="267"/>
+      <point x="1258" y="267" type="curve" smooth="yes"/>
+      <point x="915" y="267" type="line" smooth="yes"/>
+      <point x="778" y="267"/>
+      <point x="725" y="184"/>
+      <point x="725" y="115" type="curve" smooth="yes"/>
+      <point x="725" y="39"/>
+      <point x="783" y="-16"/>
+      <point x="868" y="-16" type="curve" smooth="yes"/>
+      <point x="915" y="-16"/>
+      <point x="952" y="-4"/>
+      <point x="1038" y="35" type="curve" smooth="yes"/>
+      <point x="1166" y="93" type="line"/>
+      <point x="1241" y="141" type="line"/>
+      <point x="1278" y="153" type="line"/>
+      <point x="1306" y="170"/>
+      <point x="1326" y="176"/>
+      <point x="1355" y="176" type="curve" smooth="yes"/>
+      <point x="1391" y="176"/>
+      <point x="1412" y="155"/>
+      <point x="1412" y="121" type="curve" smooth="yes"/>
+      <point x="1412" y="91"/>
+      <point x="1391" y="54"/>
+      <point x="1339" y="54" type="curve" smooth="yes"/>
+      <point x="1302" y="54"/>
+      <point x="1281" y="74"/>
+      <point x="1281" y="110" type="curve" smooth="yes"/>
+      <point x="1281" y="134"/>
+      <point x="1291" y="159"/>
+      <point x="1312" y="180" type="curve"/>
+      <point x="1220" y="145" type="line"/>
+      <point x="1236" y="131" type="line"/>
+      <point x="1229" y="117"/>
+      <point x="1225" y="101"/>
+      <point x="1225" y="85" type="curve" smooth="yes"/>
+      <point x="1225" y="24"/>
+      <point x="1267" y="-16"/>
+      <point x="1336" y="-16" type="curve" smooth="yes"/>
+      <point x="1440" y="-16"/>
+      <point x="1484" y="67"/>
+      <point x="1484" y="125" type="curve" smooth="yes"/>
+      <point x="1484" y="189"/>
+      <point x="1444" y="236"/>
+      <point x="1370" y="236" type="curve" smooth="yes"/>
+      <point x="1331" y="236"/>
+      <point x="1285" y="221"/>
+      <point x="1205" y="185" type="curve" smooth="yes"/>
+      <point x="1017" y="100" type="line" smooth="yes"/>
+      <point x="956" y="72"/>
+      <point x="919" y="60"/>
+      <point x="879" y="60" type="curve" smooth="yes"/>
+      <point x="833" y="60"/>
+      <point x="807" y="85"/>
+      <point x="807" y="121" type="curve" smooth="yes"/>
+      <point x="807" y="158"/>
+      <point x="835" y="195"/>
+      <point x="911" y="195" type="curve" smooth="yes"/>
+      <point x="1233" y="195" type="line" smooth="yes"/>
+      <point x="1403" y="195"/>
+      <point x="1540" y="283"/>
+      <point x="1540" y="436" type="curve" smooth="yes"/>
+      <point x="1540" y="532"/>
+      <point x="1484" y="596"/>
+      <point x="1376" y="596" type="curve" smooth="yes"/>
+      <point x="1289" y="596"/>
+      <point x="1219" y="552"/>
+      <point x="1182" y="475" type="curve"/>
+      <point x="1177" y="475" type="line"/>
+      <point x="1165" y="552"/>
+      <point x="1112" y="596"/>
+      <point x="1014" y="596" type="curve" smooth="yes"/>
+      <point x="980" y="596"/>
+      <point x="941" y="589"/>
+      <point x="910" y="575" type="curve"/>
+      <point x="943" y="575" type="line"/>
+      <point x="912" y="589"/>
+      <point x="877" y="596"/>
       <point x="835" y="596" type="curve" smooth="yes"/>
-      <point x="721" y="596"/>
-      <point x="641" y="554"/>
-      <point x="590" y="470" type="curve"/>
-      <point x="585" y="470" type="line"/>
-      <point x="547" y="556"/>
-      <point x="472" y="596"/>
-      <point x="365" y="596" type="curve" smooth="yes"/>
-      <point x="173" y="596"/>
-      <point x="38" y="442"/>
-      <point x="38" y="223" type="curve" smooth="yes"/>
-      <point x="38" y="77"/>
-      <point x="115" y="-16"/>
+      <point x="722" y="596"/>
+      <point x="640" y="547"/>
+      <point x="591" y="464" type="curve"/>
+      <point x="586" y="464" type="line"/>
+      <point x="552" y="549"/>
+      <point x="484" y="596"/>
+      <point x="374" y="596" type="curve" smooth="yes"/>
+      <point x="145" y="596"/>
+      <point x="37" y="402"/>
+      <point x="37" y="223" type="curve" smooth="yes"/>
+      <point x="37" y="77"/>
+      <point x="114" y="-16"/>
+    </contour>
+    <contour>
+      <point x="909" y="357" type="curve" smooth="yes"/>
+      <point x="869" y="357"/>
+      <point x="846" y="380"/>
+      <point x="846" y="418" type="curve" smooth="yes"/>
+      <point x="846" y="473"/>
+      <point x="896" y="519"/>
+      <point x="963" y="536" type="curve"/>
+      <point x="895" y="536" type="line"/>
+      <point x="954" y="517"/>
+      <point x="982" y="483"/>
+      <point x="982" y="433" type="curve" smooth="yes"/>
+      <point x="982" y="394"/>
+      <point x="955" y="357"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/oo-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/oo-malayalam.glif
@@ -4,7 +4,7 @@
   <unicode hex="0D13"/>
   <outline>
     <component base="o-malayalam"/>
-    <component base="aaMatra-malayalam" xOffset="793"/>
+    <component base="aaMatra-malayalam" xOffset="780"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/rr_rra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/rr_rra-malayalam.glif
@@ -1,38 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="rr_rra-malayalam" format="2">
-  <advance width="695"/>
+  <advance width="696"/>
   <anchor x="254" y="-311" name="bottom"/>
   <anchor x="404" y="580" name="top"/>
   <anchor x="612" y="580" name="topright"/>
   <outline>
-    <contour>
-      <point x="149" y="-327" type="curve"/>
-      <point x="206" y="-278" type="line"/>
-      <point x="184" y="-252"/>
-      <point x="160" y="-215"/>
-      <point x="160" y="-144" type="curve" smooth="yes"/>
-      <point x="160" y="-57"/>
-      <point x="207" y="13"/>
-      <point x="306" y="13" type="curve" smooth="yes"/>
-      <point x="384" y="13"/>
-      <point x="431" y="-25"/>
-      <point x="431" y="-106" type="curve" smooth="yes"/>
-      <point x="431" y="-190"/>
-      <point x="385" y="-228"/>
-      <point x="329" y="-275" type="curve"/>
-      <point x="375" y="-327" type="line"/>
-      <point x="456" y="-266"/>
-      <point x="506" y="-198"/>
-      <point x="506" y="-102" type="curve" smooth="yes"/>
-      <point x="506" y="24"/>
-      <point x="429" y="83"/>
-      <point x="308" y="83" type="curve" smooth="yes"/>
-      <point x="163" y="83"/>
-      <point x="84" y="-12"/>
-      <point x="84" y="-148" type="curve" smooth="yes"/>
-      <point x="84" y="-223"/>
-      <point x="108" y="-283"/>
-    </contour>
     <contour>
       <point x="165" y="-16" type="curve"/>
       <point x="222" y="44" type="line"/>
@@ -60,6 +32,34 @@
       <point x="43" y="258" type="curve" smooth="yes"/>
       <point x="43" y="151"/>
       <point x="85" y="56"/>
+    </contour>
+    <contour>
+      <point x="149" y="-327" type="curve"/>
+      <point x="206" y="-278" type="line"/>
+      <point x="184" y="-252"/>
+      <point x="160" y="-215"/>
+      <point x="160" y="-144" type="curve" smooth="yes"/>
+      <point x="160" y="-57"/>
+      <point x="207" y="13"/>
+      <point x="306" y="13" type="curve" smooth="yes"/>
+      <point x="384" y="13"/>
+      <point x="431" y="-25"/>
+      <point x="431" y="-106" type="curve" smooth="yes"/>
+      <point x="431" y="-190"/>
+      <point x="385" y="-228"/>
+      <point x="329" y="-275" type="curve"/>
+      <point x="375" y="-327" type="line"/>
+      <point x="456" y="-266"/>
+      <point x="506" y="-198"/>
+      <point x="506" y="-102" type="curve" smooth="yes"/>
+      <point x="506" y="24"/>
+      <point x="429" y="83"/>
+      <point x="308" y="83" type="curve" smooth="yes"/>
+      <point x="163" y="83"/>
+      <point x="84" y="-12"/>
+      <point x="84" y="-148" type="curve" smooth="yes"/>
+      <point x="84" y="-223"/>
+      <point x="108" y="-283"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/t_la-malayalam.glif
@@ -1,136 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_la-malayalam" format="2">
   <advance width="981"/>
-  <anchor x="509" y="-351" name="bottom"/>
-  <anchor x="551" y="580" name="top"/>
-  <anchor x="875" y="580" name="topright"/>
+  <anchor x="494" y="-351" name="bottom"/>
+  <anchor x="545" y="580" name="top"/>
+  <anchor x="869" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="287" y="-367" type="curve" smooth="yes"/>
-      <point x="372" y="-367"/>
-      <point x="424" y="-313"/>
-      <point x="424" y="-228" type="curve" smooth="yes"/>
-      <point x="424" y="-154"/>
-      <point x="384" y="-118"/>
-      <point x="315" y="-118" type="curve" smooth="yes"/>
-      <point x="283" y="-118"/>
-      <point x="245" y="-131"/>
-      <point x="219" y="-164" type="curve"/>
-      <point x="213" y="-163" type="line"/>
-      <point x="233" y="-78"/>
-      <point x="290" y="-27"/>
-      <point x="377" y="-27" type="curve" smooth="yes"/>
-      <point x="482" y="-27"/>
-      <point x="509" y="-86"/>
-      <point x="514" y="-174" type="curve" smooth="yes"/>
-      <point x="515" y="-192" type="line" smooth="yes"/>
-      <point x="521" y="-303"/>
-      <point x="571" y="-367"/>
-      <point x="681" y="-367" type="curve" smooth="yes"/>
+      <point x="276" y="-367" type="curve" smooth="yes"/>
+      <point x="364" y="-367"/>
+      <point x="417" y="-301"/>
+      <point x="417" y="-229" type="curve" smooth="yes"/>
+      <point x="417" y="-162"/>
+      <point x="381" y="-118"/>
+      <point x="314" y="-118" type="curve" smooth="yes"/>
+      <point x="266" y="-118"/>
+      <point x="200" y="-150"/>
+      <point x="187" y="-232" type="curve"/>
+      <point x="226" y="-176" type="line"/>
+      <point x="196" y="-163" type="line"/>
+      <point x="202" y="-188" type="line"/>
+      <point x="222" y="-91"/>
+      <point x="287" y="-27"/>
+      <point x="384" y="-27" type="curve" smooth="yes"/>
+      <point x="458" y="-27"/>
+      <point x="492" y="-64"/>
+      <point x="507" y="-157" type="curve" smooth="yes"/>
+      <point x="514" y="-200" type="line" smooth="yes"/>
+      <point x="533" y="-317"/>
+      <point x="584" y="-367"/>
+      <point x="676" y="-367" type="curve" smooth="yes"/>
       <point x="810" y="-367"/>
-      <point x="865" y="-271"/>
-      <point x="865" y="-131" type="curve" smooth="yes"/>
-      <point x="865" y="-58"/>
-      <point x="846" y="1"/>
-      <point x="816" y="43" type="curve"/>
-      <point x="773" y="-16" type="line"/>
-      <point x="894" y="84"/>
-      <point x="952" y="196"/>
-      <point x="952" y="326" type="curve" smooth="yes"/>
-      <point x="952" y="495"/>
-      <point x="848" y="596"/>
-      <point x="673" y="596" type="curve" smooth="yes"/>
-      <point x="461" y="596"/>
-      <point x="285" y="415"/>
-      <point x="285" y="197" type="curve" smooth="yes"/>
-      <point x="285" y="136"/>
-      <point x="301" y="86"/>
-      <point x="343" y="46" type="curve"/>
-      <point x="342" y="41" type="line"/>
-      <point x="212" y="16"/>
-      <point x="141" y="-83"/>
-      <point x="141" y="-210" type="curve" smooth="yes"/>
-      <point x="141" y="-316"/>
-      <point x="205" y="-367"/>
+      <point x="858" y="-239"/>
+      <point x="858" y="-140" type="curve" smooth="yes"/>
+      <point x="858" y="-71"/>
+      <point x="842" y="-10"/>
+      <point x="812" y="41" type="curve"/>
+      <point x="804" y="13" type="line"/>
+      <point x="891" y="110"/>
+      <point x="941" y="225"/>
+      <point x="941" y="338" type="curve" smooth="yes"/>
+      <point x="941" y="493"/>
+      <point x="856" y="596"/>
+      <point x="692" y="596" type="curve" smooth="yes"/>
+      <point x="626" y="596"/>
+      <point x="564" y="578"/>
+      <point x="508" y="548" type="curve"/>
+      <point x="554" y="546" type="line"/>
+      <point x="507" y="577"/>
+      <point x="450" y="596"/>
+      <point x="382" y="596" type="curve" smooth="yes"/>
+      <point x="162" y="596"/>
+      <point x="38" y="412"/>
+      <point x="38" y="234" type="curve" smooth="yes"/>
+      <point x="38" y="137"/>
+      <point x="63" y="59"/>
+      <point x="119" y="-16" type="curve"/>
+      <point x="183" y="31" type="line"/>
+      <point x="142" y="85"/>
+      <point x="119" y="159"/>
+      <point x="119" y="236" type="curve" smooth="yes"/>
+      <point x="119" y="380"/>
+      <point x="209" y="518"/>
+      <point x="376" y="518" type="curve" smooth="yes"/>
+      <point x="411" y="518"/>
+      <point x="442" y="512"/>
+      <point x="468" y="502" type="curve"/>
+      <point x="467" y="523" type="line"/>
+      <point x="354" y="443"/>
+      <point x="280" y="311"/>
+      <point x="280" y="186" type="curve" smooth="yes"/>
+      <point x="280" y="126"/>
+      <point x="298" y="77"/>
+      <point x="330" y="42" type="curve"/>
+      <point x="329" y="37" type="line"/>
+      <point x="200" y="-2"/>
+      <point x="134" y="-116"/>
+      <point x="134" y="-214" type="curve" smooth="yes"/>
+      <point x="134" y="-313"/>
+      <point x="195" y="-367"/>
     </contour>
     <contour>
-      <point x="683" y="-297" type="curve" smooth="yes"/>
-      <point x="623" y="-297"/>
-      <point x="598" y="-265"/>
-      <point x="590" y="-174" type="curve" smooth="yes"/>
-      <point x="588" y="-151" type="line" smooth="yes"/>
-      <point x="583" y="-90"/>
-      <point x="567" y="-39"/>
-      <point x="528" y="-4" type="curve"/>
-      <point x="529" y="1" type="line"/>
-      <point x="633" y="27"/>
-      <point x="690" y="130"/>
-      <point x="690" y="271" type="curve" smooth="yes"/>
-      <point x="690" y="390"/>
-      <point x="639" y="487"/>
-      <point x="557" y="543" type="curve"/>
-      <point x="469" y="502" type="line"/>
-      <point x="555" y="469"/>
-      <point x="604" y="387"/>
-      <point x="604" y="271" type="curve" smooth="yes"/>
-      <point x="604" y="148"/>
-      <point x="549" y="62"/>
-      <point x="470" y="62" type="curve" smooth="yes"/>
-      <point x="404" y="62"/>
-      <point x="367" y="111"/>
-      <point x="367" y="197" type="curve" smooth="yes"/>
-      <point x="367" y="379"/>
-      <point x="499" y="518"/>
-      <point x="673" y="518" type="curve" smooth="yes"/>
-      <point x="795" y="518"/>
-      <point x="868" y="447"/>
-      <point x="868" y="326" type="curve" smooth="yes"/>
-      <point x="868" y="221"/>
-      <point x="819" y="130"/>
-      <point x="728" y="46" type="curve"/>
-      <point x="762" y="3"/>
-      <point x="790" y="-61"/>
-      <point x="790" y="-139" type="curve" smooth="yes"/>
-      <point x="790" y="-226"/>
-      <point x="762" y="-297"/>
-    </contour>
-    <contour>
-      <point x="287" y="-302" type="curve" smooth="yes"/>
-      <point x="232" y="-302"/>
-      <point x="209" y="-264"/>
-      <point x="209" y="-218" type="curve"/>
-      <point x="190" y="-197" type="line"/>
-      <point x="201" y="-253" type="line"/>
-      <point x="209" y="-213"/>
+      <point x="276" y="-302" type="curve" smooth="yes"/>
+      <point x="228" y="-302"/>
+      <point x="201" y="-269"/>
+      <point x="201" y="-224" type="curve" smooth="yes"/>
+      <point x="201" y="-217"/>
+      <point x="202" y="-208"/>
+      <point x="204" y="-200" type="curve"/>
+      <point x="173" y="-205" type="line"/>
+      <point x="193" y="-265" type="line"/>
+      <point x="201" y="-213"/>
       <point x="242" y="-178"/>
       <point x="291" y="-178" type="curve" smooth="yes"/>
-      <point x="333" y="-178"/>
-      <point x="353" y="-199"/>
-      <point x="353" y="-233" type="curve" smooth="yes"/>
-      <point x="353" y="-276"/>
-      <point x="329" y="-302"/>
+      <point x="330" y="-178"/>
+      <point x="347" y="-201"/>
+      <point x="347" y="-233" type="curve" smooth="yes"/>
+      <point x="347" y="-272"/>
+      <point x="320" y="-302"/>
     </contour>
     <contour>
-      <point x="120" y="-16" type="curve"/>
-      <point x="186" y="33" type="line"/>
-      <point x="143" y="90"/>
-      <point x="122" y="157"/>
-      <point x="122" y="243" type="curve" smooth="yes"/>
-      <point x="122" y="407"/>
-      <point x="225" y="518"/>
-      <point x="375" y="518" type="curve" smooth="yes"/>
-      <point x="410" y="518"/>
-      <point x="442" y="512"/>
-      <point x="469" y="502" type="curve"/>
-      <point x="557" y="543" type="line"/>
-      <point x="507" y="577"/>
-      <point x="445" y="596"/>
-      <point x="375" y="596" type="curve" smooth="yes"/>
-      <point x="181" y="596"/>
-      <point x="40" y="447"/>
-      <point x="40" y="243" type="curve" smooth="yes"/>
-      <point x="40" y="141"/>
-      <point x="67" y="52"/>
+      <point x="462" y="62" type="curve" smooth="yes"/>
+      <point x="396" y="62"/>
+      <point x="363" y="108"/>
+      <point x="363" y="189" type="curve" smooth="yes"/>
+      <point x="363" y="312"/>
+      <point x="435" y="428"/>
+      <point x="542" y="484" type="curve"/>
+      <point x="503" y="484" type="line"/>
+      <point x="568" y="443"/>
+      <point x="598" y="365"/>
+      <point x="598" y="273" type="curve" smooth="yes"/>
+      <point x="598" y="179"/>
+      <point x="564" y="62"/>
+    </contour>
+    <contour>
+      <point x="682" y="-297" type="curve" smooth="yes"/>
+      <point x="629" y="-297"/>
+      <point x="601" y="-269"/>
+      <point x="587" y="-185" type="curve" smooth="yes"/>
+      <point x="580" y="-142" type="line" smooth="yes"/>
+      <point x="568" y="-67"/>
+      <point x="550" y="-27"/>
+      <point x="516" y="-3" type="curve"/>
+      <point x="517" y="2" type="line"/>
+      <point x="629" y="39"/>
+      <point x="685" y="166"/>
+      <point x="685" y="271" type="curve" smooth="yes"/>
+      <point x="685" y="370"/>
+      <point x="649" y="462"/>
+      <point x="583" y="523" type="curve"/>
+      <point x="579" y="500" type="line"/>
+      <point x="610" y="512"/>
+      <point x="644" y="518"/>
+      <point x="679" y="518" type="curve" smooth="yes"/>
+      <point x="801" y="518"/>
+      <point x="857" y="444"/>
+      <point x="857" y="330" type="curve" smooth="yes"/>
+      <point x="857" y="230"/>
+      <point x="809" y="136"/>
+      <point x="712" y="42" type="curve"/>
+      <point x="763" y="-18"/>
+      <point x="785" y="-75"/>
+      <point x="785" y="-142" type="curve" smooth="yes"/>
+      <point x="785" y="-208"/>
+      <point x="762" y="-297"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ta-malayalam.glif
@@ -2,61 +2,61 @@
 <glyph name="ta-malayalam" format="2">
   <advance width="981"/>
   <unicode hex="0D24"/>
-  <anchor x="527" y="0" name="bottom"/>
-  <anchor x="551" y="580" name="top"/>
-  <anchor x="875" y="580" name="topright"/>
+  <anchor x="521" y="0" name="bottom"/>
+  <anchor x="545" y="580" name="top"/>
+  <anchor x="869" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="120" y="-16" type="curve"/>
-      <point x="186" y="33" type="line"/>
-      <point x="143" y="90"/>
-      <point x="122" y="157"/>
-      <point x="122" y="243" type="curve" smooth="yes"/>
-      <point x="122" y="407"/>
-      <point x="225" y="518"/>
-      <point x="375" y="518" type="curve" smooth="yes"/>
-      <point x="518" y="518"/>
-      <point x="604" y="425"/>
-      <point x="604" y="271" type="curve" smooth="yes"/>
-      <point x="604" y="148"/>
-      <point x="549" y="62"/>
-      <point x="470" y="62" type="curve" smooth="yes"/>
-      <point x="404" y="62"/>
-      <point x="367" y="111"/>
-      <point x="367" y="197" type="curve" smooth="yes"/>
-      <point x="367" y="379"/>
-      <point x="499" y="518"/>
-      <point x="673" y="518" type="curve" smooth="yes"/>
-      <point x="795" y="518"/>
-      <point x="868" y="447"/>
-      <point x="868" y="326" type="curve" smooth="yes"/>
-      <point x="868" y="221"/>
-      <point x="819" y="130"/>
-      <point x="718" y="46" type="curve"/>
-      <point x="773" y="-16" type="line"/>
-      <point x="894" y="84"/>
-      <point x="952" y="196"/>
-      <point x="952" y="326" type="curve" smooth="yes"/>
-      <point x="952" y="495"/>
-      <point x="848" y="596"/>
-      <point x="673" y="596" type="curve" smooth="yes"/>
+      <point x="119" y="-16" type="curve"/>
+      <point x="183" y="31" type="line"/>
+      <point x="142" y="85"/>
+      <point x="119" y="159"/>
+      <point x="119" y="236" type="curve" smooth="yes"/>
+      <point x="119" y="380"/>
+      <point x="209" y="518"/>
+      <point x="376" y="518" type="curve" smooth="yes"/>
+      <point x="529" y="518"/>
+      <point x="598" y="412"/>
+      <point x="598" y="273" type="curve" smooth="yes"/>
+      <point x="598" y="179"/>
+      <point x="564" y="62"/>
+      <point x="462" y="62" type="curve" smooth="yes"/>
+      <point x="396" y="62"/>
+      <point x="363" y="108"/>
+      <point x="363" y="189" type="curve" smooth="yes"/>
+      <point x="363" y="361"/>
+      <point x="506" y="518"/>
+      <point x="679" y="518" type="curve" smooth="yes"/>
+      <point x="801" y="518"/>
+      <point x="857" y="444"/>
+      <point x="857" y="330" type="curve" smooth="yes"/>
+      <point x="857" y="232"/>
+      <point x="811" y="139"/>
+      <point x="716" y="46" type="curve"/>
+      <point x="777" y="-16" type="line"/>
+      <point x="883" y="88"/>
+      <point x="941" y="214"/>
+      <point x="941" y="338" type="curve" smooth="yes"/>
+      <point x="941" y="493"/>
+      <point x="856" y="596"/>
+      <point x="692" y="596" type="curve" smooth="yes"/>
       <point x="461" y="596"/>
-      <point x="285" y="415"/>
-      <point x="285" y="197" type="curve" smooth="yes"/>
-      <point x="285" y="67"/>
-      <point x="357" y="-16"/>
-      <point x="470" y="-16" type="curve" smooth="yes"/>
-      <point x="603" y="-16"/>
-      <point x="690" y="97"/>
-      <point x="690" y="271" type="curve" smooth="yes"/>
-      <point x="690" y="462"/>
-      <point x="560" y="596"/>
-      <point x="375" y="596" type="curve" smooth="yes"/>
-      <point x="181" y="596"/>
-      <point x="40" y="447"/>
-      <point x="40" y="243" type="curve" smooth="yes"/>
-      <point x="40" y="141"/>
-      <point x="67" y="52"/>
+      <point x="280" y="381"/>
+      <point x="280" y="186" type="curve" smooth="yes"/>
+      <point x="280" y="63"/>
+      <point x="348" y="-16"/>
+      <point x="456" y="-16" type="curve" smooth="yes"/>
+      <point x="608" y="-16"/>
+      <point x="685" y="144"/>
+      <point x="685" y="271" type="curve" smooth="yes"/>
+      <point x="685" y="446"/>
+      <point x="575" y="596"/>
+      <point x="382" y="596" type="curve" smooth="yes"/>
+      <point x="162" y="596"/>
+      <point x="38" y="412"/>
+      <point x="38" y="234" type="curve" smooth="yes"/>
+      <point x="38" y="137"/>
+      <point x="63" y="59"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="981"/>
   <outline>
     <component base="ta-malayalam"/>
-    <component base="halant-malayalam" xOffset="802"/>
+    <component base="halant-malayalam" xOffset="796"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="572"/>
-  <anchor x="291" y="0" name="bottom"/>
-  <anchor x="270" y="580" name="top"/>
-  <anchor x="421" y="580" name="topright"/>
+  <anchor x="215" y="-235" name="bottom"/>
+  <anchor x="334" y="580" name="top"/>
+  <anchor x="485" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="235" y="-225" type="curve" smooth="yes"/>
-      <point x="383" y="-225"/>
-      <point x="482" y="-182"/>
-      <point x="482" y="-73" type="curve" smooth="yes"/>
-      <point x="482" y="-26"/>
-      <point x="452" y="16"/>
-      <point x="392" y="32" type="curve"/>
-      <point x="392" y="37" type="line"/>
-      <point x="477" y="59"/>
-      <point x="518" y="112"/>
-      <point x="518" y="193" type="curve" smooth="yes"/>
-      <point x="518" y="288"/>
-      <point x="467" y="340"/>
-      <point x="332" y="347" type="curve" smooth="yes"/>
-      <point x="235" y="352" type="line" smooth="yes"/>
-      <point x="173" y="355"/>
-      <point x="140" y="381"/>
-      <point x="140" y="426" type="curve" smooth="yes"/>
-      <point x="140" y="486"/>
-      <point x="196" y="515"/>
-      <point x="290" y="515" type="curve" smooth="yes"/>
-      <point x="379" y="515"/>
-      <point x="440" y="494"/>
-      <point x="499" y="463" type="curve"/>
-      <point x="541" y="533" type="line"/>
-      <point x="478" y="570"/>
-      <point x="391" y="596"/>
-      <point x="289" y="596" type="curve" smooth="yes"/>
-      <point x="140" y="596"/>
-      <point x="51" y="527"/>
-      <point x="51" y="421" type="curve" smooth="yes"/>
-      <point x="51" y="333"/>
-      <point x="108" y="271"/>
-      <point x="211" y="265" type="curve" smooth="yes"/>
-      <point x="316" y="259" type="line" smooth="yes"/>
-      <point x="408" y="254"/>
-      <point x="432" y="225"/>
-      <point x="432" y="176" type="curve" smooth="yes"/>
-      <point x="432" y="104"/>
-      <point x="374" y="80"/>
-      <point x="293" y="80" type="curve" smooth="yes"/>
-      <point x="37" y="80" type="line"/>
-      <point x="24" y="6" type="line"/>
-      <point x="231" y="6" type="line" smooth="yes"/>
-      <point x="361" y="6"/>
-      <point x="399" y="-26"/>
-      <point x="399" y="-72" type="curve" smooth="yes"/>
-      <point x="399" y="-126"/>
-      <point x="352" y="-147"/>
-      <point x="236" y="-147" type="curve" smooth="yes"/>
-      <point x="133" y="-147"/>
-      <point x="61" y="-124"/>
-      <point x="6" y="-98" type="curve"/>
-      <point x="-40" y="-166" type="line"/>
-      <point x="15" y="-198"/>
-      <point x="114" y="-225"/>
+      <point x="216" y="-251" type="curve" smooth="yes"/>
+      <point x="395" y="-251"/>
+      <point x="472" y="-167"/>
+      <point x="472" y="-69" type="curve" smooth="yes"/>
+      <point x="472" y="-13"/>
+      <point x="443" y="29"/>
+      <point x="385" y="46" type="curve"/>
+      <point x="386" y="52" type="line"/>
+      <point x="469" y="78"/>
+      <point x="510" y="128"/>
+      <point x="510" y="199" type="curve" smooth="yes"/>
+      <point x="510" y="286"/>
+      <point x="452" y="334"/>
+      <point x="334" y="345" type="curve" smooth="yes"/>
+      <point x="228" y="355" type="line" smooth="yes"/>
+      <point x="167" y="361"/>
+      <point x="137" y="382"/>
+      <point x="137" y="426" type="curve" smooth="yes"/>
+      <point x="137" y="478"/>
+      <point x="181" y="516"/>
+      <point x="306" y="516" type="curve" smooth="yes"/>
+      <point x="383" y="516"/>
+      <point x="449" y="500"/>
+      <point x="505" y="468" type="curve"/>
+      <point x="544" y="538" type="line"/>
+      <point x="474" y="579"/>
+      <point x="405" y="596"/>
+      <point x="314" y="596" type="curve" smooth="yes"/>
+      <point x="115" y="596"/>
+      <point x="49" y="499"/>
+      <point x="49" y="414" type="curve" smooth="yes"/>
+      <point x="49" y="329"/>
+      <point x="108" y="277"/>
+      <point x="208" y="268" type="curve" smooth="yes"/>
+      <point x="314" y="258" type="line" smooth="yes"/>
+      <point x="394" y="250"/>
+      <point x="422" y="229"/>
+      <point x="422" y="181" type="curve" smooth="yes"/>
+      <point x="422" y="128"/>
+      <point x="377" y="86"/>
+      <point x="262" y="86" type="curve" smooth="yes"/>
+      <point x="33" y="86" type="line"/>
+      <point x="20" y="12" type="line"/>
+      <point x="274" y="12" type="line" smooth="yes"/>
+      <point x="356" y="12"/>
+      <point x="389" y="-17"/>
+      <point x="389" y="-69" type="curve" smooth="yes"/>
+      <point x="389" y="-126"/>
+      <point x="340" y="-171"/>
+      <point x="226" y="-171" type="curve" smooth="yes"/>
+      <point x="140" y="-171"/>
+      <point x="61" y="-144"/>
+      <point x="7" y="-95" type="curve"/>
+      <point x="-45" y="-156" type="line"/>
+      <point x="24" y="-218"/>
+      <point x="114" y="-251"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/tta-malayalam.glif
@@ -2,51 +2,51 @@
 <glyph name="tta-malayalam" format="2">
   <advance width="574"/>
   <unicode hex="0D1F"/>
-  <anchor x="246" y="0" name="bottom"/>
-  <anchor x="327" y="580" name="top"/>
-  <anchor x="478" y="580" name="topright"/>
+  <anchor x="253" y="0" name="bottom"/>
+  <anchor x="334" y="580" name="top"/>
+  <anchor x="485" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="279" y="-16" type="curve" smooth="yes"/>
-      <point x="427" y="-16"/>
-      <point x="514" y="50"/>
-      <point x="514" y="166" type="curve" smooth="yes"/>
-      <point x="514" y="259"/>
-      <point x="459" y="324"/>
-      <point x="316" y="334" type="curve" smooth="yes"/>
-      <point x="244" y="339" type="line" smooth="yes"/>
-      <point x="170" y="344"/>
-      <point x="137" y="374"/>
-      <point x="137" y="420" type="curve" smooth="yes"/>
-      <point x="137" y="486"/>
-      <point x="193" y="515"/>
-      <point x="287" y="515" type="curve" smooth="yes"/>
-      <point x="376" y="515"/>
-      <point x="437" y="494"/>
-      <point x="496" y="463" type="curve"/>
-      <point x="538" y="533" type="line"/>
-      <point x="475" y="570"/>
-      <point x="388" y="596"/>
-      <point x="286" y="596" type="curve" smooth="yes"/>
-      <point x="137" y="596"/>
-      <point x="49" y="527"/>
-      <point x="49" y="409" type="curve" smooth="yes"/>
-      <point x="49" y="323"/>
-      <point x="105" y="256"/>
-      <point x="223" y="249" type="curve" smooth="yes"/>
-      <point x="309" y="244" type="line" smooth="yes"/>
-      <point x="395" y="239"/>
-      <point x="428" y="205"/>
-      <point x="428" y="161" type="curve" smooth="yes"/>
-      <point x="428" y="96"/>
-      <point x="373" y="65"/>
-      <point x="281" y="65" type="curve" smooth="yes"/>
-      <point x="182" y="65"/>
-      <point x="111" y="99"/>
-      <point x="47" y="147" type="curve"/>
-      <point x="-9" y="76" type="line"/>
-      <point x="63" y="23"/>
-      <point x="148" y="-16"/>
+      <point x="270" y="-16" type="curve" smooth="yes"/>
+      <point x="440" y="-16"/>
+      <point x="516" y="74"/>
+      <point x="516" y="169" type="curve" smooth="yes"/>
+      <point x="516" y="267"/>
+      <point x="458" y="323"/>
+      <point x="344" y="333" type="curve" smooth="yes"/>
+      <point x="240" y="342" type="line" smooth="yes"/>
+      <point x="174" y="348"/>
+      <point x="143" y="372"/>
+      <point x="143" y="418" type="curve" smooth="yes"/>
+      <point x="143" y="473"/>
+      <point x="195" y="516"/>
+      <point x="314" y="516" type="curve" smooth="yes"/>
+      <point x="395" y="516"/>
+      <point x="453" y="502"/>
+      <point x="511" y="470" type="curve"/>
+      <point x="549" y="540" type="line"/>
+      <point x="481" y="578"/>
+      <point x="408" y="596"/>
+      <point x="320" y="596" type="curve" smooth="yes"/>
+      <point x="132" y="596"/>
+      <point x="57" y="500"/>
+      <point x="57" y="409" type="curve" smooth="yes"/>
+      <point x="57" y="318"/>
+      <point x="120" y="262"/>
+      <point x="221" y="253" type="curve" smooth="yes"/>
+      <point x="325" y="244" type="line" smooth="yes"/>
+      <point x="400" y="238"/>
+      <point x="430" y="214"/>
+      <point x="430" y="163" type="curve" smooth="yes"/>
+      <point x="430" y="108"/>
+      <point x="382" y="64"/>
+      <point x="276" y="64" type="curve" smooth="yes"/>
+      <point x="183" y="64"/>
+      <point x="105" y="89"/>
+      <point x="37" y="141" type="curve"/>
+      <point x="-12" y="78" type="line"/>
+      <point x="68" y="15"/>
+      <point x="161" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/tta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/tta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="574"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="halant-malayalam" xOffset="405"/>
+    <component base="halant-malayalam" xOffset="412"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="574"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="292"/>
+    <component base="lVocalicMatra-malayalam" xOffset="299"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="574"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="292"/>
+    <component base="llVocalicMatra-malayalam" xOffset="299"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/uuM_atra-malayalam.glif
@@ -4,65 +4,71 @@
   <unicode hex="0D42"/>
   <outline>
     <contour>
-      <point x="22" y="13" type="curve"/>
-      <point x="112" y="13" type="line"/>
-      <point x="173" y="124"/>
-      <point x="233" y="282"/>
-      <point x="233" y="396" type="curve" smooth="yes"/>
-      <point x="233" y="512"/>
-      <point x="172" y="585"/>
-      <point x="62" y="595" type="curve" smooth="yes"/>
-      <point x="51" y="596" type="line"/>
-      <point x="37" y="518" type="line"/>
-      <point x="113" y="511"/>
-      <point x="151" y="468"/>
-      <point x="151" y="389" type="curve" smooth="yes"/>
-      <point x="151" y="280"/>
-      <point x="88" y="124"/>
+      <point x="41" y="16" type="curve"/>
+      <point x="125" y="16" type="line"/>
+      <point x="194" y="145"/>
+      <point x="243" y="299"/>
+      <point x="243" y="394" type="curve" smooth="yes"/>
+      <point x="243" y="522"/>
+      <point x="183" y="596"/>
+      <point x="67" y="596" type="curve" smooth="yes"/>
+      <point x="59" y="596" type="line"/>
+      <point x="45" y="519" type="line"/>
+      <point x="124" y="519"/>
+      <point x="160" y="475"/>
+      <point x="160" y="388" type="curve" smooth="yes"/>
+      <point x="160" y="290"/>
+      <point x="117" y="155"/>
     </contour>
     <contour>
-      <point x="52" y="-256" type="curve" smooth="yes"/>
-      <point x="148" y="-256"/>
-      <point x="222" y="-187"/>
-      <point x="222" y="-96" type="curve" smooth="yes"/>
-      <point x="222" y="-11"/>
-      <point x="157" y="52"/>
-      <point x="67" y="52" type="curve" smooth="yes"/>
-      <point x="-28" y="52"/>
+      <point x="53" y="-185" type="curve" smooth="yes"/>
+      <point x="0" y="-185"/>
+      <point x="-37" y="-156"/>
+      <point x="-37" y="-112" type="curve" smooth="yes"/>
+      <point x="-37" y="-91"/>
+      <point x="-31" y="-74"/>
+      <point x="-19" y="-60" type="curve"/>
+      <point x="-15" y="-60" type="line"/>
+      <point x="-11" y="-100"/>
+      <point x="15" y="-127"/>
+      <point x="58" y="-127" type="curve" smooth="yes"/>
+      <point x="100" y="-127"/>
+      <point x="129" y="-103"/>
+      <point x="141" y="-60" type="curve"/>
+      <point x="145" y="-60" type="line"/>
+      <point x="148" y="-70"/>
+      <point x="150" y="-80"/>
+      <point x="150" y="-92" type="curve" smooth="yes"/>
+      <point x="150" y="-140"/>
+      <point x="122" y="-185"/>
+    </contour>
+    <contour>
+      <point x="49" y="-256" type="curve" smooth="yes"/>
+      <point x="145" y="-256"/>
+      <point x="217" y="-187"/>
+      <point x="217" y="-96" type="curve" smooth="yes"/>
+      <point x="217" y="-11"/>
+      <point x="153" y="52"/>
+      <point x="64" y="52" type="curve" smooth="yes"/>
+      <point x="-30" y="52"/>
       <point x="-104" y="-20"/>
       <point x="-104" y="-110" type="curve" smooth="yes"/>
       <point x="-104" y="-195"/>
-      <point x="-39" y="-256"/>
+      <point x="-40" y="-256"/>
     </contour>
     <contour>
-      <point x="54" y="-185" type="curve" smooth="yes"/>
-      <point x="4" y="-185"/>
-      <point x="-30" y="-153"/>
-      <point x="-30" y="-106" type="curve" smooth="yes"/>
-      <point x="-30" y="-54"/>
-      <point x="10" y="-15"/>
-      <point x="65" y="-15" type="curve" smooth="yes"/>
-      <point x="114" y="-15"/>
-      <point x="148" y="-46"/>
-      <point x="148" y="-92" type="curve" smooth="yes"/>
-      <point x="148" y="-147"/>
-      <point x="109" y="-185"/>
-    </contour>
-    <contour>
-      <point x="69" y="-125" type="curve" smooth="yes"/>
-      <point x="107" y="-125"/>
-      <point x="141" y="-114"/>
-      <point x="170" y="-93" type="curve"/>
-      <point x="154" y="-51" type="line"/>
-      <point x="130" y="-68"/>
-      <point x="104" y="-76"/>
-      <point x="71" y="-76" type="curve" smooth="yes"/>
-      <point x="25" y="-76"/>
-      <point x="-5" y="-61"/>
-      <point x="-26" y="-35" type="curve"/>
-      <point x="-55" y="-73" type="line"/>
-      <point x="-27" y="-107"/>
-      <point x="13" y="-125"/>
+      <point x="62" y="-63" type="curve" smooth="yes"/>
+      <point x="29" y="-63"/>
+      <point x="6" y="-50"/>
+      <point x="6" y="-31" type="curve" smooth="yes"/>
+      <point x="6" y="-14"/>
+      <point x="24" y="0"/>
+      <point x="76" y="0" type="curve" smooth="yes"/>
+      <point x="115" y="0"/>
+      <point x="133" y="-10"/>
+      <point x="133" y="-26" type="curve" smooth="yes"/>
+      <point x="133" y="-46"/>
+      <point x="111" y="-63"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/y_ya-malayalam.glif
@@ -1,96 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="984"/>
-  <anchor x="528" y="-281" name="bottom"/>
-  <anchor x="562" y="580" name="top"/>
-  <anchor x="868" y="580" name="topright"/>
+  <anchor x="524" y="-268" name="bottom"/>
+  <anchor x="556" y="580" name="top"/>
+  <anchor x="862" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="210" y="-291" type="line"/>
-      <point x="780" y="-291" type="line"/>
-      <point x="844" y="79" type="line"/>
-      <point x="829" y="45" type="line"/>
-      <point x="909" y="107"/>
-      <point x="956" y="213"/>
-      <point x="956" y="349" type="curve" smooth="yes"/>
-      <point x="956" y="450"/>
-      <point x="935" y="530"/>
-      <point x="891" y="596" type="curve"/>
-      <point x="822" y="553" type="line"/>
-      <point x="857" y="499"/>
-      <point x="874" y="432"/>
-      <point x="874" y="349" type="curve" smooth="yes"/>
-      <point x="874" y="173"/>
-      <point x="783" y="62"/>
-      <point x="639" y="62" type="curve" smooth="yes"/>
-      <point x="496" y="62"/>
-      <point x="419" y="152"/>
-      <point x="419" y="320" type="curve" smooth="yes"/>
-      <point x="419" y="435"/>
-      <point x="469" y="518"/>
+      <point x="204" y="-278" type="line"/>
+      <point x="774" y="-278" type="line"/>
+      <point x="844" y="121" type="line"/>
+      <point x="820" y="69" type="line"/>
+      <point x="903" y="137"/>
+      <point x="947" y="245"/>
+      <point x="947" y="349" type="curve" smooth="yes"/>
+      <point x="947" y="438"/>
+      <point x="919" y="526"/>
+      <point x="869" y="596" type="curve"/>
+      <point x="802" y="552" type="line"/>
+      <point x="846" y="489"/>
+      <point x="868" y="421"/>
+      <point x="868" y="350" type="curve" smooth="yes"/>
+      <point x="868" y="197"/>
+      <point x="767" y="62"/>
+      <point x="605" y="62" type="curve" smooth="yes"/>
+      <point x="446" y="62"/>
+      <point x="376" y="165"/>
+      <point x="376" y="303" type="curve" smooth="yes"/>
+      <point x="376" y="386"/>
+      <point x="414" y="518"/>
       <point x="539" y="518" type="curve" smooth="yes"/>
-      <point x="599" y="518"/>
-      <point x="630" y="474"/>
-      <point x="630" y="389" type="curve" smooth="yes"/>
-      <point x="630" y="247"/>
-      <point x="574" y="142"/>
-      <point x="468" y="85" type="curve"/>
-      <point x="519" y="30" type="line"/>
-      <point x="643" y="99"/>
-      <point x="712" y="228"/>
-      <point x="712" y="389" type="curve" smooth="yes"/>
-      <point x="712" y="525"/>
-      <point x="654" y="596"/>
-      <point x="543" y="596" type="curve" smooth="yes"/>
-      <point x="425" y="596"/>
-      <point x="337" y="478"/>
-      <point x="337" y="320" type="curve" smooth="yes"/>
-      <point x="337" y="122"/>
-      <point x="461" y="-16"/>
-      <point x="637" y="-16" type="curve" smooth="yes"/>
-      <point x="642" y="-16"/>
-      <point x="646" y="-16"/>
-      <point x="651" y="-16" type="curve"/>
-      <point x="595" y="30" type="line"/>
-      <point x="604" y="-19" type="line"/>
-      <point x="508" y="-70" type="line"/>
-      <point x="219" y="-235" type="line"/>
+      <point x="609" y="518"/>
+      <point x="644" y="471"/>
+      <point x="644" y="387" type="curve" smooth="yes"/>
+      <point x="644" y="269"/>
+      <point x="572" y="155"/>
+      <point x="456" y="96" type="curve"/>
+      <point x="507" y="49" type="line"/>
+      <point x="653" y="122"/>
+      <point x="726" y="259"/>
+      <point x="726" y="389" type="curve" smooth="yes"/>
+      <point x="726" y="516"/>
+      <point x="663" y="596"/>
+      <point x="547" y="596" type="curve" smooth="yes"/>
+      <point x="388" y="596"/>
+      <point x="294" y="442"/>
+      <point x="294" y="305" type="curve" smooth="yes"/>
+      <point x="294" y="126"/>
+      <point x="418" y="-12"/>
+      <point x="599" y="-12" type="curve" smooth="yes"/>
+      <point x="623" y="-12"/>
+      <point x="647" y="-10"/>
+      <point x="669" y="-5" type="curve"/>
+      <point x="582" y="33" type="line"/>
+      <point x="575" y="-15" type="line"/>
+      <point x="492" y="-57" type="line"/>
+      <point x="214" y="-222" type="line"/>
     </contour>
     <contour>
-      <point x="311" y="-262" type="line"/>
-      <point x="775" y="10" type="line"/>
-      <point x="750" y="10" type="line"/>
-      <point x="706" y="-244" type="line"/>
-      <point x="747" y="-226" type="line"/>
-      <point x="347" y="-226" type="line"/>
+      <point x="315" y="-243" type="line"/>
+      <point x="757" y="19" type="line"/>
+      <point x="744" y="18" type="line"/>
+      <point x="700" y="-231" type="line"/>
+      <point x="742" y="-213" type="line"/>
+      <point x="320" y="-213" type="line"/>
     </contour>
     <contour>
-      <point x="343" y="-16" type="curve" smooth="yes"/>
-      <point x="407" y="-16"/>
-      <point x="459" y="-3"/>
-      <point x="508" y="27" type="curve"/>
-      <point x="438" y="77" type="line"/>
-      <point x="408" y="67"/>
-      <point x="377" y="62"/>
-      <point x="343" y="62" type="curve" smooth="yes"/>
-      <point x="209" y="62"/>
-      <point x="129" y="150"/>
-      <point x="129" y="296" type="curve" smooth="yes"/>
-      <point x="129" y="429"/>
-      <point x="200" y="518"/>
-      <point x="306" y="518" type="curve" smooth="yes"/>
-      <point x="357" y="518"/>
-      <point x="390" y="503"/>
-      <point x="413" y="470" type="curve"/>
-      <point x="464" y="520" type="line"/>
-      <point x="433" y="571"/>
-      <point x="384" y="596"/>
-      <point x="312" y="596" type="curve" smooth="yes"/>
-      <point x="158" y="596"/>
-      <point x="49" y="471"/>
-      <point x="49" y="296" type="curve" smooth="yes"/>
-      <point x="49" y="107"/>
-      <point x="165" y="-16"/>
+      <point x="325" y="-16" type="curve" smooth="yes"/>
+      <point x="382" y="-16"/>
+      <point x="429" y="-3"/>
+      <point x="482" y="30" type="curve"/>
+      <point x="428" y="81" type="line"/>
+      <point x="400" y="69"/>
+      <point x="370" y="62"/>
+      <point x="333" y="62" type="curve" smooth="yes"/>
+      <point x="198" y="62"/>
+      <point x="125" y="146"/>
+      <point x="125" y="279" type="curve" smooth="yes"/>
+      <point x="125" y="385"/>
+      <point x="179" y="518"/>
+      <point x="320" y="518" type="curve" smooth="yes"/>
+      <point x="363" y="518"/>
+      <point x="387" y="505"/>
+      <point x="409" y="479" type="curve"/>
+      <point x="469" y="536" type="line"/>
+      <point x="430" y="575"/>
+      <point x="389" y="596"/>
+      <point x="323" y="596" type="curve" smooth="yes"/>
+      <point x="133" y="596"/>
+      <point x="46" y="416"/>
+      <point x="46" y="281" type="curve" smooth="yes"/>
+      <point x="46" y="105"/>
+      <point x="157" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ya-malayalam.glif
@@ -2,78 +2,78 @@
 <glyph name="ya-malayalam" format="2">
   <advance width="984"/>
   <unicode hex="0D2F"/>
-  <anchor x="531" y="0" name="bottom"/>
-  <anchor x="810" y="0" name="bottomright"/>
-  <anchor x="562" y="580" name="top"/>
-  <anchor x="868" y="580" name="topright"/>
+  <anchor x="525" y="0" name="bottom"/>
+  <anchor x="804" y="0" name="bottomright"/>
+  <anchor x="556" y="580" name="top"/>
+  <anchor x="862" y="580" name="topright"/>
   <outline>
     <contour>
-      <point x="639" y="-16" type="curve" smooth="yes"/>
-      <point x="831" y="-16"/>
-      <point x="956" y="127"/>
-      <point x="956" y="349" type="curve" smooth="yes"/>
-      <point x="956" y="450"/>
-      <point x="935" y="530"/>
-      <point x="891" y="596" type="curve"/>
-      <point x="822" y="553" type="line"/>
-      <point x="857" y="499"/>
-      <point x="874" y="432"/>
-      <point x="874" y="349" type="curve" smooth="yes"/>
-      <point x="874" y="173"/>
-      <point x="783" y="62"/>
-      <point x="639" y="62" type="curve" smooth="yes"/>
-      <point x="496" y="62"/>
-      <point x="419" y="152"/>
-      <point x="419" y="320" type="curve" smooth="yes"/>
-      <point x="419" y="435"/>
-      <point x="469" y="518"/>
+      <point x="599" y="-16" type="curve" smooth="yes"/>
+      <point x="815" y="-16"/>
+      <point x="947" y="170"/>
+      <point x="947" y="349" type="curve" smooth="yes"/>
+      <point x="947" y="438"/>
+      <point x="919" y="526"/>
+      <point x="869" y="596" type="curve"/>
+      <point x="802" y="552" type="line"/>
+      <point x="846" y="489"/>
+      <point x="868" y="421"/>
+      <point x="868" y="350" type="curve" smooth="yes"/>
+      <point x="868" y="197"/>
+      <point x="767" y="62"/>
+      <point x="605" y="62" type="curve" smooth="yes"/>
+      <point x="446" y="62"/>
+      <point x="376" y="165"/>
+      <point x="376" y="303" type="curve" smooth="yes"/>
+      <point x="376" y="386"/>
+      <point x="414" y="518"/>
       <point x="539" y="518" type="curve" smooth="yes"/>
-      <point x="599" y="518"/>
-      <point x="630" y="474"/>
-      <point x="630" y="389" type="curve" smooth="yes"/>
-      <point x="630" y="247"/>
-      <point x="574" y="142"/>
-      <point x="468" y="85" type="curve"/>
-      <point x="519" y="30" type="line"/>
-      <point x="643" y="99"/>
-      <point x="712" y="228"/>
-      <point x="712" y="389" type="curve" smooth="yes"/>
-      <point x="712" y="525"/>
-      <point x="654" y="596"/>
-      <point x="543" y="596" type="curve" smooth="yes"/>
-      <point x="425" y="596"/>
-      <point x="337" y="478"/>
-      <point x="337" y="320" type="curve" smooth="yes"/>
-      <point x="337" y="122"/>
-      <point x="462" y="-16"/>
+      <point x="609" y="518"/>
+      <point x="644" y="471"/>
+      <point x="644" y="387" type="curve" smooth="yes"/>
+      <point x="644" y="269"/>
+      <point x="572" y="155"/>
+      <point x="456" y="96" type="curve"/>
+      <point x="507" y="49" type="line"/>
+      <point x="653" y="122"/>
+      <point x="726" y="259"/>
+      <point x="726" y="389" type="curve" smooth="yes"/>
+      <point x="726" y="516"/>
+      <point x="663" y="596"/>
+      <point x="547" y="596" type="curve" smooth="yes"/>
+      <point x="388" y="596"/>
+      <point x="294" y="442"/>
+      <point x="294" y="305" type="curve" smooth="yes"/>
+      <point x="294" y="124"/>
+      <point x="418" y="-16"/>
     </contour>
     <contour>
-      <point x="343" y="-16" type="curve" smooth="yes"/>
-      <point x="407" y="-16"/>
-      <point x="459" y="-3"/>
-      <point x="508" y="27" type="curve"/>
-      <point x="438" y="77" type="line"/>
-      <point x="408" y="67"/>
-      <point x="377" y="62"/>
-      <point x="343" y="62" type="curve" smooth="yes"/>
-      <point x="209" y="62"/>
-      <point x="129" y="150"/>
-      <point x="129" y="296" type="curve" smooth="yes"/>
-      <point x="129" y="429"/>
-      <point x="200" y="518"/>
-      <point x="306" y="518" type="curve" smooth="yes"/>
-      <point x="357" y="518"/>
-      <point x="390" y="503"/>
-      <point x="413" y="470" type="curve"/>
-      <point x="464" y="520" type="line"/>
-      <point x="433" y="571"/>
-      <point x="384" y="596"/>
-      <point x="312" y="596" type="curve" smooth="yes"/>
-      <point x="158" y="596"/>
-      <point x="49" y="471"/>
-      <point x="49" y="296" type="curve" smooth="yes"/>
-      <point x="49" y="107"/>
-      <point x="165" y="-16"/>
+      <point x="325" y="-16" type="curve" smooth="yes"/>
+      <point x="382" y="-16"/>
+      <point x="429" y="-3"/>
+      <point x="482" y="30" type="curve"/>
+      <point x="428" y="81" type="line"/>
+      <point x="400" y="69"/>
+      <point x="370" y="62"/>
+      <point x="333" y="62" type="curve" smooth="yes"/>
+      <point x="198" y="62"/>
+      <point x="125" y="146"/>
+      <point x="125" y="279" type="curve" smooth="yes"/>
+      <point x="125" y="385"/>
+      <point x="179" y="518"/>
+      <point x="320" y="518" type="curve" smooth="yes"/>
+      <point x="363" y="518"/>
+      <point x="387" y="505"/>
+      <point x="409" y="479" type="curve"/>
+      <point x="469" y="536" type="line"/>
+      <point x="430" y="575"/>
+      <point x="389" y="596"/>
+      <point x="323" y="596" type="curve" smooth="yes"/>
+      <point x="133" y="596"/>
+      <point x="46" y="416"/>
+      <point x="46" y="281" type="curve" smooth="yes"/>
+      <point x="46" y="105"/>
+      <point x="157" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ya-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ya-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="984"/>
   <outline>
     <component base="ya-malayalam"/>
-    <component base="halant-malayalam" xOffset="795"/>
+    <component base="halant-malayalam" xOffset="789"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/kerning.plist
@@ -47215,7 +47215,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -47329,7 +47329,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47385,7 +47385,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47440,7 +47440,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>200</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -47487,7 +47487,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -47522,7 +47522,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>110</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -47550,8 +47550,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -47586,7 +47584,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47653,7 +47651,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47713,7 +47711,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>130</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47764,7 +47762,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>170</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -47822,7 +47820,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -47865,7 +47863,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48003,8 +48001,6 @@
       <integer>-10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48090,7 +48086,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48190,8 +48186,6 @@
       <integer>60</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48224,7 +48218,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -48304,7 +48298,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48346,8 +48340,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla-malayalam_L</key>
       <integer>-30</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -48465,8 +48457,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -48580,7 +48570,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48629,7 +48619,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>200</integer>
+      <integer>190</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48679,17 +48669,17 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>70</integer>
-      <key>public.kern2.MAL_braceright.loclMALM_R</key>
       <integer>50</integer>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>40</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
       <integer>40</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
@@ -48699,23 +48689,25 @@
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
       <integer>40</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
-      <integer>-30</integer>
+      <integer>-20</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>70</integer>
+      <key>public.kern2.MAL_tt_tta-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
-      <integer>130</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
-      <integer>90</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_uMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>74</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>220</integer>
+      <integer>210</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
       <integer>170</integer>
     </dict>
@@ -48742,7 +48734,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>120</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48791,7 +48783,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>160</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48867,7 +48859,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49078,7 +49070,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49104,8 +49096,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49134,7 +49124,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49188,7 +49178,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -49220,8 +49210,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -49338,7 +49326,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_p_pa-malayalam_L</key>
@@ -49450,7 +49438,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49495,7 +49483,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49591,7 +49579,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>170</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -49731,7 +49719,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49784,7 +49772,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>70</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49851,7 +49839,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>210</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>140</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>170</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49904,7 +49892,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>290</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>240</integer>
+      <integer>220</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -49991,7 +49979,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>130</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50140,7 +50128,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>30</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -50248,7 +50236,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>140</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>70</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_ng_ka-malayalam_L</key>
@@ -50300,6 +50288,26 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-40</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>110</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>100</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>80</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+      <key>public.kern2.MAL_quoteright.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.Man-georgian</key>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/archaicii-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/archaicii-malayalam.glif
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="archaicii-malayalam" format="2">
-  <advance width="1465"/>
+  <advance width="1469"/>
   <unicode hex="0D5F"/>
   <outline>
     <component base="archaicii-malayalam.part"/>
-    <component base="ra-malayalam" xOffset="353"/>
-    <component base="archaicii-malayalam.part" xOffset="1111"/>
+    <component base="ra-malayalam" xOffset="356"/>
+    <component base="archaicii-malayalam.part" xOffset="1113"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/archaicii-malayalam.part.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/archaicii-malayalam.part.glif
@@ -1,34 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="archaicii-malayalam.part" format="2">
-  <advance width="350"/>
+  <advance width="356"/>
   <outline>
     <contour>
-      <point x="168" y="164" type="curve" smooth="yes"/>
-      <point x="266" y="164"/>
-      <point x="336" y="230"/>
-      <point x="336" y="324" type="curve" smooth="yes"/>
-      <point x="336" y="395"/>
-      <point x="276" y="451"/>
-      <point x="199" y="451" type="curve" smooth="yes"/>
-      <point x="102" y="451"/>
-      <point x="32" y="384"/>
-      <point x="32" y="291" type="curve" smooth="yes"/>
-      <point x="32" y="219"/>
-      <point x="91" y="164"/>
+      <point x="172" y="164" type="curve" smooth="yes"/>
+      <point x="260" y="164"/>
+      <point x="330" y="232"/>
+      <point x="330" y="317" type="curve" smooth="yes"/>
+      <point x="330" y="397"/>
+      <point x="273" y="451"/>
+      <point x="187" y="451" type="curve" smooth="yes"/>
+      <point x="95" y="451"/>
+      <point x="29" y="387"/>
+      <point x="29" y="298" type="curve" smooth="yes"/>
+      <point x="29" y="219"/>
+      <point x="87" y="164"/>
     </contour>
     <contour>
-      <point x="178" y="250" type="curve" smooth="yes"/>
-      <point x="146" y="250"/>
-      <point x="123" y="271"/>
-      <point x="123" y="301" type="curve" smooth="yes"/>
-      <point x="123" y="336"/>
-      <point x="153" y="364"/>
-      <point x="190" y="364" type="curve" smooth="yes"/>
-      <point x="222" y="364"/>
-      <point x="245" y="343"/>
-      <point x="245" y="314" type="curve" smooth="yes"/>
-      <point x="245" y="279"/>
-      <point x="215" y="250"/>
+      <point x="177" y="250" type="curve" smooth="yes"/>
+      <point x="141" y="250"/>
+      <point x="121" y="270"/>
+      <point x="121" y="304" type="curve" smooth="yes"/>
+      <point x="121" y="340"/>
+      <point x="146" y="365"/>
+      <point x="182" y="365" type="curve" smooth="yes"/>
+      <point x="217" y="365"/>
+      <point x="238" y="345"/>
+      <point x="238" y="311" type="curve" smooth="yes"/>
+      <point x="238" y="275"/>
+      <point x="213" y="250"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/d_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/d_da-malayalam.glif
@@ -1,73 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="d_da-malayalam" format="2">
   <advance width="704"/>
-  <anchor x="366" y="597" name="top"/>
+  <anchor x="311" y="-249" name="bottom"/>
+  <anchor x="433" y="597" name="top"/>
   <outline>
     <contour>
-      <point x="394" y="-229" type="curve" smooth="yes"/>
-      <point x="531" y="-229"/>
-      <point x="612" y="-174"/>
-      <point x="612" y="-70" type="curve" smooth="yes"/>
-      <point x="612" y="-13"/>
-      <point x="574" y="27"/>
-      <point x="507" y="44" type="curve"/>
-      <point x="508" y="51" type="line"/>
-      <point x="581" y="59"/>
-      <point x="643" y="98"/>
-      <point x="643" y="180" type="curve" smooth="yes"/>
-      <point x="643" y="241"/>
-      <point x="608" y="281"/>
-      <point x="530" y="296" type="curve"/>
-      <point x="531" y="303" type="line"/>
-      <point x="621" y="316"/>
-      <point x="671" y="366"/>
-      <point x="671" y="441" type="curve" smooth="yes"/>
-      <point x="671" y="536"/>
-      <point x="588" y="613"/>
-      <point x="411" y="613" type="curve" smooth="yes"/>
-      <point x="183" y="613"/>
-      <point x="35" y="454"/>
-      <point x="35" y="232" type="curve" smooth="yes"/>
-      <point x="35" y="138"/>
-      <point x="56" y="59"/>
-      <point x="99" y="-16" type="curve"/>
-      <point x="206" y="45" type="line"/>
-      <point x="172" y="98"/>
-      <point x="157" y="165"/>
-      <point x="157" y="234" type="curve" smooth="yes"/>
-      <point x="157" y="389"/>
-      <point x="241" y="502"/>
-      <point x="410" y="502" type="curve" smooth="yes"/>
-      <point x="500" y="502"/>
-      <point x="546" y="473"/>
-      <point x="546" y="424" type="curve" smooth="yes"/>
-      <point x="546" y="381"/>
-      <point x="508" y="354"/>
-      <point x="445" y="354" type="curve" smooth="yes"/>
-      <point x="384" y="354" type="line"/>
-      <point x="365" y="248" type="line"/>
-      <point x="416" y="248" type="line" smooth="yes"/>
-      <point x="486" y="248"/>
-      <point x="523" y="229"/>
-      <point x="523" y="181" type="curve" smooth="yes"/>
-      <point x="523" y="120"/>
-      <point x="477" y="101"/>
-      <point x="419" y="101" type="curve" smooth="yes"/>
-      <point x="340" y="101" type="line"/>
-      <point x="321" y="-4" type="line"/>
-      <point x="393" y="-4" type="line" smooth="yes"/>
-      <point x="465" y="-4"/>
-      <point x="495" y="-23"/>
-      <point x="494" y="-59" type="curve" smooth="yes"/>
-      <point x="493" y="-100"/>
-      <point x="457" y="-116"/>
-      <point x="396" y="-116" type="curve" smooth="yes"/>
-      <point x="344" y="-116"/>
-      <point x="299" y="-109"/>
-      <point x="268" y="-97" type="curve"/>
-      <point x="210" y="-200" type="line"/>
-      <point x="244" y="-214"/>
-      <point x="310" y="-229"/>
+      <point x="346" y="-263" type="curve" smooth="yes"/>
+      <point x="513" y="-263"/>
+      <point x="602" y="-175"/>
+      <point x="602" y="-76" type="curve" smooth="yes"/>
+      <point x="602" y="-14"/>
+      <point x="566" y="32"/>
+      <point x="502" y="48" type="curve"/>
+      <point x="503" y="55" type="line"/>
+      <point x="589" y="70"/>
+      <point x="642" y="119"/>
+      <point x="642" y="185" type="curve" smooth="yes"/>
+      <point x="642" y="247"/>
+      <point x="609" y="286"/>
+      <point x="527" y="301" type="curve"/>
+      <point x="528" y="308" type="line"/>
+      <point x="618" y="329"/>
+      <point x="666" y="378"/>
+      <point x="666" y="452" type="curve" smooth="yes"/>
+      <point x="666" y="530"/>
+      <point x="602" y="613"/>
+      <point x="430" y="613" type="curve" smooth="yes"/>
+      <point x="158" y="613"/>
+      <point x="34" y="419"/>
+      <point x="34" y="238" type="curve" smooth="yes"/>
+      <point x="34" y="151"/>
+      <point x="57" y="65"/>
+      <point x="102" y="-16" type="curve"/>
+      <point x="209" y="44" type="line"/>
+      <point x="173" y="109"/>
+      <point x="157" y="174"/>
+      <point x="157" y="238" type="curve" smooth="yes"/>
+      <point x="157" y="370"/>
+      <point x="230" y="502"/>
+      <point x="422" y="502" type="curve" smooth="yes"/>
+      <point x="514" y="502"/>
+      <point x="543" y="470"/>
+      <point x="543" y="431" type="curve" smooth="yes"/>
+      <point x="543" y="384"/>
+      <point x="500" y="354"/>
+      <point x="430" y="354" type="curve" smooth="yes"/>
+      <point x="380" y="354" type="line"/>
+      <point x="361" y="248" type="line"/>
+      <point x="423" y="248" type="line" smooth="yes"/>
+      <point x="489" y="248"/>
+      <point x="519" y="227"/>
+      <point x="519" y="181" type="curve" smooth="yes"/>
+      <point x="519" y="133"/>
+      <point x="473" y="101"/>
+      <point x="406" y="101" type="curve" smooth="yes"/>
+      <point x="319" y="101" type="line"/>
+      <point x="301" y="-4" type="line"/>
+      <point x="391" y="-4" type="line" smooth="yes"/>
+      <point x="453" y="-4"/>
+      <point x="479" y="-28"/>
+      <point x="479" y="-69" type="curve" smooth="yes"/>
+      <point x="479" y="-116"/>
+      <point x="442" y="-152"/>
+      <point x="354" y="-152" type="curve" smooth="yes"/>
+      <point x="292" y="-152"/>
+      <point x="241" y="-139"/>
+      <point x="188" y="-109" type="curve"/>
+      <point x="133" y="-205" type="line"/>
+      <point x="195" y="-244"/>
+      <point x="264" y="-263"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/g_da-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/g_da-malayalam.glif
@@ -1,73 +1,77 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_da-malayalam" format="2">
-  <advance width="1002"/>
-  <anchor x="632" y="0" name="bottom"/>
-  <anchor x="553" y="597" name="top"/>
-  <anchor x="917" y="597" name="topright"/>
+  <advance width="994"/>
+  <anchor x="620" y="0" name="bottom"/>
+  <anchor x="550" y="597" name="top"/>
+  <anchor x="906" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="262" y="-16" type="curve" smooth="yes"/>
-      <point x="393" y="-16"/>
-      <point x="475" y="60"/>
-      <point x="520" y="223" type="curve" smooth="yes"/>
-      <point x="552" y="339" type="line" smooth="yes"/>
-      <point x="583" y="448"/>
-      <point x="630" y="502"/>
-      <point x="733" y="502" type="curve" smooth="yes"/>
-      <point x="811" y="502"/>
-      <point x="858" y="475"/>
-      <point x="858" y="422" type="curve" smooth="yes"/>
-      <point x="858" y="376"/>
-      <point x="822" y="347"/>
-      <point x="763" y="347" type="curve" smooth="yes"/>
-      <point x="695" y="347" type="line"/>
-      <point x="677" y="242" type="line"/>
-      <point x="730" y="242" type="line" smooth="yes"/>
-      <point x="798" y="242"/>
-      <point x="833" y="217"/>
-      <point x="833" y="168" type="curve" smooth="yes"/>
-      <point x="833" y="122"/>
-      <point x="801" y="96"/>
-      <point x="743" y="96" type="curve" smooth="yes"/>
-      <point x="704" y="96"/>
-      <point x="675" y="104"/>
-      <point x="637" y="124" type="curve"/>
-      <point x="574" y="25" type="line"/>
-      <point x="616" y="-1"/>
-      <point x="677" y="-16"/>
-      <point x="740" y="-16" type="curve" smooth="yes"/>
-      <point x="870" y="-16"/>
-      <point x="954" y="53"/>
-      <point x="954" y="158" type="curve" smooth="yes"/>
-      <point x="954" y="227"/>
-      <point x="914" y="274"/>
-      <point x="841" y="289" type="curve"/>
-      <point x="842" y="296" type="line"/>
-      <point x="929" y="307"/>
-      <point x="979" y="359"/>
-      <point x="979" y="439" type="curve" smooth="yes"/>
-      <point x="979" y="548"/>
-      <point x="892" y="613"/>
-      <point x="736" y="613" type="curve" smooth="yes"/>
-      <point x="572" y="613"/>
-      <point x="478" y="530"/>
-      <point x="429" y="352" type="curve" smooth="yes"/>
-      <point x="403" y="254" type="line" smooth="yes"/>
-      <point x="372" y="142"/>
-      <point x="332" y="95"/>
-      <point x="262" y="95" type="curve" smooth="yes"/>
-      <point x="194" y="95"/>
-      <point x="153" y="143"/>
-      <point x="153" y="223" type="curve" smooth="yes"/>
-      <point x="153" y="334"/>
-      <point x="209" y="432"/>
-      <point x="326" y="524" type="curve"/>
-      <point x="245" y="613" type="line"/>
-      <point x="107" y="506"/>
-      <point x="32" y="367"/>
-      <point x="32" y="222" type="curve" smooth="yes"/>
-      <point x="32" y="77"/>
-      <point x="122" y="-16"/>
+      <point x="273" y="-16" type="curve" smooth="yes"/>
+      <point x="412" y="-16"/>
+      <point x="506" y="74"/>
+      <point x="528" y="221" type="curve" smooth="yes"/>
+      <point x="535" y="265"/>
+      <point x="532" y="307"/>
+      <point x="539" y="351" type="curve" smooth="yes"/>
+      <point x="554" y="447"/>
+      <point x="621" y="502"/>
+      <point x="722" y="502" type="curve" smooth="yes"/>
+      <point x="795" y="502"/>
+      <point x="836" y="473"/>
+      <point x="836" y="422" type="curve" smooth="yes"/>
+      <point x="836" y="376"/>
+      <point x="800" y="347"/>
+      <point x="742" y="347" type="curve" smooth="yes"/>
+      <point x="674" y="347" type="line"/>
+      <point x="656" y="242" type="line"/>
+      <point x="708" y="242" type="line" smooth="yes"/>
+      <point x="776" y="242"/>
+      <point x="811" y="217"/>
+      <point x="811" y="168" type="curve" smooth="yes"/>
+      <point x="811" y="122"/>
+      <point x="780" y="96"/>
+      <point x="721" y="96" type="curve" smooth="yes"/>
+      <point x="683" y="96"/>
+      <point x="653" y="104"/>
+      <point x="616" y="124" type="curve"/>
+      <point x="553" y="25" type="line"/>
+      <point x="594" y="-1"/>
+      <point x="655" y="-16"/>
+      <point x="719" y="-16" type="curve" smooth="yes"/>
+      <point x="848" y="-16"/>
+      <point x="933" y="53"/>
+      <point x="933" y="158" type="curve" smooth="yes"/>
+      <point x="933" y="227"/>
+      <point x="892" y="274"/>
+      <point x="820" y="288" type="curve"/>
+      <point x="820" y="295" type="line"/>
+      <point x="907" y="306"/>
+      <point x="958" y="359"/>
+      <point x="958" y="437" type="curve" smooth="yes"/>
+      <point x="958" y="545"/>
+      <point x="870" y="613"/>
+      <point x="725" y="613" type="curve" smooth="yes"/>
+      <point x="556" y="613"/>
+      <point x="445" y="523"/>
+      <point x="421" y="372" type="curve" smooth="yes"/>
+      <point x="414" y="328"/>
+      <point x="417" y="286"/>
+      <point x="410" y="242" type="curve" smooth="yes"/>
+      <point x="396" y="148"/>
+      <point x="352" y="98"/>
+      <point x="273" y="98" type="curve" smooth="yes"/>
+      <point x="203" y="98"/>
+      <point x="153" y="146"/>
+      <point x="153" y="234" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="214" y="434"/>
+      <point x="325" y="528" type="curve"/>
+      <point x="244" y="616" type="line"/>
+      <point x="110" y="503"/>
+      <point x="33" y="374"/>
+      <point x="33" y="232" type="curve" smooth="yes"/>
+      <point x="33" y="86"/>
+      <point x="135" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/g_ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/g_ga-malayalam.glif
@@ -1,92 +1,101 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ga-malayalam" format="2">
-  <advance width="949"/>
-  <anchor x="440" y="-351" name="bottom"/>
-  <anchor x="539" y="597" name="top"/>
-  <anchor x="833" y="597" name="topright"/>
+  <advance width="950"/>
+  <anchor x="444" y="-352" name="bottom"/>
+  <anchor x="535" y="597" name="top"/>
+  <anchor x="829" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="643" y="-370" type="line"/>
-      <point x="722" y="-302"/>
-      <point x="772" y="-221"/>
-      <point x="772" y="-120" type="curve" smooth="yes"/>
-      <point x="772" y="-4"/>
-      <point x="697" y="53"/>
-      <point x="596" y="53" type="curve" smooth="yes"/>
-      <point x="490" y="53"/>
-      <point x="433" y="-1"/>
-      <point x="400" y="-135" type="curve" smooth="yes"/>
-      <point x="391" y="-171" type="line" smooth="yes"/>
-      <point x="372" y="-248"/>
-      <point x="342" y="-278"/>
-      <point x="295" y="-278" type="curve" smooth="yes"/>
-      <point x="245" y="-278"/>
-      <point x="215" y="-246"/>
-      <point x="215" y="-188" type="curve" smooth="yes"/>
-      <point x="215" y="-123"/>
-      <point x="250" y="-61"/>
-      <point x="304" y="-5" type="curve"/>
-      <point x="278" y="-16" type="line"/>
-      <point x="400" y="-10"/>
-      <point x="477" y="67"/>
-      <point x="520" y="223" type="curve" smooth="yes"/>
-      <point x="552" y="339" type="line" smooth="yes"/>
-      <point x="584" y="451"/>
-      <point x="630" y="502"/>
-      <point x="703" y="502" type="curve" smooth="yes"/>
-      <point x="770" y="502"/>
-      <point x="805" y="457"/>
-      <point x="805" y="371" type="curve" smooth="yes"/>
-      <point x="805" y="251"/>
-      <point x="748" y="137"/>
-      <point x="614" y="40" type="curve"/>
-      <point x="726" y="-16" type="line"/>
-      <point x="852" y="87"/>
-      <point x="927" y="231"/>
-      <point x="927" y="372" type="curve" smooth="yes"/>
-      <point x="927" y="523"/>
-      <point x="844" y="613"/>
-      <point x="705" y="613" type="curve" smooth="yes"/>
-      <point x="564" y="613"/>
-      <point x="479" y="533"/>
-      <point x="429" y="352" type="curve" smooth="yes"/>
-      <point x="403" y="254" type="line" smooth="yes"/>
-      <point x="372" y="142"/>
-      <point x="332" y="95"/>
-      <point x="262" y="95" type="curve" smooth="yes"/>
-      <point x="194" y="95"/>
-      <point x="153" y="143"/>
-      <point x="153" y="223" type="curve" smooth="yes"/>
-      <point x="153" y="334"/>
-      <point x="209" y="432"/>
-      <point x="326" y="524" type="curve"/>
-      <point x="245" y="613" type="line"/>
-      <point x="107" y="506"/>
-      <point x="32" y="367"/>
-      <point x="32" y="222" type="curve" smooth="yes"/>
-      <point x="32" y="107"/>
-      <point x="88" y="25"/>
-      <point x="186" y="-3" type="curve"/>
-      <point x="186" y="-10" type="line"/>
-      <point x="138" y="-67"/>
-      <point x="115" y="-129"/>
-      <point x="115" y="-196" type="curve" smooth="yes"/>
-      <point x="115" y="-303"/>
-      <point x="180" y="-368"/>
-      <point x="293" y="-368" type="curve" smooth="yes"/>
-      <point x="391" y="-368"/>
-      <point x="452" y="-316"/>
-      <point x="482" y="-187" type="curve" smooth="yes"/>
-      <point x="492" y="-145" type="line" smooth="yes"/>
-      <point x="511" y="-67"/>
-      <point x="538" y="-37"/>
-      <point x="592" y="-37" type="curve" smooth="yes"/>
-      <point x="646" y="-37"/>
-      <point x="673" y="-70"/>
-      <point x="673" y="-123" type="curve" smooth="yes"/>
-      <point x="673" y="-198"/>
-      <point x="629" y="-262"/>
-      <point x="576" y="-311" type="curve"/>
+      <point x="273" y="-8" type="curve" smooth="yes"/>
+      <point x="415" y="-8"/>
+      <point x="506" y="79"/>
+      <point x="528" y="221" type="curve" smooth="yes"/>
+      <point x="535" y="265"/>
+      <point x="532" y="307"/>
+      <point x="539" y="351" type="curve" smooth="yes"/>
+      <point x="554" y="445"/>
+      <point x="604" y="499"/>
+      <point x="684" y="499" type="curve" smooth="yes"/>
+      <point x="755" y="499"/>
+      <point x="797" y="454"/>
+      <point x="797" y="361" type="curve" smooth="yes"/>
+      <point x="797" y="252"/>
+      <point x="720" y="129"/>
+      <point x="598" y="37" type="curve"/>
+      <point x="723" y="-8" type="line"/>
+      <point x="844" y="97"/>
+      <point x="917" y="234"/>
+      <point x="917" y="363" type="curve" smooth="yes"/>
+      <point x="917" y="515"/>
+      <point x="820" y="613"/>
+      <point x="684" y="613" type="curve" smooth="yes"/>
+      <point x="539" y="613"/>
+      <point x="445" y="525"/>
+      <point x="421" y="372" type="curve" smooth="yes"/>
+      <point x="414" y="328"/>
+      <point x="417" y="286"/>
+      <point x="410" y="242" type="curve" smooth="yes"/>
+      <point x="396" y="148"/>
+      <point x="352" y="98"/>
+      <point x="273" y="98" type="curve" smooth="yes"/>
+      <point x="203" y="98"/>
+      <point x="153" y="146"/>
+      <point x="153" y="234" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="214" y="434"/>
+      <point x="325" y="528" type="curve"/>
+      <point x="244" y="616" type="line"/>
+      <point x="110" y="503"/>
+      <point x="33" y="374"/>
+      <point x="33" y="232" type="curve" smooth="yes"/>
+      <point x="33" y="91"/>
+      <point x="133" y="-8"/>
+    </contour>
+    <contour>
+      <point x="666" y="-371" type="line"/>
+      <point x="740" y="-308"/>
+      <point x="788" y="-210"/>
+      <point x="788" y="-123" type="curve" smooth="yes"/>
+      <point x="788" y="-22"/>
+      <point x="715" y="53"/>
+      <point x="613" y="53" type="curve" smooth="yes"/>
+      <point x="503" y="53"/>
+      <point x="430" y="-9"/>
+      <point x="413" y="-117" type="curve" smooth="yes"/>
+      <point x="410" y="-136"/>
+      <point x="410" y="-159"/>
+      <point x="407" y="-178" type="curve" smooth="yes"/>
+      <point x="397" y="-242"/>
+      <point x="363" y="-277"/>
+      <point x="313" y="-277" type="curve" smooth="yes"/>
+      <point x="261" y="-277"/>
+      <point x="232" y="-245"/>
+      <point x="232" y="-185" type="curve" smooth="yes"/>
+      <point x="232" y="-112"/>
+      <point x="265" y="-46"/>
+      <point x="333" y="17" type="curve"/>
+      <point x="219" y="17" type="line"/>
+      <point x="165" y="-36"/>
+      <point x="134" y="-110"/>
+      <point x="134" y="-187" type="curve" smooth="yes"/>
+      <point x="134" y="-297"/>
+      <point x="205" y="-368"/>
+      <point x="311" y="-368" type="curve" smooth="yes"/>
+      <point x="419" y="-368"/>
+      <point x="489" y="-304"/>
+      <point x="506" y="-196" type="curve" smooth="yes"/>
+      <point x="509" y="-177"/>
+      <point x="509" y="-154"/>
+      <point x="512" y="-135" type="curve" smooth="yes"/>
+      <point x="522" y="-71"/>
+      <point x="559" y="-37"/>
+      <point x="611" y="-37" type="curve" smooth="yes"/>
+      <point x="666" y="-37"/>
+      <point x="690" y="-67"/>
+      <point x="690" y="-125" type="curve" smooth="yes"/>
+      <point x="690" y="-186"/>
+      <point x="655" y="-255"/>
+      <point x="599" y="-302" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/g_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/g_la-malayalam.glif
@@ -1,116 +1,125 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_la-malayalam" format="2">
-  <advance width="949"/>
-  <anchor x="439" y="-351" name="bottom"/>
-  <anchor x="539" y="597" name="top"/>
-  <anchor x="833" y="597" name="topright"/>
+  <advance width="950"/>
+  <anchor x="427" y="-352" name="bottom"/>
+  <anchor x="535" y="597" name="top"/>
+  <anchor x="829" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="215" y="-368" type="curve" smooth="yes"/>
-      <point x="307" y="-368"/>
-      <point x="363" y="-308"/>
-      <point x="363" y="-225" type="curve" smooth="yes"/>
-      <point x="363" y="-146"/>
-      <point x="319" y="-112"/>
-      <point x="253" y="-112" type="curve" smooth="yes"/>
-      <point x="218" y="-112"/>
-      <point x="186" y="-124"/>
-      <point x="159" y="-154" type="curve"/>
-      <point x="152" y="-153" type="line"/>
-      <point x="166" y="-89"/>
-      <point x="216" y="-35"/>
-      <point x="301" y="-35" type="curve" smooth="yes"/>
-      <point x="397" y="-35"/>
-      <point x="431" y="-83"/>
-      <point x="438" y="-171" type="curve" smooth="yes"/>
-      <point x="439" y="-184" type="line" smooth="yes"/>
-      <point x="449" y="-304"/>
-      <point x="499" y="-368"/>
-      <point x="626" y="-368" type="curve" smooth="yes"/>
-      <point x="766" y="-368"/>
-      <point x="826" y="-264"/>
-      <point x="826" y="-126" type="curve" smooth="yes"/>
-      <point x="826" y="-51"/>
-      <point x="809" y="4"/>
-      <point x="775" y="52" type="curve"/>
-      <point x="760" y="15" type="line"/>
-      <point x="866" y="114"/>
-      <point x="927" y="244"/>
-      <point x="927" y="372" type="curve" smooth="yes"/>
-      <point x="927" y="523"/>
-      <point x="844" y="613"/>
-      <point x="705" y="613" type="curve" smooth="yes"/>
-      <point x="564" y="613"/>
-      <point x="479" y="533"/>
-      <point x="429" y="352" type="curve" smooth="yes"/>
-      <point x="403" y="254" type="line" smooth="yes"/>
-      <point x="372" y="142"/>
-      <point x="332" y="97"/>
-      <point x="262" y="97" type="curve" smooth="yes"/>
-      <point x="194" y="97"/>
-      <point x="153" y="143"/>
-      <point x="153" y="223" type="curve" smooth="yes"/>
-      <point x="153" y="334"/>
-      <point x="209" y="432"/>
-      <point x="326" y="524" type="curve"/>
-      <point x="245" y="613" type="line"/>
-      <point x="107" y="506"/>
-      <point x="32" y="367"/>
-      <point x="32" y="222" type="curve" smooth="yes"/>
-      <point x="32" y="123"/>
-      <point x="73" y="51"/>
-      <point x="157" y="16" type="curve"/>
-      <point x="157" y="9" type="line"/>
-      <point x="89" y="-41"/>
-      <point x="55" y="-117"/>
-      <point x="55" y="-199" type="curve" smooth="yes"/>
-      <point x="55" y="-313"/>
-      <point x="122" y="-368"/>
+      <point x="199" y="-368" type="curve" smooth="yes"/>
+      <point x="286" y="-368"/>
+      <point x="352" y="-306"/>
+      <point x="352" y="-225" type="curve" smooth="yes"/>
+      <point x="352" y="-157"/>
+      <point x="309" y="-112"/>
+      <point x="244" y="-112" type="curve" smooth="yes"/>
+      <point x="181" y="-112"/>
+      <point x="136" y="-145"/>
+      <point x="119" y="-204" type="curve"/>
+      <point x="171" y="-161" type="line"/>
+      <point x="119" y="-143" type="line"/>
+      <point x="137" y="-176" type="line"/>
+      <point x="153" y="-89"/>
+      <point x="215" y="-35"/>
+      <point x="299" y="-35" type="curve" smooth="yes"/>
+      <point x="373" y="-35"/>
+      <point x="411" y="-69"/>
+      <point x="426" y="-151" type="curve" smooth="yes"/>
+      <point x="434" y="-193" type="line" smooth="yes"/>
+      <point x="457" y="-313"/>
+      <point x="516" y="-368"/>
+      <point x="620" y="-368" type="curve" smooth="yes"/>
+      <point x="739" y="-368"/>
+      <point x="816" y="-280"/>
+      <point x="816" y="-146" type="curve" smooth="yes"/>
+      <point x="816" y="-73"/>
+      <point x="801" y="-10"/>
+      <point x="759" y="55" type="curve"/>
+      <point x="762" y="28" type="line"/>
+      <point x="859" y="128"/>
+      <point x="917" y="249"/>
+      <point x="917" y="363" type="curve" smooth="yes"/>
+      <point x="917" y="515"/>
+      <point x="820" y="613"/>
+      <point x="684" y="613" type="curve" smooth="yes"/>
+      <point x="539" y="613"/>
+      <point x="445" y="525"/>
+      <point x="421" y="372" type="curve" smooth="yes"/>
+      <point x="414" y="328"/>
+      <point x="417" y="286"/>
+      <point x="410" y="242" type="curve" smooth="yes"/>
+      <point x="396" y="148"/>
+      <point x="352" y="98"/>
+      <point x="273" y="98" type="curve" smooth="yes"/>
+      <point x="203" y="98"/>
+      <point x="153" y="146"/>
+      <point x="153" y="234" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="214" y="434"/>
+      <point x="325" y="528" type="curve"/>
+      <point x="244" y="616" type="line"/>
+      <point x="110" y="503"/>
+      <point x="33" y="374"/>
+      <point x="33" y="232" type="curve" smooth="yes"/>
+      <point x="33" y="135"/>
+      <point x="83" y="60"/>
+      <point x="159" y="20" type="curve"/>
+      <point x="159" y="12" type="line"/>
+      <point x="91" y="-32"/>
+      <point x="45" y="-115"/>
+      <point x="45" y="-195" type="curve" smooth="yes"/>
+      <point x="45" y="-299"/>
+      <point x="107" y="-368"/>
     </contour>
     <contour>
-      <point x="215" y="-288" type="curve" smooth="yes"/>
-      <point x="164" y="-288"/>
-      <point x="149" y="-250"/>
-      <point x="149" y="-213" type="curve"/>
-      <point x="133" y="-207" type="line"/>
-      <point x="141" y="-246" type="line"/>
-      <point x="153" y="-208"/>
-      <point x="181" y="-185"/>
-      <point x="218" y="-185" type="curve" smooth="yes"/>
-      <point x="255" y="-185"/>
-      <point x="273" y="-200"/>
-      <point x="273" y="-232" type="curve" smooth="yes"/>
-      <point x="273" y="-267"/>
-      <point x="251" y="-288"/>
+      <point x="199" y="-288" type="curve" smooth="yes"/>
+      <point x="163" y="-288"/>
+      <point x="137" y="-265"/>
+      <point x="137" y="-232" type="curve" smooth="yes"/>
+      <point x="137" y="-225"/>
+      <point x="138" y="-218"/>
+      <point x="140" y="-211" type="curve"/>
+      <point x="110" y="-227" type="line"/>
+      <point x="128" y="-257" type="line"/>
+      <point x="140" y="-213"/>
+      <point x="173" y="-185"/>
+      <point x="216" y="-185" type="curve" smooth="yes"/>
+      <point x="248" y="-185"/>
+      <point x="263" y="-202"/>
+      <point x="263" y="-230" type="curve" smooth="yes"/>
+      <point x="263" y="-263"/>
+      <point x="235" y="-288"/>
     </contour>
     <contour>
-      <point x="626" y="-279" type="curve" smooth="yes"/>
-      <point x="569" y="-279"/>
-      <point x="545" y="-246"/>
-      <point x="538" y="-166" type="curve" smooth="yes"/>
-      <point x="537" y="-150" type="line" smooth="yes"/>
-      <point x="529" y="-54"/>
-      <point x="495" y="12"/>
-      <point x="411" y="41" type="curve"/>
-      <point x="411" y="48" type="line"/>
-      <point x="469" y="85"/>
-      <point x="498" y="144"/>
-      <point x="520" y="223" type="curve" smooth="yes"/>
-      <point x="552" y="339" type="line" smooth="yes"/>
-      <point x="584" y="451"/>
-      <point x="630" y="500"/>
-      <point x="703" y="500" type="curve" smooth="yes"/>
-      <point x="770" y="500"/>
-      <point x="805" y="457"/>
-      <point x="805" y="371" type="curve" smooth="yes"/>
-      <point x="805" y="263"/>
-      <point x="751" y="163"/>
-      <point x="646" y="74" type="curve"/>
-      <point x="690" y="21"/>
-      <point x="725" y="-49"/>
-      <point x="725" y="-140" type="curve" smooth="yes"/>
-      <point x="725" y="-217"/>
-      <point x="697" y="-279"/>
+      <point x="622" y="-278" type="curve" smooth="yes"/>
+      <point x="572" y="-278"/>
+      <point x="545" y="-247"/>
+      <point x="531" y="-176" type="curve" smooth="yes"/>
+      <point x="523" y="-134" type="line" smooth="yes"/>
+      <point x="506" y="-45"/>
+      <point x="469" y="7"/>
+      <point x="404" y="31" type="curve"/>
+      <point x="404" y="39" type="line"/>
+      <point x="470" y="77"/>
+      <point x="516" y="140"/>
+      <point x="528" y="221" type="curve" smooth="yes"/>
+      <point x="535" y="265"/>
+      <point x="532" y="307"/>
+      <point x="539" y="351" type="curve" smooth="yes"/>
+      <point x="554" y="445"/>
+      <point x="604" y="499"/>
+      <point x="684" y="499" type="curve" smooth="yes"/>
+      <point x="755" y="499"/>
+      <point x="797" y="454"/>
+      <point x="797" y="361" type="curve" smooth="yes"/>
+      <point x="797" y="265"/>
+      <point x="733" y="154"/>
+      <point x="627" y="67" type="curve"/>
+      <point x="690" y="1"/>
+      <point x="717" y="-60"/>
+      <point x="717" y="-150" type="curve" smooth="yes"/>
+      <point x="717" y="-228"/>
+      <point x="680" y="-278"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/g_ma-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/g_ma-malayalam.glif
@@ -1,99 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_ma-malayalam" format="2">
   <advance width="1440"/>
-  <anchor x="1043" y="0" name="bottom"/>
-  <anchor x="782" y="597" name="top"/>
-  <anchor x="1376" y="597" name="topright"/>
+  <anchor x="1038" y="0" name="bottom"/>
+  <anchor x="778" y="597" name="top"/>
+  <anchor x="1373" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="262" y="-16" type="curve" smooth="yes"/>
-      <point x="393" y="-16"/>
-      <point x="475" y="60"/>
-      <point x="520" y="223" type="curve" smooth="yes"/>
-      <point x="552" y="339" type="line" smooth="yes"/>
-      <point x="584" y="451"/>
-      <point x="630" y="500"/>
-      <point x="703" y="500" type="curve" smooth="yes"/>
-      <point x="770" y="500"/>
-      <point x="803" y="463"/>
-      <point x="804" y="391" type="curve" smooth="yes"/>
-      <point x="804" y="371"/>
-      <point x="801" y="350"/>
-      <point x="797" y="326" type="curve" smooth="yes"/>
-      <point x="740" y="0" type="line"/>
-      <point x="1350" y="0" type="line"/>
-      <point x="1398" y="275" type="line" smooth="yes"/>
-      <point x="1404" y="309"/>
-      <point x="1407" y="347"/>
-      <point x="1407" y="369" type="curve" smooth="yes"/>
-      <point x="1407" y="539"/>
-      <point x="1299" y="613"/>
-      <point x="1142" y="613" type="curve" smooth="yes"/>
-      <point x="1034" y="613"/>
-      <point x="947" y="578"/>
-      <point x="893" y="501" type="curve"/>
-      <point x="886" y="501" type="line"/>
-      <point x="849" y="583"/>
-      <point x="787" y="613"/>
-      <point x="700" y="613" type="curve" smooth="yes"/>
-      <point x="564" y="613"/>
-      <point x="479" y="533"/>
-      <point x="429" y="352" type="curve" smooth="yes"/>
-      <point x="403" y="254" type="line" smooth="yes"/>
-      <point x="372" y="142"/>
-      <point x="332" y="95"/>
-      <point x="262" y="95" type="curve" smooth="yes"/>
-      <point x="194" y="95"/>
-      <point x="153" y="143"/>
-      <point x="153" y="223" type="curve" smooth="yes"/>
-      <point x="153" y="334"/>
-      <point x="209" y="432"/>
-      <point x="326" y="524" type="curve"/>
-      <point x="245" y="613" type="line"/>
-      <point x="107" y="506"/>
-      <point x="32" y="367"/>
-      <point x="32" y="222" type="curve" smooth="yes"/>
-      <point x="32" y="77"/>
-      <point x="122" y="-16"/>
+      <point x="273" y="-16" type="curve" smooth="yes"/>
+      <point x="412" y="-16"/>
+      <point x="506" y="74"/>
+      <point x="528" y="221" type="curve" smooth="yes"/>
+      <point x="535" y="265"/>
+      <point x="532" y="307"/>
+      <point x="539" y="351" type="curve" smooth="yes"/>
+      <point x="554" y="446"/>
+      <point x="609" y="499"/>
+      <point x="692" y="499" type="curve" smooth="yes"/>
+      <point x="761" y="499"/>
+      <point x="799" y="461"/>
+      <point x="799" y="394" type="curve" smooth="yes"/>
+      <point x="799" y="374"/>
+      <point x="796" y="350"/>
+      <point x="792" y="328" type="curve" smooth="yes"/>
+      <point x="734" y="0" type="line"/>
+      <point x="1339" y="0" type="line"/>
+      <point x="1387" y="273" type="line" smooth="yes"/>
+      <point x="1393" y="307"/>
+      <point x="1397" y="345"/>
+      <point x="1397" y="369" type="curve" smooth="yes"/>
+      <point x="1397" y="529"/>
+      <point x="1308" y="613"/>
+      <point x="1139" y="613" type="curve" smooth="yes"/>
+      <point x="1028" y="613"/>
+      <point x="933" y="572"/>
+      <point x="880" y="501" type="curve"/>
+      <point x="873" y="501" type="line"/>
+      <point x="846" y="570"/>
+      <point x="783" y="613"/>
+      <point x="686" y="613" type="curve" smooth="yes"/>
+      <point x="544" y="613"/>
+      <point x="445" y="525"/>
+      <point x="421" y="372" type="curve" smooth="yes"/>
+      <point x="414" y="328"/>
+      <point x="417" y="286"/>
+      <point x="410" y="242" type="curve" smooth="yes"/>
+      <point x="396" y="148"/>
+      <point x="352" y="98"/>
+      <point x="273" y="98" type="curve" smooth="yes"/>
+      <point x="203" y="98"/>
+      <point x="153" y="146"/>
+      <point x="153" y="234" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="214" y="434"/>
+      <point x="325" y="528" type="curve"/>
+      <point x="244" y="616" type="line"/>
+      <point x="110" y="503"/>
+      <point x="33" y="374"/>
+      <point x="33" y="232" type="curve" smooth="yes"/>
+      <point x="33" y="86"/>
+      <point x="135" y="-16"/>
     </contour>
     <contour>
-      <point x="814" y="48" type="line"/>
-      <point x="869" y="48" type="line"/>
-      <point x="917" y="319" type="line" smooth="yes"/>
-      <point x="933" y="409"/>
-      <point x="967" y="456"/>
-      <point x="1035" y="456" type="curve" smooth="yes"/>
-      <point x="1086" y="456"/>
-      <point x="1105" y="430"/>
-      <point x="1105" y="395" type="curve" smooth="yes"/>
-      <point x="1105" y="326"/>
-      <point x="1047" y="262"/>
-      <point x="946" y="171" type="curve" smooth="yes"/>
+      <point x="803" y="48" type="line"/>
+      <point x="863" y="48" type="line"/>
+      <point x="911" y="319" type="line" smooth="yes"/>
+      <point x="927" y="409"/>
+      <point x="961" y="456"/>
+      <point x="1026" y="456" type="curve" smooth="yes"/>
+      <point x="1079" y="456"/>
+      <point x="1099" y="428"/>
+      <point x="1099" y="387" type="curve" smooth="yes"/>
+      <point x="1099" y="335"/>
+      <point x="1070" y="296"/>
+      <point x="935" y="171" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="974" y="45" type="line"/>
-      <point x="1092" y="158" type="line" smooth="yes"/>
-      <point x="1169" y="232"/>
-      <point x="1219" y="304"/>
-      <point x="1219" y="382" type="curve" smooth="yes"/>
-      <point x="1219" y="460"/>
-      <point x="1164" y="513"/>
-      <point x="1053" y="513" type="curve"/>
-      <point x="1061" y="483" type="line"/>
-      <point x="1061" y="576" type="line"/>
-      <point x="1031" y="516" type="line"/>
-      <point x="1049" y="520"/>
-      <point x="1072" y="522"/>
-      <point x="1099" y="522" type="curve" smooth="yes"/>
-      <point x="1218" y="522"/>
-      <point x="1287" y="474"/>
-      <point x="1287" y="361" type="curve" smooth="yes"/>
-      <point x="1287" y="344"/>
-      <point x="1285" y="320"/>
-      <point x="1279" y="284" type="curve" smooth="yes"/>
-      <point x="1237" y="49" type="line"/>
-      <point x="1316" y="104" type="line"/>
-      <point x="918" y="104" type="line"/>
+      <point x="963" y="45" type="line"/>
+      <point x="1081" y="158" type="line" smooth="yes"/>
+      <point x="1177" y="250"/>
+      <point x="1213" y="310"/>
+      <point x="1213" y="379" type="curve" smooth="yes"/>
+      <point x="1213" y="467"/>
+      <point x="1155" y="518"/>
+      <point x="1055" y="518" type="curve"/>
+      <point x="1063" y="488" type="line"/>
+      <point x="1076" y="581" type="line"/>
+      <point x="1033" y="520" type="line"/>
+      <point x="1056" y="524"/>
+      <point x="1085" y="527"/>
+      <point x="1111" y="527" type="curve" smooth="yes"/>
+      <point x="1229" y="527"/>
+      <point x="1277" y="472"/>
+      <point x="1277" y="363" type="curve" smooth="yes"/>
+      <point x="1277" y="346"/>
+      <point x="1275" y="323"/>
+      <point x="1268" y="284" type="curve" smooth="yes"/>
+      <point x="1227" y="51" type="line"/>
+      <point x="1305" y="104" type="line"/>
+      <point x="907" y="104" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/g_na-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/g_na-malayalam.glif
@@ -1,70 +1,74 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g_na-malayalam" format="2">
   <advance width="1347"/>
-  <anchor x="874" y="0" name="bottom"/>
-  <anchor x="726" y="597" name="top"/>
-  <anchor x="1270" y="597" name="topright"/>
+  <anchor x="869" y="0" name="bottom"/>
+  <anchor x="722" y="597" name="top"/>
+  <anchor x="1266" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="262" y="-16" type="curve" smooth="yes"/>
-      <point x="393" y="-16"/>
-      <point x="475" y="60"/>
-      <point x="520" y="223" type="curve" smooth="yes"/>
-      <point x="558" y="359" type="line" smooth="yes"/>
-      <point x="585" y="457"/>
-      <point x="625" y="500"/>
-      <point x="697" y="500" type="curve" smooth="yes"/>
-      <point x="757" y="500"/>
-      <point x="800" y="469"/>
-      <point x="800" y="384" type="curve" smooth="yes"/>
-      <point x="800" y="356"/>
-      <point x="796" y="326"/>
-      <point x="792" y="300" type="curve" smooth="yes"/>
-      <point x="739" y="0" type="line"/>
-      <point x="861" y="0" type="line"/>
-      <point x="920" y="333" type="line" smooth="yes"/>
-      <point x="939" y="444"/>
-      <point x="996" y="502"/>
-      <point x="1081" y="502" type="curve" smooth="yes"/>
-      <point x="1160" y="502"/>
-      <point x="1202" y="454"/>
-      <point x="1202" y="363" type="curve" smooth="yes"/>
-      <point x="1202" y="253"/>
-      <point x="1152" y="166"/>
-      <point x="1038" y="76" type="curve"/>
-      <point x="1119" y="-16" type="line"/>
-      <point x="1253" y="91"/>
-      <point x="1324" y="222"/>
-      <point x="1324" y="363" type="curve" smooth="yes"/>
-      <point x="1324" y="520"/>
-      <point x="1240" y="613"/>
-      <point x="1096" y="613" type="curve" smooth="yes"/>
-      <point x="1000" y="613"/>
-      <point x="927" y="570"/>
-      <point x="881" y="491" type="curve"/>
-      <point x="874" y="491" type="line"/>
-      <point x="842" y="573"/>
-      <point x="783" y="613"/>
-      <point x="689" y="613" type="curve" smooth="yes"/>
-      <point x="561" y="613"/>
-      <point x="479" y="536"/>
-      <point x="430" y="355" type="curve" smooth="yes"/>
-      <point x="403" y="254" type="line" smooth="yes"/>
-      <point x="372" y="142"/>
-      <point x="332" y="95"/>
-      <point x="262" y="95" type="curve" smooth="yes"/>
-      <point x="194" y="95"/>
-      <point x="153" y="143"/>
-      <point x="153" y="223" type="curve" smooth="yes"/>
-      <point x="153" y="334"/>
-      <point x="209" y="432"/>
-      <point x="326" y="524" type="curve"/>
-      <point x="245" y="613" type="line"/>
-      <point x="107" y="506"/>
-      <point x="32" y="367"/>
-      <point x="32" y="222" type="curve" smooth="yes"/>
-      <point x="32" y="77"/>
-      <point x="122" y="-16"/>
+      <point x="273" y="-16" type="curve" smooth="yes"/>
+      <point x="412" y="-16"/>
+      <point x="506" y="74"/>
+      <point x="528" y="221" type="curve" smooth="yes"/>
+      <point x="535" y="265"/>
+      <point x="532" y="307"/>
+      <point x="539" y="351" type="curve" smooth="yes"/>
+      <point x="555" y="449"/>
+      <point x="605" y="500"/>
+      <point x="687" y="500" type="curve" smooth="yes"/>
+      <point x="758" y="500"/>
+      <point x="796" y="458"/>
+      <point x="796" y="384" type="curve" smooth="yes"/>
+      <point x="796" y="356"/>
+      <point x="792" y="328"/>
+      <point x="787" y="300" type="curve" smooth="yes"/>
+      <point x="734" y="0" type="line"/>
+      <point x="856" y="0" type="line"/>
+      <point x="915" y="333" type="line" smooth="yes"/>
+      <point x="935" y="444"/>
+      <point x="991" y="502"/>
+      <point x="1072" y="502" type="curve" smooth="yes"/>
+      <point x="1152" y="502"/>
+      <point x="1191" y="455"/>
+      <point x="1191" y="369" type="curve" smooth="yes"/>
+      <point x="1191" y="259"/>
+      <point x="1141" y="162"/>
+      <point x="1037" y="74" type="curve"/>
+      <point x="1116" y="-16" type="line"/>
+      <point x="1248" y="95"/>
+      <point x="1313" y="224"/>
+      <point x="1313" y="369" type="curve" smooth="yes"/>
+      <point x="1313" y="522"/>
+      <point x="1232" y="613"/>
+      <point x="1090" y="613" type="curve" smooth="yes"/>
+      <point x="994" y="613"/>
+      <point x="922" y="570"/>
+      <point x="876" y="491" type="curve"/>
+      <point x="869" y="491" type="line"/>
+      <point x="841" y="567"/>
+      <point x="781" y="613"/>
+      <point x="674" y="613" type="curve" smooth="yes"/>
+      <point x="537" y="613"/>
+      <point x="445" y="526"/>
+      <point x="421" y="372" type="curve" smooth="yes"/>
+      <point x="414" y="328"/>
+      <point x="417" y="286"/>
+      <point x="410" y="242" type="curve" smooth="yes"/>
+      <point x="396" y="148"/>
+      <point x="352" y="98"/>
+      <point x="273" y="98" type="curve" smooth="yes"/>
+      <point x="203" y="98"/>
+      <point x="153" y="146"/>
+      <point x="153" y="234" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="214" y="434"/>
+      <point x="325" y="528" type="curve"/>
+      <point x="244" y="616" type="line"/>
+      <point x="110" y="503"/>
+      <point x="33" y="374"/>
+      <point x="33" y="232" type="curve" smooth="yes"/>
+      <point x="33" y="86"/>
+      <point x="135" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ga-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ga-malayalam.glif
@@ -1,52 +1,56 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ga-malayalam" format="2">
-  <advance width="949"/>
+  <advance width="950"/>
   <unicode hex="0D17"/>
-  <anchor x="477" y="0" name="bottom"/>
-  <anchor x="539" y="597" name="top"/>
-  <anchor x="833" y="597" name="topright"/>
+  <anchor x="472" y="0" name="bottom"/>
+  <anchor x="535" y="597" name="top"/>
+  <anchor x="829" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="262" y="-16" type="curve" smooth="yes"/>
-      <point x="393" y="-16"/>
-      <point x="475" y="60"/>
-      <point x="520" y="223" type="curve" smooth="yes"/>
-      <point x="552" y="339" type="line" smooth="yes"/>
-      <point x="584" y="451"/>
-      <point x="630" y="502"/>
-      <point x="703" y="502" type="curve" smooth="yes"/>
-      <point x="770" y="502"/>
-      <point x="805" y="457"/>
-      <point x="805" y="371" type="curve" smooth="yes"/>
-      <point x="805" y="263"/>
-      <point x="751" y="163"/>
-      <point x="642" y="72" type="curve"/>
-      <point x="726" y="-16" type="line"/>
-      <point x="852" y="87"/>
-      <point x="927" y="231"/>
-      <point x="927" y="372" type="curve" smooth="yes"/>
-      <point x="927" y="523"/>
-      <point x="844" y="613"/>
-      <point x="705" y="613" type="curve" smooth="yes"/>
-      <point x="564" y="613"/>
-      <point x="479" y="533"/>
-      <point x="429" y="352" type="curve" smooth="yes"/>
-      <point x="403" y="254" type="line" smooth="yes"/>
-      <point x="372" y="142"/>
-      <point x="332" y="95"/>
-      <point x="262" y="95" type="curve" smooth="yes"/>
-      <point x="194" y="95"/>
-      <point x="153" y="143"/>
-      <point x="153" y="223" type="curve" smooth="yes"/>
-      <point x="153" y="334"/>
-      <point x="209" y="432"/>
-      <point x="326" y="524" type="curve"/>
-      <point x="245" y="613" type="line"/>
-      <point x="107" y="506"/>
-      <point x="32" y="367"/>
-      <point x="32" y="222" type="curve" smooth="yes"/>
-      <point x="32" y="77"/>
-      <point x="122" y="-16"/>
+      <point x="273" y="-16" type="curve" smooth="yes"/>
+      <point x="412" y="-16"/>
+      <point x="506" y="74"/>
+      <point x="528" y="221" type="curve" smooth="yes"/>
+      <point x="535" y="265"/>
+      <point x="532" y="307"/>
+      <point x="539" y="351" type="curve" smooth="yes"/>
+      <point x="554" y="445"/>
+      <point x="604" y="499"/>
+      <point x="684" y="499" type="curve" smooth="yes"/>
+      <point x="755" y="499"/>
+      <point x="797" y="454"/>
+      <point x="797" y="361" type="curve" smooth="yes"/>
+      <point x="797" y="267"/>
+      <point x="736" y="159"/>
+      <point x="635" y="74" type="curve"/>
+      <point x="714" y="-16" type="line"/>
+      <point x="841" y="91"/>
+      <point x="917" y="232"/>
+      <point x="917" y="363" type="curve" smooth="yes"/>
+      <point x="917" y="515"/>
+      <point x="820" y="613"/>
+      <point x="684" y="613" type="curve" smooth="yes"/>
+      <point x="539" y="613"/>
+      <point x="445" y="525"/>
+      <point x="421" y="372" type="curve" smooth="yes"/>
+      <point x="414" y="328"/>
+      <point x="417" y="286"/>
+      <point x="410" y="242" type="curve" smooth="yes"/>
+      <point x="396" y="148"/>
+      <point x="352" y="98"/>
+      <point x="273" y="98" type="curve" smooth="yes"/>
+      <point x="203" y="98"/>
+      <point x="153" y="146"/>
+      <point x="153" y="234" type="curve" smooth="yes"/>
+      <point x="153" y="338"/>
+      <point x="214" y="434"/>
+      <point x="325" y="528" type="curve"/>
+      <point x="244" y="616" type="line"/>
+      <point x="110" y="503"/>
+      <point x="33" y="374"/>
+      <point x="33" y="232" type="curve" smooth="yes"/>
+      <point x="33" y="86"/>
+      <point x="135" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ga-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ga-malayalam.half.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ga-malayalam.half" format="2">
-  <advance width="949"/>
+  <advance width="950"/>
   <outline>
     <component base="ga-malayalam"/>
-    <component base="halant-malayalam" xOffset="752"/>
+    <component base="halant-malayalam" xOffset="748"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/j_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/j_ja-malayalam.glif
@@ -1,231 +1,230 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_ja-malayalam" format="2">
-  <advance width="1641"/>
-  <anchor x="1183" y="0" name="bottom"/>
-  <anchor x="878" y="597" name="top"/>
-  <anchor x="1576" y="597" name="topright"/>
+  <advance width="1707"/>
+  <anchor x="1228" y="0" name="bottom"/>
+  <anchor x="907" y="597" name="top"/>
+  <anchor x="1606" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="353" y="-16" type="curve" smooth="yes"/>
-      <point x="643" y="-16"/>
-      <point x="782" y="79"/>
-      <point x="883" y="295" type="curve"/>
-      <point x="908" y="367" type="line"/>
-      <point x="914" y="367" type="line"/>
-      <point x="931" y="330"/>
-      <point x="971" y="309"/>
-      <point x="1017" y="309" type="curve" smooth="yes"/>
-      <point x="1097" y="309"/>
-      <point x="1153" y="352"/>
-      <point x="1153" y="423" type="curve" smooth="yes"/>
-      <point x="1153" y="483"/>
-      <point x="1120" y="520"/>
-      <point x="1061" y="520" type="curve" smooth="yes"/>
-      <point x="1036" y="520"/>
-      <point x="1014" y="515"/>
-      <point x="992" y="506" type="curve"/>
-      <point x="980" y="527" type="line"/>
-      <point x="978" y="506" type="line"/>
-      <point x="1005" y="527"/>
-      <point x="1040" y="539"/>
-      <point x="1088" y="539" type="curve" smooth="yes"/>
-      <point x="1166" y="539"/>
-      <point x="1205" y="501"/>
-      <point x="1205" y="424" type="curve" smooth="yes"/>
-      <point x="1205" y="411"/>
-      <point x="1203" y="395"/>
-      <point x="1201" y="380" type="curve" smooth="yes"/>
-      <point x="1196" y="352" type="line"/>
-      <point x="1314" y="352" type="line"/>
-      <point x="1322" y="396" type="line" smooth="yes"/>
-      <point x="1334" y="470"/>
-      <point x="1376" y="510"/>
-      <point x="1439" y="510" type="curve" smooth="yes"/>
-      <point x="1489" y="510"/>
-      <point x="1516" y="483"/>
-      <point x="1516" y="430" type="curve" smooth="yes"/>
-      <point x="1516" y="346"/>
-      <point x="1467" y="302"/>
-      <point x="1372" y="302" type="curve" smooth="yes"/>
-      <point x="1064" y="302" type="line" smooth="yes"/>
-      <point x="933" y="302"/>
-      <point x="856" y="234"/>
-      <point x="856" y="134" type="curve" smooth="yes"/>
-      <point x="856" y="41"/>
-      <point x="911" y="-16"/>
-      <point x="1015" y="-16" type="curve" smooth="yes"/>
-      <point x="1061" y="-16"/>
-      <point x="1113" y="-4"/>
-      <point x="1203" y="55" type="curve" smooth="yes"/>
-      <point x="1265" y="96" type="line"/>
-      <point x="1360" y="161" type="line"/>
-      <point x="1376" y="158" type="line"/>
-      <point x="1405" y="171"/>
-      <point x="1424" y="174"/>
-      <point x="1440" y="174" type="curve" smooth="yes"/>
-      <point x="1471" y="174"/>
-      <point x="1487" y="158"/>
-      <point x="1487" y="128" type="curve" smooth="yes"/>
-      <point x="1487" y="94"/>
-      <point x="1468" y="73"/>
-      <point x="1436" y="73" type="curve" smooth="yes"/>
-      <point x="1407" y="73"/>
-      <point x="1388" y="91"/>
-      <point x="1388" y="118" type="curve" smooth="yes"/>
-      <point x="1388" y="141"/>
-      <point x="1399" y="162"/>
-      <point x="1420" y="181" type="curve"/>
-      <point x="1281" y="161" type="line"/>
-      <point x="1345" y="90" type="line"/>
-      <point x="1346" y="157" type="line"/>
-      <point x="1321" y="136"/>
-      <point x="1311" y="116"/>
-      <point x="1311" y="86" type="curve" smooth="yes"/>
-      <point x="1311" y="24"/>
-      <point x="1358" y="-16"/>
-      <point x="1433" y="-16" type="curve" smooth="yes"/>
-      <point x="1522" y="-16"/>
-      <point x="1576" y="40"/>
-      <point x="1576" y="130" type="curve" smooth="yes"/>
-      <point x="1576" y="205"/>
-      <point x="1527" y="255"/>
-      <point x="1450" y="255" type="curve" smooth="yes"/>
-      <point x="1404" y="255"/>
-      <point x="1350" y="244"/>
-      <point x="1262" y="190" type="curve" smooth="yes"/>
-      <point x="1185" y="144" type="line" smooth="yes"/>
-      <point x="1107" y="97"/>
-      <point x="1068" y="87"/>
-      <point x="1032" y="87" type="curve" smooth="yes"/>
-      <point x="993" y="87"/>
-      <point x="969" y="107"/>
-      <point x="969" y="140" type="curve" smooth="yes"/>
-      <point x="969" y="181"/>
-      <point x="1002" y="204"/>
-      <point x="1055" y="204" type="curve" smooth="yes"/>
-      <point x="1387" y="204" type="line" smooth="yes"/>
-      <point x="1541" y="204"/>
-      <point x="1635" y="291"/>
-      <point x="1635" y="433" type="curve" smooth="yes"/>
-      <point x="1635" y="547"/>
-      <point x="1568" y="613"/>
-      <point x="1455" y="613" type="curve" smooth="yes"/>
-      <point x="1373" y="613"/>
-      <point x="1313" y="575"/>
-      <point x="1280" y="502" type="curve"/>
-      <point x="1273" y="502" type="line"/>
-      <point x="1255" y="575"/>
-      <point x="1194" y="613"/>
-      <point x="1093" y="613" type="curve" smooth="yes"/>
-      <point x="969" y="613"/>
-      <point x="904" y="558"/>
-      <point x="850" y="431" type="curve" smooth="yes"/>
-      <point x="806" y="329" type="line" smooth="yes"/>
-      <point x="728" y="155"/>
-      <point x="602" y="87"/>
-      <point x="360" y="87" type="curve" smooth="yes"/>
-      <point x="181" y="87"/>
-      <point x="138" y="113"/>
-      <point x="138" y="152" type="curve" smooth="yes"/>
-      <point x="138" y="188"/>
-      <point x="170" y="204"/>
-      <point x="225" y="204" type="curve" smooth="yes"/>
-      <point x="519" y="204" type="line" smooth="yes"/>
-      <point x="699" y="204"/>
-      <point x="800" y="298"/>
-      <point x="800" y="443" type="curve" smooth="yes"/>
-      <point x="800" y="550"/>
-      <point x="738" y="613"/>
-      <point x="640" y="613" type="curve" smooth="yes"/>
-      <point x="560" y="613"/>
-      <point x="501" y="577"/>
-      <point x="469" y="502" type="curve"/>
-      <point x="462" y="502" type="line"/>
-      <point x="443" y="575"/>
-      <point x="384" y="613"/>
-      <point x="290" y="613" type="curve" smooth="yes"/>
-      <point x="160" y="613"/>
-      <point x="68" y="545"/>
-      <point x="68" y="443" type="curve" smooth="yes"/>
-      <point x="68" y="360"/>
-      <point x="124" y="309"/>
-      <point x="214" y="309" type="curve" smooth="yes"/>
-      <point x="295" y="309"/>
-      <point x="351" y="352"/>
-      <point x="351" y="429" type="curve" smooth="yes"/>
-      <point x="351" y="483"/>
-      <point x="318" y="520"/>
-      <point x="258" y="520" type="curve" smooth="yes"/>
-      <point x="234" y="520"/>
-      <point x="214" y="516"/>
-      <point x="194" y="506" type="curve"/>
-      <point x="183" y="527" type="line"/>
-      <point x="182" y="506" type="line"/>
-      <point x="208" y="527"/>
-      <point x="243" y="539"/>
-      <point x="291" y="539" type="curve" smooth="yes"/>
-      <point x="359" y="539"/>
-      <point x="397" y="501"/>
-      <point x="397" y="424" type="curve" smooth="yes"/>
-      <point x="397" y="411"/>
-      <point x="395" y="395"/>
-      <point x="393" y="380" type="curve" smooth="yes"/>
-      <point x="388" y="352" type="line"/>
-      <point x="506" y="352" type="line"/>
-      <point x="513" y="396" type="line" smooth="yes"/>
-      <point x="526" y="470"/>
-      <point x="559" y="510"/>
-      <point x="615" y="510" type="curve" smooth="yes"/>
-      <point x="663" y="510"/>
-      <point x="686" y="483"/>
-      <point x="686" y="440" type="curve" smooth="yes"/>
-      <point x="686" y="346"/>
-      <point x="637" y="302"/>
-      <point x="527" y="302" type="curve" smooth="yes"/>
-      <point x="221" y="302" type="line" smooth="yes"/>
-      <point x="94" y="302"/>
-      <point x="20" y="244"/>
-      <point x="20" y="153" type="curve" smooth="yes"/>
-      <point x="20" y="60"/>
-      <point x="88" y="-16"/>
+      <point x="286" y="-16" type="curve" smooth="yes"/>
+      <point x="639" y="-16"/>
+      <point x="805" y="82"/>
+      <point x="917" y="289" type="curve"/>
+      <point x="930" y="334" type="line"/>
+      <point x="936" y="334" type="line"/>
+      <point x="952" y="303"/>
+      <point x="985" y="286"/>
+      <point x="1026" y="286" type="curve" smooth="yes"/>
+      <point x="1123" y="286"/>
+      <point x="1179" y="358"/>
+      <point x="1179" y="426" type="curve" smooth="yes"/>
+      <point x="1179" y="482"/>
+      <point x="1144" y="520"/>
+      <point x="1077" y="520" type="curve" smooth="yes"/>
+      <point x="1053" y="520"/>
+      <point x="1034" y="517"/>
+      <point x="1014" y="511" type="curve"/>
+      <point x="1003" y="538" type="line"/>
+      <point x="1001" y="511" type="line"/>
+      <point x="1035" y="530"/>
+      <point x="1070" y="539"/>
+      <point x="1119" y="539" type="curve" smooth="yes"/>
+      <point x="1194" y="539"/>
+      <point x="1232" y="500"/>
+      <point x="1232" y="436" type="curve" smooth="yes"/>
+      <point x="1232" y="421"/>
+      <point x="1230" y="403"/>
+      <point x="1227" y="386" type="curve" smooth="yes"/>
+      <point x="1216" y="323" type="line"/>
+      <point x="1334" y="323" type="line"/>
+      <point x="1345" y="386" type="line" smooth="yes"/>
+      <point x="1358" y="463"/>
+      <point x="1408" y="509"/>
+      <point x="1479" y="509" type="curve" smooth="yes"/>
+      <point x="1539" y="509"/>
+      <point x="1570" y="479"/>
+      <point x="1570" y="422" type="curve" smooth="yes"/>
+      <point x="1570" y="335"/>
+      <point x="1487" y="278"/>
+      <point x="1360" y="278" type="curve" smooth="yes"/>
+      <point x="1071" y="278" type="line" smooth="yes"/>
+      <point x="934" y="278"/>
+      <point x="876" y="196"/>
+      <point x="876" y="119" type="curve" smooth="yes"/>
+      <point x="876" y="40"/>
+      <point x="934" y="-16"/>
+      <point x="1033" y="-16" type="curve" smooth="yes"/>
+      <point x="1076" y="-16"/>
+      <point x="1112" y="-6"/>
+      <point x="1184" y="29" type="curve" smooth="yes"/>
+      <point x="1326" y="97" type="line"/>
+      <point x="1404" y="155" type="line"/>
+      <point x="1423" y="153" type="line"/>
+      <point x="1457" y="168"/>
+      <point x="1479" y="175"/>
+      <point x="1502" y="175" type="curve" smooth="yes"/>
+      <point x="1533" y="175"/>
+      <point x="1545" y="161"/>
+      <point x="1545" y="133" type="curve" smooth="yes"/>
+      <point x="1545" y="105"/>
+      <point x="1526" y="73"/>
+      <point x="1483" y="73" type="curve" smooth="yes"/>
+      <point x="1454" y="73"/>
+      <point x="1436" y="89"/>
+      <point x="1436" y="116" type="curve" smooth="yes"/>
+      <point x="1436" y="138"/>
+      <point x="1445" y="159"/>
+      <point x="1463" y="178" type="curve"/>
+      <point x="1349" y="145" type="line"/>
+      <point x="1371" y="123" type="line"/>
+      <point x="1364" y="107"/>
+      <point x="1363" y="94"/>
+      <point x="1363" y="80" type="curve" smooth="yes"/>
+      <point x="1363" y="27"/>
+      <point x="1408" y="-16"/>
+      <point x="1479" y="-16" type="curve" smooth="yes"/>
+      <point x="1587" y="-16"/>
+      <point x="1635" y="63"/>
+      <point x="1635" y="129" type="curve" smooth="yes"/>
+      <point x="1635" y="199"/>
+      <point x="1587" y="243"/>
+      <point x="1506" y="243" type="curve" smooth="yes"/>
+      <point x="1452" y="243"/>
+      <point x="1391" y="228"/>
+      <point x="1305" y="187" type="curve" smooth="yes"/>
+      <point x="1154" y="115" type="line" smooth="yes"/>
+      <point x="1108" y="93"/>
+      <point x="1080" y="84"/>
+      <point x="1051" y="84" type="curve" smooth="yes"/>
+      <point x="1017" y="84"/>
+      <point x="996" y="101"/>
+      <point x="996" y="129" type="curve" smooth="yes"/>
+      <point x="996" y="158"/>
+      <point x="1017" y="184"/>
+      <point x="1071" y="184" type="curve" smooth="yes"/>
+      <point x="1358" y="184" type="line" smooth="yes"/>
+      <point x="1554" y="184"/>
+      <point x="1690" y="288"/>
+      <point x="1690" y="434" type="curve" smooth="yes"/>
+      <point x="1690" y="547"/>
+      <point x="1624" y="613"/>
+      <point x="1512" y="613" type="curve" smooth="yes"/>
+      <point x="1423" y="613"/>
+      <point x="1350" y="569"/>
+      <point x="1312" y="494" type="curve"/>
+      <point x="1305" y="494" type="line"/>
+      <point x="1290" y="563"/>
+      <point x="1243" y="613"/>
+      <point x="1130" y="613" type="curve" smooth="yes"/>
+      <point x="1023" y="613"/>
+      <point x="936" y="563"/>
+      <point x="879" y="430" type="curve" smooth="yes"/>
+      <point x="848" y="358" type="line" smooth="yes"/>
+      <point x="765" y="164"/>
+      <point x="603" y="87"/>
+      <point x="299" y="87" type="curve" smooth="yes"/>
+      <point x="172" y="87"/>
+      <point x="134" y="102"/>
+      <point x="134" y="138" type="curve" smooth="yes"/>
+      <point x="134" y="163"/>
+      <point x="155" y="184"/>
+      <point x="207" y="184" type="curve" smooth="yes"/>
+      <point x="469" y="184" type="line" smooth="yes"/>
+      <point x="683" y="184"/>
+      <point x="822" y="317"/>
+      <point x="822" y="452" type="curve" smooth="yes"/>
+      <point x="822" y="554"/>
+      <point x="767" y="613"/>
+      <point x="671" y="613" type="curve" smooth="yes"/>
+      <point x="592" y="613"/>
+      <point x="528" y="569"/>
+      <point x="492" y="494" type="curve"/>
+      <point x="485" y="494" type="line"/>
+      <point x="470" y="563"/>
+      <point x="423" y="613"/>
+      <point x="310" y="613" type="curve" smooth="yes"/>
+      <point x="144" y="613"/>
+      <point x="63" y="511"/>
+      <point x="63" y="422" type="curve" smooth="yes"/>
+      <point x="63" y="342"/>
+      <point x="115" y="286"/>
+      <point x="199" y="286" type="curve" smooth="yes"/>
+      <point x="300" y="286"/>
+      <point x="359" y="358"/>
+      <point x="359" y="426" type="curve" smooth="yes"/>
+      <point x="359" y="482"/>
+      <point x="324" y="520"/>
+      <point x="257" y="520" type="curve" smooth="yes"/>
+      <point x="233" y="520"/>
+      <point x="214" y="517"/>
+      <point x="194" y="511" type="curve"/>
+      <point x="183" y="538" type="line"/>
+      <point x="181" y="511" type="line"/>
+      <point x="215" y="530"/>
+      <point x="250" y="539"/>
+      <point x="299" y="539" type="curve" smooth="yes"/>
+      <point x="374" y="539"/>
+      <point x="412" y="500"/>
+      <point x="412" y="436" type="curve" smooth="yes"/>
+      <point x="412" y="421"/>
+      <point x="410" y="403"/>
+      <point x="407" y="386" type="curve" smooth="yes"/>
+      <point x="396" y="323" type="line"/>
+      <point x="514" y="323" type="line"/>
+      <point x="525" y="386" type="line" smooth="yes"/>
+      <point x="538" y="463"/>
+      <point x="582" y="509"/>
+      <point x="645" y="509" type="curve" smooth="yes"/>
+      <point x="690" y="509"/>
+      <point x="714" y="484"/>
+      <point x="714" y="438" type="curve" smooth="yes"/>
+      <point x="714" y="344"/>
+      <point x="633" y="278"/>
+      <point x="478" y="278" type="curve" smooth="yes"/>
+      <point x="207" y="278" type="line" smooth="yes"/>
+      <point x="71" y="278"/>
+      <point x="14" y="204"/>
+      <point x="14" y="133" type="curve" smooth="yes"/>
+      <point x="14" y="44"/>
+      <point x="94" y="-16"/>
     </contour>
     <contour>
-      <point x="221" y="390" type="curve" smooth="yes"/>
-      <point x="185" y="390"/>
-      <point x="165" y="410"/>
-      <point x="165" y="444" type="curve" smooth="yes"/>
-      <point x="165" y="460"/>
-      <point x="169" y="473"/>
-      <point x="177" y="488" type="curve"/>
-      <point x="149" y="488" type="line"/>
-      <point x="141" y="449" type="line"/>
-      <point x="164" y="464"/>
-      <point x="190" y="472"/>
-      <point x="218" y="472" type="curve" smooth="yes"/>
-      <point x="250" y="472"/>
-      <point x="270" y="459"/>
-      <point x="270" y="433" type="curve" smooth="yes"/>
-      <point x="270" y="407"/>
-      <point x="251" y="390"/>
+      <point x="205" y="367" type="curve" smooth="yes"/>
+      <point x="172" y="367"/>
+      <point x="151" y="390"/>
+      <point x="151" y="423" type="curve" smooth="yes"/>
+      <point x="151" y="446"/>
+      <point x="156" y="463"/>
+      <point x="166" y="481" type="curve"/>
+      <point x="147" y="481" type="line"/>
+      <point x="140" y="438" type="line"/>
+      <point x="161" y="458"/>
+      <point x="186" y="470"/>
+      <point x="218" y="470" type="curve" smooth="yes"/>
+      <point x="252" y="470"/>
+      <point x="267" y="453"/>
+      <point x="267" y="425" type="curve" smooth="yes"/>
+      <point x="267" y="395"/>
+      <point x="246" y="367"/>
     </contour>
     <contour>
-      <point x="1019" y="390" type="curve" smooth="yes"/>
-      <point x="984" y="390"/>
-      <point x="962" y="410"/>
-      <point x="962" y="444" type="curve" smooth="yes"/>
-      <point x="962" y="460"/>
-      <point x="966" y="473"/>
-      <point x="974" y="488" type="curve"/>
-      <point x="946" y="488" type="line"/>
-      <point x="938" y="449" type="line"/>
-      <point x="961" y="464"/>
-      <point x="987" y="472"/>
-      <point x="1015" y="472" type="curve" smooth="yes"/>
-      <point x="1053" y="472"/>
-      <point x="1072" y="459"/>
-      <point x="1072" y="432" type="curve" smooth="yes"/>
-      <point x="1072" y="406"/>
-      <point x="1051" y="390"/>
+      <point x="1025" y="367" type="curve" smooth="yes"/>
+      <point x="992" y="367"/>
+      <point x="971" y="390"/>
+      <point x="971" y="423" type="curve" smooth="yes"/>
+      <point x="971" y="446"/>
+      <point x="976" y="463"/>
+      <point x="986" y="481" type="curve"/>
+      <point x="967" y="481" type="line"/>
+      <point x="960" y="438" type="line"/>
+      <point x="981" y="458"/>
+      <point x="1006" y="470"/>
+      <point x="1038" y="470" type="curve" smooth="yes"/>
+      <point x="1072" y="470"/>
+      <point x="1087" y="453"/>
+      <point x="1087" y="425" type="curve" smooth="yes"/>
+      <point x="1087" y="395"/>
+      <point x="1066" y="367"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/j_nya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/j_nya-malayalam.glif
@@ -1,194 +1,194 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="j_nya-malayalam" format="2">
-  <advance width="2255"/>
-  <anchor x="1833" y="0" name="bottom"/>
-  <anchor x="1129" y="597" name="top"/>
-  <anchor x="2112" y="597" name="topright"/>
+  <advance width="2286"/>
+  <anchor x="1809" y="0" name="bottom"/>
+  <anchor x="1179" y="597" name="top"/>
+  <anchor x="2193" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="355" y="-16" type="curve" smooth="yes"/>
-      <point x="581" y="-16"/>
-      <point x="707" y="35"/>
-      <point x="809" y="158" type="curve"/>
-      <point x="877" y="158" type="line"/>
-      <point x="810" y="277" type="line"/>
-      <point x="808" y="261"/>
-      <point x="806" y="245"/>
-      <point x="806" y="229" type="curve" smooth="yes"/>
-      <point x="806" y="87"/>
-      <point x="884" y="-16"/>
-      <point x="1022" y="-16" type="curve" smooth="yes"/>
-      <point x="1141" y="-16"/>
-      <point x="1221" y="70"/>
-      <point x="1221" y="198" type="curve" smooth="yes"/>
-      <point x="1221" y="295"/>
-      <point x="1165" y="354"/>
-      <point x="1073" y="354" type="curve" smooth="yes"/>
-      <point x="1018" y="354"/>
-      <point x="970" y="334"/>
-      <point x="933" y="295" type="curve"/>
-      <point x="894" y="307" type="line"/>
-      <point x="888" y="141" type="line"/>
-      <point x="919" y="213"/>
-      <point x="972" y="257"/>
-      <point x="1029" y="257" type="curve" smooth="yes"/>
-      <point x="1075" y="257"/>
-      <point x="1100" y="231"/>
-      <point x="1100" y="184" type="curve" smooth="yes"/>
-      <point x="1100" y="131"/>
-      <point x="1068" y="95"/>
-      <point x="1021" y="95" type="curve" smooth="yes"/>
-      <point x="953" y="95"/>
-      <point x="921" y="145"/>
-      <point x="921" y="235" type="curve" smooth="yes"/>
-      <point x="921" y="394"/>
-      <point x="1012" y="502"/>
-      <point x="1149" y="502" type="curve" smooth="yes"/>
-      <point x="1252" y="502"/>
-      <point x="1305" y="450"/>
-      <point x="1305" y="359" type="curve" smooth="yes"/>
-      <point x="1305" y="333"/>
-      <point x="1301" y="304"/>
-      <point x="1296" y="275" type="curve" smooth="yes"/>
-      <point x="1248" y="0" type="line"/>
-      <point x="1370" y="0" type="line"/>
-      <point x="1428" y="331" type="line" smooth="yes"/>
-      <point x="1448" y="445"/>
-      <point x="1511" y="502"/>
-      <point x="1614" y="502" type="curve" smooth="yes"/>
-      <point x="1755" y="502"/>
-      <point x="1829" y="423"/>
-      <point x="1829" y="281" type="curve" smooth="yes"/>
-      <point x="1829" y="178"/>
-      <point x="1789" y="97"/>
-      <point x="1718" y="97" type="curve" smooth="yes"/>
-      <point x="1662" y="97"/>
-      <point x="1630" y="136"/>
-      <point x="1630" y="212" type="curve" smooth="yes"/>
-      <point x="1630" y="375"/>
-      <point x="1750" y="502"/>
-      <point x="1924" y="502" type="curve" smooth="yes"/>
-      <point x="2036" y="502"/>
-      <point x="2106" y="445"/>
-      <point x="2106" y="343" type="curve" smooth="yes"/>
-      <point x="2106" y="232"/>
-      <point x="2058" y="152"/>
-      <point x="1959" y="62" type="curve"/>
-      <point x="2043" y="-14" type="line"/>
-      <point x="2163" y="87"/>
-      <point x="2225" y="199"/>
-      <point x="2225" y="343" type="curve" smooth="yes"/>
-      <point x="2225" y="517"/>
-      <point x="2117" y="613"/>
-      <point x="1937" y="613" type="curve" smooth="yes"/>
-      <point x="1707" y="613"/>
-      <point x="1517" y="424"/>
-      <point x="1517" y="199" type="curve" smooth="yes"/>
-      <point x="1517" y="61"/>
-      <point x="1587" y="-16"/>
-      <point x="1714" y="-16" type="curve" smooth="yes"/>
-      <point x="1854" y="-16"/>
-      <point x="1945" y="105"/>
-      <point x="1945" y="277" type="curve" smooth="yes"/>
-      <point x="1945" y="470"/>
-      <point x="1811" y="613"/>
-      <point x="1628" y="613" type="curve" smooth="yes"/>
-      <point x="1517" y="613"/>
-      <point x="1433" y="570"/>
-      <point x="1382" y="484" type="curve"/>
-      <point x="1375" y="484" type="line"/>
-      <point x="1335" y="570"/>
-      <point x="1257" y="613"/>
-      <point x="1148" y="613" type="curve" smooth="yes"/>
-      <point x="992" y="613"/>
-      <point x="891" y="535"/>
-      <point x="816" y="355" type="curve" smooth="yes"/>
-      <point x="727" y="142"/>
-      <point x="590" y="87"/>
-      <point x="357" y="87" type="curve" smooth="yes"/>
+      <point x="286" y="-16" type="curve" smooth="yes"/>
+      <point x="543" y="-16"/>
+      <point x="721" y="42"/>
+      <point x="834" y="167" type="curve"/>
+      <point x="902" y="167" type="line"/>
+      <point x="842" y="277" type="line"/>
+      <point x="840" y="259"/>
+      <point x="838" y="241"/>
+      <point x="838" y="223" type="curve" smooth="yes"/>
+      <point x="838" y="84"/>
+      <point x="909" y="-16"/>
+      <point x="1040" y="-16" type="curve" smooth="yes"/>
+      <point x="1192" y="-16"/>
+      <point x="1258" y="108"/>
+      <point x="1258" y="199" type="curve" smooth="yes"/>
+      <point x="1258" y="302"/>
+      <point x="1200" y="364"/>
+      <point x="1105" y="364" type="curve" smooth="yes"/>
+      <point x="1046" y="364"/>
+      <point x="995" y="341"/>
+      <point x="956" y="295" type="curve"/>
+      <point x="917" y="307" type="line"/>
+      <point x="917" y="147" type="line"/>
+      <point x="950" y="221"/>
+      <point x="1001" y="261"/>
+      <point x="1062" y="261" type="curve" smooth="yes"/>
+      <point x="1111" y="261"/>
+      <point x="1138" y="235"/>
+      <point x="1138" y="189" type="curve" smooth="yes"/>
+      <point x="1138" y="146"/>
+      <point x="1109" y="92"/>
+      <point x="1047" y="92" type="curve" smooth="yes"/>
+      <point x="977" y="92"/>
+      <point x="943" y="143"/>
+      <point x="943" y="235" type="curve" smooth="yes"/>
+      <point x="943" y="386"/>
+      <point x="1043" y="502"/>
+      <point x="1185" y="502" type="curve" smooth="yes"/>
+      <point x="1284" y="502"/>
+      <point x="1335" y="451"/>
+      <point x="1335" y="361" type="curve" smooth="yes"/>
+      <point x="1335" y="334"/>
+      <point x="1331" y="303"/>
+      <point x="1326" y="273" type="curve" smooth="yes"/>
+      <point x="1278" y="0" type="line"/>
+      <point x="1400" y="0" type="line"/>
+      <point x="1458" y="329" type="line" smooth="yes"/>
+      <point x="1478" y="444"/>
+      <point x="1540" y="502"/>
+      <point x="1642" y="502" type="curve" smooth="yes"/>
+      <point x="1784" y="502"/>
+      <point x="1858" y="416"/>
+      <point x="1858" y="261" type="curve" smooth="yes"/>
+      <point x="1858" y="163"/>
+      <point x="1815" y="97"/>
+      <point x="1750" y="97" type="curve" smooth="yes"/>
+      <point x="1692" y="97"/>
+      <point x="1661" y="136"/>
+      <point x="1661" y="199" type="curve" smooth="yes"/>
+      <point x="1661" y="353"/>
+      <point x="1779" y="502"/>
+      <point x="1955" y="502" type="curve" smooth="yes"/>
+      <point x="2064" y="502"/>
+      <point x="2125" y="437"/>
+      <point x="2125" y="320" type="curve" smooth="yes"/>
+      <point x="2125" y="227"/>
+      <point x="2089" y="152"/>
+      <point x="2002" y="65" type="curve"/>
+      <point x="2087" y="-14" type="line"/>
+      <point x="2196" y="96"/>
+      <point x="2245" y="201"/>
+      <point x="2245" y="326" type="curve" smooth="yes"/>
+      <point x="2245" y="511"/>
+      <point x="2145" y="613"/>
+      <point x="1966" y="613" type="curve" smooth="yes"/>
+      <point x="1744" y="613"/>
+      <point x="1547" y="403"/>
+      <point x="1547" y="192" type="curve" smooth="yes"/>
+      <point x="1547" y="63"/>
+      <point x="1621" y="-16"/>
+      <point x="1744" y="-16" type="curve" smooth="yes"/>
+      <point x="1882" y="-16"/>
+      <point x="1976" y="97"/>
+      <point x="1976" y="265" type="curve" smooth="yes"/>
+      <point x="1976" y="465"/>
+      <point x="1840" y="613"/>
+      <point x="1654" y="613" type="curve" smooth="yes"/>
+      <point x="1549" y="613"/>
+      <point x="1469" y="569"/>
+      <point x="1421" y="481" type="curve"/>
+      <point x="1414" y="481" type="line"/>
+      <point x="1381" y="564"/>
+      <point x="1314" y="613"/>
+      <point x="1195" y="613" type="curve" smooth="yes"/>
+      <point x="1044" y="613"/>
+      <point x="928" y="527"/>
+      <point x="849" y="345" type="curve" smooth="yes"/>
+      <point x="772" y="167"/>
+      <point x="613" y="87"/>
+      <point x="299" y="87" type="curve" smooth="yes"/>
       <point x="179" y="87"/>
-      <point x="138" y="113"/>
-      <point x="138" y="152" type="curve" smooth="yes"/>
-      <point x="138" y="188"/>
-      <point x="170" y="204"/>
-      <point x="225" y="204" type="curve" smooth="yes"/>
-      <point x="514" y="204" type="line" smooth="yes"/>
-      <point x="695" y="204"/>
-      <point x="796" y="298"/>
-      <point x="796" y="443" type="curve" smooth="yes"/>
-      <point x="796" y="550"/>
-      <point x="734" y="613"/>
-      <point x="638" y="613" type="curve" smooth="yes"/>
-      <point x="560" y="613"/>
-      <point x="503" y="576"/>
-      <point x="471" y="502" type="curve"/>
-      <point x="464" y="502" type="line"/>
-      <point x="446" y="575"/>
-      <point x="387" y="613"/>
-      <point x="290" y="613" type="curve" smooth="yes"/>
-      <point x="160" y="613"/>
-      <point x="68" y="545"/>
-      <point x="68" y="443" type="curve" smooth="yes"/>
-      <point x="68" y="360"/>
-      <point x="124" y="309"/>
-      <point x="214" y="309" type="curve" smooth="yes"/>
-      <point x="295" y="309"/>
-      <point x="351" y="352"/>
-      <point x="351" y="429" type="curve" smooth="yes"/>
-      <point x="351" y="483"/>
-      <point x="318" y="520"/>
-      <point x="258" y="520" type="curve" smooth="yes"/>
-      <point x="236" y="520"/>
-      <point x="214" y="515"/>
-      <point x="195" y="506" type="curve"/>
-      <point x="183" y="527" type="line"/>
-      <point x="182" y="506" type="line"/>
-      <point x="208" y="527"/>
-      <point x="243" y="539"/>
-      <point x="291" y="539" type="curve" smooth="yes"/>
-      <point x="359" y="539"/>
-      <point x="397" y="501"/>
-      <point x="397" y="424" type="curve" smooth="yes"/>
-      <point x="397" y="411"/>
-      <point x="395" y="395"/>
-      <point x="393" y="380" type="curve" smooth="yes"/>
-      <point x="388" y="352" type="line"/>
-      <point x="506" y="352" type="line"/>
-      <point x="513" y="396" type="line" smooth="yes"/>
-      <point x="526" y="470"/>
-      <point x="559" y="510"/>
-      <point x="613" y="510" type="curve" smooth="yes"/>
-      <point x="658" y="510"/>
-      <point x="682" y="483"/>
-      <point x="682" y="440" type="curve" smooth="yes"/>
-      <point x="682" y="346"/>
-      <point x="633" y="302"/>
-      <point x="523" y="302" type="curve" smooth="yes"/>
-      <point x="221" y="302" type="line" smooth="yes"/>
-      <point x="94" y="302"/>
-      <point x="20" y="244"/>
-      <point x="20" y="153" type="curve" smooth="yes"/>
-      <point x="20" y="60"/>
-      <point x="88" y="-16"/>
+      <point x="134" y="103"/>
+      <point x="134" y="140" type="curve" smooth="yes"/>
+      <point x="134" y="164"/>
+      <point x="154" y="184"/>
+      <point x="203" y="184" type="curve" smooth="yes"/>
+      <point x="469" y="184" type="line" smooth="yes"/>
+      <point x="698" y="184"/>
+      <point x="825" y="316"/>
+      <point x="825" y="450" type="curve" smooth="yes"/>
+      <point x="825" y="553"/>
+      <point x="769" y="613"/>
+      <point x="670" y="613" type="curve" smooth="yes"/>
+      <point x="591" y="613"/>
+      <point x="528" y="569"/>
+      <point x="492" y="494" type="curve"/>
+      <point x="485" y="494" type="line"/>
+      <point x="470" y="563"/>
+      <point x="423" y="613"/>
+      <point x="310" y="613" type="curve" smooth="yes"/>
+      <point x="144" y="613"/>
+      <point x="63" y="511"/>
+      <point x="63" y="422" type="curve" smooth="yes"/>
+      <point x="63" y="342"/>
+      <point x="115" y="286"/>
+      <point x="199" y="286" type="curve" smooth="yes"/>
+      <point x="300" y="286"/>
+      <point x="359" y="358"/>
+      <point x="359" y="426" type="curve" smooth="yes"/>
+      <point x="359" y="482"/>
+      <point x="324" y="520"/>
+      <point x="257" y="520" type="curve" smooth="yes"/>
+      <point x="233" y="520"/>
+      <point x="214" y="517"/>
+      <point x="194" y="511" type="curve"/>
+      <point x="183" y="538" type="line"/>
+      <point x="181" y="511" type="line"/>
+      <point x="215" y="530"/>
+      <point x="250" y="539"/>
+      <point x="299" y="539" type="curve" smooth="yes"/>
+      <point x="374" y="539"/>
+      <point x="412" y="500"/>
+      <point x="412" y="436" type="curve" smooth="yes"/>
+      <point x="412" y="421"/>
+      <point x="410" y="403"/>
+      <point x="407" y="386" type="curve" smooth="yes"/>
+      <point x="396" y="323" type="line"/>
+      <point x="514" y="323" type="line"/>
+      <point x="525" y="386" type="line" smooth="yes"/>
+      <point x="538" y="463"/>
+      <point x="582" y="509"/>
+      <point x="644" y="509" type="curve" smooth="yes"/>
+      <point x="690" y="509"/>
+      <point x="715" y="483"/>
+      <point x="715" y="436" type="curve" smooth="yes"/>
+      <point x="715" y="348"/>
+      <point x="638" y="278"/>
+      <point x="478" y="278" type="curve" smooth="yes"/>
+      <point x="203" y="278" type="line" smooth="yes"/>
+      <point x="70" y="278"/>
+      <point x="14" y="205"/>
+      <point x="14" y="135" type="curve" smooth="yes"/>
+      <point x="14" y="45"/>
+      <point x="94" y="-16"/>
     </contour>
     <contour>
-      <point x="221" y="390" type="curve" smooth="yes"/>
-      <point x="185" y="390"/>
-      <point x="165" y="410"/>
-      <point x="165" y="444" type="curve" smooth="yes"/>
-      <point x="165" y="460"/>
-      <point x="169" y="473"/>
-      <point x="177" y="488" type="curve"/>
-      <point x="149" y="488" type="line"/>
-      <point x="141" y="449" type="line"/>
-      <point x="164" y="464"/>
-      <point x="190" y="472"/>
-      <point x="218" y="472" type="curve" smooth="yes"/>
-      <point x="250" y="472"/>
-      <point x="270" y="459"/>
-      <point x="270" y="433" type="curve" smooth="yes"/>
-      <point x="270" y="407"/>
-      <point x="251" y="390"/>
+      <point x="205" y="367" type="curve" smooth="yes"/>
+      <point x="172" y="367"/>
+      <point x="151" y="390"/>
+      <point x="151" y="423" type="curve" smooth="yes"/>
+      <point x="151" y="446"/>
+      <point x="156" y="463"/>
+      <point x="166" y="481" type="curve"/>
+      <point x="147" y="481" type="line"/>
+      <point x="140" y="438" type="line"/>
+      <point x="161" y="458"/>
+      <point x="186" y="470"/>
+      <point x="218" y="470" type="curve" smooth="yes"/>
+      <point x="252" y="470"/>
+      <point x="267" y="453"/>
+      <point x="267" y="425" type="curve" smooth="yes"/>
+      <point x="267" y="395"/>
+      <point x="246" y="367"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ja-malayalam.glif
@@ -1,139 +1,138 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam" format="2">
-  <advance width="847"/>
+  <advance width="889"/>
   <unicode hex="0D1C"/>
-  <anchor x="392" y="0" name="bottom"/>
-  <anchor x="502" y="597" name="top"/>
-  <anchor x="785" y="597" name="topright"/>
+  <anchor x="410" y="0" name="bottom"/>
+  <anchor x="498" y="597" name="top"/>
+  <anchor x="788" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="179" y="-16" type="curve" smooth="yes"/>
-      <point x="251" y="-16"/>
-      <point x="309" y="3"/>
-      <point x="404" y="59" type="curve" smooth="yes"/>
-      <point x="468" y="97" type="line"/>
-      <point x="555" y="149" type="line"/>
-      <point x="575" y="158" type="line"/>
-      <point x="606" y="171"/>
-      <point x="627" y="174"/>
-      <point x="643" y="174" type="curve" smooth="yes"/>
-      <point x="675" y="174"/>
-      <point x="690" y="158"/>
-      <point x="690" y="128" type="curve" smooth="yes"/>
-      <point x="690" y="94"/>
-      <point x="671" y="73"/>
-      <point x="639" y="73" type="curve" smooth="yes"/>
-      <point x="610" y="73"/>
-      <point x="592" y="91"/>
-      <point x="592" y="118" type="curve" smooth="yes"/>
-      <point x="592" y="141"/>
-      <point x="602" y="162"/>
-      <point x="623" y="181" type="curve"/>
-      <point x="486" y="162" type="line"/>
-      <point x="542" y="87" type="line"/>
-      <point x="549" y="157" type="line"/>
-      <point x="524" y="136"/>
-      <point x="514" y="117"/>
-      <point x="514" y="88" type="curve" smooth="yes"/>
-      <point x="514" y="24"/>
-      <point x="561" y="-16"/>
-      <point x="636" y="-16" type="curve" smooth="yes"/>
-      <point x="725" y="-16"/>
-      <point x="779" y="40"/>
-      <point x="779" y="130" type="curve" smooth="yes"/>
-      <point x="779" y="205"/>
-      <point x="730" y="255"/>
-      <point x="653" y="255" type="curve" smooth="yes"/>
-      <point x="607" y="255"/>
-      <point x="556" y="237"/>
-      <point x="465" y="190" type="curve" smooth="yes"/>
-      <point x="387" y="149" type="line" smooth="yes"/>
-      <point x="296" y="102"/>
-      <point x="251" y="87"/>
-      <point x="204" y="87" type="curve" smooth="yes"/>
-      <point x="163" y="87"/>
-      <point x="139" y="107"/>
-      <point x="139" y="140" type="curve" smooth="yes"/>
-      <point x="139" y="181"/>
-      <point x="170" y="204"/>
-      <point x="225" y="204" type="curve" smooth="yes"/>
-      <point x="590" y="204" type="line" smooth="yes"/>
-      <point x="744" y="204"/>
-      <point x="838" y="291"/>
-      <point x="838" y="433" type="curve" smooth="yes"/>
-      <point x="838" y="547"/>
-      <point x="773" y="613"/>
-      <point x="657" y="613" type="curve" smooth="yes"/>
-      <point x="575" y="613"/>
-      <point x="513" y="575"/>
-      <point x="483" y="502" type="curve"/>
-      <point x="476" y="502" type="line"/>
-      <point x="458" y="575"/>
-      <point x="397" y="613"/>
-      <point x="296" y="613" type="curve" smooth="yes"/>
-      <point x="160" y="613"/>
-      <point x="68" y="545"/>
-      <point x="68" y="443" type="curve" smooth="yes"/>
-      <point x="68" y="360"/>
-      <point x="124" y="309"/>
-      <point x="214" y="309" type="curve" smooth="yes"/>
-      <point x="300" y="309"/>
-      <point x="356" y="352"/>
-      <point x="356" y="423" type="curve" smooth="yes"/>
-      <point x="356" y="483"/>
-      <point x="323" y="520"/>
-      <point x="262" y="520" type="curve" smooth="yes"/>
-      <point x="239" y="520"/>
-      <point x="217" y="516"/>
-      <point x="194" y="506" type="curve"/>
-      <point x="183" y="527" type="line"/>
-      <point x="182" y="506" type="line"/>
-      <point x="208" y="527"/>
-      <point x="243" y="539"/>
-      <point x="291" y="539" type="curve" smooth="yes"/>
-      <point x="369" y="539"/>
-      <point x="408" y="501"/>
-      <point x="408" y="424" type="curve" smooth="yes"/>
-      <point x="408" y="411"/>
-      <point x="406" y="395"/>
-      <point x="404" y="380" type="curve" smooth="yes"/>
-      <point x="400" y="352" type="line"/>
-      <point x="518" y="352" type="line"/>
-      <point x="525" y="396" type="line" smooth="yes"/>
-      <point x="537" y="470"/>
-      <point x="577" y="510"/>
-      <point x="640" y="510" type="curve" smooth="yes"/>
-      <point x="692" y="510"/>
-      <point x="719" y="483"/>
-      <point x="719" y="430" type="curve" smooth="yes"/>
-      <point x="719" y="346"/>
-      <point x="670" y="302"/>
-      <point x="575" y="302" type="curve" smooth="yes"/>
-      <point x="221" y="302" type="line" smooth="yes"/>
-      <point x="94" y="302"/>
-      <point x="20" y="240"/>
-      <point x="20" y="134" type="curve" smooth="yes"/>
-      <point x="20" y="41"/>
-      <point x="80" y="-16"/>
+      <point x="180" y="-16" type="curve" smooth="yes"/>
+      <point x="229" y="-16"/>
+      <point x="275" y="-3"/>
+      <point x="363" y="35" type="curve" smooth="yes"/>
+      <point x="506" y="97" type="line"/>
+      <point x="584" y="155" type="line"/>
+      <point x="603" y="153" type="line"/>
+      <point x="637" y="168"/>
+      <point x="659" y="175"/>
+      <point x="682" y="175" type="curve" smooth="yes"/>
+      <point x="713" y="175"/>
+      <point x="725" y="161"/>
+      <point x="725" y="133" type="curve" smooth="yes"/>
+      <point x="725" y="105"/>
+      <point x="706" y="73"/>
+      <point x="663" y="73" type="curve" smooth="yes"/>
+      <point x="634" y="73"/>
+      <point x="616" y="89"/>
+      <point x="616" y="116" type="curve" smooth="yes"/>
+      <point x="616" y="138"/>
+      <point x="625" y="159"/>
+      <point x="643" y="178" type="curve"/>
+      <point x="529" y="145" type="line"/>
+      <point x="551" y="123" type="line"/>
+      <point x="544" y="107"/>
+      <point x="543" y="94"/>
+      <point x="543" y="80" type="curve" smooth="yes"/>
+      <point x="543" y="27"/>
+      <point x="588" y="-16"/>
+      <point x="659" y="-16" type="curve" smooth="yes"/>
+      <point x="767" y="-16"/>
+      <point x="815" y="63"/>
+      <point x="815" y="129" type="curve" smooth="yes"/>
+      <point x="815" y="199"/>
+      <point x="767" y="243"/>
+      <point x="686" y="243" type="curve" smooth="yes"/>
+      <point x="632" y="243"/>
+      <point x="577" y="227"/>
+      <point x="485" y="187" type="curve" smooth="yes"/>
+      <point x="333" y="121" type="line" smooth="yes"/>
+      <point x="269" y="93"/>
+      <point x="233" y="84"/>
+      <point x="193" y="84" type="curve" smooth="yes"/>
+      <point x="155" y="84"/>
+      <point x="134" y="102"/>
+      <point x="134" y="131" type="curve" smooth="yes"/>
+      <point x="134" y="160"/>
+      <point x="155" y="184"/>
+      <point x="207" y="184" type="curve" smooth="yes"/>
+      <point x="538" y="184" type="line" smooth="yes"/>
+      <point x="734" y="184"/>
+      <point x="870" y="288"/>
+      <point x="870" y="434" type="curve" smooth="yes"/>
+      <point x="870" y="547"/>
+      <point x="804" y="613"/>
+      <point x="692" y="613" type="curve" smooth="yes"/>
+      <point x="603" y="613"/>
+      <point x="530" y="569"/>
+      <point x="492" y="494" type="curve"/>
+      <point x="485" y="494" type="line"/>
+      <point x="470" y="563"/>
+      <point x="423" y="613"/>
+      <point x="310" y="613" type="curve" smooth="yes"/>
+      <point x="144" y="613"/>
+      <point x="63" y="511"/>
+      <point x="63" y="422" type="curve" smooth="yes"/>
+      <point x="63" y="342"/>
+      <point x="115" y="286"/>
+      <point x="199" y="286" type="curve" smooth="yes"/>
+      <point x="300" y="286"/>
+      <point x="359" y="358"/>
+      <point x="359" y="426" type="curve" smooth="yes"/>
+      <point x="359" y="482"/>
+      <point x="324" y="520"/>
+      <point x="257" y="520" type="curve" smooth="yes"/>
+      <point x="233" y="520"/>
+      <point x="214" y="517"/>
+      <point x="194" y="511" type="curve"/>
+      <point x="183" y="538" type="line"/>
+      <point x="181" y="511" type="line"/>
+      <point x="215" y="530"/>
+      <point x="250" y="539"/>
+      <point x="299" y="539" type="curve" smooth="yes"/>
+      <point x="374" y="539"/>
+      <point x="412" y="500"/>
+      <point x="412" y="436" type="curve" smooth="yes"/>
+      <point x="412" y="421"/>
+      <point x="410" y="403"/>
+      <point x="407" y="386" type="curve" smooth="yes"/>
+      <point x="396" y="323" type="line"/>
+      <point x="514" y="323" type="line"/>
+      <point x="525" y="386" type="line" smooth="yes"/>
+      <point x="538" y="463"/>
+      <point x="588" y="509"/>
+      <point x="659" y="509" type="curve" smooth="yes"/>
+      <point x="719" y="509"/>
+      <point x="750" y="479"/>
+      <point x="750" y="422" type="curve" smooth="yes"/>
+      <point x="750" y="335"/>
+      <point x="667" y="278"/>
+      <point x="540" y="278" type="curve" smooth="yes"/>
+      <point x="207" y="278" type="line" smooth="yes"/>
+      <point x="71" y="278"/>
+      <point x="14" y="199"/>
+      <point x="14" y="125" type="curve" smooth="yes"/>
+      <point x="14" y="40"/>
+      <point x="77" y="-16"/>
     </contour>
     <contour>
-      <point x="223" y="390" type="curve" smooth="yes"/>
-      <point x="187" y="390"/>
-      <point x="165" y="410"/>
-      <point x="165" y="444" type="curve" smooth="yes"/>
-      <point x="165" y="460"/>
-      <point x="169" y="473"/>
-      <point x="177" y="488" type="curve"/>
-      <point x="149" y="488" type="line"/>
-      <point x="141" y="449" type="line"/>
-      <point x="164" y="464"/>
-      <point x="190" y="472"/>
-      <point x="218" y="472" type="curve" smooth="yes"/>
-      <point x="256" y="472"/>
-      <point x="275" y="459"/>
-      <point x="275" y="432" type="curve" smooth="yes"/>
-      <point x="275" y="406"/>
-      <point x="254" y="390"/>
+      <point x="205" y="367" type="curve" smooth="yes"/>
+      <point x="172" y="367"/>
+      <point x="151" y="390"/>
+      <point x="151" y="423" type="curve" smooth="yes"/>
+      <point x="151" y="446"/>
+      <point x="156" y="463"/>
+      <point x="166" y="481" type="curve"/>
+      <point x="147" y="481" type="line"/>
+      <point x="140" y="438" type="line"/>
+      <point x="161" y="458"/>
+      <point x="186" y="470"/>
+      <point x="218" y="470" type="curve" smooth="yes"/>
+      <point x="252" y="470"/>
+      <point x="267" y="453"/>
+      <point x="267" y="425" type="curve" smooth="yes"/>
+      <point x="267" y="395"/>
+      <point x="246" y="367"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ja-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ja-malayalam.half.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja-malayalam.half" format="2">
-  <advance width="847"/>
+  <advance width="889"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="halant-malayalam" xOffset="704"/>
+    <component base="halant-malayalam" xOffset="707"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ja_lV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_lVocalicMatra-malayalam" format="2">
-  <advance width="847"/>
+  <advance width="889"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="439"/>
+    <component base="lVocalicMatra-malayalam" xOffset="457"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ja_llV_ocalicM_atra-malayalam.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ja_llVocalicMatra-malayalam" format="2">
-  <advance width="847"/>
+  <advance width="889"/>
   <outline>
     <component base="ja-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="439"/>
+    <component base="llVocalicMatra-malayalam" xOffset="457"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/kC_hillu-malayalam.glif
@@ -2,113 +2,112 @@
 <glyph name="kChillu-malayalam" format="2">
   <advance width="1079"/>
   <unicode hex="0D7F"/>
-  <anchor x="692" y="0" name="bottom"/>
-  <anchor x="385" y="597" name="top"/>
+  <anchor x="615" y="0" name="bottom"/>
+  <anchor x="413" y="597" name="top"/>
   <outline>
     <contour>
-      <point x="179" y="-16" type="curve" smooth="yes"/>
-      <point x="259" y="-16"/>
-      <point x="324" y="27"/>
-      <point x="352" y="86" type="curve"/>
-      <point x="359" y="86" type="line"/>
-      <point x="390" y="21"/>
-      <point x="447" y="-16"/>
-      <point x="527" y="-16" type="curve" smooth="yes"/>
-      <point x="607" y="-16"/>
-      <point x="655" y="22"/>
-      <point x="687" y="84" type="curve"/>
-      <point x="694" y="84" type="line"/>
-      <point x="710" y="29"/>
-      <point x="754" y="-16"/>
-      <point x="850" y="-16" type="curve" smooth="yes"/>
-      <point x="961" y="-16"/>
-      <point x="1038" y="52"/>
-      <point x="1038" y="179" type="curve" smooth="yes"/>
-      <point x="1038" y="273"/>
-      <point x="975" y="346"/>
-      <point x="837" y="346" type="curve" smooth="yes"/>
-      <point x="807" y="346" type="line"/>
-      <point x="742" y="245" type="line"/>
-      <point x="813" y="245" type="line" smooth="yes"/>
-      <point x="893" y="245"/>
-      <point x="918" y="215"/>
-      <point x="918" y="174" type="curve" smooth="yes"/>
-      <point x="918" y="127"/>
-      <point x="890" y="95"/>
-      <point x="841" y="95" type="curve" smooth="yes"/>
-      <point x="791" y="95"/>
-      <point x="763" y="124"/>
-      <point x="763" y="176" type="curve" smooth="yes"/>
-      <point x="763" y="254"/>
-      <point x="823" y="333"/>
-      <point x="907" y="423" type="curve" smooth="yes"/>
-      <point x="980" y="500"/>
-      <point x="1043" y="568"/>
-      <point x="1043" y="668" type="curve" smooth="yes"/>
-      <point x="1043" y="750"/>
-      <point x="997" y="813"/>
-      <point x="873" y="813" type="curve" smooth="yes"/>
-      <point x="815" y="813"/>
-      <point x="759" y="798"/>
-      <point x="717" y="777" type="curve"/>
-      <point x="744" y="678" type="line"/>
-      <point x="775" y="693"/>
-      <point x="814" y="704"/>
-      <point x="850" y="704" type="curve" smooth="yes"/>
-      <point x="903" y="704"/>
-      <point x="923" y="683"/>
-      <point x="923" y="647" type="curve" smooth="yes"/>
-      <point x="923" y="600"/>
-      <point x="890" y="560"/>
-      <point x="835" y="496" type="curve" smooth="yes"/>
-      <point x="814" y="471"/>
-      <point x="799" y="450"/>
-      <point x="788" y="429" type="curve"/>
-      <point x="723" y="429" type="line"/>
-      <point x="784" y="303" type="line"/>
-      <point x="786" y="326"/>
-      <point x="787" y="347"/>
-      <point x="787" y="368" type="curve" smooth="yes"/>
-      <point x="787" y="505"/>
-      <point x="739" y="613"/>
-      <point x="593" y="613" type="curve" smooth="yes"/>
-      <point x="450" y="613"/>
-      <point x="358" y="505"/>
-      <point x="330" y="337" type="curve" smooth="yes"/>
-      <point x="320" y="276"/>
-      <point x="323" y="242"/>
-      <point x="318" y="216" type="curve" smooth="yes"/>
-      <point x="304" y="136"/>
-      <point x="266" y="93"/>
-      <point x="206" y="93" type="curve" smooth="yes"/>
-      <point x="154" y="93"/>
-      <point x="124" y="121"/>
-      <point x="124" y="166" type="curve" smooth="yes"/>
-      <point x="124" y="217"/>
-      <point x="160" y="245"/>
-      <point x="225" y="245" type="curve" smooth="yes"/>
-      <point x="731" y="245" type="line"/>
-      <point x="731" y="346" type="line"/>
-      <point x="232" y="346" type="line" smooth="yes"/>
-      <point x="91" y="346"/>
-      <point x="5" y="275"/>
-      <point x="5" y="154" type="curve" smooth="yes"/>
-      <point x="5" y="54"/>
-      <point x="72" y="-16"/>
+      <point x="170" y="-16" type="curve" smooth="yes"/>
+      <point x="244" y="-16"/>
+      <point x="299" y="26"/>
+      <point x="335" y="95" type="curve"/>
+      <point x="343" y="95" type="line"/>
+      <point x="363" y="27"/>
+      <point x="423" y="-16"/>
+      <point x="506" y="-16" type="curve" smooth="yes"/>
+      <point x="567" y="-16"/>
+      <point x="626" y="13"/>
+      <point x="665" y="83" type="curve"/>
+      <point x="673" y="83" type="line"/>
+      <point x="692" y="25"/>
+      <point x="743" y="-16"/>
+      <point x="825" y="-16" type="curve" smooth="yes"/>
+      <point x="953" y="-16"/>
+      <point x="1031" y="79"/>
+      <point x="1031" y="192" type="curve" smooth="yes"/>
+      <point x="1031" y="293"/>
+      <point x="964" y="366"/>
+      <point x="836" y="366" type="curve" smooth="yes"/>
+      <point x="805" y="366" type="line"/>
+      <point x="740" y="265" type="line"/>
+      <point x="819" y="265" type="line" smooth="yes"/>
+      <point x="887" y="265"/>
+      <point x="914" y="236"/>
+      <point x="914" y="186" type="curve" smooth="yes"/>
+      <point x="914" y="135"/>
+      <point x="877" y="95"/>
+      <point x="825" y="95" type="curve" smooth="yes"/>
+      <point x="780" y="95"/>
+      <point x="752" y="121"/>
+      <point x="752" y="167" type="curve" smooth="yes"/>
+      <point x="752" y="228"/>
+      <point x="792" y="300"/>
+      <point x="904" y="417" type="curve" smooth="yes"/>
+      <point x="999" y="517"/>
+      <point x="1039" y="582"/>
+      <point x="1039" y="654" type="curve" smooth="yes"/>
+      <point x="1039" y="759"/>
+      <point x="971" y="823"/>
+      <point x="861" y="823" type="curve" smooth="yes"/>
+      <point x="797" y="823"/>
+      <point x="743" y="808"/>
+      <point x="687" y="776" type="curve"/>
+      <point x="737" y="676" type="line"/>
+      <point x="776" y="700"/>
+      <point x="813" y="714"/>
+      <point x="852" y="714" type="curve" smooth="yes"/>
+      <point x="903" y="714"/>
+      <point x="922" y="687"/>
+      <point x="922" y="650" type="curve" smooth="yes"/>
+      <point x="922" y="614"/>
+      <point x="898" y="577"/>
+      <point x="854" y="529" type="curve" smooth="yes"/>
+      <point x="819" y="490"/>
+      <point x="797" y="457"/>
+      <point x="781" y="420" type="curve"/>
+      <point x="773" y="420" type="line"/>
+      <point x="773" y="422"/>
+      <point x="773" y="423"/>
+      <point x="773" y="425" type="curve" smooth="yes"/>
+      <point x="773" y="533"/>
+      <point x="714" y="613"/>
+      <point x="605" y="613" type="curve" smooth="yes"/>
+      <point x="460" y="613"/>
+      <point x="355" y="500"/>
+      <point x="324" y="319" type="curve" smooth="yes"/>
+      <point x="318" y="286"/>
+      <point x="318" y="246"/>
+      <point x="313" y="212" type="curve" smooth="yes"/>
+      <point x="303" y="142"/>
+      <point x="258" y="95"/>
+      <point x="196" y="95" type="curve" smooth="yes"/>
+      <point x="154" y="95"/>
+      <point x="122" y="120"/>
+      <point x="122" y="167" type="curve" smooth="yes"/>
+      <point x="122" y="227"/>
+      <point x="171" y="265"/>
+      <point x="247" y="265" type="curve" smooth="yes"/>
+      <point x="722" y="265" type="line"/>
+      <point x="743" y="366" type="line"/>
+      <point x="258" y="366" type="line" smooth="yes"/>
+      <point x="105" y="366"/>
+      <point x="4" y="286"/>
+      <point x="4" y="154" type="curve" smooth="yes"/>
+      <point x="4" y="54"/>
+      <point x="69" y="-16"/>
     </contour>
     <contour>
-      <point x="529" y="95" type="curve" smooth="yes"/>
-      <point x="465" y="95"/>
-      <point x="428" y="142"/>
-      <point x="428" y="236" type="curve" smooth="yes"/>
-      <point x="428" y="360"/>
-      <point x="473" y="503"/>
-      <point x="582" y="503" type="curve" smooth="yes"/>
-      <point x="646" y="503"/>
-      <point x="679" y="457"/>
-      <point x="679" y="365" type="curve" smooth="yes"/>
-      <point x="679" y="247"/>
-      <point x="641" y="95"/>
+      <point x="511" y="95" type="curve" smooth="yes"/>
+      <point x="451" y="95"/>
+      <point x="421" y="135"/>
+      <point x="421" y="209" type="curve" smooth="yes"/>
+      <point x="421" y="299"/>
+      <point x="460" y="502"/>
+      <point x="591" y="502" type="curve" smooth="yes"/>
+      <point x="647" y="502"/>
+      <point x="675" y="463"/>
+      <point x="675" y="390" type="curve" smooth="yes"/>
+      <point x="675" y="289"/>
+      <point x="634" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/k_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/k_ka-malayalam.glif
@@ -1,98 +1,98 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ka-malayalam" format="2">
   <advance width="1476"/>
-  <anchor x="1057" y="0" name="bottom"/>
-  <anchor x="826" y="597" name="top"/>
-  <anchor x="1332" y="597" name="topright"/>
+  <anchor x="998" y="0" name="bottom"/>
+  <anchor x="873" y="597" name="top"/>
+  <anchor x="1379" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="179" y="-16" type="curve" smooth="yes"/>
-      <point x="259" y="-16"/>
-      <point x="320" y="27"/>
-      <point x="349" y="90" type="curve"/>
-      <point x="356" y="90" type="line"/>
-      <point x="386" y="21"/>
-      <point x="449" y="-16"/>
-      <point x="529" y="-16" type="curve" smooth="yes"/>
-      <point x="699" y="-16"/>
-      <point x="799" y="169"/>
-      <point x="799" y="378" type="curve" smooth="yes"/>
-      <point x="799" y="515"/>
-      <point x="734" y="613"/>
-      <point x="595" y="613" type="curve" smooth="yes"/>
-      <point x="450" y="613"/>
-      <point x="358" y="505"/>
-      <point x="330" y="337" type="curve" smooth="yes"/>
-      <point x="320" y="276"/>
-      <point x="323" y="242"/>
-      <point x="318" y="216" type="curve" smooth="yes"/>
-      <point x="304" y="136"/>
-      <point x="266" y="93"/>
-      <point x="206" y="93" type="curve" smooth="yes"/>
-      <point x="154" y="93"/>
-      <point x="124" y="121"/>
-      <point x="124" y="166" type="curve" smooth="yes"/>
-      <point x="124" y="217"/>
-      <point x="160" y="245"/>
-      <point x="225" y="245" type="curve" smooth="yes"/>
-      <point x="963" y="245" type="line" smooth="yes"/>
-      <point x="1033" y="245"/>
-      <point x="1061" y="217"/>
-      <point x="1061" y="162" type="curve" smooth="yes"/>
-      <point x="1061" y="124"/>
-      <point x="1044" y="92"/>
-      <point x="1003" y="92" type="curve" smooth="yes"/>
-      <point x="959" y="92"/>
-      <point x="937" y="126"/>
-      <point x="937" y="201" type="curve" smooth="yes"/>
-      <point x="937" y="341"/>
-      <point x="1017" y="501"/>
-      <point x="1172" y="501" type="curve" smooth="yes"/>
-      <point x="1279" y="501"/>
-      <point x="1325" y="432"/>
-      <point x="1325" y="341" type="curve" smooth="yes"/>
-      <point x="1325" y="226"/>
-      <point x="1272" y="134"/>
-      <point x="1199" y="50" type="curve"/>
+      <point x="170" y="-16" type="curve" smooth="yes"/>
+      <point x="244" y="-16"/>
+      <point x="299" y="26"/>
+      <point x="335" y="95" type="curve"/>
+      <point x="343" y="95" type="line"/>
+      <point x="363" y="27"/>
+      <point x="423" y="-16"/>
+      <point x="506" y="-16" type="curve" smooth="yes"/>
+      <point x="715" y="-16"/>
+      <point x="792" y="230"/>
+      <point x="792" y="389" type="curve" smooth="yes"/>
+      <point x="792" y="525"/>
+      <point x="721" y="613"/>
+      <point x="603" y="613" type="curve" smooth="yes"/>
+      <point x="463" y="613"/>
+      <point x="355" y="500"/>
+      <point x="324" y="319" type="curve" smooth="yes"/>
+      <point x="318" y="286"/>
+      <point x="318" y="246"/>
+      <point x="313" y="212" type="curve" smooth="yes"/>
+      <point x="303" y="142"/>
+      <point x="258" y="95"/>
+      <point x="196" y="95" type="curve" smooth="yes"/>
+      <point x="154" y="95"/>
+      <point x="122" y="120"/>
+      <point x="122" y="167" type="curve" smooth="yes"/>
+      <point x="122" y="227"/>
+      <point x="171" y="265"/>
+      <point x="247" y="265" type="curve" smooth="yes"/>
+      <point x="975" y="265" type="line" smooth="yes"/>
+      <point x="1036" y="265"/>
+      <point x="1061" y="243"/>
+      <point x="1061" y="192" type="curve" smooth="yes"/>
+      <point x="1061" y="134"/>
+      <point x="1029" y="92"/>
+      <point x="987" y="92" type="curve" smooth="yes"/>
+      <point x="949" y="92"/>
+      <point x="930" y="116"/>
+      <point x="930" y="170" type="curve" smooth="yes"/>
+      <point x="930" y="301"/>
+      <point x="1005" y="501"/>
+      <point x="1184" y="501" type="curve" smooth="yes"/>
+      <point x="1272" y="501"/>
+      <point x="1318" y="450"/>
+      <point x="1318" y="358" type="curve" smooth="yes"/>
+      <point x="1318" y="250"/>
+      <point x="1279" y="150"/>
+      <point x="1200" y="58" type="curve"/>
       <point x="1293" y="-16" type="line"/>
-      <point x="1389" y="90"/>
-      <point x="1448" y="202"/>
-      <point x="1448" y="350" type="curve" smooth="yes"/>
-      <point x="1448" y="517"/>
-      <point x="1347" y="613"/>
-      <point x="1175" y="613" type="curve" smooth="yes"/>
-      <point x="949" y="613"/>
-      <point x="823" y="416"/>
-      <point x="823" y="200" type="curve" smooth="yes"/>
-      <point x="823" y="74"/>
-      <point x="877" y="-16"/>
-      <point x="1006" y="-16" type="curve" smooth="yes"/>
-      <point x="1114" y="-16"/>
-      <point x="1175" y="61"/>
-      <point x="1175" y="167" type="curve" smooth="yes"/>
-      <point x="1175" y="277"/>
-      <point x="1103" y="346"/>
-      <point x="955" y="346" type="curve" smooth="yes"/>
-      <point x="232" y="346" type="line" smooth="yes"/>
-      <point x="91" y="346"/>
-      <point x="5" y="275"/>
-      <point x="5" y="154" type="curve" smooth="yes"/>
-      <point x="5" y="54"/>
-      <point x="72" y="-16"/>
+      <point x="1385" y="90"/>
+      <point x="1440" y="224"/>
+      <point x="1440" y="364" type="curve" smooth="yes"/>
+      <point x="1440" y="519"/>
+      <point x="1353" y="613"/>
+      <point x="1195" y="613" type="curve" smooth="yes"/>
+      <point x="964" y="613"/>
+      <point x="817" y="383"/>
+      <point x="817" y="166" type="curve" smooth="yes"/>
+      <point x="817" y="55"/>
+      <point x="878" y="-16"/>
+      <point x="978" y="-16" type="curve" smooth="yes"/>
+      <point x="1105" y="-16"/>
+      <point x="1177" y="94"/>
+      <point x="1177" y="201" type="curve" smooth="yes"/>
+      <point x="1177" y="306"/>
+      <point x="1114" y="366"/>
+      <point x="995" y="366" type="curve" smooth="yes"/>
+      <point x="258" y="366" type="line" smooth="yes"/>
+      <point x="105" y="366"/>
+      <point x="4" y="286"/>
+      <point x="4" y="154" type="curve" smooth="yes"/>
+      <point x="4" y="54"/>
+      <point x="69" y="-16"/>
     </contour>
     <contour>
-      <point x="529" y="95" type="curve" smooth="yes"/>
-      <point x="465" y="95"/>
-      <point x="428" y="142"/>
-      <point x="428" y="236" type="curve" smooth="yes"/>
-      <point x="428" y="360"/>
-      <point x="473" y="503"/>
-      <point x="582" y="503" type="curve" smooth="yes"/>
-      <point x="646" y="503"/>
-      <point x="679" y="457"/>
-      <point x="679" y="365" type="curve" smooth="yes"/>
-      <point x="679" y="247"/>
-      <point x="641" y="95"/>
+      <point x="511" y="95" type="curve" smooth="yes"/>
+      <point x="451" y="95"/>
+      <point x="421" y="135"/>
+      <point x="421" y="209" type="curve" smooth="yes"/>
+      <point x="421" y="299"/>
+      <point x="460" y="502"/>
+      <point x="591" y="502" type="curve" smooth="yes"/>
+      <point x="647" y="502"/>
+      <point x="676" y="464"/>
+      <point x="676" y="391" type="curve" smooth="yes"/>
+      <point x="676" y="296"/>
+      <point x="634" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/k_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/k_la-malayalam.glif
@@ -1,145 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_la-malayalam" format="2">
   <advance width="1074"/>
-  <anchor x="572" y="-358" name="bottom"/>
-  <anchor x="610" y="597" name="top"/>
-  <anchor x="966" y="557" name="topright"/>
+  <anchor x="549" y="-352" name="bottom"/>
+  <anchor x="605" y="597" name="top"/>
+  <anchor x="960" y="557" name="topright"/>
   <outline>
     <contour>
-      <point x="348" y="-374" type="curve" smooth="yes"/>
-      <point x="440" y="-374"/>
-      <point x="496" y="-314"/>
-      <point x="496" y="-232" type="curve" smooth="yes"/>
-      <point x="496" y="-152"/>
-      <point x="452" y="-119"/>
-      <point x="386" y="-119" type="curve" smooth="yes"/>
-      <point x="351" y="-119"/>
-      <point x="319" y="-131"/>
-      <point x="292" y="-160" type="curve"/>
-      <point x="261" y="-154" type="line"/>
-      <point x="283" y="-169" type="line"/>
-      <point x="293" y="-101"/>
-      <point x="345" y="-41"/>
-      <point x="434" y="-41" type="curve" smooth="yes"/>
-      <point x="530" y="-41"/>
-      <point x="564" y="-89"/>
-      <point x="571" y="-177" type="curve" smooth="yes"/>
-      <point x="572" y="-191" type="line" smooth="yes"/>
-      <point x="582" y="-310"/>
-      <point x="632" y="-374"/>
-      <point x="759" y="-374" type="curve" smooth="yes"/>
-      <point x="899" y="-374"/>
-      <point x="959" y="-270"/>
-      <point x="959" y="-133" type="curve" smooth="yes"/>
-      <point x="959" y="-55"/>
-      <point x="941" y="2"/>
-      <point x="910" y="46" type="curve"/>
-      <point x="823" y="-4" type="line"/>
-      <point x="842" y="-40"/>
-      <point x="858" y="-87"/>
-      <point x="858" y="-143" type="curve" smooth="yes"/>
-      <point x="858" y="-223"/>
-      <point x="830" y="-285"/>
-      <point x="759" y="-285" type="curve" smooth="yes"/>
-      <point x="702" y="-285"/>
-      <point x="678" y="-253"/>
-      <point x="672" y="-172" type="curve" smooth="yes"/>
-      <point x="670" y="-156" type="line" smooth="yes"/>
-      <point x="664" y="-91"/>
-      <point x="648" y="-39"/>
-      <point x="606" y="-3" type="curve"/>
-      <point x="606" y="4" type="line"/>
-      <point x="737" y="56"/>
-      <point x="799" y="218"/>
-      <point x="799" y="378" type="curve" smooth="yes"/>
-      <point x="799" y="515"/>
-      <point x="734" y="613"/>
-      <point x="597" y="613" type="curve" smooth="yes"/>
-      <point x="454" y="613"/>
-      <point x="358" y="505"/>
-      <point x="330" y="337" type="curve" smooth="yes"/>
-      <point x="320" y="276"/>
-      <point x="323" y="242"/>
-      <point x="318" y="216" type="curve" smooth="yes"/>
-      <point x="304" y="136"/>
-      <point x="266" y="93"/>
-      <point x="206" y="93" type="curve" smooth="yes"/>
-      <point x="154" y="93"/>
-      <point x="124" y="121"/>
-      <point x="124" y="166" type="curve" smooth="yes"/>
-      <point x="124" y="217"/>
-      <point x="160" y="245"/>
-      <point x="225" y="245" type="curve" smooth="yes"/>
-      <point x="821" y="245" type="line" smooth="yes"/>
-      <point x="889" y="245"/>
-      <point x="917" y="217"/>
-      <point x="917" y="175" type="curve" smooth="yes"/>
-      <point x="917" y="133"/>
-      <point x="894" y="95"/>
-      <point x="835" y="95" type="curve" smooth="yes"/>
-      <point x="812" y="95"/>
-      <point x="797" y="98"/>
-      <point x="779" y="105" type="curve"/>
-      <point x="734" y="5" type="line"/>
-      <point x="765" y="-9"/>
-      <point x="801" y="-16"/>
-      <point x="839" y="-16" type="curve" smooth="yes"/>
-      <point x="963" y="-16"/>
-      <point x="1034" y="64"/>
-      <point x="1034" y="174" type="curve" smooth="yes"/>
-      <point x="1034" y="277"/>
-      <point x="965" y="346"/>
-      <point x="818" y="346" type="curve" smooth="yes"/>
-      <point x="232" y="346" type="line" smooth="yes"/>
-      <point x="91" y="346"/>
-      <point x="5" y="275"/>
-      <point x="5" y="154" type="curve" smooth="yes"/>
-      <point x="5" y="54"/>
-      <point x="72" y="-16"/>
-      <point x="179" y="-16" type="curve" smooth="yes"/>
-      <point x="259" y="-16"/>
-      <point x="320" y="27"/>
-      <point x="349" y="90" type="curve"/>
-      <point x="356" y="90" type="line"/>
-      <point x="362" y="73"/>
-      <point x="374" y="59"/>
-      <point x="390" y="47" type="curve"/>
-      <point x="389" y="40" type="line"/>
-      <point x="264" y="14"/>
-      <point x="189" y="-80"/>
-      <point x="189" y="-205" type="curve" smooth="yes"/>
-      <point x="189" y="-320"/>
-      <point x="255" y="-374"/>
+      <point x="326" y="-368" type="curve" smooth="yes"/>
+      <point x="435" y="-368"/>
+      <point x="482" y="-285"/>
+      <point x="482" y="-225" type="curve" smooth="yes"/>
+      <point x="482" y="-154"/>
+      <point x="445" y="-112"/>
+      <point x="382" y="-112" type="curve" smooth="yes"/>
+      <point x="328" y="-112"/>
+      <point x="276" y="-143"/>
+      <point x="254" y="-208" type="curve"/>
+      <point x="299" y="-165" type="line"/>
+      <point x="247" y="-148" type="line"/>
+      <point x="270" y="-179" type="line"/>
+      <point x="283" y="-103"/>
+      <point x="350" y="-35"/>
+      <point x="440" y="-35" type="curve" smooth="yes"/>
+      <point x="511" y="-35"/>
+      <point x="543" y="-71"/>
+      <point x="558" y="-151" type="curve" smooth="yes"/>
+      <point x="566" y="-193" type="line" smooth="yes"/>
+      <point x="589" y="-311"/>
+      <point x="646" y="-368"/>
+      <point x="752" y="-368" type="curve" smooth="yes"/>
+      <point x="870" y="-368"/>
+      <point x="946" y="-280"/>
+      <point x="946" y="-146" type="curve" smooth="yes"/>
+      <point x="946" y="-72"/>
+      <point x="933" y="-9"/>
+      <point x="892" y="58" type="curve"/>
+      <point x="800" y="8" type="line"/>
+      <point x="831" y="-38"/>
+      <point x="847" y="-92"/>
+      <point x="847" y="-150" type="curve" smooth="yes"/>
+      <point x="847" y="-227"/>
+      <point x="810" y="-278"/>
+      <point x="753" y="-278" type="curve" smooth="yes"/>
+      <point x="704" y="-278"/>
+      <point x="677" y="-249"/>
+      <point x="663" y="-176" type="curve" smooth="yes"/>
+      <point x="655" y="-134" type="line" smooth="yes"/>
+      <point x="641" y="-58"/>
+      <point x="624" y="-20"/>
+      <point x="587" y="6" type="curve"/>
+      <point x="589" y="15" type="line"/>
+      <point x="755" y="76"/>
+      <point x="792" y="280"/>
+      <point x="792" y="391" type="curve" smooth="yes"/>
+      <point x="792" y="526"/>
+      <point x="721" y="613"/>
+      <point x="603" y="613" type="curve" smooth="yes"/>
+      <point x="463" y="613"/>
+      <point x="355" y="500"/>
+      <point x="324" y="319" type="curve" smooth="yes"/>
+      <point x="318" y="286"/>
+      <point x="318" y="246"/>
+      <point x="313" y="212" type="curve" smooth="yes"/>
+      <point x="303" y="142"/>
+      <point x="258" y="95"/>
+      <point x="196" y="95" type="curve" smooth="yes"/>
+      <point x="154" y="95"/>
+      <point x="122" y="120"/>
+      <point x="122" y="167" type="curve" smooth="yes"/>
+      <point x="122" y="227"/>
+      <point x="171" y="265"/>
+      <point x="247" y="265" type="curve" smooth="yes"/>
+      <point x="818" y="265" type="line" smooth="yes"/>
+      <point x="883" y="265"/>
+      <point x="909" y="236"/>
+      <point x="909" y="186" type="curve" smooth="yes"/>
+      <point x="909" y="132"/>
+      <point x="875" y="95"/>
+      <point x="818" y="95" type="curve" smooth="yes"/>
+      <point x="798" y="95"/>
+      <point x="784" y="98"/>
+      <point x="770" y="103" type="curve"/>
+      <point x="729" y="-2" type="line"/>
+      <point x="755" y="-11"/>
+      <point x="783" y="-16"/>
+      <point x="815" y="-16" type="curve" smooth="yes"/>
+      <point x="948" y="-16"/>
+      <point x="1025" y="79"/>
+      <point x="1025" y="187" type="curve" smooth="yes"/>
+      <point x="1025" y="293"/>
+      <point x="960" y="366"/>
+      <point x="828" y="366" type="curve" smooth="yes"/>
+      <point x="258" y="366" type="line" smooth="yes"/>
+      <point x="105" y="366"/>
+      <point x="4" y="286"/>
+      <point x="4" y="154" type="curve" smooth="yes"/>
+      <point x="4" y="54"/>
+      <point x="69" y="-16"/>
+      <point x="170" y="-16" type="curve" smooth="yes"/>
+      <point x="244" y="-16"/>
+      <point x="299" y="26"/>
+      <point x="335" y="95" type="curve"/>
+      <point x="343" y="95" type="line"/>
+      <point x="349" y="75"/>
+      <point x="361" y="57"/>
+      <point x="374" y="43" type="curve"/>
+      <point x="372" y="32" type="line"/>
+      <point x="251" y="-8"/>
+      <point x="176" y="-114"/>
+      <point x="176" y="-215" type="curve" smooth="yes"/>
+      <point x="176" y="-307"/>
+      <point x="236" y="-368"/>
     </contour>
     <contour>
-      <point x="348" y="-294" type="curve" smooth="yes"/>
-      <point x="297" y="-294"/>
-      <point x="282" y="-256"/>
-      <point x="282" y="-220" type="curve"/>
-      <point x="266" y="-214" type="line"/>
-      <point x="274" y="-253" type="line"/>
-      <point x="286" y="-214"/>
-      <point x="314" y="-191"/>
-      <point x="351" y="-191" type="curve" smooth="yes"/>
-      <point x="388" y="-191"/>
-      <point x="406" y="-207"/>
-      <point x="406" y="-238" type="curve" smooth="yes"/>
-      <point x="406" y="-273"/>
-      <point x="384" y="-294"/>
+      <point x="329" y="-288" type="curve" smooth="yes"/>
+      <point x="292" y="-288"/>
+      <point x="265" y="-264"/>
+      <point x="265" y="-232" type="curve" smooth="yes"/>
+      <point x="265" y="-224"/>
+      <point x="265" y="-217"/>
+      <point x="267" y="-209" type="curve"/>
+      <point x="240" y="-227" type="line"/>
+      <point x="258" y="-257" type="line"/>
+      <point x="270" y="-213"/>
+      <point x="306" y="-185"/>
+      <point x="348" y="-185" type="curve" smooth="yes"/>
+      <point x="378" y="-185"/>
+      <point x="393" y="-202"/>
+      <point x="393" y="-229" type="curve" smooth="yes"/>
+      <point x="393" y="-263"/>
+      <point x="368" y="-288"/>
     </contour>
     <contour>
-      <point x="529" y="95" type="curve" smooth="yes"/>
-      <point x="465" y="95"/>
-      <point x="428" y="142"/>
-      <point x="428" y="236" type="curve" smooth="yes"/>
-      <point x="428" y="360"/>
-      <point x="473" y="503"/>
-      <point x="582" y="503" type="curve" smooth="yes"/>
-      <point x="646" y="503"/>
-      <point x="679" y="457"/>
-      <point x="679" y="365" type="curve" smooth="yes"/>
-      <point x="679" y="247"/>
-      <point x="641" y="95"/>
+      <point x="511" y="95" type="curve" smooth="yes"/>
+      <point x="451" y="95"/>
+      <point x="421" y="135"/>
+      <point x="421" y="209" type="curve" smooth="yes"/>
+      <point x="421" y="299"/>
+      <point x="460" y="502"/>
+      <point x="591" y="502" type="curve" smooth="yes"/>
+      <point x="647" y="502"/>
+      <point x="676" y="464"/>
+      <point x="676" y="391" type="curve" smooth="yes"/>
+      <point x="676" y="296"/>
+      <point x="634" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.glif
@@ -1,115 +1,115 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ssa-malayalam" format="2">
   <advance width="1742"/>
-  <anchor x="1237" y="0" name="bottom"/>
-  <anchor x="954" y="597" name="top"/>
-  <anchor x="1670" y="597" name="topright"/>
+  <anchor x="1229" y="0" name="bottom"/>
+  <anchor x="947" y="597" name="top"/>
+  <anchor x="1664" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="180" y="-16" type="curve" smooth="yes"/>
-      <point x="260" y="-16"/>
-      <point x="321" y="27"/>
-      <point x="349" y="90" type="curve"/>
-      <point x="357" y="90" type="line"/>
-      <point x="387" y="21"/>
-      <point x="450" y="-16"/>
-      <point x="530" y="-16" type="curve" smooth="yes"/>
-      <point x="700" y="-16"/>
-      <point x="800" y="169"/>
-      <point x="800" y="378" type="curve" smooth="yes"/>
-      <point x="800" y="520"/>
-      <point x="731" y="613"/>
-      <point x="598" y="613" type="curve" smooth="yes"/>
-      <point x="455" y="613"/>
-      <point x="359" y="505"/>
-      <point x="331" y="337" type="curve" smooth="yes"/>
-      <point x="321" y="276"/>
-      <point x="324" y="242"/>
-      <point x="319" y="216" type="curve" smooth="yes"/>
-      <point x="305" y="136"/>
-      <point x="267" y="93"/>
-      <point x="207" y="93" type="curve" smooth="yes"/>
-      <point x="155" y="93"/>
-      <point x="126" y="122"/>
-      <point x="126" y="169" type="curve" smooth="yes"/>
-      <point x="126" y="223"/>
-      <point x="161" y="251"/>
-      <point x="226" y="251" type="curve" smooth="yes"/>
-      <point x="818" y="251" type="line" smooth="yes"/>
-      <point x="883" y="251"/>
-      <point x="906" y="226"/>
-      <point x="906" y="181" type="curve" smooth="yes"/>
-      <point x="906" y="142"/>
-      <point x="887" y="109"/>
-      <point x="833" y="76" type="curve"/>
-      <point x="849" y="0" type="line"/>
-      <point x="1622" y="0" type="line"/>
-      <point x="1726" y="597" type="line"/>
-      <point x="1653" y="597" type="line"/>
-      <point x="1552" y="428"/>
-      <point x="1449" y="332"/>
-      <point x="1310" y="332" type="curve" smooth="yes"/>
-      <point x="1212" y="332"/>
-      <point x="1175" y="378"/>
-      <point x="1175" y="433" type="curve" smooth="yes"/>
-      <point x="1175" y="479"/>
-      <point x="1200" y="506"/>
-      <point x="1241" y="506" type="curve" smooth="yes"/>
-      <point x="1277" y="506"/>
-      <point x="1291" y="488"/>
-      <point x="1291" y="454" type="curve" smooth="yes"/>
-      <point x="1291" y="445"/>
-      <point x="1289" y="425"/>
-      <point x="1285" y="405" type="curve" smooth="yes"/>
-      <point x="1224" y="54" type="line"/>
-      <point x="1343" y="54" type="line"/>
-      <point x="1401" y="386" type="line" smooth="yes"/>
-      <point x="1405" y="411"/>
-      <point x="1409" y="438"/>
-      <point x="1409" y="461" type="curve" smooth="yes"/>
-      <point x="1409" y="559"/>
-      <point x="1353" y="613"/>
-      <point x="1249" y="613" type="curve" smooth="yes"/>
-      <point x="1134" y="613"/>
-      <point x="1061" y="540"/>
-      <point x="1061" y="426" type="curve" smooth="yes"/>
-      <point x="1061" y="300"/>
-      <point x="1164" y="226"/>
-      <point x="1300" y="226" type="curve" smooth="yes"/>
-      <point x="1398" y="226"/>
-      <point x="1482" y="263"/>
-      <point x="1550" y="333" type="curve"/>
-      <point x="1557" y="330" type="line"/>
-      <point x="1507" y="42" type="line"/>
-      <point x="1588" y="105" type="line"/>
-      <point x="928" y="105" type="line"/>
-      <point x="935" y="54" type="line"/>
-      <point x="992" y="80"/>
-      <point x="1028" y="131"/>
-      <point x="1028" y="201" type="curve" smooth="yes"/>
-      <point x="1028" y="290"/>
-      <point x="969" y="352"/>
-      <point x="830" y="352" type="curve" smooth="yes"/>
-      <point x="233" y="352" type="line" smooth="yes"/>
-      <point x="92" y="352"/>
-      <point x="6" y="281"/>
-      <point x="6" y="157" type="curve" smooth="yes"/>
-      <point x="6" y="54"/>
-      <point x="73" y="-16"/>
+      <point x="170" y="-16" type="curve" smooth="yes"/>
+      <point x="244" y="-16"/>
+      <point x="299" y="26"/>
+      <point x="335" y="95" type="curve"/>
+      <point x="343" y="95" type="line"/>
+      <point x="363" y="27"/>
+      <point x="423" y="-16"/>
+      <point x="506" y="-16" type="curve" smooth="yes"/>
+      <point x="715" y="-16"/>
+      <point x="792" y="230"/>
+      <point x="792" y="389" type="curve" smooth="yes"/>
+      <point x="792" y="525"/>
+      <point x="721" y="613"/>
+      <point x="603" y="613" type="curve" smooth="yes"/>
+      <point x="463" y="613"/>
+      <point x="355" y="500"/>
+      <point x="324" y="319" type="curve" smooth="yes"/>
+      <point x="318" y="286"/>
+      <point x="318" y="246"/>
+      <point x="313" y="212" type="curve" smooth="yes"/>
+      <point x="303" y="142"/>
+      <point x="258" y="95"/>
+      <point x="196" y="95" type="curve" smooth="yes"/>
+      <point x="154" y="95"/>
+      <point x="122" y="120"/>
+      <point x="122" y="167" type="curve" smooth="yes"/>
+      <point x="122" y="227"/>
+      <point x="171" y="265"/>
+      <point x="247" y="265" type="curve" smooth="yes"/>
+      <point x="816" y="265" type="line" smooth="yes"/>
+      <point x="878" y="265"/>
+      <point x="900" y="239"/>
+      <point x="900" y="194" type="curve" smooth="yes"/>
+      <point x="900" y="152"/>
+      <point x="876" y="116"/>
+      <point x="836" y="79" type="curve"/>
+      <point x="852" y="0" type="line"/>
+      <point x="1614" y="0" type="line"/>
+      <point x="1720" y="597" type="line"/>
+      <point x="1644" y="597" type="line"/>
+      <point x="1519" y="409"/>
+      <point x="1411" y="330"/>
+      <point x="1276" y="330" type="curve" smooth="yes"/>
+      <point x="1200" y="330"/>
+      <point x="1168" y="365"/>
+      <point x="1168" y="417" type="curve" smooth="yes"/>
+      <point x="1168" y="471"/>
+      <point x="1203" y="506"/>
+      <point x="1243" y="506" type="curve" smooth="yes"/>
+      <point x="1274" y="506"/>
+      <point x="1286" y="491"/>
+      <point x="1286" y="462" type="curve" smooth="yes"/>
+      <point x="1286" y="452"/>
+      <point x="1285" y="441"/>
+      <point x="1283" y="428" type="curve" smooth="yes"/>
+      <point x="1217" y="54" type="line"/>
+      <point x="1335" y="54" type="line"/>
+      <point x="1399" y="416" type="line" smooth="yes"/>
+      <point x="1403" y="436"/>
+      <point x="1405" y="456"/>
+      <point x="1405" y="474" type="curve" smooth="yes"/>
+      <point x="1405" y="556"/>
+      <point x="1357" y="613"/>
+      <point x="1256" y="613" type="curve" smooth="yes"/>
+      <point x="1139" y="613"/>
+      <point x="1055" y="528"/>
+      <point x="1055" y="411" type="curve" smooth="yes"/>
+      <point x="1055" y="308"/>
+      <point x="1130" y="228"/>
+      <point x="1269" y="228" type="curve" smooth="yes"/>
+      <point x="1375" y="228"/>
+      <point x="1467" y="272"/>
+      <point x="1549" y="355" type="curve"/>
+      <point x="1555" y="355" type="line"/>
+      <point x="1500" y="42" type="line"/>
+      <point x="1581" y="105" type="line"/>
+      <point x="982" y="105" type="line"/>
+      <point x="980" y="112" type="line"/>
+      <point x="1005" y="143"/>
+      <point x="1022" y="180"/>
+      <point x="1022" y="217" type="curve" smooth="yes"/>
+      <point x="1022" y="304"/>
+      <point x="972" y="366"/>
+      <point x="836" y="366" type="curve" smooth="yes"/>
+      <point x="258" y="366" type="line" smooth="yes"/>
+      <point x="105" y="366"/>
+      <point x="4" y="286"/>
+      <point x="4" y="154" type="curve" smooth="yes"/>
+      <point x="4" y="54"/>
+      <point x="69" y="-16"/>
     </contour>
     <contour>
-      <point x="530" y="95" type="curve" smooth="yes"/>
-      <point x="466" y="95"/>
-      <point x="429" y="142"/>
-      <point x="429" y="236" type="curve" smooth="yes"/>
-      <point x="429" y="360"/>
-      <point x="474" y="503"/>
-      <point x="584" y="503" type="curve" smooth="yes"/>
-      <point x="648" y="503"/>
-      <point x="681" y="457"/>
-      <point x="681" y="365" type="curve" smooth="yes"/>
-      <point x="681" y="247"/>
-      <point x="642" y="95"/>
+      <point x="511" y="95" type="curve" smooth="yes"/>
+      <point x="451" y="95"/>
+      <point x="421" y="135"/>
+      <point x="421" y="209" type="curve" smooth="yes"/>
+      <point x="421" y="299"/>
+      <point x="460" y="502"/>
+      <point x="591" y="502" type="curve" smooth="yes"/>
+      <point x="647" y="502"/>
+      <point x="676" y="464"/>
+      <point x="676" y="391" type="curve" smooth="yes"/>
+      <point x="676" y="296"/>
+      <point x="634" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/k_ssa-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1742"/>
   <outline>
     <component base="k_ssa-malayalam"/>
-    <component base="halant-malayalam" xOffset="1589"/>
+    <component base="halant-malayalam" xOffset="1583"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/k_ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/k_ta-malayalam.glif
@@ -1,114 +1,114 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_ta-malayalam" format="2">
   <advance width="1835"/>
-  <anchor x="1370" y="0" name="bottom"/>
-  <anchor x="899" y="597" name="top"/>
-  <anchor x="1730" y="597" name="topright"/>
+  <anchor x="1358" y="0" name="bottom"/>
+  <anchor x="894" y="597" name="top"/>
+  <anchor x="1719" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="179" y="-16" type="curve" smooth="yes"/>
-      <point x="259" y="-16"/>
-      <point x="320" y="27"/>
-      <point x="349" y="90" type="curve"/>
-      <point x="356" y="90" type="line"/>
-      <point x="386" y="21"/>
-      <point x="449" y="-16"/>
-      <point x="529" y="-16" type="curve" smooth="yes"/>
-      <point x="699" y="-16"/>
-      <point x="799" y="169"/>
-      <point x="799" y="378" type="curve" smooth="yes"/>
-      <point x="799" y="515"/>
-      <point x="734" y="613"/>
-      <point x="595" y="613" type="curve" smooth="yes"/>
-      <point x="450" y="613"/>
-      <point x="358" y="505"/>
-      <point x="330" y="337" type="curve" smooth="yes"/>
-      <point x="320" y="276"/>
-      <point x="323" y="242"/>
-      <point x="318" y="216" type="curve" smooth="yes"/>
-      <point x="304" y="136"/>
-      <point x="266" y="93"/>
-      <point x="206" y="93" type="curve" smooth="yes"/>
-      <point x="154" y="93"/>
-      <point x="124" y="121"/>
-      <point x="124" y="166" type="curve" smooth="yes"/>
-      <point x="124" y="217"/>
-      <point x="160" y="245"/>
-      <point x="225" y="245" type="curve" smooth="yes"/>
-      <point x="901" y="245" type="line"/>
-      <point x="901" y="346" type="line"/>
-      <point x="232" y="346" type="line" smooth="yes"/>
-      <point x="91" y="346"/>
-      <point x="5" y="275"/>
-      <point x="5" y="154" type="curve" smooth="yes"/>
-      <point x="5" y="54"/>
-      <point x="72" y="-16"/>
+      <point x="934" y="-16" type="curve"/>
+      <point x="1029" y="51" type="line"/>
+      <point x="983" y="111"/>
+      <point x="963" y="168"/>
+      <point x="963" y="243" type="curve" smooth="yes"/>
+      <point x="963" y="385"/>
+      <point x="1051" y="506"/>
+      <point x="1209" y="506" type="curve" smooth="yes"/>
+      <point x="1342" y="506"/>
+      <point x="1408" y="409"/>
+      <point x="1408" y="280" type="curve" smooth="yes"/>
+      <point x="1408" y="210"/>
+      <point x="1381" y="95"/>
+      <point x="1292" y="95" type="curve" smooth="yes"/>
+      <point x="1237" y="95"/>
+      <point x="1204" y="133"/>
+      <point x="1204" y="207" type="curve" smooth="yes"/>
+      <point x="1204" y="361"/>
+      <point x="1329" y="506"/>
+      <point x="1513" y="506" type="curve" smooth="yes"/>
+      <point x="1622" y="506"/>
+      <point x="1675" y="441"/>
+      <point x="1675" y="333" type="curve" smooth="yes"/>
+      <point x="1675" y="244"/>
+      <point x="1632" y="159"/>
+      <point x="1539" y="65" type="curve"/>
+      <point x="1626" y="-16" type="line"/>
+      <point x="1737" y="94"/>
+      <point x="1797" y="218"/>
+      <point x="1797" y="337" type="curve" smooth="yes"/>
+      <point x="1797" y="499"/>
+      <point x="1703" y="613"/>
+      <point x="1529" y="613" type="curve" smooth="yes"/>
+      <point x="1288" y="613"/>
+      <point x="1086" y="412"/>
+      <point x="1086" y="201" type="curve" smooth="yes"/>
+      <point x="1086" y="73"/>
+      <point x="1155" y="-16"/>
+      <point x="1282" y="-16" type="curve" smooth="yes"/>
+      <point x="1440" y="-16"/>
+      <point x="1531" y="139"/>
+      <point x="1531" y="286" type="curve" smooth="yes"/>
+      <point x="1531" y="459"/>
+      <point x="1418" y="613"/>
+      <point x="1221" y="613" type="curve" smooth="yes"/>
+      <point x="981" y="613"/>
+      <point x="846" y="431"/>
+      <point x="846" y="237" type="curve" smooth="yes"/>
+      <point x="846" y="147"/>
+      <point x="873" y="63"/>
     </contour>
     <contour>
-      <point x="529" y="95" type="curve" smooth="yes"/>
-      <point x="465" y="95"/>
-      <point x="428" y="142"/>
-      <point x="428" y="236" type="curve" smooth="yes"/>
-      <point x="428" y="360"/>
-      <point x="473" y="503"/>
-      <point x="582" y="503" type="curve" smooth="yes"/>
-      <point x="646" y="503"/>
-      <point x="679" y="457"/>
-      <point x="679" y="365" type="curve" smooth="yes"/>
-      <point x="679" y="247"/>
-      <point x="641" y="95"/>
+      <point x="170" y="-16" type="curve" smooth="yes"/>
+      <point x="244" y="-16"/>
+      <point x="299" y="26"/>
+      <point x="335" y="95" type="curve"/>
+      <point x="343" y="95" type="line"/>
+      <point x="363" y="27"/>
+      <point x="423" y="-16"/>
+      <point x="506" y="-16" type="curve" smooth="yes"/>
+      <point x="715" y="-16"/>
+      <point x="792" y="230"/>
+      <point x="792" y="389" type="curve" smooth="yes"/>
+      <point x="792" y="525"/>
+      <point x="721" y="613"/>
+      <point x="603" y="613" type="curve" smooth="yes"/>
+      <point x="463" y="613"/>
+      <point x="355" y="500"/>
+      <point x="324" y="319" type="curve" smooth="yes"/>
+      <point x="318" y="286"/>
+      <point x="318" y="246"/>
+      <point x="313" y="212" type="curve" smooth="yes"/>
+      <point x="303" y="142"/>
+      <point x="258" y="95"/>
+      <point x="196" y="95" type="curve" smooth="yes"/>
+      <point x="154" y="95"/>
+      <point x="122" y="120"/>
+      <point x="122" y="167" type="curve" smooth="yes"/>
+      <point x="122" y="227"/>
+      <point x="171" y="265"/>
+      <point x="247" y="265" type="curve" smooth="yes"/>
+      <point x="913" y="265" type="line"/>
+      <point x="913" y="366" type="line"/>
+      <point x="258" y="366" type="line" smooth="yes"/>
+      <point x="105" y="366"/>
+      <point x="4" y="286"/>
+      <point x="4" y="154" type="curve" smooth="yes"/>
+      <point x="4" y="54"/>
+      <point x="69" y="-16"/>
     </contour>
     <contour>
-      <point x="946" y="-16" type="curve"/>
-      <point x="1044" y="54" type="line"/>
-      <point x="999" y="112"/>
-      <point x="978" y="175"/>
-      <point x="978" y="246" type="curve" smooth="yes"/>
-      <point x="978" y="398"/>
-      <point x="1075" y="506"/>
-      <point x="1211" y="506" type="curve" smooth="yes"/>
-      <point x="1338" y="506"/>
-      <point x="1409" y="421"/>
-      <point x="1409" y="270" type="curve" smooth="yes"/>
-      <point x="1409" y="165"/>
-      <point x="1365" y="95"/>
-      <point x="1298" y="95" type="curve" smooth="yes"/>
-      <point x="1242" y="95"/>
-      <point x="1212" y="135"/>
-      <point x="1212" y="209" type="curve" smooth="yes"/>
-      <point x="1212" y="378"/>
-      <point x="1337" y="506"/>
-      <point x="1501" y="506" type="curve" smooth="yes"/>
-      <point x="1615" y="506"/>
-      <point x="1682" y="439"/>
-      <point x="1682" y="323" type="curve" smooth="yes"/>
-      <point x="1682" y="226"/>
-      <point x="1637" y="144"/>
-      <point x="1547" y="73" type="curve"/>
-      <point x="1624" y="-16" type="line"/>
-      <point x="1746" y="81"/>
-      <point x="1804" y="190"/>
-      <point x="1804" y="323" type="curve" smooth="yes"/>
-      <point x="1804" y="499"/>
-      <point x="1699" y="613"/>
-      <point x="1508" y="613" type="curve" smooth="yes"/>
-      <point x="1294" y="613"/>
-      <point x="1094" y="416"/>
-      <point x="1094" y="204" type="curve" smooth="yes"/>
-      <point x="1094" y="68"/>
-      <point x="1172" y="-16"/>
-      <point x="1298" y="-16" type="curve" smooth="yes"/>
-      <point x="1438" y="-16"/>
-      <point x="1532" y="99"/>
-      <point x="1532" y="270" type="curve" smooth="yes"/>
-      <point x="1532" y="469"/>
-      <point x="1397" y="613"/>
-      <point x="1211" y="613" type="curve" smooth="yes"/>
-      <point x="1005" y="613"/>
-      <point x="858" y="460"/>
-      <point x="858" y="246" type="curve" smooth="yes"/>
-      <point x="858" y="146"/>
-      <point x="887" y="59"/>
+      <point x="511" y="95" type="curve" smooth="yes"/>
+      <point x="451" y="95"/>
+      <point x="421" y="135"/>
+      <point x="421" y="209" type="curve" smooth="yes"/>
+      <point x="421" y="299"/>
+      <point x="460" y="502"/>
+      <point x="591" y="502" type="curve" smooth="yes"/>
+      <point x="647" y="502"/>
+      <point x="676" y="464"/>
+      <point x="676" y="391" type="curve" smooth="yes"/>
+      <point x="676" y="296"/>
+      <point x="634" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/k_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/k_tta-malayalam.glif
@@ -1,128 +1,119 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="k_tta-malayalam" format="2">
   <advance width="1074"/>
-  <anchor x="704" y="-351" name="bottom"/>
-  <anchor x="610" y="597" name="top"/>
-  <anchor x="966" y="557" name="topright"/>
+  <anchor x="743" y="-351" name="bottom"/>
+  <anchor x="605" y="597" name="top"/>
+  <anchor x="960" y="557" name="topright"/>
   <outline>
     <contour>
-      <point x="732" y="-367" type="curve" smooth="yes"/>
-      <point x="872" y="-367"/>
-      <point x="937" y="-316"/>
-      <point x="937" y="-230" type="curve" smooth="yes"/>
-      <point x="937" y="-162"/>
-      <point x="900" y="-119"/>
-      <point x="782" y="-113" type="curve" smooth="yes"/>
-      <point x="718" y="-109" type="line" smooth="yes"/>
-      <point x="666" y="-106"/>
-      <point x="645" y="-92"/>
-      <point x="645" y="-71" type="curve" smooth="yes"/>
-      <point x="645" y="-50"/>
-      <point x="669" y="-32"/>
-      <point x="749" y="-32" type="curve" smooth="yes"/>
-      <point x="813" y="-32"/>
-      <point x="880" y="-45"/>
-      <point x="925" y="-61" type="curve"/>
-      <point x="959" y="19" type="line"/>
-      <point x="903" y="40"/>
-      <point x="837" y="54"/>
-      <point x="758" y="54" type="curve" smooth="yes"/>
-      <point x="734" y="54"/>
-      <point x="709" y="51"/>
-      <point x="686" y="45" type="curve"/>
-      <point x="683" y="52" type="line"/>
-      <point x="763" y="128"/>
-      <point x="799" y="254"/>
-      <point x="799" y="378" type="curve" smooth="yes"/>
-      <point x="799" y="515"/>
-      <point x="734" y="613"/>
-      <point x="595" y="613" type="curve" smooth="yes"/>
-      <point x="450" y="613"/>
-      <point x="358" y="505"/>
-      <point x="330" y="337" type="curve" smooth="yes"/>
-      <point x="320" y="276"/>
-      <point x="323" y="242"/>
-      <point x="318" y="216" type="curve" smooth="yes"/>
-      <point x="304" y="136"/>
-      <point x="266" y="93"/>
-      <point x="206" y="93" type="curve" smooth="yes"/>
-      <point x="154" y="93"/>
-      <point x="124" y="121"/>
-      <point x="124" y="166" type="curve" smooth="yes"/>
-      <point x="124" y="217"/>
-      <point x="160" y="245"/>
-      <point x="225" y="245" type="curve" smooth="yes"/>
-      <point x="821" y="245" type="line" smooth="yes"/>
-      <point x="889" y="245"/>
-      <point x="917" y="217"/>
-      <point x="917" y="175" type="curve" smooth="yes"/>
-      <point x="917" y="133"/>
-      <point x="894" y="95"/>
-      <point x="835" y="95" type="curve" smooth="yes"/>
-      <point x="812" y="95"/>
-      <point x="797" y="98"/>
-      <point x="779" y="105" type="curve"/>
-      <point x="734" y="5" type="line"/>
-      <point x="765" y="-9"/>
-      <point x="801" y="-16"/>
-      <point x="839" y="-16" type="curve" smooth="yes"/>
-      <point x="963" y="-16"/>
-      <point x="1034" y="64"/>
-      <point x="1034" y="174" type="curve" smooth="yes"/>
-      <point x="1034" y="277"/>
-      <point x="965" y="346"/>
-      <point x="818" y="346" type="curve" smooth="yes"/>
-      <point x="232" y="346" type="line" smooth="yes"/>
-      <point x="91" y="346"/>
-      <point x="5" y="275"/>
-      <point x="5" y="154" type="curve" smooth="yes"/>
-      <point x="5" y="54"/>
-      <point x="72" y="-16"/>
-      <point x="179" y="-16" type="curve" smooth="yes"/>
-      <point x="259" y="-16"/>
-      <point x="320" y="27"/>
-      <point x="349" y="90" type="curve"/>
-      <point x="356" y="90" type="line"/>
-      <point x="386" y="21"/>
-      <point x="449" y="-16"/>
-      <point x="525" y="-16" type="curve" smooth="yes"/>
-      <point x="540" y="-16"/>
-      <point x="561" y="-13"/>
-      <point x="575" y="-8" type="curve"/>
-      <point x="579" y="-15" type="line"/>
-      <point x="554" y="-36"/>
-      <point x="545" y="-62"/>
-      <point x="545" y="-90" type="curve" smooth="yes"/>
-      <point x="545" y="-144"/>
-      <point x="586" y="-192"/>
-      <point x="696" y="-197" type="curve" smooth="yes"/>
-      <point x="761" y="-200" type="line" smooth="yes"/>
-      <point x="825" y="-204"/>
-      <point x="837" y="-219"/>
-      <point x="837" y="-238" type="curve" smooth="yes"/>
-      <point x="837" y="-264"/>
-      <point x="816" y="-281"/>
-      <point x="738" y="-281" type="curve" smooth="yes"/>
-      <point x="650" y="-281"/>
-      <point x="586" y="-261"/>
-      <point x="546" y="-240" type="curve"/>
-      <point x="499" y="-314" type="line"/>
-      <point x="549" y="-346"/>
-      <point x="633" y="-367"/>
+      <point x="743" y="-368" type="curve" smooth="yes"/>
+      <point x="881" y="-368"/>
+      <point x="955" y="-309"/>
+      <point x="955" y="-233" type="curve" smooth="yes"/>
+      <point x="955" y="-165"/>
+      <point x="920" y="-128"/>
+      <point x="814" y="-116" type="curve" smooth="yes"/>
+      <point x="743" y="-108" type="line" smooth="yes"/>
+      <point x="701" y="-103"/>
+      <point x="684" y="-95"/>
+      <point x="684" y="-75" type="curve" smooth="yes"/>
+      <point x="684" y="-49"/>
+      <point x="720" y="-33"/>
+      <point x="794" y="-33" type="curve" smooth="yes"/>
+      <point x="856" y="-33"/>
+      <point x="904" y="-43"/>
+      <point x="948" y="-62" type="curve"/>
+      <point x="978" y="19" type="line"/>
+      <point x="963" y="26"/>
+      <point x="943" y="32"/>
+      <point x="924" y="36" type="curve"/>
+      <point x="925" y="43" type="line"/>
+      <point x="993" y="72"/>
+      <point x="1030" y="128"/>
+      <point x="1030" y="199" type="curve" smooth="yes"/>
+      <point x="1030" y="298"/>
+      <point x="963" y="366"/>
+      <point x="828" y="366" type="curve" smooth="yes"/>
+      <point x="258" y="366" type="line" smooth="yes"/>
+      <point x="105" y="366"/>
+      <point x="4" y="286"/>
+      <point x="4" y="154" type="curve" smooth="yes"/>
+      <point x="4" y="54"/>
+      <point x="69" y="-16"/>
+      <point x="170" y="-16" type="curve" smooth="yes"/>
+      <point x="244" y="-16"/>
+      <point x="299" y="26"/>
+      <point x="335" y="95" type="curve"/>
+      <point x="343" y="95" type="line"/>
+      <point x="363" y="27"/>
+      <point x="423" y="-16"/>
+      <point x="506" y="-16" type="curve" smooth="yes"/>
+      <point x="715" y="-16"/>
+      <point x="792" y="230"/>
+      <point x="792" y="389" type="curve" smooth="yes"/>
+      <point x="792" y="525"/>
+      <point x="721" y="613"/>
+      <point x="603" y="613" type="curve" smooth="yes"/>
+      <point x="463" y="613"/>
+      <point x="355" y="500"/>
+      <point x="324" y="319" type="curve" smooth="yes"/>
+      <point x="318" y="286"/>
+      <point x="318" y="246"/>
+      <point x="313" y="212" type="curve" smooth="yes"/>
+      <point x="303" y="142"/>
+      <point x="258" y="95"/>
+      <point x="196" y="95" type="curve" smooth="yes"/>
+      <point x="154" y="95"/>
+      <point x="122" y="120"/>
+      <point x="122" y="167" type="curve" smooth="yes"/>
+      <point x="122" y="227"/>
+      <point x="171" y="265"/>
+      <point x="247" y="265" type="curve" smooth="yes"/>
+      <point x="817" y="265" type="line" smooth="yes"/>
+      <point x="884" y="265"/>
+      <point x="913" y="232"/>
+      <point x="913" y="184" type="curve" smooth="yes"/>
+      <point x="913" y="127"/>
+      <point x="876" y="95"/>
+      <point x="829" y="95" type="curve" smooth="yes"/>
+      <point x="811" y="95"/>
+      <point x="794" y="99"/>
+      <point x="777" y="108" type="curve"/>
+      <point x="739" y="22" type="line"/>
+      <point x="789" y="49" type="line"/>
+      <point x="674" y="44"/>
+      <point x="584" y="-3"/>
+      <point x="584" y="-88" type="curve" smooth="yes"/>
+      <point x="584" y="-149"/>
+      <point x="628" y="-184"/>
+      <point x="709" y="-193" type="curve" smooth="yes"/>
+      <point x="780" y="-201" type="line" smooth="yes"/>
+      <point x="841" y="-208"/>
+      <point x="855" y="-217"/>
+      <point x="855" y="-239" type="curve" smooth="yes"/>
+      <point x="855" y="-266"/>
+      <point x="821" y="-282"/>
+      <point x="751" y="-282" type="curve" smooth="yes"/>
+      <point x="688" y="-282"/>
+      <point x="625" y="-265"/>
+      <point x="570" y="-233" type="curve"/>
+      <point x="529" y="-318" type="line"/>
+      <point x="586" y="-350"/>
+      <point x="664" y="-368"/>
     </contour>
     <contour>
-      <point x="529" y="95" type="curve" smooth="yes"/>
-      <point x="465" y="95"/>
-      <point x="428" y="142"/>
-      <point x="428" y="236" type="curve" smooth="yes"/>
-      <point x="428" y="360"/>
-      <point x="473" y="503"/>
-      <point x="582" y="503" type="curve" smooth="yes"/>
-      <point x="646" y="503"/>
-      <point x="679" y="457"/>
-      <point x="679" y="365" type="curve" smooth="yes"/>
-      <point x="679" y="247"/>
-      <point x="641" y="95"/>
+      <point x="511" y="95" type="curve" smooth="yes"/>
+      <point x="451" y="95"/>
+      <point x="421" y="135"/>
+      <point x="421" y="209" type="curve" smooth="yes"/>
+      <point x="421" y="299"/>
+      <point x="460" y="502"/>
+      <point x="591" y="502" type="curve" smooth="yes"/>
+      <point x="647" y="502"/>
+      <point x="676" y="464"/>
+      <point x="676" y="391" type="curve" smooth="yes"/>
+      <point x="676" y="296"/>
+      <point x="634" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ka-malayalam.glif
@@ -2,80 +2,80 @@
 <glyph name="ka-malayalam" format="2">
   <advance width="1074"/>
   <unicode hex="0D15"/>
-  <anchor x="616" y="0" name="bottom"/>
-  <anchor x="610" y="597" name="top"/>
-  <anchor x="966" y="557" name="topright"/>
+  <anchor x="610" y="0" name="bottom"/>
+  <anchor x="605" y="597" name="top"/>
+  <anchor x="960" y="557" name="topright"/>
   <outline>
     <contour>
-      <point x="179" y="-16" type="curve" smooth="yes"/>
-      <point x="259" y="-16"/>
-      <point x="320" y="27"/>
-      <point x="349" y="90" type="curve"/>
-      <point x="356" y="90" type="line"/>
-      <point x="386" y="21"/>
-      <point x="449" y="-16"/>
-      <point x="529" y="-16" type="curve" smooth="yes"/>
-      <point x="699" y="-16"/>
-      <point x="799" y="169"/>
-      <point x="799" y="378" type="curve" smooth="yes"/>
-      <point x="799" y="520"/>
-      <point x="730" y="613"/>
-      <point x="597" y="613" type="curve" smooth="yes"/>
-      <point x="454" y="613"/>
-      <point x="358" y="505"/>
-      <point x="330" y="337" type="curve" smooth="yes"/>
-      <point x="320" y="276"/>
-      <point x="323" y="242"/>
-      <point x="318" y="216" type="curve" smooth="yes"/>
-      <point x="304" y="136"/>
-      <point x="266" y="93"/>
-      <point x="206" y="93" type="curve" smooth="yes"/>
-      <point x="154" y="93"/>
-      <point x="124" y="121"/>
-      <point x="124" y="166" type="curve" smooth="yes"/>
-      <point x="124" y="217"/>
-      <point x="160" y="245"/>
-      <point x="225" y="245" type="curve" smooth="yes"/>
-      <point x="821" y="245" type="line" smooth="yes"/>
-      <point x="888" y="245"/>
-      <point x="917" y="218"/>
-      <point x="917" y="175" type="curve" smooth="yes"/>
-      <point x="917" y="128"/>
-      <point x="890" y="95"/>
-      <point x="835" y="95" type="curve" smooth="yes"/>
-      <point x="814" y="95"/>
-      <point x="798" y="98"/>
-      <point x="779" y="105" type="curve"/>
-      <point x="734" y="5" type="line"/>
-      <point x="766" y="-9"/>
-      <point x="802" y="-16"/>
-      <point x="839" y="-16" type="curve" smooth="yes"/>
-      <point x="959" y="-16"/>
-      <point x="1034" y="60"/>
-      <point x="1034" y="174" type="curve" smooth="yes"/>
-      <point x="1034" y="279"/>
-      <point x="962" y="346"/>
-      <point x="818" y="346" type="curve" smooth="yes"/>
-      <point x="232" y="346" type="line" smooth="yes"/>
-      <point x="91" y="346"/>
-      <point x="5" y="275"/>
-      <point x="5" y="154" type="curve" smooth="yes"/>
-      <point x="5" y="54"/>
-      <point x="72" y="-16"/>
+      <point x="170" y="-16" type="curve" smooth="yes"/>
+      <point x="244" y="-16"/>
+      <point x="299" y="26"/>
+      <point x="335" y="95" type="curve"/>
+      <point x="343" y="95" type="line"/>
+      <point x="363" y="27"/>
+      <point x="423" y="-16"/>
+      <point x="506" y="-16" type="curve" smooth="yes"/>
+      <point x="715" y="-16"/>
+      <point x="792" y="230"/>
+      <point x="792" y="389" type="curve" smooth="yes"/>
+      <point x="792" y="525"/>
+      <point x="721" y="613"/>
+      <point x="603" y="613" type="curve" smooth="yes"/>
+      <point x="463" y="613"/>
+      <point x="355" y="500"/>
+      <point x="324" y="319" type="curve" smooth="yes"/>
+      <point x="318" y="286"/>
+      <point x="318" y="246"/>
+      <point x="313" y="212" type="curve" smooth="yes"/>
+      <point x="303" y="142"/>
+      <point x="258" y="95"/>
+      <point x="196" y="95" type="curve" smooth="yes"/>
+      <point x="154" y="95"/>
+      <point x="122" y="120"/>
+      <point x="122" y="167" type="curve" smooth="yes"/>
+      <point x="122" y="227"/>
+      <point x="171" y="265"/>
+      <point x="247" y="265" type="curve" smooth="yes"/>
+      <point x="818" y="265" type="line" smooth="yes"/>
+      <point x="883" y="265"/>
+      <point x="909" y="236"/>
+      <point x="909" y="186" type="curve" smooth="yes"/>
+      <point x="909" y="132"/>
+      <point x="875" y="95"/>
+      <point x="818" y="95" type="curve" smooth="yes"/>
+      <point x="798" y="95"/>
+      <point x="784" y="98"/>
+      <point x="770" y="103" type="curve"/>
+      <point x="729" y="-2" type="line"/>
+      <point x="755" y="-11"/>
+      <point x="783" y="-16"/>
+      <point x="815" y="-16" type="curve" smooth="yes"/>
+      <point x="948" y="-16"/>
+      <point x="1025" y="79"/>
+      <point x="1025" y="187" type="curve" smooth="yes"/>
+      <point x="1025" y="293"/>
+      <point x="960" y="366"/>
+      <point x="828" y="366" type="curve" smooth="yes"/>
+      <point x="258" y="366" type="line" smooth="yes"/>
+      <point x="105" y="366"/>
+      <point x="4" y="286"/>
+      <point x="4" y="154" type="curve" smooth="yes"/>
+      <point x="4" y="54"/>
+      <point x="69" y="-16"/>
     </contour>
     <contour>
-      <point x="531" y="95" type="curve" smooth="yes"/>
-      <point x="466" y="95"/>
-      <point x="428" y="142"/>
-      <point x="428" y="236" type="curve" smooth="yes"/>
-      <point x="428" y="381"/>
-      <point x="482" y="503"/>
-      <point x="584" y="503" type="curve" smooth="yes"/>
-      <point x="645" y="503"/>
-      <point x="679" y="460"/>
-      <point x="679" y="365" type="curve" smooth="yes"/>
-      <point x="679" y="229"/>
-      <point x="632" y="95"/>
+      <point x="511" y="95" type="curve" smooth="yes"/>
+      <point x="451" y="95"/>
+      <point x="421" y="135"/>
+      <point x="421" y="209" type="curve" smooth="yes"/>
+      <point x="421" y="299"/>
+      <point x="460" y="502"/>
+      <point x="591" y="502" type="curve" smooth="yes"/>
+      <point x="647" y="502"/>
+      <point x="676" y="464"/>
+      <point x="676" y="391" type="curve" smooth="yes"/>
+      <point x="676" y="296"/>
+      <point x="634" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ka-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ka-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1074"/>
   <outline>
     <component base="ka-malayalam"/>
-    <component base="halant-malayalam" xOffset="885" yOffset="-40"/>
+    <component base="halant-malayalam" xOffset="879" yOffset="-40"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/m_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/m_la-malayalam.glif
@@ -1,57 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="m_la-malayalam" format="2">
   <advance width="707"/>
-  <anchor x="260" y="-351" name="bottom"/>
+  <anchor x="255" y="-352" name="bottom"/>
   <anchor x="416" y="597" name="top"/>
   <anchor x="645" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="36" y="-368" type="curve" smooth="yes"/>
-      <point x="127" y="-368"/>
-      <point x="183" y="-308"/>
-      <point x="183" y="-225" type="curve" smooth="yes"/>
-      <point x="183" y="-146"/>
-      <point x="139" y="-112"/>
-      <point x="74" y="-112" type="curve" smooth="yes"/>
-      <point x="39" y="-112"/>
-      <point x="7" y="-124"/>
-      <point x="-20" y="-154" type="curve"/>
-      <point x="-28" y="-153" type="line"/>
-      <point x="-14" y="-89"/>
-      <point x="37" y="-35"/>
-      <point x="122" y="-35" type="curve" smooth="yes"/>
-      <point x="218" y="-35"/>
-      <point x="252" y="-83"/>
-      <point x="259" y="-171" type="curve" smooth="yes"/>
-      <point x="260" y="-184" type="line" smooth="yes"/>
-      <point x="269" y="-304"/>
-      <point x="319" y="-368"/>
-      <point x="446" y="-368" type="curve" smooth="yes"/>
-      <point x="586" y="-368"/>
-      <point x="647" y="-264"/>
-      <point x="647" y="-126" type="curve" smooth="yes"/>
-      <point x="647" y="-49"/>
-      <point x="628" y="8"/>
-      <point x="598" y="53" type="curve"/>
-      <point x="511" y="3" type="line"/>
-      <point x="530" y="-33"/>
-      <point x="546" y="-80"/>
-      <point x="546" y="-136" type="curve" smooth="yes"/>
-      <point x="546" y="-217"/>
-      <point x="518" y="-279"/>
-      <point x="447" y="-279" type="curve" smooth="yes"/>
-      <point x="389" y="-279"/>
-      <point x="365" y="-246"/>
-      <point x="359" y="-166" type="curve" smooth="yes"/>
-      <point x="358" y="-147" type="line" smooth="yes"/>
-      <point x="353" y="-87"/>
-      <point x="341" y="-37"/>
-      <point x="300" y="-6" type="curve"/>
-      <point x="302" y="0" type="line"/>
-      <point x="607" y="0" type="line"/>
-      <point x="655" y="275" type="line" smooth="yes"/>
-      <point x="661" y="305"/>
-      <point x="664" y="344"/>
+      <point x="-4" y="0" type="line"/>
+      <point x="606" y="0" type="line"/>
+      <point x="654" y="273" type="line" smooth="yes"/>
+      <point x="660" y="305"/>
+      <point x="664" y="343"/>
       <point x="664" y="369" type="curve" smooth="yes"/>
       <point x="664" y="530"/>
       <point x="572" y="613"/>
@@ -59,30 +18,75 @@
       <point x="204" y="613"/>
       <point x="87" y="515"/>
       <point x="54" y="330" type="curve" smooth="yes"/>
-      <point x="-4" y="0" type="line"/>
-      <point x="29" y="0" type="line"/>
-      <point x="31" y="36" type="line"/>
-      <point x="-64" y="0"/>
-      <point x="-124" y="-87"/>
-      <point x="-124" y="-199" type="curve" smooth="yes"/>
-      <point x="-124" y="-313"/>
-      <point x="-57" y="-368"/>
     </contour>
     <contour>
-      <point x="36" y="-288" type="curve" smooth="yes"/>
-      <point x="-15" y="-288"/>
-      <point x="-30" y="-250"/>
-      <point x="-30" y="-213" type="curve"/>
-      <point x="-46" y="-207" type="line"/>
-      <point x="-38" y="-246" type="line"/>
-      <point x="-27" y="-208"/>
-      <point x="2" y="-185"/>
-      <point x="39" y="-185" type="curve" smooth="yes"/>
-      <point x="75" y="-185"/>
-      <point x="93" y="-200"/>
-      <point x="93" y="-232" type="curve" smooth="yes"/>
-      <point x="93" y="-267"/>
-      <point x="71" y="-288"/>
+      <point x="97" y="-368" type="curve" smooth="yes"/>
+      <point x="211" y="-368"/>
+      <point x="249" y="-283"/>
+      <point x="249" y="-216" type="curve" smooth="yes"/>
+      <point x="249" y="-148"/>
+      <point x="210" y="-102"/>
+      <point x="146" y="-102" type="curve" smooth="yes"/>
+      <point x="89" y="-102"/>
+      <point x="43" y="-141"/>
+      <point x="25" y="-206" type="curve"/>
+      <point x="67" y="-161" type="line"/>
+      <point x="16" y="-144" type="line"/>
+      <point x="35" y="-179" type="line"/>
+      <point x="47" y="-97"/>
+      <point x="104" y="-29"/>
+      <point x="190" y="-29" type="curve" smooth="yes"/>
+      <point x="265" y="-29"/>
+      <point x="294" y="-61"/>
+      <point x="294" y="-136" type="curve" smooth="yes"/>
+      <point x="294" y="-214" type="line" smooth="yes"/>
+      <point x="294" y="-310"/>
+      <point x="348" y="-368"/>
+      <point x="431" y="-368" type="curve" smooth="yes"/>
+      <point x="566" y="-368"/>
+      <point x="599" y="-247"/>
+      <point x="599" y="-163" type="curve" smooth="yes"/>
+      <point x="599" y="-85"/>
+      <point x="574" y="-6"/>
+      <point x="528" y="65" type="curve"/>
+      <point x="449" y="17" type="line"/>
+      <point x="486" y="-39"/>
+      <point x="503" y="-96"/>
+      <point x="503" y="-159" type="curve" smooth="yes"/>
+      <point x="503" y="-208"/>
+      <point x="494" y="-278"/>
+      <point x="437" y="-278" type="curve" smooth="yes"/>
+      <point x="407" y="-278"/>
+      <point x="386" y="-259"/>
+      <point x="386" y="-207" type="curve" smooth="yes"/>
+      <point x="386" y="-129" type="line" smooth="yes"/>
+      <point x="386" y="-12"/>
+      <point x="322" y="51"/>
+      <point x="202" y="51" type="curve" smooth="yes"/>
+      <point x="52" y="51"/>
+      <point x="-56" y="-56"/>
+      <point x="-56" y="-204" type="curve" smooth="yes"/>
+      <point x="-56" y="-307"/>
+      <point x="9" y="-368"/>
+    </contour>
+    <contour>
+      <point x="99" y="-288" type="curve" smooth="yes"/>
+      <point x="55" y="-288"/>
+      <point x="32" y="-255"/>
+      <point x="32" y="-210" type="curve" smooth="yes"/>
+      <point x="32" y="-201"/>
+      <point x="34" y="-193"/>
+      <point x="38" y="-187" type="curve"/>
+      <point x="13" y="-192" type="line"/>
+      <point x="25" y="-244" type="line"/>
+      <point x="40" y="-203"/>
+      <point x="74" y="-172"/>
+      <point x="114" y="-172" type="curve" smooth="yes"/>
+      <point x="146" y="-172"/>
+      <point x="161" y="-192"/>
+      <point x="161" y="-224" type="curve" smooth="yes"/>
+      <point x="161" y="-251"/>
+      <point x="143" y="-288"/>
     </contour>
     <contour>
       <point x="71" y="48" type="line"/>
@@ -95,7 +99,7 @@
       <point x="362" y="435"/>
       <point x="362" y="395" type="curve" smooth="yes"/>
       <point x="362" y="336"/>
-      <point x="323" y="281"/>
+      <point x="323" y="282"/>
       <point x="203" y="171" type="curve" smooth="yes"/>
     </contour>
     <contour>
@@ -115,9 +119,9 @@
       <point x="490" y="527"/>
       <point x="544" y="475"/>
       <point x="544" y="361" type="curve" smooth="yes"/>
-      <point x="544" y="341"/>
-      <point x="542" y="315"/>
-      <point x="536" y="284" type="curve" smooth="yes"/>
+      <point x="544" y="342"/>
+      <point x="541" y="315"/>
+      <point x="536" y="286" type="curve" smooth="yes"/>
       <point x="494" y="49" type="line"/>
       <point x="573" y="104" type="line"/>
       <point x="175" y="104" type="line"/>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ng_ka-malayalam.glif
@@ -1,103 +1,103 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng_ka-malayalam" format="2">
   <advance width="1079"/>
-  <anchor x="625" y="0" name="bottom"/>
-  <anchor x="616" y="597" name="top"/>
-  <anchor x="969" y="597" name="topright"/>
+  <anchor x="618" y="0" name="bottom"/>
+  <anchor x="610" y="597" name="top"/>
+  <anchor x="964" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="182" y="-16" type="curve" smooth="yes"/>
-      <point x="264" y="-16"/>
-      <point x="324" y="29"/>
-      <point x="351" y="90" type="curve"/>
-      <point x="358" y="90" type="line"/>
-      <point x="389" y="19"/>
-      <point x="452" y="-16"/>
-      <point x="532" y="-16" type="curve" smooth="yes"/>
-      <point x="712" y="-16"/>
-      <point x="801" y="184"/>
-      <point x="801" y="378" type="curve" smooth="yes"/>
-      <point x="801" y="515"/>
-      <point x="736" y="613"/>
-      <point x="600" y="613" type="curve" smooth="yes"/>
-      <point x="525" y="613"/>
-      <point x="458" y="577"/>
-      <point x="420" y="508" type="curve"/>
-      <point x="413" y="508" type="line"/>
-      <point x="392" y="570"/>
-      <point x="338" y="613"/>
-      <point x="249" y="613" type="curve" smooth="yes"/>
+      <point x="171" y="-16" type="curve" smooth="yes"/>
+      <point x="246" y="-16"/>
+      <point x="299" y="18"/>
+      <point x="342" y="93" type="curve"/>
+      <point x="349" y="93" type="line"/>
+      <point x="369" y="25"/>
+      <point x="428" y="-16"/>
+      <point x="510" y="-16" type="curve" smooth="yes"/>
+      <point x="720" y="-16"/>
+      <point x="797" y="230"/>
+      <point x="797" y="389" type="curve" smooth="yes"/>
+      <point x="797" y="525"/>
+      <point x="725" y="613"/>
+      <point x="609" y="613" type="curve" smooth="yes"/>
+      <point x="529" y="613"/>
+      <point x="465" y="578"/>
+      <point x="416" y="502" type="curve"/>
+      <point x="409" y="502" type="line"/>
+      <point x="392" y="568"/>
+      <point x="343" y="613"/>
+      <point x="258" y="613" type="curve" smooth="yes"/>
       <point x="141" y="613"/>
-      <point x="67" y="543"/>
-      <point x="67" y="445" type="curve" smooth="yes"/>
-      <point x="67" y="386"/>
-      <point x="91" y="341"/>
-      <point x="135" y="313" type="curve"/>
-      <point x="135" y="306" type="line"/>
-      <point x="54" y="289"/>
-      <point x="8" y="228"/>
-      <point x="8" y="148" type="curve" smooth="yes"/>
-      <point x="8" y="49"/>
+      <point x="66" y="534"/>
+      <point x="66" y="442" type="curve" smooth="yes"/>
+      <point x="66" y="390"/>
+      <point x="96" y="347"/>
+      <point x="137" y="325" type="curve"/>
+      <point x="136" y="318" type="line"/>
+      <point x="52" y="285"/>
+      <point x="6" y="218"/>
+      <point x="6" y="139" type="curve" smooth="yes"/>
+      <point x="6" y="50"/>
       <point x="75" y="-16"/>
     </contour>
     <contour>
-      <point x="532" y="95" type="curve" smooth="yes"/>
-      <point x="468" y="95"/>
-      <point x="431" y="142"/>
-      <point x="431" y="236" type="curve" smooth="yes"/>
-      <point x="431" y="360"/>
-      <point x="475" y="503"/>
-      <point x="584" y="503" type="curve" smooth="yes"/>
-      <point x="649" y="503"/>
-      <point x="682" y="457"/>
-      <point x="682" y="365" type="curve" smooth="yes"/>
-      <point x="682" y="247"/>
-      <point x="644" y="95"/>
+      <point x="820" y="-16" type="curve" smooth="yes"/>
+      <point x="953" y="-16"/>
+      <point x="1030" y="79"/>
+      <point x="1030" y="187" type="curve" smooth="yes"/>
+      <point x="1030" y="293"/>
+      <point x="965" y="366"/>
+      <point x="833" y="366" type="curve" smooth="yes"/>
+      <point x="262" y="366" type="line" smooth="yes"/>
+      <point x="211" y="366"/>
+      <point x="180" y="388"/>
+      <point x="180" y="430" type="curve" smooth="yes"/>
+      <point x="180" y="468"/>
+      <point x="211" y="502"/>
+      <point x="269" y="502" type="curve" smooth="yes"/>
+      <point x="324" y="502"/>
+      <point x="349" y="470"/>
+      <point x="349" y="419" type="curve" smooth="yes"/>
+      <point x="349" y="405"/>
+      <point x="347" y="388"/>
+      <point x="344" y="369" type="curve" smooth="yes"/>
+      <point x="318" y="217" type="line" smooth="yes"/>
+      <point x="305" y="141"/>
+      <point x="263" y="95"/>
+      <point x="204" y="95" type="curve" smooth="yes"/>
+      <point x="155" y="95"/>
+      <point x="126" y="124"/>
+      <point x="126" y="167" type="curve" smooth="yes"/>
+      <point x="126" y="226"/>
+      <point x="174" y="265"/>
+      <point x="250" y="265" type="curve" smooth="yes"/>
+      <point x="823" y="265" type="line" smooth="yes"/>
+      <point x="888" y="265"/>
+      <point x="914" y="236"/>
+      <point x="914" y="186" type="curve" smooth="yes"/>
+      <point x="914" y="132"/>
+      <point x="880" y="95"/>
+      <point x="823" y="95" type="curve" smooth="yes"/>
+      <point x="803" y="95"/>
+      <point x="789" y="98"/>
+      <point x="775" y="103" type="curve"/>
+      <point x="734" y="-2" type="line"/>
+      <point x="760" y="-11"/>
+      <point x="788" y="-16"/>
     </contour>
     <contour>
-      <point x="842" y="-16" type="curve" smooth="yes"/>
-      <point x="966" y="-16"/>
-      <point x="1037" y="64"/>
-      <point x="1037" y="174" type="curve" smooth="yes"/>
-      <point x="1037" y="277"/>
-      <point x="968" y="346"/>
-      <point x="821" y="346" type="curve" smooth="yes"/>
-      <point x="285" y="346" type="line" smooth="yes"/>
-      <point x="213" y="346"/>
-      <point x="182" y="379"/>
-      <point x="182" y="425" type="curve" smooth="yes"/>
-      <point x="182" y="471"/>
-      <point x="214" y="502"/>
-      <point x="265" y="502" type="curve" smooth="yes"/>
-      <point x="322" y="502"/>
-      <point x="351" y="466"/>
-      <point x="351" y="404" type="curve" smooth="yes"/>
-      <point x="351" y="389"/>
-      <point x="348" y="365"/>
-      <point x="345" y="347" type="curve" smooth="yes"/>
-      <point x="323" y="220" type="line" smooth="yes"/>
-      <point x="309" y="137"/>
-      <point x="271" y="93"/>
-      <point x="207" y="93" type="curve" smooth="yes"/>
-      <point x="159" y="93"/>
-      <point x="127" y="118"/>
-      <point x="127" y="166" type="curve" smooth="yes"/>
-      <point x="127" y="216"/>
-      <point x="160" y="245"/>
-      <point x="227" y="245" type="curve" smooth="yes"/>
-      <point x="824" y="245" type="line" smooth="yes"/>
-      <point x="892" y="245"/>
-      <point x="919" y="217"/>
-      <point x="919" y="175" type="curve" smooth="yes"/>
-      <point x="919" y="133"/>
-      <point x="897" y="95"/>
-      <point x="838" y="95" type="curve" smooth="yes"/>
-      <point x="815" y="95"/>
-      <point x="800" y="98"/>
-      <point x="782" y="105" type="curve"/>
-      <point x="737" y="5" type="line"/>
-      <point x="768" y="-9"/>
-      <point x="803" y="-16"/>
+      <point x="515" y="95" type="curve" smooth="yes"/>
+      <point x="456" y="95"/>
+      <point x="426" y="135"/>
+      <point x="426" y="209" type="curve" smooth="yes"/>
+      <point x="426" y="299"/>
+      <point x="465" y="502"/>
+      <point x="595" y="502" type="curve" smooth="yes"/>
+      <point x="652" y="502"/>
+      <point x="681" y="464"/>
+      <point x="681" y="391" type="curve" smooth="yes"/>
+      <point x="681" y="296"/>
+      <point x="639" y="95"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ny_ja-malayalam.glif
@@ -1,192 +1,193 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ny_ja-malayalam" format="2">
-  <advance width="1558"/>
-  <anchor x="1104" y="0" name="bottom"/>
-  <anchor x="881" y="597" name="top"/>
-  <anchor x="1496" y="597" name="topright"/>
+  <advance width="1599"/>
+  <anchor x="1120" y="0" name="bottom"/>
+  <anchor x="853" y="597" name="top"/>
+  <anchor x="1498" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="256" y="-16" type="curve" smooth="yes"/>
-      <point x="376" y="-16"/>
-      <point x="455" y="70"/>
-      <point x="455" y="198" type="curve" smooth="yes"/>
-      <point x="455" y="295"/>
-      <point x="399" y="354"/>
-      <point x="307" y="354" type="curve" smooth="yes"/>
-      <point x="252" y="354"/>
-      <point x="204" y="334"/>
-      <point x="168" y="295" type="curve"/>
-      <point x="128" y="307" type="line"/>
-      <point x="122" y="141" type="line"/>
-      <point x="153" y="213"/>
-      <point x="206" y="257"/>
-      <point x="263" y="257" type="curve" smooth="yes"/>
-      <point x="309" y="257"/>
-      <point x="335" y="231"/>
-      <point x="335" y="184" type="curve" smooth="yes"/>
-      <point x="335" y="131"/>
-      <point x="302" y="95"/>
-      <point x="255" y="95" type="curve" smooth="yes"/>
-      <point x="190" y="95"/>
-      <point x="155" y="146"/>
-      <point x="155" y="235" type="curve" smooth="yes"/>
-      <point x="155" y="394"/>
-      <point x="249" y="502"/>
-      <point x="387" y="502" type="curve" smooth="yes"/>
-      <point x="486" y="502"/>
-      <point x="539" y="447"/>
-      <point x="539" y="352" type="curve" smooth="yes"/>
-      <point x="539" y="333"/>
-      <point x="537" y="310"/>
-      <point x="532" y="281" type="curve" smooth="yes"/>
-      <point x="482" y="0" type="line"/>
-      <point x="604" y="0" type="line"/>
-      <point x="663" y="331" type="line" smooth="yes"/>
-      <point x="683" y="445"/>
-      <point x="741" y="532"/>
+      <point x="245" y="-16" type="curve" smooth="yes"/>
+      <point x="398" y="-16"/>
+      <point x="458" y="108"/>
+      <point x="458" y="197" type="curve" smooth="yes"/>
+      <point x="458" y="300"/>
+      <point x="404" y="364"/>
+      <point x="308" y="364" type="curve" smooth="yes"/>
+      <point x="251" y="364"/>
+      <point x="200" y="343"/>
+      <point x="162" y="303" type="curve"/>
+      <point x="122" y="315" type="line"/>
+      <point x="122" y="155" type="line"/>
+      <point x="153" y="221"/>
+      <point x="208" y="261"/>
+      <point x="264" y="261" type="curve" smooth="yes"/>
+      <point x="314" y="261"/>
+      <point x="338" y="232"/>
+      <point x="338" y="188" type="curve" smooth="yes"/>
+      <point x="338" y="142"/>
+      <point x="311" y="92"/>
+      <point x="249" y="92" type="curve" smooth="yes"/>
+      <point x="185" y="92"/>
+      <point x="147" y="146"/>
+      <point x="147" y="235" type="curve" smooth="yes"/>
+      <point x="147" y="374"/>
+      <point x="222" y="502"/>
+      <point x="384" y="502" type="curve" smooth="yes"/>
+      <point x="484" y="502"/>
+      <point x="534" y="445"/>
+      <point x="534" y="357" type="curve" smooth="yes"/>
+      <point x="534" y="337"/>
+      <point x="532" y="313"/>
+      <point x="527" y="283" type="curve" smooth="yes"/>
+      <point x="477" y="0" type="line"/>
+      <point x="599" y="0" type="line"/>
+      <point x="658" y="333" type="line" smooth="yes"/>
+      <point x="681" y="463"/>
+      <point x="762" y="532"/>
       <point x="887" y="532" type="curve" smooth="yes"/>
-      <point x="920" y="532"/>
-      <point x="922" y="531"/>
-      <point x="938" y="528" type="curve"/>
-      <point x="806" y="569" type="line"/>
-      <point x="827" y="514" type="line"/>
-      <point x="798" y="491"/>
-      <point x="778" y="463"/>
-      <point x="778" y="422" type="curve" smooth="yes"/>
-      <point x="778" y="350"/>
-      <point x="837" y="309"/>
-      <point x="926" y="309" type="curve" smooth="yes"/>
-      <point x="1013" y="309"/>
-      <point x="1080" y="353"/>
-      <point x="1080" y="440" type="curve" smooth="yes"/>
-      <point x="1080" y="465"/>
-      <point x="1070" y="506"/>
-      <point x="1032" y="532" type="curve"/>
-      <point x="1069" y="588" type="line"/>
-      <point x="980" y="537" type="line"/>
+      <point x="907" y="532"/>
+      <point x="928" y="530"/>
+      <point x="941" y="528" type="curve"/>
+      <point x="821" y="546" type="line"/>
+      <point x="828" y="518" type="line"/>
+      <point x="791" y="495"/>
+      <point x="767" y="453"/>
+      <point x="767" y="413" type="curve" smooth="yes"/>
+      <point x="767" y="342"/>
+      <point x="825" y="292"/>
+      <point x="909" y="292" type="curve" smooth="yes"/>
+      <point x="1022" y="292"/>
+      <point x="1071" y="370"/>
+      <point x="1071" y="434" type="curve" smooth="yes"/>
+      <point x="1071" y="474"/>
+      <point x="1054" y="506"/>
+      <point x="1020" y="532" type="curve"/>
+      <point x="1038" y="571" type="line"/>
+      <point x="982" y="538" type="line"/>
       <point x="989" y="539"/>
-      <point x="998" y="540"/>
-      <point x="1011" y="540" type="curve" smooth="yes"/>
-      <point x="1085" y="540"/>
-      <point x="1122" y="501"/>
-      <point x="1122" y="424" type="curve" smooth="yes"/>
-      <point x="1122" y="411"/>
-      <point x="1120" y="395"/>
-      <point x="1118" y="380" type="curve" smooth="yes"/>
-      <point x="1113" y="352" type="line"/>
-      <point x="1231" y="352" type="line"/>
-      <point x="1239" y="396" type="line" smooth="yes"/>
-      <point x="1251" y="470"/>
-      <point x="1291" y="510"/>
-      <point x="1352" y="510" type="curve" smooth="yes"/>
-      <point x="1405" y="510"/>
-      <point x="1432" y="483"/>
-      <point x="1432" y="430" type="curve" smooth="yes"/>
-      <point x="1432" y="346"/>
-      <point x="1382" y="302"/>
-      <point x="1287" y="302" type="curve" smooth="yes"/>
-      <point x="933" y="302" type="line" smooth="yes"/>
-      <point x="807" y="302"/>
-      <point x="732" y="240"/>
-      <point x="732" y="134" type="curve" smooth="yes"/>
-      <point x="732" y="41"/>
-      <point x="792" y="-16"/>
-      <point x="892" y="-16" type="curve" smooth="yes"/>
-      <point x="963" y="-16"/>
-      <point x="1022" y="3"/>
-      <point x="1116" y="59" type="curve" smooth="yes"/>
-      <point x="1181" y="97" type="line"/>
-      <point x="1276" y="159" type="line"/>
-      <point x="1288" y="155" type="line"/>
-      <point x="1319" y="170"/>
-      <point x="1338" y="174"/>
-      <point x="1356" y="174" type="curve" smooth="yes"/>
-      <point x="1387" y="174"/>
-      <point x="1403" y="158"/>
-      <point x="1403" y="128" type="curve" smooth="yes"/>
-      <point x="1403" y="94"/>
-      <point x="1384" y="73"/>
-      <point x="1351" y="73" type="curve" smooth="yes"/>
-      <point x="1322" y="73"/>
-      <point x="1304" y="91"/>
-      <point x="1304" y="118" type="curve" smooth="yes"/>
-      <point x="1304" y="141"/>
-      <point x="1314" y="162"/>
-      <point x="1335" y="181" type="curve"/>
-      <point x="1193" y="162" type="line"/>
-      <point x="1263" y="88" type="line"/>
-      <point x="1262" y="157" type="line"/>
-      <point x="1236" y="136"/>
-      <point x="1226" y="117"/>
-      <point x="1226" y="88" type="curve" smooth="yes"/>
-      <point x="1226" y="24"/>
-      <point x="1273" y="-16"/>
-      <point x="1348" y="-16" type="curve" smooth="yes"/>
-      <point x="1437" y="-16"/>
-      <point x="1492" y="40"/>
-      <point x="1492" y="130" type="curve" smooth="yes"/>
-      <point x="1492" y="205"/>
-      <point x="1442" y="255"/>
-      <point x="1365" y="255" type="curve" smooth="yes"/>
-      <point x="1319" y="255"/>
-      <point x="1268" y="237"/>
-      <point x="1177" y="190" type="curve" smooth="yes"/>
-      <point x="1099" y="149" type="line" smooth="yes"/>
-      <point x="1009" y="102"/>
-      <point x="964" y="87"/>
-      <point x="917" y="87" type="curve" smooth="yes"/>
-      <point x="875" y="87"/>
-      <point x="851" y="107"/>
-      <point x="851" y="140" type="curve" smooth="yes"/>
-      <point x="851" y="181"/>
-      <point x="882" y="204"/>
-      <point x="938" y="204" type="curve" smooth="yes"/>
-      <point x="1303" y="204" type="line" smooth="yes"/>
-      <point x="1456" y="204"/>
-      <point x="1550" y="291"/>
-      <point x="1550" y="433" type="curve" smooth="yes"/>
-      <point x="1550" y="547"/>
-      <point x="1485" y="613"/>
-      <point x="1370" y="613" type="curve" smooth="yes"/>
-      <point x="1290" y="613"/>
-      <point x="1228" y="577"/>
-      <point x="1197" y="502" type="curve"/>
-      <point x="1190" y="502" type="line"/>
-      <point x="1169" y="577"/>
-      <point x="1112" y="613"/>
-      <point x="1019" y="613" type="curve" smooth="yes"/>
-      <point x="968" y="613"/>
-      <point x="928" y="599"/>
-      <point x="900" y="586" type="curve"/>
-      <point x="907" y="533" type="line"/>
-      <point x="973" y="527"/>
-      <point x="990" y="483"/>
-      <point x="990" y="456" type="curve" smooth="yes"/>
-      <point x="990" y="420"/>
-      <point x="971" y="392"/>
-      <point x="929" y="392" type="curve" smooth="yes"/>
-      <point x="895" y="392"/>
-      <point x="873" y="411"/>
-      <point x="873" y="448" type="curve" smooth="yes"/>
-      <point x="873" y="481"/>
-      <point x="898" y="532"/>
-      <point x="978" y="535" type="curve"/>
-      <point x="986" y="591" type="line"/>
-      <point x="957" y="604"/>
-      <point x="921" y="613"/>
-      <point x="869" y="613" type="curve" smooth="yes"/>
-      <point x="751" y="613"/>
-      <point x="668" y="570"/>
-      <point x="617" y="486" type="curve"/>
-      <point x="610" y="486" type="line"/>
-      <point x="570" y="570"/>
-      <point x="493" y="613"/>
+      <point x="1000" y="539"/>
+      <point x="1012" y="539" type="curve" smooth="yes"/>
+      <point x="1091" y="539"/>
+      <point x="1122" y="500"/>
+      <point x="1122" y="436" type="curve" smooth="yes"/>
+      <point x="1122" y="421"/>
+      <point x="1120" y="403"/>
+      <point x="1117" y="386" type="curve" smooth="yes"/>
+      <point x="1106" y="323" type="line"/>
+      <point x="1224" y="323" type="line"/>
+      <point x="1235" y="386" type="line" smooth="yes"/>
+      <point x="1248" y="463"/>
+      <point x="1298" y="509"/>
+      <point x="1369" y="509" type="curve" smooth="yes"/>
+      <point x="1429" y="509"/>
+      <point x="1460" y="479"/>
+      <point x="1460" y="422" type="curve" smooth="yes"/>
+      <point x="1460" y="335"/>
+      <point x="1377" y="278"/>
+      <point x="1250" y="278" type="curve" smooth="yes"/>
+      <point x="917" y="278" type="line" smooth="yes"/>
+      <point x="781" y="278"/>
+      <point x="724" y="199"/>
+      <point x="724" y="125" type="curve" smooth="yes"/>
+      <point x="724" y="40"/>
+      <point x="787" y="-16"/>
+      <point x="890" y="-16" type="curve" smooth="yes"/>
+      <point x="939" y="-16"/>
+      <point x="985" y="-3"/>
+      <point x="1073" y="35" type="curve" smooth="yes"/>
+      <point x="1216" y="97" type="line"/>
+      <point x="1294" y="155" type="line"/>
+      <point x="1313" y="153" type="line"/>
+      <point x="1347" y="168"/>
+      <point x="1369" y="175"/>
+      <point x="1392" y="175" type="curve" smooth="yes"/>
+      <point x="1423" y="175"/>
+      <point x="1435" y="161"/>
+      <point x="1435" y="133" type="curve" smooth="yes"/>
+      <point x="1435" y="105"/>
+      <point x="1416" y="73"/>
+      <point x="1373" y="73" type="curve" smooth="yes"/>
+      <point x="1344" y="73"/>
+      <point x="1326" y="89"/>
+      <point x="1326" y="116" type="curve" smooth="yes"/>
+      <point x="1326" y="138"/>
+      <point x="1335" y="159"/>
+      <point x="1353" y="178" type="curve"/>
+      <point x="1239" y="145" type="line"/>
+      <point x="1261" y="123" type="line"/>
+      <point x="1254" y="107"/>
+      <point x="1253" y="94"/>
+      <point x="1253" y="80" type="curve" smooth="yes"/>
+      <point x="1253" y="27"/>
+      <point x="1298" y="-16"/>
+      <point x="1369" y="-16" type="curve" smooth="yes"/>
+      <point x="1477" y="-16"/>
+      <point x="1525" y="63"/>
+      <point x="1525" y="129" type="curve" smooth="yes"/>
+      <point x="1525" y="199"/>
+      <point x="1477" y="243"/>
+      <point x="1396" y="243" type="curve" smooth="yes"/>
+      <point x="1342" y="243"/>
+      <point x="1287" y="227"/>
+      <point x="1195" y="187" type="curve" smooth="yes"/>
+      <point x="1043" y="121" type="line" smooth="yes"/>
+      <point x="979" y="93"/>
+      <point x="943" y="84"/>
+      <point x="903" y="84" type="curve" smooth="yes"/>
+      <point x="865" y="84"/>
+      <point x="844" y="102"/>
+      <point x="844" y="131" type="curve" smooth="yes"/>
+      <point x="844" y="160"/>
+      <point x="865" y="184"/>
+      <point x="917" y="184" type="curve" smooth="yes"/>
+      <point x="1248" y="184" type="line" smooth="yes"/>
+      <point x="1444" y="184"/>
+      <point x="1580" y="288"/>
+      <point x="1580" y="434" type="curve" smooth="yes"/>
+      <point x="1580" y="547"/>
+      <point x="1514" y="613"/>
+      <point x="1402" y="613" type="curve" smooth="yes"/>
+      <point x="1313" y="613"/>
+      <point x="1240" y="569"/>
+      <point x="1202" y="494" type="curve"/>
+      <point x="1195" y="494" type="line"/>
+      <point x="1181" y="563"/>
+      <point x="1132" y="613"/>
+      <point x="1027" y="613" type="curve" smooth="yes"/>
+      <point x="988" y="613"/>
+      <point x="949" y="605"/>
+      <point x="913" y="589" type="curve"/>
+      <point x="967" y="589" type="line"/>
+      <point x="939" y="604"/>
+      <point x="903" y="613"/>
+      <point x="861" y="613" type="curve" smooth="yes"/>
+      <point x="750" y="613"/>
+      <point x="668" y="567"/>
+      <point x="619" y="478" type="curve"/>
+      <point x="612" y="478" type="line"/>
+      <point x="572" y="567"/>
+      <point x="495" y="613"/>
       <point x="383" y="613" type="curve" smooth="yes"/>
-      <point x="181" y="613"/>
-      <point x="36" y="454"/>
-      <point x="36" y="233" type="curve" smooth="yes"/>
-      <point x="36" y="82"/>
-      <point x="121" y="-16"/>
+      <point x="149" y="613"/>
+      <point x="35" y="414"/>
+      <point x="35" y="233" type="curve" smooth="yes"/>
+      <point x="35" y="77"/>
+      <point x="118" y="-16"/>
+    </contour>
+    <contour>
+      <point x="915" y="374" type="curve" smooth="yes"/>
+      <point x="881" y="374"/>
+      <point x="859" y="394"/>
+      <point x="859" y="426" type="curve" smooth="yes"/>
+      <point x="859" y="467"/>
+      <point x="892" y="502"/>
+      <point x="953" y="524" type="curve"/>
+      <point x="912" y="524" type="line"/>
+      <point x="960" y="504"/>
+      <point x="983" y="477"/>
+      <point x="983" y="440" type="curve" smooth="yes"/>
+      <point x="983" y="409"/>
+      <point x="961" y="374"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/oo-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/oo-malayalam.glif
@@ -4,7 +4,7 @@
   <unicode hex="0D13"/>
   <outline>
     <component base="o-malayalam"/>
-    <component base="aaMatra-malayalam" xOffset="824"/>
+    <component base="aaMatra-malayalam" xOffset="819"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/rr_rra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/rr_rra-malayalam.glif
@@ -1,65 +1,65 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="rr_rra-malayalam" format="2">
-  <advance width="728"/>
-  <anchor x="231" y="-316" name="bottom"/>
-  <anchor x="421" y="597" name="top"/>
-  <anchor x="638" y="597" name="topright"/>
+  <advance width="734"/>
+  <anchor x="270" y="-316" name="bottom"/>
+  <anchor x="410" y="597" name="top"/>
+  <anchor x="639" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="121" y="-328" type="curve"/>
-      <point x="203" y="-266" type="line"/>
-      <point x="184" y="-242"/>
-      <point x="164" y="-203"/>
-      <point x="164" y="-144" type="curve" smooth="yes"/>
-      <point x="164" y="-66"/>
-      <point x="210" y="1"/>
-      <point x="306" y="1" type="curve" smooth="yes"/>
-      <point x="376" y="1"/>
-      <point x="426" y="-34"/>
-      <point x="426" y="-113" type="curve" smooth="yes"/>
-      <point x="426" y="-183"/>
-      <point x="392" y="-220"/>
-      <point x="343" y="-262" type="curve"/>
-      <point x="407" y="-328" type="line"/>
-      <point x="483" y="-265"/>
-      <point x="528" y="-202"/>
-      <point x="528" y="-107" type="curve" smooth="yes"/>
-      <point x="528" y="27"/>
-      <point x="441" y="93"/>
-      <point x="307" y="93" type="curve" smooth="yes"/>
-      <point x="142" y="93"/>
-      <point x="62" y="-15"/>
-      <point x="62" y="-149" type="curve" smooth="yes"/>
-      <point x="62" y="-226"/>
-      <point x="86" y="-284"/>
+      <point x="152" y="-16" type="curve"/>
+      <point x="230" y="70" type="line"/>
+      <point x="179" y="116"/>
+      <point x="155" y="175"/>
+      <point x="155" y="254" type="curve" smooth="yes"/>
+      <point x="155" y="380"/>
+      <point x="239" y="502"/>
+      <point x="397" y="502" type="curve" smooth="yes"/>
+      <point x="514" y="502"/>
+      <point x="573" y="436"/>
+      <point x="573" y="325" type="curve" smooth="yes"/>
+      <point x="573" y="226"/>
+      <point x="522" y="134"/>
+      <point x="424" y="72" type="curve"/>
+      <point x="496" y="-16" type="line"/>
+      <point x="617" y="63"/>
+      <point x="695" y="200"/>
+      <point x="695" y="329" type="curve" smooth="yes"/>
+      <point x="695" y="498"/>
+      <point x="583" y="613"/>
+      <point x="409" y="613" type="curve" smooth="yes"/>
+      <point x="182" y="613"/>
+      <point x="36" y="440"/>
+      <point x="36" y="252" type="curve" smooth="yes"/>
+      <point x="36" y="144"/>
+      <point x="74" y="56"/>
     </contour>
     <contour>
-      <point x="154" y="-16" type="curve"/>
-      <point x="240" y="68" type="line"/>
-      <point x="184" y="120"/>
-      <point x="158" y="181"/>
-      <point x="158" y="257" type="curve" smooth="yes"/>
-      <point x="158" y="405"/>
-      <point x="253" y="502"/>
-      <point x="397" y="502" type="curve" smooth="yes"/>
-      <point x="515" y="502"/>
-      <point x="583" y="439"/>
-      <point x="583" y="328" type="curve" smooth="yes"/>
-      <point x="583" y="221"/>
-      <point x="536" y="146"/>
-      <point x="415" y="68" type="curve"/>
-      <point x="476" y="-22" type="line"/>
-      <point x="631" y="69"/>
-      <point x="704" y="185"/>
-      <point x="704" y="328" type="curve" smooth="yes"/>
-      <point x="704" y="506"/>
-      <point x="590" y="613"/>
-      <point x="401" y="613" type="curve" smooth="yes"/>
-      <point x="184" y="613"/>
-      <point x="38" y="470"/>
-      <point x="38" y="257" type="curve" smooth="yes"/>
-      <point x="38" y="148"/>
-      <point x="78" y="52"/>
+      <point x="133" y="-332" type="curve"/>
+      <point x="211" y="-270" type="line"/>
+      <point x="183" y="-237"/>
+      <point x="169" y="-199"/>
+      <point x="169" y="-155" type="curve" smooth="yes"/>
+      <point x="169" y="-62"/>
+      <point x="231" y="1"/>
+      <point x="321" y="1" type="curve" smooth="yes"/>
+      <point x="399" y="1"/>
+      <point x="436" y="-38"/>
+      <point x="436" y="-111" type="curve" smooth="yes"/>
+      <point x="436" y="-162"/>
+      <point x="407" y="-214"/>
+      <point x="352" y="-261" type="curve"/>
+      <point x="417" y="-332" type="line"/>
+      <point x="497" y="-263"/>
+      <point x="535" y="-190"/>
+      <point x="535" y="-103" type="curve" smooth="yes"/>
+      <point x="535" y="20"/>
+      <point x="457" y="93"/>
+      <point x="329" y="93" type="curve" smooth="yes"/>
+      <point x="178" y="93"/>
+      <point x="68" y="-11"/>
+      <point x="68" y="-158" type="curve" smooth="yes"/>
+      <point x="68" y="-223"/>
+      <point x="89" y="-280"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/t_la-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/t_la-malayalam.glif
@@ -1,136 +1,149 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="t_la-malayalam" format="2">
   <advance width="1020"/>
-  <anchor x="514" y="-351" name="bottom"/>
-  <anchor x="570" y="597" name="top"/>
-  <anchor x="909" y="597" name="topright"/>
+  <anchor x="514" y="-352" name="bottom"/>
+  <anchor x="565" y="597" name="top"/>
+  <anchor x="904" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="290" y="-368" type="curve" smooth="yes"/>
-      <point x="381" y="-368"/>
-      <point x="437" y="-308"/>
-      <point x="437" y="-225" type="curve" smooth="yes"/>
-      <point x="437" y="-146"/>
-      <point x="393" y="-112"/>
-      <point x="327" y="-112" type="curve" smooth="yes"/>
-      <point x="293" y="-112"/>
-      <point x="261" y="-124"/>
-      <point x="233" y="-154" type="curve"/>
-      <point x="226" y="-153" type="line"/>
-      <point x="240" y="-89"/>
-      <point x="291" y="-35"/>
-      <point x="376" y="-35" type="curve" smooth="yes"/>
-      <point x="472" y="-35"/>
-      <point x="506" y="-83"/>
-      <point x="513" y="-171" type="curve" smooth="yes"/>
-      <point x="514" y="-184" type="line" smooth="yes"/>
-      <point x="523" y="-304"/>
-      <point x="573" y="-368"/>
-      <point x="700" y="-368" type="curve" smooth="yes"/>
-      <point x="840" y="-368"/>
-      <point x="900" y="-264"/>
-      <point x="900" y="-126" type="curve" smooth="yes"/>
-      <point x="900" y="-49"/>
-      <point x="882" y="8"/>
-      <point x="851" y="53" type="curve"/>
-      <point x="803" y="-16" type="line"/>
-      <point x="925" y="81"/>
-      <point x="983" y="190"/>
-      <point x="983" y="323" type="curve" smooth="yes"/>
-      <point x="983" y="499"/>
-      <point x="878" y="613"/>
-      <point x="687" y="613" type="curve" smooth="yes"/>
-      <point x="473" y="613"/>
-      <point x="273" y="416"/>
-      <point x="273" y="211" type="curve" smooth="yes"/>
-      <point x="273" y="150"/>
-      <point x="289" y="95"/>
-      <point x="333" y="57" type="curve"/>
-      <point x="332" y="50" type="line"/>
-      <point x="204" y="23"/>
-      <point x="130" y="-76"/>
-      <point x="130" y="-199" type="curve" smooth="yes"/>
-      <point x="130" y="-313"/>
-      <point x="197" y="-368"/>
-    </contour>
-    <contour>
-      <point x="701" y="-279" type="curve" smooth="yes"/>
-      <point x="643" y="-279"/>
-      <point x="620" y="-246"/>
-      <point x="613" y="-166" type="curve" smooth="yes"/>
-      <point x="612" y="-150" type="line" smooth="yes"/>
-      <point x="607" y="-89"/>
-      <point x="591" y="-33"/>
-      <point x="552" y="1" type="curve"/>
-      <point x="553" y="8" type="line"/>
-      <point x="655" y="43"/>
-      <point x="711" y="137"/>
-      <point x="711" y="270" type="curve" smooth="yes"/>
-      <point x="711" y="385"/>
-      <point x="665" y="482"/>
-      <point x="591" y="543" type="curve"/>
-      <point x="473" y="491" type="line"/>
-      <point x="548" y="461"/>
-      <point x="588" y="384"/>
-      <point x="588" y="270" type="curve" smooth="yes"/>
-      <point x="588" y="165"/>
-      <point x="544" y="95"/>
-      <point x="477" y="95" type="curve" smooth="yes"/>
-      <point x="421" y="95"/>
-      <point x="391" y="135"/>
-      <point x="391" y="209" type="curve" smooth="yes"/>
-      <point x="391" y="378"/>
-      <point x="516" y="506"/>
-      <point x="680" y="506" type="curve" smooth="yes"/>
-      <point x="794" y="506"/>
-      <point x="861" y="439"/>
-      <point x="861" y="323" type="curve" smooth="yes"/>
-      <point x="861" y="226"/>
-      <point x="816" y="144"/>
-      <point x="729" y="73" type="curve"/>
-      <point x="767" y="17"/>
-      <point x="800" y="-49"/>
-      <point x="800" y="-136" type="curve" smooth="yes"/>
-      <point x="800" y="-217"/>
-      <point x="772" y="-279"/>
-    </contour>
-    <contour>
-      <point x="290" y="-288" type="curve" smooth="yes"/>
-      <point x="239" y="-288"/>
-      <point x="223" y="-250"/>
-      <point x="223" y="-213" type="curve"/>
-      <point x="208" y="-207" type="line"/>
-      <point x="215" y="-246" type="line"/>
-      <point x="227" y="-208"/>
-      <point x="256" y="-185"/>
-      <point x="292" y="-185" type="curve" smooth="yes"/>
-      <point x="329" y="-185"/>
-      <point x="347" y="-200"/>
-      <point x="347" y="-232" type="curve" smooth="yes"/>
-      <point x="347" y="-267"/>
-      <point x="325" y="-288"/>
-    </contour>
-    <contour>
-      <point x="125" y="-16" type="curve"/>
-      <point x="223" y="54" type="line"/>
-      <point x="178" y="112"/>
-      <point x="157" y="175"/>
-      <point x="157" y="246" type="curve" smooth="yes"/>
-      <point x="157" y="398"/>
-      <point x="254" y="506"/>
-      <point x="390" y="506" type="curve" smooth="yes"/>
+      <point x="280" y="-368" type="curve" smooth="yes"/>
+      <point x="389" y="-368"/>
+      <point x="436" y="-285"/>
+      <point x="436" y="-225" type="curve" smooth="yes"/>
+      <point x="436" y="-154"/>
+      <point x="399" y="-112"/>
+      <point x="336" y="-112" type="curve" smooth="yes"/>
+      <point x="282" y="-112"/>
+      <point x="230" y="-143"/>
+      <point x="208" y="-208" type="curve"/>
+      <point x="253" y="-165" type="line"/>
+      <point x="201" y="-148" type="line"/>
+      <point x="224" y="-179" type="line"/>
+      <point x="237" y="-103"/>
+      <point x="304" y="-35"/>
+      <point x="394" y="-35" type="curve" smooth="yes"/>
+      <point x="465" y="-35"/>
+      <point x="497" y="-71"/>
+      <point x="512" y="-151" type="curve" smooth="yes"/>
+      <point x="520" y="-193" type="line" smooth="yes"/>
+      <point x="543" y="-311"/>
+      <point x="600" y="-368"/>
+      <point x="706" y="-368" type="curve" smooth="yes"/>
+      <point x="824" y="-368"/>
+      <point x="900" y="-280"/>
+      <point x="900" y="-146" type="curve" smooth="yes"/>
+      <point x="900" y="-72"/>
+      <point x="887" y="-9"/>
+      <point x="846" y="58" type="curve"/>
+      <point x="843" y="12" type="line"/>
+      <point x="936" y="115"/>
+      <point x="981" y="219"/>
+      <point x="981" y="331" type="curve" smooth="yes"/>
+      <point x="981" y="497"/>
+      <point x="889" y="613"/>
+      <point x="718" y="613" type="curve" smooth="yes"/>
+      <point x="649" y="613"/>
+      <point x="583" y="597"/>
+      <point x="524" y="568" type="curve"/>
+      <point x="576" y="568" type="line"/>
+      <point x="530" y="596"/>
+      <point x="475" y="613"/>
+      <point x="410" y="613" type="curve" smooth="yes"/>
+      <point x="170" y="613"/>
+      <point x="35" y="431"/>
+      <point x="35" y="237" type="curve" smooth="yes"/>
+      <point x="35" y="147"/>
+      <point x="62" y="63"/>
+      <point x="123" y="-16" type="curve"/>
+      <point x="218" y="51" type="line"/>
+      <point x="172" y="111"/>
+      <point x="152" y="168"/>
+      <point x="152" y="243" type="curve" smooth="yes"/>
+      <point x="152" y="385"/>
+      <point x="240" y="506"/>
+      <point x="398" y="506" type="curve" smooth="yes"/>
       <point x="421" y="506"/>
-      <point x="449" y="501"/>
-      <point x="473" y="491" type="curve"/>
-      <point x="591" y="543" type="line"/>
-      <point x="537" y="587"/>
-      <point x="468" y="613"/>
-      <point x="390" y="613" type="curve" smooth="yes"/>
-      <point x="184" y="613"/>
-      <point x="37" y="460"/>
-      <point x="37" y="246" type="curve" smooth="yes"/>
-      <point x="37" y="146"/>
-      <point x="66" y="59"/>
+      <point x="442" y="503"/>
+      <point x="461" y="498" type="curve"/>
+      <point x="458" y="529" type="line"/>
+      <point x="348" y="450"/>
+      <point x="275" y="327"/>
+      <point x="275" y="201" type="curve" smooth="yes"/>
+      <point x="275" y="138"/>
+      <point x="294" y="85"/>
+      <point x="331" y="49" type="curve"/>
+      <point x="329" y="40" type="line"/>
+      <point x="204" y="0"/>
+      <point x="130" y="-108"/>
+      <point x="130" y="-215" type="curve" smooth="yes"/>
+      <point x="130" y="-307"/>
+      <point x="190" y="-368"/>
+    </contour>
+    <contour>
+      <point x="283" y="-288" type="curve" smooth="yes"/>
+      <point x="246" y="-288"/>
+      <point x="219" y="-264"/>
+      <point x="219" y="-232" type="curve" smooth="yes"/>
+      <point x="219" y="-224"/>
+      <point x="219" y="-217"/>
+      <point x="221" y="-209" type="curve"/>
+      <point x="194" y="-227" type="line"/>
+      <point x="212" y="-257" type="line"/>
+      <point x="224" y="-213"/>
+      <point x="260" y="-185"/>
+      <point x="302" y="-185" type="curve" smooth="yes"/>
+      <point x="332" y="-185"/>
+      <point x="347" y="-202"/>
+      <point x="347" y="-229" type="curve" smooth="yes"/>
+      <point x="347" y="-263"/>
+      <point x="322" y="-288"/>
+    </contour>
+    <contour>
+      <point x="481" y="95" type="curve" smooth="yes"/>
+      <point x="426" y="95"/>
+      <point x="393" y="133"/>
+      <point x="393" y="207" type="curve" smooth="yes"/>
+      <point x="393" y="315"/>
+      <point x="455" y="419"/>
+      <point x="556" y="471" type="curve"/>
+      <point x="511" y="475" type="line"/>
+      <point x="569" y="436"/>
+      <point x="597" y="365"/>
+      <point x="597" y="280" type="curve" smooth="yes"/>
+      <point x="597" y="210"/>
+      <point x="570" y="95"/>
+    </contour>
+    <contour>
+      <point x="707" y="-278" type="curve" smooth="yes"/>
+      <point x="658" y="-278"/>
+      <point x="631" y="-249"/>
+      <point x="617" y="-176" type="curve" smooth="yes"/>
+      <point x="609" y="-134" type="line" smooth="yes"/>
+      <point x="595" y="-60"/>
+      <point x="578" y="-24"/>
+      <point x="544" y="1" type="curve"/>
+      <point x="546" y="10" type="line"/>
+      <point x="658" y="50"/>
+      <point x="720" y="170"/>
+      <point x="720" y="286" type="curve" smooth="yes"/>
+      <point x="720" y="382"/>
+      <point x="685" y="473"/>
+      <point x="619" y="535" type="curve"/>
+      <point x="615" y="494" type="line"/>
+      <point x="642" y="502"/>
+      <point x="671" y="506"/>
+      <point x="702" y="506" type="curve" smooth="yes"/>
+      <point x="808" y="506"/>
+      <point x="859" y="439"/>
+      <point x="859" y="327" type="curve" smooth="yes"/>
+      <point x="859" y="236"/>
+      <point x="816" y="148"/>
+      <point x="721" y="55" type="curve"/>
+      <point x="774" y="-4"/>
+      <point x="801" y="-75"/>
+      <point x="801" y="-150" type="curve" smooth="yes"/>
+      <point x="801" y="-227"/>
+      <point x="764" y="-278"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ta-malayalam.glif
@@ -2,61 +2,61 @@
 <glyph name="ta-malayalam" format="2">
   <advance width="1020"/>
   <unicode hex="0D24"/>
-  <anchor x="549" y="0" name="bottom"/>
-  <anchor x="570" y="597" name="top"/>
-  <anchor x="909" y="597" name="topright"/>
+  <anchor x="543" y="0" name="bottom"/>
+  <anchor x="565" y="597" name="top"/>
+  <anchor x="904" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="125" y="-16" type="curve"/>
-      <point x="223" y="54" type="line"/>
-      <point x="178" y="112"/>
-      <point x="157" y="175"/>
-      <point x="157" y="246" type="curve" smooth="yes"/>
-      <point x="157" y="398"/>
-      <point x="254" y="506"/>
-      <point x="390" y="506" type="curve" smooth="yes"/>
-      <point x="517" y="506"/>
-      <point x="588" y="421"/>
-      <point x="588" y="270" type="curve" smooth="yes"/>
-      <point x="588" y="165"/>
-      <point x="544" y="95"/>
-      <point x="477" y="95" type="curve" smooth="yes"/>
-      <point x="421" y="95"/>
-      <point x="391" y="135"/>
-      <point x="391" y="209" type="curve" smooth="yes"/>
-      <point x="391" y="378"/>
-      <point x="516" y="506"/>
-      <point x="680" y="506" type="curve" smooth="yes"/>
-      <point x="794" y="506"/>
-      <point x="861" y="439"/>
-      <point x="861" y="323" type="curve" smooth="yes"/>
-      <point x="861" y="226"/>
-      <point x="816" y="144"/>
-      <point x="726" y="73" type="curve"/>
-      <point x="803" y="-16" type="line"/>
-      <point x="925" y="81"/>
-      <point x="983" y="190"/>
-      <point x="983" y="323" type="curve" smooth="yes"/>
-      <point x="983" y="499"/>
-      <point x="878" y="613"/>
-      <point x="687" y="613" type="curve" smooth="yes"/>
-      <point x="473" y="613"/>
-      <point x="273" y="416"/>
-      <point x="273" y="204" type="curve" smooth="yes"/>
-      <point x="273" y="68"/>
-      <point x="351" y="-16"/>
-      <point x="477" y="-16" type="curve" smooth="yes"/>
-      <point x="617" y="-16"/>
-      <point x="711" y="99"/>
-      <point x="711" y="270" type="curve" smooth="yes"/>
-      <point x="711" y="469"/>
-      <point x="576" y="613"/>
-      <point x="390" y="613" type="curve" smooth="yes"/>
-      <point x="184" y="613"/>
-      <point x="37" y="460"/>
-      <point x="37" y="246" type="curve" smooth="yes"/>
-      <point x="37" y="146"/>
-      <point x="66" y="59"/>
+      <point x="123" y="-16" type="curve"/>
+      <point x="218" y="51" type="line"/>
+      <point x="172" y="111"/>
+      <point x="152" y="168"/>
+      <point x="152" y="243" type="curve" smooth="yes"/>
+      <point x="152" y="385"/>
+      <point x="240" y="506"/>
+      <point x="398" y="506" type="curve" smooth="yes"/>
+      <point x="531" y="506"/>
+      <point x="597" y="409"/>
+      <point x="597" y="280" type="curve" smooth="yes"/>
+      <point x="597" y="210"/>
+      <point x="570" y="95"/>
+      <point x="481" y="95" type="curve" smooth="yes"/>
+      <point x="426" y="95"/>
+      <point x="393" y="133"/>
+      <point x="393" y="207" type="curve" smooth="yes"/>
+      <point x="393" y="361"/>
+      <point x="518" y="506"/>
+      <point x="702" y="506" type="curve" smooth="yes"/>
+      <point x="808" y="506"/>
+      <point x="859" y="439"/>
+      <point x="859" y="327" type="curve" smooth="yes"/>
+      <point x="859" y="239"/>
+      <point x="818" y="155"/>
+      <point x="728" y="65" type="curve"/>
+      <point x="815" y="-16" type="line"/>
+      <point x="927" y="96"/>
+      <point x="981" y="209"/>
+      <point x="981" y="331" type="curve" smooth="yes"/>
+      <point x="981" y="497"/>
+      <point x="889" y="613"/>
+      <point x="718" y="613" type="curve" smooth="yes"/>
+      <point x="477" y="613"/>
+      <point x="275" y="412"/>
+      <point x="275" y="201" type="curve" smooth="yes"/>
+      <point x="275" y="73"/>
+      <point x="344" y="-16"/>
+      <point x="471" y="-16" type="curve" smooth="yes"/>
+      <point x="629" y="-16"/>
+      <point x="720" y="139"/>
+      <point x="720" y="286" type="curve" smooth="yes"/>
+      <point x="720" y="459"/>
+      <point x="607" y="613"/>
+      <point x="410" y="613" type="curve" smooth="yes"/>
+      <point x="170" y="613"/>
+      <point x="35" y="431"/>
+      <point x="35" y="237" type="curve" smooth="yes"/>
+      <point x="35" y="147"/>
+      <point x="62" y="63"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1020"/>
   <outline>
     <component base="ta-malayalam"/>
-    <component base="halant-malayalam" xOffset="828"/>
+    <component base="halant-malayalam" xOffset="823"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/tt_tta-malayalam.glif
@@ -1,67 +1,67 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tt_tta-malayalam" format="2">
   <advance width="611"/>
-  <anchor x="307" y="0" name="bottom"/>
-  <anchor x="288" y="597" name="top"/>
-  <anchor x="477" y="597" name="topright"/>
+  <anchor x="237" y="-235" name="bottom"/>
+  <anchor x="354" y="597" name="top"/>
+  <anchor x="543" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="240" y="-229" type="curve" smooth="yes"/>
-      <point x="422" y="-229"/>
-      <point x="526" y="-177"/>
-      <point x="526" y="-61" type="curve" smooth="yes"/>
-      <point x="526" y="-1"/>
-      <point x="490" y="40"/>
-      <point x="435" y="54" type="curve"/>
-      <point x="435" y="61" type="line"/>
-      <point x="510" y="73"/>
-      <point x="562" y="131"/>
-      <point x="562" y="213" type="curve" smooth="yes"/>
-      <point x="562" y="306"/>
-      <point x="510" y="362"/>
-      <point x="367" y="371" type="curve" smooth="yes"/>
-      <point x="253" y="378" type="line" smooth="yes"/>
-      <point x="190" y="381"/>
-      <point x="168" y="403"/>
-      <point x="168" y="434" type="curve" smooth="yes"/>
-      <point x="168" y="481"/>
-      <point x="222" y="503"/>
-      <point x="299" y="503" type="curve" smooth="yes"/>
-      <point x="387" y="503"/>
-      <point x="463" y="478"/>
-      <point x="524" y="443" type="curve"/>
-      <point x="581" y="540" type="line"/>
-      <point x="511" y="584"/>
-      <point x="417" y="613"/>
-      <point x="309" y="613" type="curve" smooth="yes"/>
-      <point x="145" y="613"/>
-      <point x="48" y="540"/>
-      <point x="48" y="426" type="curve" smooth="yes"/>
-      <point x="48" y="332"/>
-      <point x="104" y="266"/>
-      <point x="225" y="259" type="curve" smooth="yes"/>
-      <point x="338" y="252" type="line" smooth="yes"/>
-      <point x="418" y="248"/>
-      <point x="442" y="224"/>
-      <point x="442" y="186" type="curve" smooth="yes"/>
-      <point x="442" y="137"/>
-      <point x="399" y="118"/>
-      <point x="336" y="118" type="curve" smooth="yes"/>
-      <point x="33" y="118" type="line"/>
-      <point x="15" y="13" type="line"/>
-      <point x="296" y="13" type="line" smooth="yes"/>
-      <point x="377" y="13"/>
-      <point x="405" y="-10"/>
-      <point x="405" y="-48" type="curve" smooth="yes"/>
-      <point x="405" y="-97"/>
-      <point x="365" y="-116"/>
-      <point x="256" y="-116" type="curve" smooth="yes"/>
-      <point x="146" y="-116"/>
-      <point x="65" y="-95"/>
-      <point x="17" y="-73" type="curve"/>
-      <point x="-45" y="-175" type="line"/>
-      <point x="16" y="-206"/>
-      <point x="126" y="-229"/>
+      <point x="246" y="-251" type="curve" smooth="yes"/>
+      <point x="437" y="-251"/>
+      <point x="515" y="-156"/>
+      <point x="515" y="-53" type="curve" smooth="yes"/>
+      <point x="515" y="1"/>
+      <point x="488" y="39"/>
+      <point x="431" y="60" type="curve"/>
+      <point x="433" y="68" type="line"/>
+      <point x="514" y="92"/>
+      <point x="556" y="146"/>
+      <point x="556" y="216" type="curve" smooth="yes"/>
+      <point x="556" y="304"/>
+      <point x="495" y="351"/>
+      <point x="364" y="363" type="curve" smooth="yes"/>
+      <point x="243" y="374" type="line" smooth="yes"/>
+      <point x="188" y="379"/>
+      <point x="165" y="397"/>
+      <point x="165" y="430" type="curve" smooth="yes"/>
+      <point x="165" y="476"/>
+      <point x="204" y="503"/>
+      <point x="312" y="503" type="curve" smooth="yes"/>
+      <point x="393" y="503"/>
+      <point x="463" y="486"/>
+      <point x="530" y="449" type="curve"/>
+      <point x="582" y="546" type="line"/>
+      <point x="507" y="591"/>
+      <point x="424" y="613"/>
+      <point x="324" y="613" type="curve" smooth="yes"/>
+      <point x="117" y="613"/>
+      <point x="46" y="511"/>
+      <point x="46" y="417" type="curve" smooth="yes"/>
+      <point x="46" y="327"/>
+      <point x="109" y="265"/>
+      <point x="215" y="255" type="curve" smooth="yes"/>
+      <point x="336" y="244" type="line" smooth="yes"/>
+      <point x="407" y="238"/>
+      <point x="434" y="221"/>
+      <point x="434" y="185" type="curve" smooth="yes"/>
+      <point x="434" y="143"/>
+      <point x="394" y="114"/>
+      <point x="308" y="114" type="curve" smooth="yes"/>
+      <point x="26" y="114" type="line"/>
+      <point x="9" y="13" type="line"/>
+      <point x="306" y="13" type="line" smooth="yes"/>
+      <point x="376" y="13"/>
+      <point x="400" y="-10"/>
+      <point x="400" y="-53" type="curve" smooth="yes"/>
+      <point x="400" y="-102"/>
+      <point x="354" y="-141"/>
+      <point x="258" y="-141" type="curve" smooth="yes"/>
+      <point x="164" y="-141"/>
+      <point x="85" y="-116"/>
+      <point x="17" y="-65" type="curve"/>
+      <point x="-49" y="-153" type="line"/>
+      <point x="40" y="-219"/>
+      <point x="135" y="-251"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/tta-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/tta-malayalam.glif
@@ -2,51 +2,51 @@
 <glyph name="tta-malayalam" format="2">
   <advance width="613"/>
   <unicode hex="0D1F"/>
-  <anchor x="262" y="0" name="bottom"/>
-  <anchor x="348" y="597" name="top"/>
-  <anchor x="536" y="597" name="topright"/>
+  <anchor x="267" y="0" name="bottom"/>
+  <anchor x="354" y="597" name="top"/>
+  <anchor x="543" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="301" y="-16" type="curve" smooth="yes"/>
-      <point x="458" y="-16"/>
-      <point x="557" y="52"/>
-      <point x="557" y="178" type="curve" smooth="yes"/>
-      <point x="557" y="273"/>
-      <point x="502" y="347"/>
-      <point x="345" y="356" type="curve" smooth="yes"/>
-      <point x="264" y="360" type="line" smooth="yes"/>
-      <point x="193" y="364"/>
-      <point x="166" y="391"/>
-      <point x="166" y="427" type="curve" smooth="yes"/>
-      <point x="166" y="481"/>
-      <point x="220" y="503"/>
-      <point x="296" y="503" type="curve" smooth="yes"/>
-      <point x="384" y="503"/>
-      <point x="461" y="478"/>
-      <point x="522" y="443" type="curve"/>
-      <point x="579" y="540" type="line"/>
-      <point x="509" y="584"/>
-      <point x="414" y="613"/>
-      <point x="307" y="613" type="curve" smooth="yes"/>
-      <point x="145" y="613"/>
-      <point x="46" y="536"/>
-      <point x="46" y="411" type="curve" smooth="yes"/>
-      <point x="46" y="320"/>
-      <point x="104" y="247"/>
-      <point x="237" y="239" type="curve" smooth="yes"/>
-      <point x="328" y="234" type="line" smooth="yes"/>
-      <point x="411" y="230"/>
-      <point x="438" y="203"/>
-      <point x="438" y="168" type="curve" smooth="yes"/>
-      <point x="438" y="118"/>
-      <point x="393" y="94"/>
-      <point x="313" y="94" type="curve" smooth="yes"/>
-      <point x="206" y="94"/>
-      <point x="132" y="129"/>
-      <point x="65" y="176" type="curve"/>
-      <point x="-9" y="79" type="line"/>
-      <point x="71" y="22"/>
-      <point x="166" y="-16"/>
+      <point x="287" y="-16" type="curve" smooth="yes"/>
+      <point x="478" y="-16"/>
+      <point x="558" y="75"/>
+      <point x="558" y="181" type="curve" smooth="yes"/>
+      <point x="558" y="284"/>
+      <point x="495" y="343"/>
+      <point x="374" y="354" type="curve" smooth="yes"/>
+      <point x="253" y="365" type="line" smooth="yes"/>
+      <point x="197" y="370"/>
+      <point x="172" y="391"/>
+      <point x="172" y="425" type="curve" smooth="yes"/>
+      <point x="172" y="468"/>
+      <point x="217" y="503"/>
+      <point x="331" y="503" type="curve" smooth="yes"/>
+      <point x="412" y="503"/>
+      <point x="477" y="488"/>
+      <point x="540" y="454" type="curve"/>
+      <point x="591" y="551" type="line"/>
+      <point x="517" y="593"/>
+      <point x="436" y="613"/>
+      <point x="343" y="613" type="curve" smooth="yes"/>
+      <point x="135" y="613"/>
+      <point x="52" y="517"/>
+      <point x="52" y="412" type="curve" smooth="yes"/>
+      <point x="52" y="318"/>
+      <point x="119" y="256"/>
+      <point x="225" y="246" type="curve" smooth="yes"/>
+      <point x="346" y="235" type="line" smooth="yes"/>
+      <point x="412" y="229"/>
+      <point x="439" y="211"/>
+      <point x="439" y="171" type="curve" smooth="yes"/>
+      <point x="439" y="127"/>
+      <point x="399" y="94"/>
+      <point x="299" y="94" type="curve" smooth="yes"/>
+      <point x="201" y="94"/>
+      <point x="116" y="121"/>
+      <point x="48" y="173" type="curve"/>
+      <point x="-16" y="83" type="line"/>
+      <point x="64" y="21"/>
+      <point x="177" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/tta-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/tta-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="613"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="halant-malayalam" xOffset="455"/>
+    <component base="halant-malayalam" xOffset="462"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/tta_lV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="613"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="lVocalicMatra-malayalam" xOffset="309"/>
+    <component base="lVocalicMatra-malayalam" xOffset="314"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/tta_llV_ocalicM_atra-malayalam.glif
@@ -3,7 +3,7 @@
   <advance width="613"/>
   <outline>
     <component base="tta-malayalam"/>
-    <component base="llVocalicMatra-malayalam" xOffset="309"/>
+    <component base="llVocalicMatra-malayalam" xOffset="314"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/uuM_atra-malayalam.glif
@@ -4,65 +4,71 @@
   <unicode hex="0D42"/>
   <outline>
     <contour>
-      <point x="23" y="18" type="curve"/>
-      <point x="143" y="18" type="line"/>
-      <point x="217" y="140"/>
-      <point x="270" y="286"/>
-      <point x="270" y="386" type="curve" smooth="yes"/>
-      <point x="270" y="515"/>
-      <point x="195" y="601"/>
-      <point x="69" y="611" type="curve" smooth="yes"/>
-      <point x="49" y="613" type="line"/>
-      <point x="29" y="503" type="line"/>
-      <point x="107" y="497"/>
-      <point x="149" y="453"/>
-      <point x="149" y="379" type="curve" smooth="yes"/>
-      <point x="149" y="285"/>
-      <point x="95" y="140"/>
+      <point x="42" y="19" type="curve"/>
+      <point x="150" y="19" type="line"/>
+      <point x="232" y="153"/>
+      <point x="285" y="300"/>
+      <point x="285" y="395" type="curve" smooth="yes"/>
+      <point x="285" y="529"/>
+      <point x="208" y="613"/>
+      <point x="78" y="613" type="curve" smooth="yes"/>
+      <point x="61" y="613" type="line"/>
+      <point x="42" y="503" type="line"/>
+      <point x="126" y="503"/>
+      <point x="163" y="462"/>
+      <point x="163" y="383" type="curve" smooth="yes"/>
+      <point x="163" y="298"/>
+      <point x="113" y="149"/>
     </contour>
     <contour>
-      <point x="68" y="-276" type="curve" smooth="yes"/>
-      <point x="179" y="-276"/>
-      <point x="263" y="-198"/>
-      <point x="263" y="-95" type="curve" smooth="yes"/>
-      <point x="263" y="0"/>
-      <point x="190" y="69"/>
-      <point x="87" y="69" type="curve" smooth="yes"/>
-      <point x="-22" y="69"/>
+      <point x="70" y="-184" type="curve" smooth="yes"/>
+      <point x="14" y="-184"/>
+      <point x="-19" y="-153"/>
+      <point x="-19" y="-111" type="curve" smooth="yes"/>
+      <point x="-19" y="-94"/>
+      <point x="-15" y="-80"/>
+      <point x="-7" y="-67" type="curve"/>
+      <point x="0" y="-67" type="line"/>
+      <point x="4" y="-107"/>
+      <point x="32" y="-130"/>
+      <point x="78" y="-130" type="curve" smooth="yes"/>
+      <point x="118" y="-130"/>
+      <point x="146" y="-109"/>
+      <point x="162" y="-67" type="curve"/>
+      <point x="169" y="-67" type="line"/>
+      <point x="171" y="-74"/>
+      <point x="172" y="-81"/>
+      <point x="172" y="-89" type="curve" smooth="yes"/>
+      <point x="172" y="-130"/>
+      <point x="147" y="-184"/>
+    </contour>
+    <contour>
+      <point x="66" y="-276" type="curve" smooth="yes"/>
+      <point x="176" y="-276"/>
+      <point x="259" y="-198"/>
+      <point x="259" y="-95" type="curve" smooth="yes"/>
+      <point x="259" y="0"/>
+      <point x="187" y="69"/>
+      <point x="85" y="69" type="curve" smooth="yes"/>
+      <point x="-23" y="69"/>
       <point x="-108" y="-12"/>
       <point x="-108" y="-113" type="curve" smooth="yes"/>
       <point x="-108" y="-207"/>
-      <point x="-34" y="-276"/>
+      <point x="-35" y="-276"/>
     </contour>
     <contour>
-      <point x="73" y="-184" type="curve" smooth="yes"/>
-      <point x="16" y="-184"/>
-      <point x="-16" y="-150"/>
-      <point x="-16" y="-104" type="curve" smooth="yes"/>
-      <point x="-16" y="-49"/>
-      <point x="27" y="-8"/>
-      <point x="86" y="-8" type="curve" smooth="yes"/>
-      <point x="138" y="-8"/>
-      <point x="171" y="-41"/>
-      <point x="171" y="-88" type="curve" smooth="yes"/>
-      <point x="171" y="-144"/>
-      <point x="129" y="-184"/>
-    </contour>
-    <contour>
-      <point x="89" y="-122" type="curve" smooth="yes"/>
-      <point x="138" y="-122"/>
-      <point x="179" y="-104"/>
-      <point x="210" y="-75" type="curve"/>
-      <point x="191" y="-36" type="line"/>
-      <point x="169" y="-54"/>
-      <point x="137" y="-68"/>
-      <point x="94" y="-68" type="curve" smooth="yes"/>
-      <point x="35" y="-68"/>
-      <point x="2" y="-45"/>
-      <point x="-16" y="-17" type="curve"/>
-      <point x="-48" y="-53" type="line"/>
-      <point x="-22" y="-94"/>
-      <point x="22" y="-122"/>
+      <point x="82" y="-64" type="curve" smooth="yes"/>
+      <point x="43" y="-64"/>
+      <point x="23" y="-50"/>
+      <point x="23" y="-34" type="curve" smooth="yes"/>
+      <point x="23" y="-15"/>
+      <point x="47" y="-2"/>
+      <point x="96" y="-2" type="curve" smooth="yes"/>
+      <point x="136" y="-2"/>
+      <point x="154" y="-11"/>
+      <point x="154" y="-27" type="curve" smooth="yes"/>
+      <point x="154" y="-47"/>
+      <point x="128" y="-64"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/y_ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/y_ya-malayalam.glif
@@ -1,96 +1,96 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="y_ya-malayalam" format="2">
   <advance width="1023"/>
-  <anchor x="546" y="-287" name="bottom"/>
-  <anchor x="588" y="597" name="top"/>
-  <anchor x="889" y="597" name="topright"/>
+  <anchor x="541" y="-281" name="bottom"/>
+  <anchor x="576" y="597" name="top"/>
+  <anchor x="884" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="215" y="-290" type="line"/>
-      <point x="829" y="-290" type="line"/>
-      <point x="897" y="98" type="line"/>
-      <point x="873" y="51" type="line"/>
-      <point x="952" y="116"/>
-      <point x="999" y="223"/>
-      <point x="999" y="361" type="curve" smooth="yes"/>
-      <point x="999" y="459"/>
-      <point x="976" y="543"/>
-      <point x="931" y="613" type="curve"/>
-      <point x="825" y="554" type="line"/>
-      <point x="860" y="499"/>
-      <point x="877" y="435"/>
-      <point x="877" y="358" type="curve" smooth="yes"/>
-      <point x="877" y="199"/>
-      <point x="794" y="95"/>
-      <point x="668" y="95" type="curve" smooth="yes"/>
-      <point x="527" y="95"/>
-      <point x="459" y="166"/>
-      <point x="459" y="315" type="curve" smooth="yes"/>
-      <point x="459" y="426"/>
-      <point x="502" y="502"/>
-      <point x="566" y="502" type="curve" smooth="yes"/>
-      <point x="613" y="502"/>
-      <point x="636" y="467"/>
-      <point x="636" y="394" type="curve" smooth="yes"/>
-      <point x="636" y="273"/>
-      <point x="580" y="168"/>
-      <point x="487" y="114" type="curve"/>
-      <point x="552" y="46" type="line"/>
-      <point x="689" y="127"/>
-      <point x="757" y="244"/>
-      <point x="757" y="397" type="curve" smooth="yes"/>
-      <point x="757" y="536"/>
+      <point x="209" y="-284" type="line"/>
+      <point x="823" y="-284" type="line"/>
+      <point x="896" y="126" type="line"/>
+      <point x="868" y="75" type="line"/>
+      <point x="948" y="148"/>
+      <point x="985" y="250"/>
+      <point x="985" y="333" type="curve" smooth="yes"/>
+      <point x="985" y="434"/>
+      <point x="956" y="533"/>
+      <point x="902" y="613" type="curve"/>
+      <point x="796" y="552" type="line"/>
+      <point x="845" y="481"/>
+      <point x="867" y="411"/>
+      <point x="867" y="326" type="curve" smooth="yes"/>
+      <point x="867" y="233"/>
+      <point x="807" y="94"/>
+      <point x="639" y="94" type="curve" smooth="yes"/>
+      <point x="492" y="94"/>
+      <point x="423" y="186"/>
+      <point x="423" y="309" type="curve" smooth="yes"/>
+      <point x="423" y="411"/>
+      <point x="460" y="503"/>
+      <point x="550" y="503" type="curve" smooth="yes"/>
+      <point x="605" y="503"/>
+      <point x="630" y="466"/>
+      <point x="630" y="395" type="curve" smooth="yes"/>
+      <point x="630" y="277"/>
+      <point x="567" y="171"/>
+      <point x="474" y="120" type="curve"/>
+      <point x="545" y="58" type="line"/>
+      <point x="669" y="131"/>
+      <point x="750" y="266"/>
+      <point x="750" y="401" type="curve" smooth="yes"/>
+      <point x="750" y="527"/>
       <point x="693" y="613"/>
-      <point x="576" y="613" type="curve" smooth="yes"/>
-      <point x="444" y="613"/>
-      <point x="340" y="483"/>
-      <point x="340" y="315" type="curve" smooth="yes"/>
-      <point x="340" y="123"/>
-      <point x="478" y="-16"/>
-      <point x="669" y="-16" type="curve" smooth="yes"/>
-      <point x="680" y="-16"/>
-      <point x="690" y="-15"/>
-      <point x="701" y="-15" type="curve"/>
-      <point x="583" y="54" type="line"/>
-      <point x="597" y="-15" type="line"/>
-      <point x="509" y="-58" type="line"/>
-      <point x="226" y="-221" type="line"/>
+      <point x="563" y="613" type="curve" smooth="yes"/>
+      <point x="409" y="613"/>
+      <point x="303" y="460"/>
+      <point x="303" y="312" type="curve" smooth="yes"/>
+      <point x="303" y="136"/>
+      <point x="427" y="-11"/>
+      <point x="628" y="-11" type="curve" smooth="yes"/>
+      <point x="652" y="-11"/>
+      <point x="673" y="-8"/>
+      <point x="693" y="-3" type="curve"/>
+      <point x="577" y="38" type="line"/>
+      <point x="568" y="-16" type="line"/>
+      <point x="502" y="-49" type="line"/>
+      <point x="221" y="-215" type="line"/>
     </contour>
     <contour>
-      <point x="343" y="-252" type="line"/>
-      <point x="788" y="8" type="line"/>
-      <point x="764" y="8" type="line"/>
-      <point x="721" y="-239" type="line"/>
-      <point x="791" y="-206" type="line"/>
-      <point x="384" y="-206" type="line"/>
+      <point x="374" y="-224" type="line"/>
+      <point x="796" y="26" type="line"/>
+      <point x="761" y="26" type="line"/>
+      <point x="718" y="-220" type="line"/>
+      <point x="785" y="-200" type="line"/>
+      <point x="378" y="-200" type="line"/>
     </contour>
     <contour>
-      <point x="357" y="-16" type="curve" smooth="yes"/>
-      <point x="418" y="-16"/>
-      <point x="473" y="-2"/>
-      <point x="521" y="26" type="curve"/>
-      <point x="441" y="107" type="line"/>
-      <point x="415" y="98"/>
-      <point x="388" y="95"/>
-      <point x="357" y="95" type="curve" smooth="yes"/>
-      <point x="238" y="95"/>
-      <point x="164" y="174"/>
-      <point x="164" y="302" type="curve" smooth="yes"/>
-      <point x="164" y="426"/>
-      <point x="226" y="502"/>
-      <point x="325" y="502" type="curve" smooth="yes"/>
-      <point x="367" y="502"/>
-      <point x="395" y="490"/>
-      <point x="417" y="462" type="curve"/>
-      <point x="490" y="540" type="line"/>
-      <point x="453" y="589"/>
-      <point x="400" y="613"/>
-      <point x="326" y="613" type="curve" smooth="yes"/>
-      <point x="163" y="613"/>
-      <point x="46" y="482"/>
-      <point x="46" y="299" type="curve" smooth="yes"/>
-      <point x="46" y="108"/>
-      <point x="168" y="-16"/>
+      <point x="330" y="-16" type="curve" smooth="yes"/>
+      <point x="400" y="-16"/>
+      <point x="458" y="2"/>
+      <point x="510" y="34" type="curve"/>
+      <point x="439" y="109" type="line"/>
+      <point x="411" y="98"/>
+      <point x="378" y="90"/>
+      <point x="338" y="90" type="curve" smooth="yes"/>
+      <point x="226" y="90"/>
+      <point x="161" y="164"/>
+      <point x="161" y="290" type="curve" smooth="yes"/>
+      <point x="161" y="394"/>
+      <point x="212" y="503"/>
+      <point x="330" y="503" type="curve" smooth="yes"/>
+      <point x="365" y="503"/>
+      <point x="389" y="493"/>
+      <point x="415" y="472" type="curve"/>
+      <point x="489" y="554" type="line"/>
+      <point x="447" y="593"/>
+      <point x="410" y="613"/>
+      <point x="344" y="613" type="curve" smooth="yes"/>
+      <point x="145" y="613"/>
+      <point x="43" y="444"/>
+      <point x="43" y="292" type="curve" smooth="yes"/>
+      <point x="43" y="106"/>
+      <point x="157" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ya-malayalam.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ya-malayalam.glif
@@ -2,78 +2,78 @@
 <glyph name="ya-malayalam" format="2">
   <advance width="1023"/>
   <unicode hex="0D2F"/>
-  <anchor x="553" y="0" name="bottom"/>
-  <anchor x="860" y="0" name="bottomright"/>
-  <anchor x="588" y="597" name="top"/>
-  <anchor x="889" y="597" name="topright"/>
+  <anchor x="547" y="0" name="bottom"/>
+  <anchor x="853" y="0" name="bottomright"/>
+  <anchor x="576" y="597" name="top"/>
+  <anchor x="884" y="597" name="topright"/>
   <outline>
     <contour>
-      <point x="670" y="-16" type="curve" smooth="yes"/>
-      <point x="870" y="-16"/>
-      <point x="999" y="132"/>
-      <point x="999" y="361" type="curve" smooth="yes"/>
-      <point x="999" y="459"/>
-      <point x="976" y="543"/>
-      <point x="931" y="613" type="curve"/>
-      <point x="825" y="554" type="line"/>
-      <point x="860" y="499"/>
-      <point x="877" y="435"/>
-      <point x="877" y="358" type="curve" smooth="yes"/>
-      <point x="877" y="199"/>
-      <point x="794" y="95"/>
-      <point x="668" y="95" type="curve" smooth="yes"/>
-      <point x="527" y="95"/>
-      <point x="459" y="166"/>
-      <point x="459" y="315" type="curve" smooth="yes"/>
-      <point x="459" y="426"/>
-      <point x="502" y="502"/>
-      <point x="566" y="502" type="curve" smooth="yes"/>
-      <point x="613" y="502"/>
-      <point x="636" y="467"/>
-      <point x="636" y="394" type="curve" smooth="yes"/>
-      <point x="636" y="273"/>
-      <point x="580" y="168"/>
-      <point x="487" y="114" type="curve"/>
-      <point x="552" y="46" type="line"/>
-      <point x="689" y="127"/>
-      <point x="757" y="244"/>
-      <point x="757" y="397" type="curve" smooth="yes"/>
-      <point x="757" y="536"/>
+      <point x="635" y="-16" type="curve" smooth="yes"/>
+      <point x="893" y="-16"/>
+      <point x="985" y="189"/>
+      <point x="985" y="333" type="curve" smooth="yes"/>
+      <point x="985" y="434"/>
+      <point x="956" y="533"/>
+      <point x="902" y="613" type="curve"/>
+      <point x="796" y="552" type="line"/>
+      <point x="845" y="481"/>
+      <point x="867" y="411"/>
+      <point x="867" y="326" type="curve" smooth="yes"/>
+      <point x="867" y="233"/>
+      <point x="807" y="94"/>
+      <point x="639" y="94" type="curve" smooth="yes"/>
+      <point x="492" y="94"/>
+      <point x="423" y="186"/>
+      <point x="423" y="309" type="curve" smooth="yes"/>
+      <point x="423" y="411"/>
+      <point x="460" y="503"/>
+      <point x="550" y="503" type="curve" smooth="yes"/>
+      <point x="605" y="503"/>
+      <point x="630" y="466"/>
+      <point x="630" y="395" type="curve" smooth="yes"/>
+      <point x="630" y="277"/>
+      <point x="567" y="171"/>
+      <point x="474" y="120" type="curve"/>
+      <point x="545" y="58" type="line"/>
+      <point x="669" y="131"/>
+      <point x="750" y="266"/>
+      <point x="750" y="401" type="curve" smooth="yes"/>
+      <point x="750" y="527"/>
       <point x="693" y="613"/>
-      <point x="576" y="613" type="curve" smooth="yes"/>
-      <point x="444" y="613"/>
-      <point x="340" y="483"/>
-      <point x="340" y="315" type="curve" smooth="yes"/>
-      <point x="340" y="122"/>
-      <point x="478" y="-16"/>
+      <point x="563" y="613" type="curve" smooth="yes"/>
+      <point x="409" y="613"/>
+      <point x="303" y="460"/>
+      <point x="303" y="312" type="curve" smooth="yes"/>
+      <point x="303" y="133"/>
+      <point x="429" y="-16"/>
     </contour>
     <contour>
-      <point x="357" y="-16" type="curve" smooth="yes"/>
-      <point x="418" y="-16"/>
-      <point x="473" y="-2"/>
-      <point x="521" y="26" type="curve"/>
-      <point x="441" y="107" type="line"/>
-      <point x="415" y="98"/>
-      <point x="388" y="95"/>
-      <point x="357" y="95" type="curve" smooth="yes"/>
-      <point x="238" y="95"/>
-      <point x="164" y="174"/>
-      <point x="164" y="302" type="curve" smooth="yes"/>
-      <point x="164" y="426"/>
-      <point x="226" y="502"/>
-      <point x="325" y="502" type="curve" smooth="yes"/>
-      <point x="367" y="502"/>
-      <point x="395" y="490"/>
-      <point x="417" y="462" type="curve"/>
-      <point x="490" y="540" type="line"/>
-      <point x="453" y="589"/>
-      <point x="400" y="613"/>
-      <point x="326" y="613" type="curve" smooth="yes"/>
-      <point x="163" y="613"/>
-      <point x="46" y="482"/>
-      <point x="46" y="299" type="curve" smooth="yes"/>
-      <point x="46" y="108"/>
-      <point x="168" y="-16"/>
+      <point x="330" y="-16" type="curve" smooth="yes"/>
+      <point x="400" y="-16"/>
+      <point x="458" y="2"/>
+      <point x="510" y="34" type="curve"/>
+      <point x="439" y="109" type="line"/>
+      <point x="411" y="98"/>
+      <point x="378" y="90"/>
+      <point x="338" y="90" type="curve" smooth="yes"/>
+      <point x="226" y="90"/>
+      <point x="161" y="164"/>
+      <point x="161" y="290" type="curve" smooth="yes"/>
+      <point x="161" y="394"/>
+      <point x="212" y="503"/>
+      <point x="330" y="503" type="curve" smooth="yes"/>
+      <point x="365" y="503"/>
+      <point x="389" y="493"/>
+      <point x="415" y="472" type="curve"/>
+      <point x="489" y="554" type="line"/>
+      <point x="447" y="593"/>
+      <point x="410" y="613"/>
+      <point x="344" y="613" type="curve" smooth="yes"/>
+      <point x="145" y="613"/>
+      <point x="43" y="444"/>
+      <point x="43" y="292" type="curve" smooth="yes"/>
+      <point x="43" y="106"/>
+      <point x="157" y="-16"/>
     </contour>
   </outline>
   <lib>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ya-malayalam.half.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ya-malayalam.half.glif
@@ -3,7 +3,7 @@
   <advance width="1023"/>
   <outline>
     <component base="ya-malayalam"/>
-    <component base="halant-malayalam" xOffset="808"/>
+    <component base="halant-malayalam" xOffset="803"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/kerning.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/kerning.plist
@@ -48539,7 +48539,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>83</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>57</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -48655,7 +48655,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>73</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48711,7 +48711,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>190</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -48768,7 +48768,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>263</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>200</integer>
+      <integer>190</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>233</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -48815,7 +48815,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>133</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>93</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -48850,7 +48850,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>123</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>97</integer>
       <key>public.kern2.MAL_one-malayalam_L</key>
@@ -48878,8 +48878,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>67</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -48914,7 +48912,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>153</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>90</integer>
+      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>103</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49043,7 +49041,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>187</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>137</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>157</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49096,7 +49094,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>263</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>197</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>230</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49154,7 +49152,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>77</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>47</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49335,8 +49333,6 @@
       <integer>-10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>57</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49422,7 +49418,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>79</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>33</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -49522,8 +49518,6 @@
       <integer>60</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>103</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>60</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>73</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -49556,7 +49550,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>177</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>80</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>147</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -49638,7 +49632,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>43</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49680,8 +49674,6 @@
       <integer>-20</integer>
       <key>public.kern2.MAL_llla-malayalam_L</key>
       <integer>-37</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>67</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -49799,8 +49791,6 @@
       <integer>30</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>73</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -49914,7 +49904,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>180</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>140</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>150</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -49967,7 +49957,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>193</integer>
+      <integer>180</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>220</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50017,45 +50007,47 @@
       <key>public.kern2.MAL_asterisk.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_bha_lVocalicMatra-malayalam_L</key>
-      <integer>77</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_braceright.loclMALM_R</key>
       <integer>50</integer>
       <key>public.kern2.MAL_bracketright.loclMALM_R</key>
-      <integer>47</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_comma.loclMALM_R</key>
-      <integer>30</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_da_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>100</integer>
       <key>public.kern2.MAL_ja_lVocalicMatra-malayalam_L</key>
-      <integer>47</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>147</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
-      <integer>117</integer>
+      <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
-      <integer>40</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
-      <integer>20</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
-      <integer>-30</integer>
+      <integer>-20</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-20</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
       <integer>20</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>90</integer>
+      <key>public.kern2.MAL_tt_tta-malayalam_L</key>
+      <integer>10</integer>
       <key>public.kern2.MAL_tta_lVocalicMatra-malayalam_L</key>
-      <integer>143</integer>
+      <integer>160</integer>
       <key>public.kern2.MAL_ttha_lVocalicMatra-malayalam_L</key>
-      <integer>97</integer>
+      <integer>110</integer>
       <key>public.kern2.MAL_uMatra-malayalam_L</key>
-      <integer>80</integer>
+      <integer>84</integer>
       <key>public.kern2.MAL_va-malayalam.post_L</key>
-      <integer>233</integer>
+      <integer>220</integer>
       <key>public.kern2.MAL_ya-malayalam.post_L</key>
-      <integer>170</integer>
+      <integer>180</integer>
     </dict>
     <key>public.kern1.MAL_ma_lVocalicMatra-malayalam_R</key>
     <dict>
@@ -50080,7 +50072,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>160</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>113</integer>
+      <integer>90</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50131,7 +50123,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>237</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>190</integer>
+      <integer>160</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>197</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50165,7 +50157,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>73</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>27</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
       <key>public.kern2.MAL_period.loclMALM_R</key>
@@ -50207,7 +50199,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>90</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>57</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>47</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -50422,7 +50414,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>120</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>63</integer>
+      <integer>50</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>80</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50449,7 +50441,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>60</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>27</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50478,7 +50470,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>97</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>63</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -50532,7 +50524,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>100</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>50</integer>
+      <integer>40</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>40</integer>
       <key>public.kern2.MAL_o-malayalam_L</key>
@@ -50564,8 +50556,6 @@
       <integer>20</integer>
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>50</integer>
-      <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
@@ -50753,7 +50743,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>227</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>163</integer>
+      <integer>164</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>193</integer>
       <key>public.kern2.MAL_rVocalic-malayalam_L</key>
@@ -50794,7 +50784,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>147</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>100</integer>
+      <integer>80</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>133</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50841,7 +50831,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>237</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>173</integer>
+      <integer>150</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>177</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -50941,7 +50931,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>217</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>163</integer>
+      <integer>150</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>177</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -51083,7 +51073,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>107</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>57</integer>
+      <integer>30</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>57</integer>
       <key>public.kern2.MAL_question.loclMALM_R</key>
@@ -51136,7 +51126,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>77</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>23</integer>
+      <integer>20</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>47</integer>
       <key>public.kern2.MAL_rVocalicMatra-malayalam_L</key>
@@ -51203,7 +51193,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>217</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>160</integer>
+      <integer>150</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>177</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -51256,7 +51246,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>290</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>240</integer>
+      <integer>230</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>250</integer>
       <key>public.kern2.MAL_p_la-malayalam_L</key>
@@ -51343,7 +51333,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>137</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>80</integer>
+      <integer>70</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>113</integer>
       <key>public.kern2.MAL_parenright.loclMALM_R</key>
@@ -51494,7 +51484,7 @@
       <key>public.kern2.MAL_llla_lVocalicMatra-malayalam_L</key>
       <integer>63</integer>
       <key>public.kern2.MAL_m_la-malayalam_L</key>
-      <integer>40</integer>
+      <integer>10</integer>
       <key>public.kern2.MAL_ma_lVocalicMatra-malayalam_L</key>
       <integer>37</integer>
       <key>public.kern2.MAL_ra_lVocalicMatra-malayalam_L</key>
@@ -51654,6 +51644,26 @@
       <integer>-40</integer>
       <key>public.kern2.MAL_quoteright.loclMALM_R</key>
       <integer>-40</integer>
+    </dict>
+    <key>public.kern1.bha-malayalam.half</key>
+    <dict>
+      <key>public.kern2.MAL_braceright.loclMALM_R</key>
+      <integer>90</integer>
+      <key>public.kern2.MAL_bracketright.loclMALM_R</key>
+      <integer>93</integer>
+      <key>public.kern2.MAL_comma.loclMALM_R</key>
+      <integer>20</integer>
+      <key>public.kern2.MAL_parenright.loclMALM_R</key>
+      <integer>54</integer>
+      <key>public.kern2.MAL_period.loclMALM_R</key>
+      <integer>30</integer>
+      <key>public.kern2.MAL_quoteright.loclMALM_R</key>
+      <integer>30</integer>
+    </dict>
+    <key>v_la-malayalam</key>
+    <dict>
+      <key>public.kern2.MAL_uMatra-malayalam_L</key>
+      <integer>70</integer>
     </dict>
     <key>public.kern1.Man-georgian</key>
     <dict>

--- a/source/GoogleSans/malayalam.fea
+++ b/source/GoogleSans/malayalam.fea
@@ -39,7 +39,6 @@ feature akhn {
         #biconsonant
         sub ka-malayalam halant-malayalam ka-malayalam by k_ka-malayalam;
         sub ka-malayalam halant-malayalam ta-malayalam by k_ta-malayalam;
-        sub ka-malayalam halant-malayalam tta-malayalam by k_tta-malayalam;
         sub ka-malayalam halant-malayalam la-malayalam by k_la-malayalam;
         sub ka-malayalam halant-malayalam ssa-malayalam by k_ssa-malayalam;
         sub ga-malayalam halant-malayalam ga-malayalam by g_ga-malayalam;
@@ -81,13 +80,10 @@ feature akhn {
         sub na-malayalam halant-malayalam rra-malayalam by n_rra-malayalam;
         sub na-malayalam halant-malayalam ta-malayalam by n_ta-malayalam;
         sub na-malayalam halant-malayalam tha-malayalam by n_tha-malayalam;
-        sub pa-malayalam halant-malayalam ta-malayalam by p_ta-malayalam;
         sub pa-malayalam halant-malayalam pa-malayalam by p_pa-malayalam;
         sub pa-malayalam halant-malayalam la-malayalam by p_la-malayalam;
         sub pha-malayalam halant-malayalam la-malayalam by ph_la-malayalam;
         sub ba-malayalam halant-malayalam ba-malayalam by b_ba-malayalam;
-        sub ba-malayalam halant-malayalam da-malayalam by b_da-malayalam;
-        sub ba-malayalam halant-malayalam dha-malayalam by b_dha-malayalam;
         sub ba-malayalam halant-malayalam la-malayalam by b_la-malayalam;
         sub ma-malayalam halant-malayalam ma-malayalam by m_ma-malayalam;
         sub ma-malayalam halant-malayalam pa-malayalam by m_pa-malayalam;
@@ -101,7 +97,6 @@ feature akhn {
         sub sha-malayalam halant-malayalam cha-malayalam by sh_cha-malayalam;
         sub sha-malayalam halant-malayalam sha-malayalam by sh_sha-malayalam;
         sub sha-malayalam halant-malayalam la-malayalam by sh_la-malayalam;
-        sub ssa-malayalam halant-malayalam tta-malayalam by ss_tta-malayalam;
         sub sa-malayalam halant-malayalam sa-malayalam by s_sa-malayalam;
         sub sa-malayalam halant-malayalam tha-malayalam by s_tha-malayalam;
         sub sa-malayalam halant-malayalam la-malayalam by s_la-malayalam;
@@ -182,6 +177,18 @@ feature psts {
     } MALM_dflt_psts_consonant_postBaseForm_ligatures;
 
 } psts;
+
+feature hist {
+	script mlm2;
+	lookup MALM_dflt_hist_historicalConjuncts {
+		sub ka-malayalam halant-malayalam tta-malayalam by k_tta-malayalam;
+		sub pa-malayalam halant-malayalam ta-malayalam by p_ta-malayalam;
+		sub ba-malayalam halant-malayalam da-malayalam by b_da-malayalam;
+		sub ba-malayalam halant-malayalam dha-malayalam by b_dha-malayalam;
+		sub ssa-malayalam halant-malayalam tta-malayalam by ss_tta-malayalam;
+	} MALM_dflt_hist_historicalConjuncts;
+	
+} hist;
 
 feature haln {
     script mlm2;

--- a/source/GoogleSans/malayalam.fea
+++ b/source/GoogleSans/malayalam.fea
@@ -118,7 +118,7 @@ feature akhn {
         sub llla-malayalam halant-malayalam zerowidthjoiner by lllChillu-malayalam;
         sub nna-malayalam halant-malayalam zerowidthjoiner by nnChillu-malayalam;
         sub na-malayalam halant-malayalam zerowidthjoiner by nChillu-malayalam;
-        sub rra-malayalam halant-malayalam zerowidthjoiner by rrChillu-malayalam;
+        sub ra-malayalam halant-malayalam zerowidthjoiner by rrChillu-malayalam;
         sub la-malayalam halant-malayalam zerowidthjoiner by lChillu-malayalam;
         sub lla-malayalam halant-malayalam zerowidthjoiner by llChillu-malayalam;
         sub ka-malayalam halant-malayalam zerowidthjoiner by kChillu-malayalam;
@@ -151,6 +151,7 @@ feature blws {
     script mlm2;
     lookup MALM_dflt_blws_lVocalicMatraLigatures {
         #lVocalicMatra
+		sub ja-malayalam lVocalicMatra-malayalam by ja_lVocalicMatra-malayalam;
         sub tta-malayalam lVocalicMatra-malayalam by tta_lVocalicMatra-malayalam;
         sub ttha-malayalam lVocalicMatra-malayalam by ttha_lVocalicMatra-malayalam;
         sub da-malayalam lVocalicMatra-malayalam by da_lVocalicMatra-malayalam;
@@ -160,6 +161,7 @@ feature blws {
         sub rra-malayalam lVocalicMatra-malayalam by rra_lVocalicMatra-malayalam;
         sub llla-malayalam lVocalicMatra-malayalam by llla_lVocalicMatra-malayalam;
         #llVocalicMatra
+		sub ja-malayalam llVocalicMatra-malayalam by ja_llVocalicMatra-malayalam;
         sub tta-malayalam llVocalicMatra-malayalam by tta_llVocalicMatra-malayalam;
         sub ttha-malayalam llVocalicMatra-malayalam by ttha_llVocalicMatra-malayalam;
         sub da-malayalam llVocalicMatra-malayalam by da_llVocalicMatra-malayalam;


### PR DESCRIPTION
Fixes #681
### Sub-issue 1

Test string: `ക്ട പ്ത ബ്ദ ബ്ധ ഷ്ട`
#### Before:
<img width="1585" height="612" alt="Screenshot 2025-10-09 at 10 53 49 PM" src="https://github.com/user-attachments/assets/9a7dac33-ae0b-43ad-a3c8-d63d7f533ce8" />

#### After:
Default behaviour:
<img width="1915" height="612" alt="Screenshot 2025-10-09 at 10 55 14 PM" src="https://github.com/user-attachments/assets/8b85e78b-c942-4f2a-bd70-991eca482f7b" />
When `hist` is activated:
<img width="1915" height="612" alt="Screenshot 2025-10-09 at 10 55 20 PM" src="https://github.com/user-attachments/assets/693b99c5-54d9-4cfa-aada-8a1ad79c287f" />

---

### Sub-issue 2
- [ ] 'ka' and its conjuncts/ligatures: ```ക ൿ ക്ക ക്ത ക്ട ക്ല ക്ഷ ങ്ക```
#### Before:
<img width="2016" height="846" alt="Screenshot 2025-10-27 at 2 25 48 PM" src="https://github.com/user-attachments/assets/cf4935ab-f6d8-4a24-bf2e-03073499b90b" />

#### After:
<img width="2016" height="846" alt="Screenshot 2025-10-27 at 2 27 02 PM" src="https://github.com/user-attachments/assets/aa6914a6-0c3f-4aac-9f27-c3bcf71fe8a9" />

---

- [ ] 'ga' and its conjuncts/ligatures: ```ഗ ഗ് ഗ്ഗ ഗ്ദ ഗ്മ ഗ്ന ഗ്ല```
#### Before:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 30 28 PM" src="https://github.com/user-attachments/assets/bbf0e041-8e98-4ef6-afad-3844c7304979" />

#### After:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 30 37 PM" src="https://github.com/user-attachments/assets/dd579425-17da-430b-b81b-db2c394963d0" />

---

- [ ] 'ja' and its conjuncts/ligatures: ```ജ ജ് ജ്ജ ജ്ഞ ഞ്ജ ജൢ ജൣ```
#### Before:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 33 08 PM" src="https://github.com/user-attachments/assets/1050acf9-9521-47cd-8b55-f314aa67bafd" />

#### After:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 33 17 PM" src="https://github.com/user-attachments/assets/962f0d48-d68b-4809-ae78-dde96c302a8e" />

---

- [ ] [Upright] 'tta' and its conjuncts/ligatures: ```ട ട്ട```
- [ ] [Italic] 'tta' and its conjuncts/ligatures: ```ട ട് ട്ട ടൢ ടൣ```
#### Before:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 35 01 PM" src="https://github.com/user-attachments/assets/ae21270e-a0e1-4a6e-ba61-ae93507c695c" />

#### After:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 35 08 PM" src="https://github.com/user-attachments/assets/bfed492c-77f2-40ff-94c0-86e9d8c57b2a" />

---

- [ ] 'ya' and its conjuncts/ligatures: ```യ യ്യ```
#### Before:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 37 28 PM" src="https://github.com/user-attachments/assets/242fb2e7-0229-4cbd-817f-d61a0128e57a" />

#### After:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 37 32 PM" src="https://github.com/user-attachments/assets/ccb4c0aa-4f89-4779-8fff-e79a1885a944" />

---

- [ ] 'd_da' & ny_ca': ```ദ്ദ ഞ്ച```
#### Before:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 53 21 PM" src="https://github.com/user-attachments/assets/8568a630-6f81-4aeb-b93a-1efce58bad52" />

#### After:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 53 26 PM" src="https://github.com/user-attachments/assets/0ecf8b08-0eac-4757-aa1c-676d61642ba3" />

---

- [ ] 'uuMatra': ```കൂ```
#### Before:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 51 25 PM" src="https://github.com/user-attachments/assets/530063d5-049b-4bb8-b877-a182c952b6bc" />

#### After:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 51 40 PM" src="https://github.com/user-attachments/assets/cb25d5a0-b57f-4da4-8e85-6e4540bbeb8d" />

---

- [ ] [Italic only] 'ta' and its conjuncts/ligatures: ```ത ത് ത്ല```
#### Before:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 48 35 PM" src="https://github.com/user-attachments/assets/94e79063-ccd4-4976-9ff9-2902a552071a" />

#### After:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 48 46 PM" src="https://github.com/user-attachments/assets/3f86453a-263d-430f-9a20-50aa96692cc3" />

---

### Sub-issue 3
- [ ] 'm_la': ```മ്ല```
#### Before:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 54 09 PM" src="https://github.com/user-attachments/assets/b559e479-c4ab-4e87-95ac-68089431906b" />

#### After:
<img width="2016" height="612" alt="Screenshot 2025-10-27 at 2 54 18 PM" src="https://github.com/user-attachments/assets/4618c4f6-95ba-4183-951d-3cd9d2aced08" />

---

### Sub-issue 4

Test string: `ജൢ ജൣ`
#### Before:
<img width="1304" height="612" alt="Screenshot 2025-10-09 at 10 45 10 PM" src="https://github.com/user-attachments/assets/559c2a40-6843-4c10-b3d4-071b27c57393" />

#### After:
<img width="1304" height="612" alt="Screenshot 2025-10-09 at 10 44 50 PM" src="https://github.com/user-attachments/assets/7653f200-bc39-419d-bf54-247cecb1256f" />
