### PR TITLE
Increase timeout for Figma build/testing

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -271,7 +271,7 @@ jobs:
     needs:
       - build-variable
     runs-on: googlefonts-64cores-256GB
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Check out source repository
         uses: actions/checkout@v6


### PR DESCRIPTION
10 mins -> 15 mins