### PR TITLE
Release prep v14000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Google Sans Changelog
 
+
+## v14.000
+### New
+- Added Arabic script support (#729)
+
+
 ## v13.002
 ### Changed
 - Updated `.logo` and `.super` glyphs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## v14.000
 ### New
-- Added Arabic script support (#729)
+- Added Arabic script support (#729) for: Arabic, Baluchi, Kazakh, Pashto, Punjabi, Somali, Uyghur, Uzbek.
 
 
 ## v13.002

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
@@ -83,9 +83,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>526</integer>
   </dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/fontinfo.plist
@@ -136,9 +136,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>526</integer>
   </dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/fontinfo.plist
@@ -83,9 +83,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>526</integer>
   </dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/fontinfo.plist
@@ -144,9 +144,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>526</integer>
   </dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
@@ -83,9 +83,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>510</integer>
   </dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/fontinfo.plist
@@ -136,9 +136,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>510</integer>
   </dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/fontinfo.plist
@@ -83,9 +83,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>510</integer>
   </dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/fontinfo.plist
@@ -144,9 +144,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>510</integer>
   </dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
@@ -83,9 +83,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>526</integer>
   </dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/fontinfo.plist
@@ -118,9 +118,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>526</integer>
   </dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/fontinfo.plist
@@ -83,9 +83,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>526</integer>
   </dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/fontinfo.plist
@@ -134,9 +134,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>526</integer>
   </dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
@@ -91,9 +91,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>510</integer>
   </dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/fontinfo.plist
@@ -91,9 +91,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>510</integer>
   </dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/fontinfo.plist
@@ -91,9 +91,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>510</integer>
   </dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/fontinfo.plist
@@ -91,9 +91,9 @@
     <key>unitsPerEm</key>
     <integer>1000</integer>
     <key>versionMajor</key>
-    <integer>13</integer>
+    <integer>14</integer>
     <key>versionMinor</key>
-    <integer>2</integer>
+    <integer>0</integer>
     <key>xHeight</key>
     <integer>510</integer>
   </dict>


### PR DESCRIPTION
File size comparison report between fonts from this branch (with added Arabic to the upright font) vs: previous release v13.002.

**Uprights:**
Font 1: 14.000;GOOG;GoogleSans-Regular
Unicode count: 3749

Font 2: 13.002;GOOG;GoogleSans-Regular
Unicode count: 3281
```
+------------+-----------------------+-----------------------+
| Table      |   Font 1 Size (bytes) |   Font 2 Size (bytes) |
+============+=======================+=======================+
| BASE       |                   520 |                   494 |
+------------+-----------------------+-----------------------+
| GDEF       |                 23486 |                 19858 |
+------------+-----------------------+-----------------------+
| GPOS       |               1064310 |               1023002 |
+------------+-----------------------+-----------------------+
| GSUB       |                114704 |                107156 |
+------------+-----------------------+-----------------------+
| HVAR       |                 23959 |                 22243 |
+------------+-----------------------+-----------------------+
| MVAR       |                    63 |                    63 |
+------------+-----------------------+-----------------------+
| OS/2       |                    96 |                    96 |
+------------+-----------------------+-----------------------+
| STAT       |                   198 |                   198 |
+------------+-----------------------+-----------------------+
| avar       |                    58 |                    58 |
+------------+-----------------------+-----------------------+
| cmap       |                  6800 |                  5792 |
+------------+-----------------------+-----------------------+
| fvar       |                   124 |                   124 |
+------------+-----------------------+-----------------------+
| gasp       |                     8 |                     8 |
+------------+-----------------------+-----------------------+
| glyf       |               1144111 |               1086822 |
+------------+-----------------------+-----------------------+
| gvar       |               2415114 |               2356304 |
+------------+-----------------------+-----------------------+
| head       |                    54 |                    54 |
+------------+-----------------------+-----------------------+
| hhea       |                    36 |                    36 |
+------------+-----------------------+-----------------------+
| hmtx       |                 33242 |                 30074 |
+------------+-----------------------+-----------------------+
| loca       |                 33248 |                 30104 |
+------------+-----------------------+-----------------------+
| maxp       |                    32 |                    32 |
+------------+-----------------------+-----------------------+
| name       |                  2142 |                  2142 |
+------------+-----------------------+-----------------------+
| post       |                112243 |                 98556 |
+------------+-----------------------+-----------------------+
| prep       |                     7 |                     7 |
+------------+-----------------------+-----------------------+
| Total Size |               4974555 |               4783223 |
+------------+-----------------------+-----------------------+
```

**Italics:**
Font 1: 14.000;GOOG;GoogleSans-Italic
Unicode count: 3281

Font 2: 13.002;GOOG;GoogleSans-Italic
Unicode count: 3281

```
+------------+-----------------------+-----------------------+
| Table      |   Font 1 Size (bytes) |   Font 2 Size (bytes) |
+============+=======================+=======================+
| BASE       |                   520 |                   494 |
+------------+-----------------------+-----------------------+
| GDEF       |                 26375 |                 26375 |
+------------+-----------------------+-----------------------+
| GPOS       |               1078656 |               1078656 |
+------------+-----------------------+-----------------------+
| GSUB       |                107176 |                107176 |
+------------+-----------------------+-----------------------+
| HVAR       |                 24217 |                 24217 |
+------------+-----------------------+-----------------------+
| MVAR       |                    63 |                    63 |
+------------+-----------------------+-----------------------+
| OS/2       |                    96 |                    96 |
+------------+-----------------------+-----------------------+
| STAT       |                   194 |                   194 |
+------------+-----------------------+-----------------------+
| avar       |                    58 |                    58 |
+------------+-----------------------+-----------------------+
| cmap       |                  5792 |                  5792 |
+------------+-----------------------+-----------------------+
| fvar       |                   124 |                   124 |
+------------+-----------------------+-----------------------+
| gasp       |                     8 |                     8 |
+------------+-----------------------+-----------------------+
| glyf       |               1134224 |               1134224 |
+------------+-----------------------+-----------------------+
| gvar       |               2540572 |               2540572 |
+------------+-----------------------+-----------------------+
| head       |                    54 |                    54 |
+------------+-----------------------+-----------------------+
| hhea       |                    36 |                    36 |
+------------+-----------------------+-----------------------+
| hmtx       |                 30054 |                 30054 |
+------------+-----------------------+-----------------------+
| loca       |                 30084 |                 30084 |
+------------+-----------------------+-----------------------+
| maxp       |                    32 |                    32 |
+------------+-----------------------+-----------------------+
| name       |                  2174 |                  2174 |
+------------+-----------------------+-----------------------+
| post       |                 98528 |                 98528 |
+------------+-----------------------+-----------------------+
| prep       |                     7 |                     7 |
+------------+-----------------------+-----------------------+
| Total Size |               5079044 |               5079018 |
+------------+-----------------------+-----------------------+
```

