### PR TITLE
Update usWinAscent for Arabic

### DIFF
--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
@@ -53,7 +53,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
@@ -53,7 +53,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/fontinfo.plist
@@ -106,7 +106,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/fontinfo.plist
@@ -106,7 +106,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/fontinfo.plist
@@ -53,7 +53,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/fontinfo.plist
@@ -53,7 +53,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/fontinfo.plist
@@ -104,7 +104,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/fontinfo.plist
@@ -104,7 +104,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
@@ -53,7 +53,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
@@ -53,7 +53,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/fontinfo.plist
@@ -106,7 +106,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/fontinfo.plist
@@ -106,7 +106,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/fontinfo.plist
@@ -53,7 +53,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/fontinfo.plist
@@ -53,7 +53,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/fontinfo.plist
@@ -104,7 +104,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/fontinfo.plist
@@ -104,7 +104,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
@@ -53,7 +53,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
@@ -53,7 +53,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509       </integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/fontinfo.plist
@@ -88,7 +88,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509       </integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/fontinfo.plist
@@ -88,7 +88,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/fontinfo.plist
@@ -53,7 +53,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/fontinfo.plist
@@ -53,7 +53,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509       </integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/fontinfo.plist
@@ -94,7 +94,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/fontinfo.plist
@@ -94,7 +94,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509       </integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509       </integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509       </integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509       </integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1462</integer>
+    <integer>1540</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1540</integer>
+    <integer>1509       </integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/family.fea
+++ b/source/GoogleSans/family.fea
@@ -2072,7 +2072,7 @@ table BASE {
         tml2 romn 0,
         tel2 romn 0,
         thai romn 0;
-    HorizAxis.MinMax arab dflt -685, 1323;
+    HorizAxis.MinMax arab dflt -946, 1540;
     HorizAxis.MinMax armn dflt -286, 1040;
     HorizAxis.MinMax bng2 dflt -604, 1165;
     HorizAxis.MinMax cyrl dflt -286, 977;

--- a/source/GoogleSans/family.fea
+++ b/source/GoogleSans/family.fea
@@ -2072,7 +2072,7 @@ table BASE {
         tml2 romn 0,
         tel2 romn 0,
         thai romn 0;
-    HorizAxis.MinMax arab dflt -946, 1540;
+    HorizAxis.MinMax arab dflt -685, 1323;
     HorizAxis.MinMax armn dflt -286, 1040;
     HorizAxis.MinMax bng2 dflt -604, 1165;
     HorizAxis.MinMax cyrl dflt -286, 977;


### PR DESCRIPTION
According to fontheight, the diffenator_arabic corpus has some Arabic words that can reach from -946 ("بُنيٍّ") to 1540 ("كُلٌّ") in some weights, so I'm 

1. adjusting the BASE metrics for Arabic, and
2. bumping usWinAscent to 1540 to avoid clipping.

Khaled suggested to also incorporate https://github.com/aliftype/quran-data/tree/main/quran into fontheight for testing, as it might surface higher heights and deeper depths.