### PR TITLE
Add script to merge_variable_fea.py and apply to Telugu and Arabic features

### DIFF
--- a/scripts/merge_variable_fea.py
+++ b/scripts/merge_variable_fea.py
@@ -103,8 +103,10 @@ DEVICE_SLOTS = ("xPlaDevice", "yPlaDevice", "xAdvDevice", "yAdvDevice")
 
 _GLYPH_CLASS_RE = re.compile(r"\[([^\]]+)\]")
 
+Location = dict[str, int | float]
 
-def parse_location(spec: str) -> dict:
+
+def parse_location(spec: str) -> Location:
     """'opsz=18,wght=400' -> {'opsz': 18, 'wght': 400} (int where integral)."""
     loc = {}
     for part in spec.split(","):
@@ -116,13 +118,13 @@ def parse_location(spec: str) -> dict:
     return loc
 
 
-def glyph_names_from_ufo(ufo_path: str) -> set:
+def glyph_names_from_ufo(ufo_path: str) -> set[str]:
     return set(UFOReader(ufo_path).getGlyphSet().keys())
 
 
 def parse_master(
-    frag_path: str, glyph_names: set, context: list, include_dir: str
-) -> list:
+    frag_path: str, glyph_names: set[str], context: list[str], include_dir: str
+) -> list[ast.Statement]:
     """Parse one fragment with prepended context includes; return only the
     fragment's own top-level statements (context statements sliced off)."""
     preamble = "".join(f"include({c});\n" for c in context)
@@ -140,7 +142,7 @@ def parse_master(
     return full.statements[n_ctx:]
 
 
-def meaningful(stmts: list) -> list:
+def meaningful(stmts: list[ast.Statement]) -> list[ast.Statement]:
     """Statements that carry structure/values (standalone comments dropped from
     pairing; they remain in the reference tree and so in the output)."""
     return [s for s in stmts if not isinstance(s, ast.Comment)]
@@ -150,7 +152,7 @@ def is_block(node) -> bool:
     return hasattr(node, "statements") and isinstance(node.statements, list)
 
 
-def block_header(node) -> tuple:
+def block_header(node) -> tuple[str, str | None, bool | None]:
     """Block identity independent of its body (and its body's comments)."""
     return (
         type(node).__name__,
@@ -200,20 +202,20 @@ def signature(stmt) -> str:
     )
 
 
-def shape(node) -> tuple:
+def shape(node) -> tuple[str, str | None, bool | None] | tuple[str, str]:
     """Per-statement alignment key: block header, or leaf signature."""
     if is_block(node):
         return block_header(node)
     return ("leaf", signature(node))
 
 
-def aligned(mlists: list) -> bool:
+def aligned(mlists: list[list[ast.Statement]]) -> bool:
     """True if every master has the same statement shapes in the same order."""
     shapes = [tuple(shape(s) for s in ml) for ml in mlists]
     return all(s == shapes[0] for s in shapes)
 
 
-def value_holders(stmt) -> list:
+def value_holders(stmt) -> list[ast.Anchor | ast.ValueRecord]:
     """Ordered Anchor/ValueRecord objects carrying mergeable numerics in `stmt`
     itself (not its child statements). [] for purely structural statements;
     ligature-caret positions are bare numbers, not holder objects, and are merged
@@ -237,7 +239,7 @@ def value_holders(stmt) -> list:
     return []
 
 
-def holder_slots(h) -> tuple:
+def holder_slots(h) -> tuple[str, ...]:
     """Numeric slot names on a value holder; raises on shapes the merge can't
     express (device tables, contourpoint anchors). NULL anchors never reach here:
     feaLib parses '<anchor NULL>' to a value-less component, so value_holders
@@ -270,7 +272,11 @@ def caret_holder(stmt):
     return None
 
 
-def _variabilize(vals: list, locations: list, where: str):
+def _variabilize(
+    vals: list[int | float | VariableScalar | None],
+    locations: list[Location],
+    where: str,
+):
     """One numeric value per master for a single slot. Returns a VariableScalar to
     write when the masters disagree, or None to leave the slot untouched (every
     master equal, or the slot is unset in every master). Raises if the slot is set
@@ -290,7 +296,11 @@ def _variabilize(vals: list, locations: list, where: str):
     return None
 
 
-def merge_holder_lists(holders_per_master: list, locations: list, where: str):
+def merge_holder_lists(
+    holders_per_master: list[list[ast.Anchor | ast.ValueRecord]],
+    locations: list[Location],
+    where: str,
+):
     """Merge parallel holders, mutating the reference master's holders: a numeric
     slot that differs across masters becomes a VariableScalar."""
     ref = holders_per_master[0]
@@ -302,7 +312,11 @@ def merge_holder_lists(holders_per_master: list, locations: list, where: str):
                 setattr(h0, slot, vs)
 
 
-def merge_caret_lists(carets_per_master: list, locations: list, where: str):
+def merge_caret_lists(
+    carets_per_master: list[list[int | float | VariableScalar]],
+    locations: list[Location],
+    where: str,
+):
     """Merge parallel ligature-caret lists, mutating the reference master's list: a
     caret position that differs across masters becomes a VariableScalar."""
     ref = carets_per_master[0]
@@ -315,7 +329,7 @@ def merge_caret_lists(carets_per_master: list, locations: list, where: str):
             ref[i] = vs
 
 
-def _markclass_run(stmts: list):
+def _markclass_run(stmts: list[ast.Statement]):
     """(lo, hi) inclusive span covering every MarkClassDefinition among `stmts`,
     or None if there are none. Comments may sit inside the run; any other kind of
     statement between two markClass defs means the block is non-contiguous."""
@@ -332,12 +346,12 @@ def _markclass_run(stmts: list):
     return lo, hi
 
 
-def _glyph_set(container) -> tuple:
+def _glyph_set(container) -> tuple[str, ...]:
     """Glyph names of a feaLib glyph container (GlyphName/GlyphClass/...)."""
     return tuple(container.glyphSet())
 
 
-def _decompose_run(run: list):
+def _decompose_run(run: list[ast.Statement]):
     """run -> ({(class, glyph): Anchor}, [(class, [glyphs])], {class: MarkClass})."""
     entries, groups, classes = {}, [], {}
     for s in run:
@@ -357,7 +371,7 @@ def _decompose_run(run: list):
     return entries, groups, classes
 
 
-def canonicalize_markclass_level(real_lists: list, where: str):
+def canonicalize_markclass_level(real_lists: list[list[ast.Statement]], where: str):
     """Reconcile markClass grouping divergence at one statement level: rewrite
     every master's markClass run in place to the reference master's grouping,
     splitting a group only where its glyphs' anchors diverge within some master.
@@ -404,7 +418,11 @@ def canonicalize_markclass_level(real_lists: list, where: str):
         rl[lo:hi + 1] = rebuilt[mi]
 
 
-def merge_level(real_lists: list, locations: list, where: str):
+def merge_level(
+    real_lists: list[list[ast.Statement]],
+    locations: list[Location],
+    where: str,
+):
     """Merge parallel statement lists for one level, recursing into blocks.
     Mutates the reference master's nodes (and, on divergence, every master's
     markClass run) in place."""
@@ -448,11 +466,11 @@ def merge_level(real_lists: list, locations: list, where: str):
 
 
 def merge_files(
-    input_files: list,
+    input_files: list[str],
     output_file: str,
-    locations: list,
+    locations: list[str],
     ufo: str,
-    context: list,
+    context: list[str],
     include_dir=None,
 ):
     if len(input_files) != len(locations):

--- a/scripts/merge_variable_fea.py
+++ b/scripts/merge_variable_fea.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+r"""Merge per-master FEA files into a single variable FEA via the feaLib AST.
+
+Given N feature files, one per designspace master, emit one feature file in which
+numeric values that differ across masters become feaLib variable scalars
+'(axis=val:num ...)', while values equal at every master stay plain numbers.
+
+Rather than line/regex manipulation, each per-master fragment is parsed into a
+feaLib AST; the parallel statement trees are walked together, and any numeric
+leaf -- a ValueRecord field (x/y placement, x/y advance), an Anchor coordinate,
+or a ligature caret position -- that differs across masters is replaced by a
+VariableScalar populated per master location. The reference (first) master's tree
+is then serialized with asFea().
+
+Parse context
+-------------
+feaLib has to fully parse each input before it can be merged: that needs the glyph
+set, and -- when an input is an include fragment rather than a self-contained file
+-- the sibling files that define its context. GoogleSans' per-master Telugu/Arabic
+inputs are such fragments: never compiled standalone, only pulled into an assembled
+features.fea after the files that define their context. They reference glyphs by
+name (hyphenated names like 'kha-telugu.below' look like FEA glyph ranges to the
+parser unless it knows the glyph set) and may reference glyph classes defined in
+sibling files (Telugu's @TEL_* live in telugu.fea). So:
+
+  --ufo PATH        default-master UFO; its glyph names are handed to the parser
+                    so hyphenated names aren't misread as ranges (required).
+  --context FILE..  .fea files prepended as include(...) before each fragment so
+                    feaLib can resolve external @classes (e.g. telugu.fea). The
+                    context's own statements are discarded; only each fragment's
+                    statements are merged. Self-contained inputs need none; among
+                    the GoogleSans inputs Arabic needs none, Telugu needs
+                    telugu.fea. Includes are resolved against --include-dir,
+                    which defaults to the directory of the first input file.
+
+Reconciled divergences
+-----------------------
+Inputs must hold the same statements in the same order, with two divergences
+reconciled automatically (mirroring the structure feaLib already models):
+  - glyph classes are unordered, so masters whose '[...]' contents are reordered
+    still match; the reference master's order is kept in the output;
+  - the markClass block may group glyphs differently across masters (two glyphs
+    that share an anchor in one master can be collapsed into one statement). It is
+    decomposed per (class, glyph) and re-emitted in the reference layout, keeping a
+    group intact unless its glyphs carry different anchors in some master, in which
+    case it is split. Requires the markClass statements to be contiguous *when*
+    they diverge; an already-aligned block (the common case) is merged in place and
+    may be non-contiguous. This reconciliation is defensive: the current GoogleSans
+    masters are already aligned (identical grouping), so it engages only if future
+    generated fragments group glyphs differently.
+
+Comments (including Glyphs' '# Automatic Code' markers) are preserved; the parser
+keeps them and asFea() re-emits them. Input order does not affect merged values
+(scalars are keyed by location); the first file only sets the reference layout, so
+pass the default master first.
+
+Anything variable FEA cannot express -- a differing set of statements, markClass
+entries that don't match across masters, device tables, or contourpoint anchors --
+fails loudly rather than silently emitting a wrong font. A NULL anchor (a ligature
+component with no attachment) carries no value to variabilize: when every master
+agrees on it, it passes through unchanged; a slot that is NULL in some masters but
+positioned in others is a structure mismatch and fails loud.
+
+Usage (the GoogleSans Telugu/Arabic variable features, run from the repo root;
+--include-dir defaults to the fragment directory, so --context resolves there):
+
+    python scripts/merge_variable_fea.py \
+        source/GoogleSans/telugu-opsz18-wght380.fea \
+        source/GoogleSans/telugu-opsz18-wght734.fea \
+        source/GoogleSans/telugu-opsz17-wght380.fea \
+        source/GoogleSans/telugu-opsz17-wght734.fea \
+        -l "opsz=18,wght=400" "opsz=18,wght=700" "opsz=17,wght=400" "opsz=17,wght=700" \
+        --ufo source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo \
+        --context telugu.fea \
+        -o source/GoogleSans/telugu-variable.fea
+
+    python scripts/merge_variable_fea.py \
+        source/GoogleSans/arabic-opsz18-wght380.fea \
+        source/GoogleSans/arabic-opsz18-wght734.fea \
+        source/GoogleSans/arabic-opsz17-wght380.fea \
+        source/GoogleSans/arabic-opsz17-wght734.fea \
+        -l "opsz=18,wght=400" "opsz=18,wght=700" "opsz=17,wght=400" "opsz=17,wght=700" \
+        --ufo source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo \
+        -o source/GoogleSans/arabic-variable.fea
+
+Telugu-Italic mirrors the Telugu command with the italic per-master fragments and
+--ufo source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo.
+"""
+
+import argparse
+import io
+import os
+import re
+
+from fontTools.feaLib import ast
+from fontTools.feaLib.parser import Parser
+from fontTools.feaLib.variableScalar import VariableScalar
+from fontTools.ufoLib import UFOReader
+
+ANCHOR_SLOTS = ("x", "y")
+VALUEREC_SLOTS = ("xPlacement", "yPlacement", "xAdvance", "yAdvance")
+DEVICE_SLOTS = ("xPlaDevice", "yPlaDevice", "xAdvDevice", "yAdvDevice")
+
+_GLYPH_CLASS_RE = re.compile(r"\[([^\]]+)\]")
+
+
+def parse_location(spec: str) -> dict:
+    """'opsz=18,wght=400' -> {'opsz': 18, 'wght': 400} (int where integral)."""
+    loc = {}
+    for part in spec.split(","):
+        tag, sep, val = part.partition("=")
+        if not sep:
+            raise ValueError(f"bad location component {part!r} in {spec!r}")
+        f = float(val)
+        loc[tag.strip()] = int(f) if f.is_integer() else f
+    return loc
+
+
+def glyph_names_from_ufo(ufo_path: str) -> set:
+    return set(UFOReader(ufo_path).getGlyphSet().keys())
+
+
+def parse_master(
+    frag_path: str, glyph_names: set, context: list, include_dir: str
+) -> list:
+    """Parse one fragment with prepended context includes; return only the
+    fragment's own top-level statements (context statements sliced off)."""
+    preamble = "".join(f"include({c});\n" for c in context)
+    n_ctx = 0
+    if context:
+        ctx_tree = Parser(
+            io.StringIO(preamble), glyphNames=glyph_names, includeDir=include_dir
+        ).parse()
+        n_ctx = len(ctx_tree.statements)
+    with open(frag_path) as f:
+        text = f.read()
+    full = Parser(
+        io.StringIO(preamble + text), glyphNames=glyph_names, includeDir=include_dir
+    ).parse()
+    return full.statements[n_ctx:]
+
+
+def meaningful(stmts: list) -> list:
+    """Statements that carry structure/values (standalone comments dropped from
+    pairing; they remain in the reference tree and so in the output)."""
+    return [s for s in stmts if not isinstance(s, ast.Comment)]
+
+
+def is_block(node) -> bool:
+    return hasattr(node, "statements") and isinstance(node.statements, list)
+
+
+def block_header(node) -> tuple:
+    """Block identity independent of its body (and its body's comments)."""
+    return (
+        type(node).__name__,
+        getattr(node, "name", None),
+        getattr(node, "use_extension", None),
+    )
+
+
+def signature(stmt) -> str:
+    """Equality skeleton for a leaf statement: the statement serialized with its
+    numeric values neutralized, leaving structure and glyph operands. Only the
+    values are blanked -- the ValueRecord/Anchor fields are zeroed around the
+    asFea() call, then restored -- so glyph names keep their digits (a statement
+    differing only in a glyph differs here). Glyph-class member order is normalized
+    (the bracketed run is sorted in the serialized text) so masters that reorder a
+    class still match -- except in substitutions, where a class's order can be
+    significant (one-to-one class subs), so those are left as-is and a reorder
+    fails loud rather than being silently flattened."""
+    saved = []
+    for h in value_holders(stmt):
+        if isinstance(h, ast.Anchor):
+            slots = ANCHOR_SLOTS
+        elif isinstance(h, ast.ValueRecord):
+            slots = VALUEREC_SLOTS
+        else:
+            slots = ()
+        for slot in slots:
+            v = getattr(h, slot)
+            if v is not None:
+                saved.append((h, slot, v))
+                setattr(h, slot, 0)
+    carets = caret_holder(stmt)
+    saved_carets = list(carets) if carets is not None else None
+    if carets is not None:
+        carets[:] = [0] * len(carets)
+    try:
+        s = stmt.asFea()
+    finally:
+        for h, slot, v in saved:
+            setattr(h, slot, v)
+        if carets is not None and saved_carets is not None:
+            carets[:] = saved_carets
+    if "Subst" in type(stmt).__name__:
+        return s  # class order can be significant in a one-to-one sub; don't touch
+    return _GLYPH_CLASS_RE.sub(
+        lambda m: "[" + " ".join(sorted(m.group(1).split())) + "]", s
+    )
+
+
+def shape(node) -> tuple:
+    """Per-statement alignment key: block header, or leaf signature."""
+    if is_block(node):
+        return block_header(node)
+    return ("leaf", signature(node))
+
+
+def aligned(mlists: list) -> bool:
+    """True if every master has the same statement shapes in the same order."""
+    shapes = [tuple(shape(s) for s in ml) for ml in mlists]
+    return all(s == shapes[0] for s in shapes)
+
+
+def value_holders(stmt) -> list:
+    """Ordered Anchor/ValueRecord objects carrying mergeable numerics in `stmt`
+    itself (not its child statements). [] for purely structural statements;
+    ligature-caret positions are bare numbers, not holder objects, and are merged
+    separately via caret_holder()."""
+    tn = type(stmt).__name__
+    if tn == "MarkClassDefinition":
+        return [stmt.anchor]
+    if tn in ("MarkBasePosStatement", "MarkMarkPosStatement"):
+        return [anc for anc, _ in stmt.marks]
+    if tn == "MarkLigPosStatement":
+        return [anc for comp in stmt.marks for anc, _ in (comp or [])]
+    if tn == "CursivePosStatement":
+        # entry/exit anchors; either may be NULL (None) for an open connection.
+        return [a for a in (stmt.entryAnchor, stmt.exitAnchor) if a is not None]
+    if tn == "SinglePosStatement":
+        return [vr for _, vr in stmt.pos]
+    if tn == "PairPosStatement":
+        return [vr for vr in (stmt.valuerecord1, stmt.valuerecord2) if vr is not None]
+    if tn == "ValueRecordDefinition":
+        return [stmt.value]
+    return []
+
+
+def holder_slots(h) -> tuple:
+    """Numeric slot names on a value holder; raises on shapes the merge can't
+    express (device tables, contourpoint anchors). NULL anchors never reach here:
+    feaLib parses '<anchor NULL>' to a value-less component, so value_holders
+    yields no holder for it. An anchor that is NULL in every master is dropped and
+    passes through unchanged; one that is NULL in some masters but positioned in
+    others changes the statement's asFea and fails the alignment check upstream."""
+    if isinstance(h, ast.Anchor):
+        if h.contourpoint is not None:
+            raise ValueError("contourpoint anchor not supported")
+        if h.xDeviceTable is not None or h.yDeviceTable is not None:
+            raise ValueError("anchor device table not supported")
+        return ANCHOR_SLOTS
+    if isinstance(h, ast.ValueRecord):
+        if any(getattr(h, d, None) is not None for d in DEVICE_SLOTS):
+            raise ValueError("value record device table not supported")
+        return VALUEREC_SLOTS
+    raise TypeError(f"unexpected value holder {type(h).__name__}")
+
+
+def caret_holder(stmt):
+    """The mutable list of ligature-caret X-coordinates for a LigatureCaretByPos
+    statement (coordinates, mergeable like any other), else None.
+
+    LigatureCaretByIndex is deliberately excluded: its carets are contour-point
+    indices, which name a point rather than a coordinate and so do not interpolate
+    -- a differing index is a real structural difference, not a value to merge, and
+    is caught by the alignment check (signature does not blank it)."""
+    if type(stmt).__name__ == "LigatureCaretByPosStatement":
+        return stmt.carets
+    return None
+
+
+def _variabilize(vals: list, locations: list, where: str):
+    """One numeric value per master for a single slot. Returns a VariableScalar to
+    write when the masters disagree, or None to leave the slot untouched (every
+    master equal, or the slot is unset in every master). Raises if the slot is set
+    in some masters but not others, or if an input is already a variable scalar."""
+    present = [v is not None for v in vals]
+    if any(present) and not all(present):
+        raise ValueError(f"{where}: present in some masters but not others")
+    if vals[0] is None:
+        return None
+    if any(isinstance(v, VariableScalar) for v in vals):
+        raise ValueError(f"{where}: input already contains a variable scalar")
+    if len(set(vals)) > 1:
+        vs = VariableScalar()
+        for loc, val in zip(locations, vals):
+            vs.add_value(loc, val)
+        return vs
+    return None
+
+
+def merge_holder_lists(holders_per_master: list, locations: list, where: str):
+    """Merge parallel holders, mutating the reference master's holders: a numeric
+    slot that differs across masters becomes a VariableScalar."""
+    ref = holders_per_master[0]
+    for i, h0 in enumerate(ref):
+        for slot in holder_slots(h0):
+            vals = [getattr(hpm[i], slot) for hpm in holders_per_master]
+            vs = _variabilize(vals, locations, f"{where}: {slot}")
+            if vs is not None:
+                setattr(h0, slot, vs)
+
+
+def merge_caret_lists(carets_per_master: list, locations: list, where: str):
+    """Merge parallel ligature-caret lists, mutating the reference master's list: a
+    caret position that differs across masters becomes a VariableScalar."""
+    ref = carets_per_master[0]
+    if len({len(c) for c in carets_per_master}) != 1:
+        raise ValueError(f"{where}: ligature caret count mismatch")
+    for i in range(len(ref)):
+        vals = [c[i] for c in carets_per_master]
+        vs = _variabilize(vals, locations, f"{where}: caret {i + 1}")
+        if vs is not None:
+            ref[i] = vs
+
+
+def _markclass_run(stmts: list):
+    """(lo, hi) inclusive span covering every MarkClassDefinition among `stmts`,
+    or None if there are none. Comments may sit inside the run; any other kind of
+    statement between two markClass defs means the block is non-contiguous."""
+    idxs = [i for i, s in enumerate(stmts) if isinstance(s, ast.MarkClassDefinition)]
+    if not idxs:
+        return None
+    lo, hi = idxs[0], idxs[-1]
+    for i in range(lo, hi + 1):
+        if not isinstance(stmts[i], (ast.MarkClassDefinition, ast.Comment)):
+            raise ValueError(
+                "markClass statements are not contiguous; cannot "
+                "reconcile grouping divergence"
+            )
+    return lo, hi
+
+
+def _glyph_set(container) -> tuple:
+    """Glyph names of a feaLib glyph container (GlyphName/GlyphClass/...)."""
+    return tuple(container.glyphSet())
+
+
+def _decompose_run(run: list):
+    """run -> ({(class, glyph): Anchor}, [(class, [glyphs])], {class: MarkClass})."""
+    entries, groups, classes = {}, [], {}
+    for s in run:
+        if not isinstance(s, ast.MarkClassDefinition):
+            continue
+        # the reconciled anchors are rebuilt from x/y only; an anchor carrying
+        # more (contourpoint, device tables) must fail loud, not drop it silently
+        holder_slots(s.anchor)
+        cls = s.markClass.name
+        classes[cls] = s.markClass
+        glyphs = list(_glyph_set(s.glyphs))
+        for g in glyphs:
+            if (cls, g) in entries:
+                raise ValueError(f"glyph {g} defined twice in @{cls}")
+            entries[(cls, g)] = s.anchor
+        groups.append((cls, glyphs))
+    return entries, groups, classes
+
+
+def canonicalize_markclass_level(real_lists: list, where: str):
+    """Reconcile markClass grouping divergence at one statement level: rewrite
+    every master's markClass run in place to the reference master's grouping,
+    splitting a group only where its glyphs' anchors diverge within some master.
+    Anchors stay per-master; the positional merge that follows variabilizes them.
+    """
+    bounds = [_markclass_run(rl) for rl in real_lists]
+    if all(b is None for b in bounds):
+        return
+    if any(b is None for b in bounds):
+        raise ValueError(
+            f"{where}: markClass block present in some masters but not others"
+        )
+    spans = [b for b in bounds if b is not None]  # all non-None past the guards
+
+    decomp = [_decompose_run(rl[lo:hi + 1]) for rl, (lo, hi) in zip(real_lists, spans)]
+    keysets = [set(d[0]) for d in decomp]
+    if any(k != keysets[0] for k in keysets):
+        union = set().union(*keysets)
+        diverging = sorted(f"@{c} {g}" for c, g in union - set.intersection(*keysets))
+        raise ValueError(
+            f"{where}: markClass diverges structurally (not mergeable); differing "
+            f"entries include: {', '.join(diverging[:8])}"
+        )
+
+    entries = [d[0] for d in decomp]
+    ref_groups, classes = decomp[0][1], decomp[0][2]
+    n = len(real_lists)
+    rebuilt = [[] for _ in range(n)]
+    for cls, glyphs in ref_groups:
+        uniform = all(
+            len({(entries[mi][(cls, g)].x, entries[mi][(cls, g)].y) for g in glyphs}) == 1
+            for mi in range(n)
+        )
+        emit = [glyphs] if uniform else [[g] for g in glyphs]
+        for grp in emit:
+            for mi in range(n):
+                a = entries[mi][(cls, grp[0])]
+                rebuilt[mi].append(
+                    ast.MarkClassDefinition(
+                        classes[cls], ast.Anchor(a.x, a.y), ast.GlyphClass(list(grp))
+                    )
+                )
+    for mi, (rl, (lo, hi)) in enumerate(zip(real_lists, spans)):
+        rl[lo:hi + 1] = rebuilt[mi]
+
+
+def merge_level(real_lists: list, locations: list, where: str):
+    """Merge parallel statement lists for one level, recursing into blocks.
+    Mutates the reference master's nodes (and, on divergence, every master's
+    markClass run) in place."""
+    mlists = [meaningful(rl) for rl in real_lists]
+    if not aligned(mlists):
+        if any(any(isinstance(s, ast.MarkClassDefinition) for s in ml) for ml in mlists):
+            canonicalize_markclass_level(real_lists, where)
+            mlists = [meaningful(rl) for rl in real_lists]
+        if not aligned(mlists):
+            counts = [len(ml) for ml in mlists]
+            if len(set(counts)) != 1:
+                raise ValueError(f"{where}: statement count mismatch: {counts}")
+            for i, nodes in enumerate(zip(*mlists)):
+                if len({shape(n) for n in nodes}) != 1:
+                    raise ValueError(
+                        f"{where}: statement {i + 1} structure mismatch:\n  "
+                        + "\n  ".join(sorted({signature(n).strip()[:120] for n in nodes}))
+                    )
+
+    ref = mlists[0]
+    for i, node0 in enumerate(ref):
+        nodes = [ml[i] for ml in mlists]
+        if is_block(node0):
+            merge_level(
+                [n.statements for n in nodes],
+                locations,
+                f"{where} > {block_header(node0)[1] or block_header(node0)[0]}",
+            )
+        else:
+            where_i = f"{where} statement {i + 1}"
+            holders = [value_holders(n) for n in nodes]
+            if len({len(h) for h in holders}) != 1:
+                raise ValueError(
+                    f"{where}: value-holder count mismatch at statement {i + 1}"
+                )
+            if holders[0]:
+                merge_holder_lists(holders, locations, where_i)
+            carets = [caret_holder(n) for n in nodes]
+            if carets[0] is not None:
+                merge_caret_lists(carets, locations, where_i)
+
+
+def merge_files(
+    input_files: list,
+    output_file: str,
+    locations: list,
+    ufo: str,
+    context: list,
+    include_dir=None,
+):
+    if len(input_files) != len(locations):
+        raise ValueError("number of files must match number of locations")
+    # include() in the prepended --context is resolved relative to this; default
+    # to the fragment's own directory so the common case needs no --include-dir.
+    if include_dir is None:
+        include_dir = os.path.dirname(input_files[0]) or "."
+    glyph_names = glyph_names_from_ufo(ufo)
+    locs = [parse_location(s) for s in locations]
+    masters = [parse_master(f, glyph_names, context, include_dir) for f in input_files]
+    merge_level(masters, locs, "root")
+
+    out = ast.FeatureFile()
+    out.statements = masters[0]
+    text = out.asFea()
+    if not text.endswith("\n"):
+        text += "\n"
+    with open(output_file, "w") as f:
+        f.write(text)
+
+    first_axis = locations[0].split(",")[0].split("=")[0]
+    n_scalars = text.count("(" + first_axis + "=")
+    print(
+        f"Merged {len(input_files)} masters -> {output_file}; "
+        f"{n_scalars} variable scalars"
+    )
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Merge per-master FEA into variable FEA (feaLib AST)"
+    )
+    p.add_argument("files", nargs="+", help="per-master input FEA fragments")
+    p.add_argument("-o", "--output", required=True, help="output FEA file")
+    p.add_argument(
+        "-l",
+        "--locations",
+        nargs="+",
+        required=True,
+        help='userspace location per file, e.g. "opsz=18,wght=400"; '
+        "same count and order as the input files",
+    )
+    p.add_argument(
+        "--ufo",
+        required=True,
+        help="default-master UFO (its glyph names disambiguate "
+        "hyphenated names from glyph ranges)",
+    )
+    p.add_argument(
+        "--context",
+        nargs="*",
+        default=[],
+        metavar="FEA",
+        help="context .fea files to include before each fragment "
+        "(define external @classes); their statements are dropped",
+    )
+    p.add_argument(
+        "--include-dir",
+        default=None,
+        help="directory feaLib resolves include() against "
+        "(default: the first input file's directory)",
+    )
+    args = p.parse_args()
+    if len(args.files) != len(args.locations):
+        p.error("number of files must match number of locations")
+    merge_files(
+        args.files, args.output, args.locations, args.ufo, args.context, args.include_dir
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_merge_variable_fea.py
+++ b/scripts/test_merge_variable_fea.py
@@ -1,0 +1,381 @@
+"""Unit tests for merge_variable_fea.py (the feaLib-AST merge)."""
+
+import io
+
+import pytest
+from fontTools.feaLib import ast
+from fontTools.feaLib.parser import Parser
+
+import merge_variable_fea as mvf
+
+GLYPHS = {"a", "b", "c", "x", "y", "f_i", "acutecomb", "gravecomb", "uni0041", "uni0042"}
+
+
+def _parse(text, glyphs=GLYPHS):
+    return Parser(io.StringIO(text), glyphNames=glyphs).parse().statements
+
+
+def merge(fragments, locations, glyphs=GLYPHS):
+    """Parse each fragment string, merge, return the reference master's asFea."""
+    masters = [_parse(f, glyphs) for f in fragments]
+    locs = [mvf.parse_location(s) for s in locations]
+    mvf.merge_level(masters, locs, "root")
+    out = ast.FeatureFile()
+    out.statements = masters[0]
+    return out.asFea()
+
+
+class TestParseLocation:
+    def test_integers(self):
+        assert mvf.parse_location("opsz=18,wght=400") == {"opsz": 18, "wght": 400}
+
+    def test_float_kept_when_not_integral(self):
+        assert mvf.parse_location("wght=400.5") == {"wght": 400.5}
+
+    def test_integral_float_coerced_to_int(self):
+        assert mvf.parse_location("wght=400.0") == {"wght": 400}
+
+    def test_missing_equals_raises(self):
+        with pytest.raises(ValueError):
+            mvf.parse_location("opsz18")
+
+
+class TestSignature:
+    def test_differing_values_same_signature(self):
+        a = _parse("feature kern { pos a b -40; } kern;")[0].statements[0]
+        b = _parse("feature kern { pos a b -60; } kern;")[0].statements[0]
+        assert mvf.signature(a) == mvf.signature(b)
+
+    def test_glyph_class_order_ignored(self):
+        a = _parse("feature kern { pos [a b c] x -1; } kern;")[0].statements[0]
+        b = _parse("feature kern { pos [c b a] x -1; } kern;")[0].statements[0]
+        assert mvf.signature(a) == mvf.signature(b)
+
+    def test_different_glyphs_differ(self):
+        a = _parse("feature kern { pos a b -1; } kern;")[0].statements[0]
+        b = _parse("feature kern { pos a c -1; } kern;")[0].statements[0]
+        assert mvf.signature(a) != mvf.signature(b)
+
+    def test_glyph_names_differing_only_by_digit_differ(self):
+        # Regression: signature blanks values by zeroing the ValueRecord, not by
+        # blanking digits in text, so digits inside glyph names are preserved.
+        a = _parse("feature kern { pos uni0041 b -1; } kern;")[0].statements[0]
+        b = _parse("feature kern { pos uni0042 b -1; } kern;")[0].statements[0]
+        assert mvf.signature(a) != mvf.signature(b)
+
+
+class TestHolderSlots:
+    def test_anchor_slots(self):
+        assert mvf.holder_slots(ast.Anchor(1, 2)) == ("x", "y")
+
+    def test_value_record_slots(self):
+        assert mvf.holder_slots(ast.ValueRecord(xAdvance=5)) == (
+            "xPlacement",
+            "yPlacement",
+            "xAdvance",
+            "yAdvance",
+        )
+
+    def test_contourpoint_anchor_raises(self):
+        with pytest.raises(ValueError, match="contourpoint"):
+            mvf.holder_slots(ast.Anchor(1, 2, contourpoint=3))
+
+
+class TestAlignedMerge:
+    def test_equal_value_stays_plain(self):
+        out = merge(["feature kern { pos a b -40; } kern;"] * 2, ["opsz=18", "opsz=17"])
+        assert "pos a b -40;" in out
+        assert "opsz=18:" not in out
+
+    def test_differing_value_becomes_variable_scalar(self):
+        out = merge(
+            [
+                "feature kern { pos a b -40; } kern;",
+                "feature kern { pos a b -60; } kern;",
+            ],
+            ["opsz=18", "opsz=17"],
+        )
+        assert "pos a b (opsz=18:-40 opsz=17:-60);" in out
+
+    def test_value_record_fields_merge_independently(self):
+        out = merge(
+            [
+                "feature kern { pos a b <10 20 30 40>; } kern;",
+                "feature kern { pos a b <10 25 30 45>; } kern;",
+            ],
+            ["opsz=18", "opsz=17"],
+        )
+        # xPlacement(10) and xAdvance(30) equal -> plain; y fields differ -> scalar
+        assert "(opsz=18:20 opsz=17:25)" in out
+        assert "(opsz=18:40 opsz=17:45)" in out
+
+    def test_anchor_coords_merge(self):
+        frag = (
+            "feature mark {{ markClass acutecomb <anchor 0 500> @TOP;"
+            " pos base a <anchor {x} 600> mark @TOP; }} mark;"
+        )
+        out = merge([frag.format(x=250), frag.format(x=240)], ["opsz=18", "opsz=17"])
+        assert "(opsz=18:250 opsz=17:240)" in out
+
+    def test_shared_null_anchor_passes_through(self):
+        # A NULL ligature component every master agrees on carries no value to
+        # variabilize; it is kept verbatim while the real anchor still merges.
+        frag = (
+            "feature mark {{ markClass acutecomb <anchor 0 500> @TOP;"
+            " pos ligature f_i <anchor {x} 600> mark @TOP"
+            " ligComponent <anchor NULL>; }} mark;"
+        )
+        out = merge([frag.format(x=100), frag.format(x=120)], ["opsz=18", "opsz=17"])
+        assert "<anchor NULL>" in out
+        assert "(opsz=18:100 opsz=17:120)" in out
+
+    def test_cursive_anchors_merge(self):
+        frag = (
+            "feature curs {{ pos cursive [a b] <anchor {e} 0> <anchor 50 -10>; }} curs;"
+        )
+        out = merge([frag.format(e=100), frag.format(e=110)], ["opsz=18", "opsz=17"])
+        assert "(opsz=18:100 opsz=17:110)" in out  # entry x varied
+        assert "<anchor 50 -10>" in out  # exit unchanged
+
+    def test_cursive_null_entry_shared_passes_through(self):
+        # An open (NULL) entry anchor every master shares carries no value; the
+        # real exit anchor still merges.
+        frag = (
+            "feature curs {{ pos cursive [a b] <anchor NULL> <anchor {x} -10>; }} curs;"
+        )
+        out = merge([frag.format(x=50), frag.format(x=60)], ["opsz=18", "opsz=17"])
+        assert "<anchor NULL>" in out
+        assert "(opsz=18:50 opsz=17:60)" in out
+
+    def test_ligature_carets_merge(self):
+        frag = "table GDEF {{ LigatureCaretByPos f_i {a} 500; }} GDEF;"
+        out = merge([frag.format(a=400), frag.format(a=420)], ["opsz=18", "opsz=17"])
+        assert "LigatureCaretByPos f_i (opsz=18:400 opsz=17:420) 500;" in out
+
+    def test_ligature_caret_equal_stays_plain(self):
+        out = merge(
+            ["table GDEF { LigatureCaretByPos f_i 400 500; } GDEF;"] * 2,
+            ["opsz=18", "opsz=17"],
+        )
+        assert "LigatureCaretByPos f_i 400 500;" in out
+        assert "opsz=18:" not in out
+
+    def test_multiline_statement_merges_correctly(self):
+        # The motivating bug: a pos split across physical lines. The line-oriented
+        # regex merge silently freezes the continuation value; the AST merge does
+        # not, because the value comes from the ValueRecord, not the line.
+        out = merge(
+            [
+                "feature kern {\n  pos a b\n    -40;\n} kern;",
+                "feature kern {\n  pos a b\n    -60;\n} kern;",
+            ],
+            ["opsz=18", "opsz=17"],
+        )
+        assert "pos a b (opsz=18:-40 opsz=17:-60);" in out
+
+    def test_comments_preserved(self):
+        out = merge(
+            ["feature kern {\n  # keep me\n  pos a b -40;\n} kern;"] * 2,
+            ["opsz=18", "opsz=17"],
+        )
+        assert "# keep me" in out
+
+    def test_comment_divergence_does_not_block_merge(self):
+        out = merge(
+            [
+                "feature kern {\n  # one\n  pos a b -40;\n} kern;",
+                "feature kern {\n  # two\n  pos a b -60;\n} kern;",
+            ],
+            ["opsz=18", "opsz=17"],
+        )
+        assert "pos a b (opsz=18:-40 opsz=17:-60);" in out
+
+
+class TestLoudFailures:
+    def test_statement_count_mismatch(self):
+        with pytest.raises(ValueError, match="count mismatch"):
+            merge(
+                [
+                    "feature kern { pos a b -1; pos a c -1; } kern;",
+                    "feature kern { pos a b -1; } kern;",
+                ],
+                ["opsz=18", "opsz=17"],
+            )
+
+    def test_structure_mismatch(self):
+        with pytest.raises(ValueError, match="structure mismatch"):
+            merge(
+                [
+                    "feature kern { pos a b -1; } kern;",
+                    "feature kern { pos a c -1; } kern;",
+                ],
+                ["opsz=18", "opsz=17"],
+            )
+
+    def test_glyph_digit_difference_fails_loud(self):
+        # Masters differing only by a digit in a glyph name must not be silently
+        # mis-merged (the old text-blanking signature would have aligned them).
+        with pytest.raises(ValueError, match="structure mismatch"):
+            merge(
+                [
+                    "feature kern { pos uni0041 b -40; } kern;",
+                    "feature kern { pos uni0042 b -60; } kern;",
+                ],
+                ["opsz=18", "opsz=17"],
+            )
+
+    def test_null_anchor_divergent_fails(self):
+        # NULL in one master but positioned in another is not expressible: the
+        # statement's structure differs, so the alignment check rejects it.
+        null = (
+            "feature mark { markClass acutecomb <anchor 0 500> @TOP;"
+            " pos ligature f_i <anchor 100 600> mark @TOP"
+            " ligComponent <anchor NULL>; } mark;"
+        )
+        real = (
+            "feature mark { markClass acutecomb <anchor 0 500> @TOP;"
+            " pos ligature f_i <anchor 100 600> mark @TOP"
+            " ligComponent <anchor 5 5> mark @TOP; } mark;"
+        )
+        with pytest.raises(ValueError, match="structure mismatch"):
+            merge([null, real], ["opsz=18", "opsz=17"])
+
+    def test_ligature_caret_by_index_not_variabilized(self):
+        # Caret indices reference contour points; a differing index is a real
+        # structural difference, not a coordinate to interpolate -> fail loud.
+        with pytest.raises(ValueError, match="structure mismatch"):
+            merge(
+                [
+                    "table GDEF { LigatureCaretByIndex f_i 7; } GDEF;",
+                    "table GDEF { LigatureCaretByIndex f_i 9; } GDEF;",
+                ],
+                ["opsz=18", "opsz=17"],
+            )
+
+    def test_ligature_caret_count_guard(self):
+        # Defensive: unequal caret counts are rejected by the alignment gate first
+        # (blanked carets serialize differently), so exercise the merge guard.
+        with pytest.raises(ValueError, match="caret count mismatch"):
+            mvf.merge_caret_lists(
+                [[400, 500], [400]], [{"opsz": 18}, {"opsz": 17}], "root"
+            )
+
+    def test_divergent_class_substitution_fails(self):
+        # One-to-one class subs are order-significant (a->x, b->y); reordered source
+        # classes encode a different mapping and must not be silently flattened by
+        # the glyph-class sort, which is skipped for substitutions.
+        with pytest.raises(ValueError, match="structure mismatch"):
+            merge(
+                [
+                    "feature ss01 { sub [a b] by [x y]; } ss01;",
+                    "feature ss01 { sub [b a] by [x y]; } ss01;",
+                ],
+                ["opsz=18", "opsz=17"],
+            )
+
+    def test_value_present_in_some_only(self):
+        # Defensive guard: a numeric slot set in one master but absent in another
+        # (unreachable through the alignment gate, since differing value-record
+        # shapes fail the structure check first, so exercise it directly).
+        h0 = [ast.ValueRecord(xAdvance=10)]
+        h1 = [ast.ValueRecord(xAdvance=10, yAdvance=5)]
+        with pytest.raises(ValueError, match="present in some"):
+            mvf.merge_holder_lists([h0, h1], [{"opsz": 18}, {"opsz": 17}], "root")
+
+
+class TestMarkClassCanonicalization:
+    def test_split_on_divergent_anchor(self):
+        # A groups [a b]@100; B splits a@100 b@200 -> b must become variable.
+        out = merge(
+            [
+                "feature t { markClass [a b] <anchor 100 0> @C; } t;",
+                "feature t { markClass [a] <anchor 100 0> @C;"
+                " markClass [b] <anchor 200 0> @C; } t;",
+            ],
+            ["opsz=18", "opsz=17"],
+        )
+        assert "markClass [a] <anchor 100 0> @C;" in out
+        assert "markClass [b] <anchor (opsz=18:100 opsz=17:200) 0> @C;" in out
+
+    def test_regroup_keeps_group_when_uniform(self):
+        # A grouped; B as two stmts but uniform anchor -> reconcile to one group.
+        out = merge(
+            [
+                "feature t { markClass [a b] <anchor 100 0> @C; } t;",
+                "feature t { markClass [a] <anchor 150 0> @C;"
+                " markClass [b] <anchor 150 0> @C; } t;",
+            ],
+            ["opsz=18", "opsz=17"],
+        )
+        assert "markClass [a b] <anchor (opsz=18:100 opsz=17:150) 0> @C;" in out
+
+    def test_contourpoint_anchor_fails_not_dropped(self):
+        # Reconciled anchors are rebuilt from x/y only; a contourpoint must be
+        # rejected, not silently dropped in the rebuild.
+        with pytest.raises(ValueError, match="contourpoint"):
+            merge(
+                [
+                    "feature t { markClass [a b] <anchor 1 0 contourpoint 2> @C; } t;",
+                    "feature t { markClass [a] <anchor 1 0 contourpoint 2> @C;"
+                    " markClass [b] <anchor 2 0 contourpoint 2> @C; } t;",
+                ],
+                ["opsz=18", "opsz=17"],
+            )
+
+    def test_device_table_anchor_fails_not_dropped(self):
+        dev1 = "<anchor 100 0 <device 11 1> <device NULL>>"
+        dev2 = "<anchor 200 0 <device 11 1> <device NULL>>"
+        with pytest.raises(ValueError, match="device"):
+            merge(
+                [
+                    f"feature t {{ markClass [a b] {dev1} @C; }} t;",
+                    f"feature t {{ markClass [a] {dev1} @C;"
+                    f" markClass [b] {dev2} @C; }} t;",
+                ],
+                ["opsz=18", "opsz=17"],
+            )
+
+    def test_divergent_keys_fail_loud(self):
+        with pytest.raises(ValueError, match="diverges structurally"):
+            merge(
+                [
+                    "feature t { markClass [a b] <anchor 100 0> @C; } t;",
+                    "feature t { markClass [a] <anchor 100 0> @C; } t;",
+                ],
+                ["opsz=18", "opsz=17"],
+            )
+
+    def test_noncontiguous_divergent_block_fails(self):
+        # markClass run interrupted by a pos statement, AND grouping diverges.
+        with pytest.raises(ValueError, match="not contiguous"):
+            merge(
+                [
+                    "feature t { markClass [a b] <anchor 1 0> @C; pos x y -1; } t;",
+                    "feature t { markClass [a] <anchor 1 0> @C; pos x y -1;"
+                    " markClass [b] <anchor 2 0> @C; } t;",
+                ],
+                ["opsz=18", "opsz=17"],
+            )
+
+    def test_block_present_in_some_only(self):
+        with pytest.raises(ValueError, match="present in some"):
+            merge(
+                [
+                    "feature t { markClass [a] <anchor 1 0> @C; pos x y -1; } t;",
+                    "feature t { pos x y -1; pos x a -1; } t;",
+                ],
+                ["opsz=18", "opsz=17"],
+            )
+
+
+class TestIntegration:
+    def test_three_masters(self):
+        out = merge(
+            [
+                "feature kern { pos a b -40; } kern;",
+                "feature kern { pos a b -50; } kern;",
+                "feature kern { pos a b -60; } kern;",
+            ],
+            ["opsz=18", "opsz=17", "opsz=16"],
+        )
+        assert "(opsz=18:-40 opsz=17:-50 opsz=16:-60)" in out

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/features.fea
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/features.fea
@@ -1,4 +1,4 @@
 include(family_uprights.fea);
 
-include(telugu-opsz17-wght380.fea)
-include(arabic-opsz17-wght380.fea);
+include(telugu-variable.fea)
+include(arabic-variable.fea);

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/features.fea
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/features.fea
@@ -1,4 +1,4 @@
 include(family_uprights.fea);
 
-include(telugu-opsz17-wght380.fea)
-include(arabic-opsz17-wght380.fea);
+include(telugu-variable.fea)
+include(arabic-variable.fea);

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/features.fea
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/features.fea
@@ -1,4 +1,4 @@
 include(family_uprights.fea);
 
-include(telugu-opsz17-wght380.fea)
-include(arabic-opsz17-wght380.fea);
+include(telugu-variable.fea)
+include(arabic-variable.fea);

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/features.fea
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/features.fea
@@ -1,4 +1,4 @@
 include(family_uprights.fea);
 
-include(telugu-opsz17-wght734.fea)
-include(arabic-opsz17-wght734.fea);
+include(telugu-variable.fea)
+include(arabic-variable.fea);

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/features.fea
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/features.fea
@@ -1,4 +1,4 @@
 include(family_uprights.fea);
 
-include(telugu-opsz18-wght380.fea)
-include(arabic-opsz18-wght380.fea);
+include(telugu-variable.fea)
+include(arabic-variable.fea);

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/features.fea
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/features.fea
@@ -1,4 +1,4 @@
 include(family_uprights.fea);
 
-include(telugu-opsz18-wght380.fea)
-include(arabic-opsz18-wght380.fea);
+include(telugu-variable.fea)
+include(arabic-variable.fea);

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/features.fea
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/features.fea
@@ -1,4 +1,4 @@
 include(family_uprights.fea);
 
-include(telugu-opsz18-wght380.fea)
-include(arabic-opsz18-wght380.fea);
+include(telugu-variable.fea)
+include(arabic-variable.fea);

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/features.fea
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/features.fea
@@ -1,4 +1,4 @@
 include(family_uprights.fea);
 
-include(telugu-opsz18-wght734.fea)
-include(arabic-opsz18-wght734.fea);
+include(telugu-variable.fea)
+include(arabic-variable.fea);

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/features.fea
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/features.fea
@@ -1,3 +1,3 @@
 include(family_italics.fea);
 
-include(telugu-Italic-opsz17-wght380.fea)
+include(telugu-Italic-variable.fea)

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/features.fea
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/features.fea
@@ -1,3 +1,3 @@
 include(family_italics.fea);
 
-include(telugu-Italic-opsz17-wght380.fea)
+include(telugu-Italic-variable.fea)

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/features.fea
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/features.fea
@@ -1,3 +1,3 @@
 include(family_italics.fea);
 
-include(telugu-Italic-opsz17-wght380.fea)
+include(telugu-Italic-variable.fea)

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/features.fea
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/features.fea
@@ -1,3 +1,3 @@
 include(family_italics.fea);
 
-include(telugu-Italic-opsz17-wght734.fea)
+include(telugu-Italic-variable.fea)

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/features.fea
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/features.fea
@@ -1,3 +1,3 @@
 include(family_italics.fea);
 
-include(telugu-Italic-opsz18-wght380.fea)
+include(telugu-Italic-variable.fea)

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/features.fea
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/features.fea
@@ -1,3 +1,3 @@
 include(family_italics.fea);
 
-include(telugu-Italic-opsz18-wght380.fea)
+include(telugu-Italic-variable.fea)

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/features.fea
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/features.fea
@@ -1,3 +1,3 @@
 include(family_italics.fea);
 
-include(telugu-Italic-opsz18-wght380.fea)
+include(telugu-Italic-variable.fea)

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/features.fea
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/features.fea
@@ -1,3 +1,3 @@
 include(family_italics.fea);
 
-include(telugu-Italic-opsz18-wght734.fea)
+include(telugu-Italic-variable.fea)

--- a/source/GoogleSans/arabic-variable.fea
+++ b/source/GoogleSans/arabic-variable.fea
@@ -1,0 +1,4306 @@
+markClass ishmaam-ar <anchor (opsz=18,wght=400:472 opsz=18,wght=700:520 opsz=17,wght=400:472 opsz=17,wght=700:520) 0> @MC_below_arabic;
+markClass imaala-ar <anchor (opsz=18,wght=400:322 opsz=18,wght=700:338 opsz=17,wght=400:322 opsz=17,wght=700:338) 0> @MC_below_arabic;
+markClass tasheel-ar <anchor (opsz=18,wght=400:468 opsz=18,wght=700:530 opsz=17,wght=400:473 opsz=17,wght=700:540) 0> @MC_below_arabic;
+markClass dotbelow-ar <anchor (opsz=18,wght=400:52 opsz=18,wght=700:64 opsz=17,wght=400:78 opsz=17,wght=700:84) 0> @MC_bottom_arabic;
+markClass dotbelow_threedotsdownbelow-ar <anchor (opsz=18,wght=400:79 opsz=18,wght=700:97 opsz=17,wght=400:111 opsz=17,wght=700:116) (opsz=18,wght=400:0 opsz=18,wght=700:-1 opsz=17,wght=400:0 opsz=17,wght=700:-1)> @MC_bottom_arabic;
+markClass twodotshorizontalbelow-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) 0> @MC_bottom_arabic;
+markClass twodotshorizontalbelow_tahabove-ar <anchor (opsz=18,wght=400:115 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:-4 opsz=18,wght=700:30 opsz=17,wght=400:24 opsz=17,wght=700:64)> @MC_bottom_arabic;
+markClass twodotsverticalbelow-ar <anchor (opsz=18,wght=400:52 opsz=18,wght=700:63 opsz=17,wght=400:78 opsz=17,wght=700:84) (opsz=18,wght=400:0 opsz=18,wght=700:4 opsz=17,wght=400:0 opsz=17,wght=700:0)> @MC_bottom_arabic;
+markClass threedotshorizontalbelow-ar <anchor (opsz=18,wght=400:159 opsz=18,wght=700:196 opsz=17,wght=400:219 opsz=17,wght=700:227) 0> @MC_bottom_arabic;
+markClass threedotsupbelow-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) 0> @MC_bottom_arabic;
+markClass threedotsdownbelow-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) 0> @MC_bottom_arabic;
+markClass fourdotsbelow-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) 0> @MC_bottom_arabic;
+markClass hamzabelow-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:131 opsz=17,wght=400:117 opsz=17,wght=700:131) 0> @MC_bottom_arabic;
+markClass wavyhamzabelow-ar <anchor (opsz=18,wght=400:142 opsz=18,wght=700:199 opsz=17,wght=400:162 opsz=17,wght=700:199) 0> @MC_bottom_arabic;
+markClass vbelow-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) 0> @MC_bottom_arabic;
+markClass vinvertedbelow-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) 0> @MC_bottom_arabic;
+markClass ring-ar <anchor (opsz=18,wght=400:97 opsz=18,wght=700:101 opsz=17,wght=400:97 opsz=17,wght=700:101) (opsz=18,wght=400:-57 opsz=18,wght=700:-54 opsz=17,wght=400:-32 opsz=17,wght=700:-30)> @MC_bottom_arabic;
+markClass fourbelow-ar <anchor 86 (opsz=18,wght=400:-20 opsz=18,wght=700:-33 opsz=17,wght=400:-20 opsz=17,wght=700:-33)> @MC_bottom_arabic;
+markClass doubleverticalbarbelow-ar <anchor (opsz=18,wght=400:80 opsz=18,wght=700:86 opsz=17,wght=400:80 opsz=17,wght=700:86) 0> @MC_bottom_arabic;
+markClass tahbelow-ar <anchor (opsz=18,wght=400:115 opsz=18,wght=700:121 opsz=17,wght=400:115 opsz=17,wght=700:121) 0> @MC_bottom_arabic;
+markClass rounddotattachedbelow-ar <anchor (opsz=18,wght=400:74 opsz=18,wght=700:82 opsz=17,wght=400:74 opsz=17,wght=700:82) (opsz=18,wght=400:-130 opsz=18,wght=700:-120 opsz=17,wght=400:-130 opsz=17,wght=700:-120)> @MC_bottom_arabic;
+markClass kasraattached-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) (opsz=18,wght=400:-172 opsz=18,wght=700:-193 opsz=17,wght=400:-172 opsz=17,wght=700:-193)> @MC_bottom_arabic;
+markClass kasraattachedright-ar <anchor (opsz=18,wght=400:40 opsz=18,wght=700:64 opsz=17,wght=400:40 opsz=17,wght=700:64) (opsz=18,wght=400:-185 opsz=18,wght=700:-203 opsz=17,wght=400:-185 opsz=17,wght=700:-203)> @MC_bottom_arabic;
+markClass ringbelow-ar <anchor (opsz=18,wght=400:97 opsz=18,wght=700:101 opsz=17,wght=400:97 opsz=17,wght=700:101) (opsz=18,wght=400:-164 opsz=18,wght=700:-174 opsz=17,wght=400:-163 opsz=17,wght=700:-174)> @MC_bottom_arabic;
+markClass hehgoalMark-ar <anchor (opsz=18,wght=400:81 opsz=18,wght=700:113 opsz=17,wght=400:81 opsz=17,wght=700:113) 0> @MC_bottom_arabic;
+markClass kasra-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 0> @MC_bottom_arabic;
+markClass kasratan-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 0> @MC_bottom_arabic;
+markClass openkasratan-ar <anchor (opsz=18,wght=400:150 opsz=18,wght=700:159 opsz=17,wght=400:150 opsz=17,wght=700:159) 0> @MC_bottom_arabic;
+markClass kasraDotbelow-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 50> @MC_bottom_arabic;
+markClass kasrasmall-ar <anchor 84 0> @MC_bottom_arabic;
+markClass kasraCurly-ar <anchor (opsz=18,wght=400:106 opsz=18,wght=700:122 opsz=17,wght=400:106 opsz=17,wght=700:122) 0> @MC_bottom_arabic;
+markClass kasratanCurly-ar <anchor (opsz=18,wght=400:106 opsz=18,wght=700:122 opsz=17,wght=400:106 opsz=17,wght=700:122) 0> @MC_bottom_arabic;
+markClass dammaturnedbelow-ar <anchor (opsz=18,wght=400:109 opsz=18,wght=700:115 opsz=17,wght=400:109 opsz=17,wght=700:115) 0> @MC_bottom_arabic;
+markClass sukunbelow-ar <anchor (opsz=18,wght=400:84 opsz=18,wght=700:88 opsz=17,wght=400:84 opsz=17,wght=700:88) 0> @MC_bottom_arabic;
+markClass toneloopbelow-ar <anchor (opsz=18,wght=400:102 opsz=18,wght=700:120 opsz=17,wght=400:102 opsz=17,wght=700:120) 0> @MC_bottom_arabic;
+markClass leftarrowheadbelow-ar <anchor (opsz=18,wght=400:75 opsz=18,wght=700:74 opsz=17,wght=400:75 opsz=17,wght=700:74) 0> @MC_bottom_arabic;
+markClass rightarrowheadbelow-ar <anchor (opsz=18,wght=400:75 opsz=18,wght=700:74 opsz=17,wght=400:75 opsz=17,wght=700:74) 0> @MC_bottom_arabic;
+markClass toneonedotbelow-ar <anchor (opsz=18,wght=400:39 opsz=18,wght=700:44 opsz=17,wght=400:39 opsz=17,wght=700:44) 0> @MC_bottom_arabic;
+markClass tonetwodotsbelow-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 0> @MC_bottom_arabic;
+markClass rhombusStopbelow-ar <anchor (opsz=18,wght=400:85 opsz=18,wght=700:112 opsz=17,wght=400:85 opsz=17,wght=700:112) 0> @MC_bottom_arabic;
+markClass rounddotbelow-ar <anchor (opsz=18,wght=400:70 opsz=18,wght=700:73 opsz=17,wght=400:70 opsz=17,wght=700:73) 0> @MC_bottom_arabic;
+markClass largerounddotbelow-ar <anchor (opsz=18,wght=400:114 opsz=18,wght=700:126 opsz=17,wght=400:114 opsz=17,wght=700:126) 0> @MC_bottom_arabic;
+markClass circlebelow-ar <anchor (opsz=18,wght=400:124 opsz=18,wght=700:141 opsz=17,wght=400:124 opsz=17,wght=700:141) 0> @MC_bottom_arabic;
+markClass dotcirclebelow-ar <anchor (opsz=18,wght=400:124 opsz=18,wght=700:141 opsz=17,wght=400:124 opsz=17,wght=700:141) 0> @MC_bottom_arabic;
+markClass alefbelow-ar <anchor (opsz=18,wght=400:32 opsz=18,wght=700:43 opsz=17,wght=400:33 opsz=17,wght=700:43) 0> @MC_bottom_arabic;
+markClass meembelow-ar <anchor (opsz=18,wght=400:91 opsz=18,wght=700:101 opsz=17,wght=400:91 opsz=17,wght=700:101) 0> @MC_bottom_arabic;
+markClass wawbelow-ar <anchor (opsz=18,wght=400:83 opsz=18,wght=700:96 opsz=17,wght=400:83 opsz=17,wght=700:96) 0> @MC_bottom_arabic;
+markClass noonKasrabelow-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 0> @MC_bottom_arabic;
+markClass seenbelow-ar <anchor (opsz=18,wght=400:177 opsz=18,wght=700:189 opsz=17,wght=400:177 opsz=17,wght=700:189) 0> @MC_bottom_arabic;
+markClass meembelow-ar <anchor (opsz=18,wght=400:181 opsz=18,wght=700:201 opsz=17,wght=400:181 opsz=17,wght=700:201) (opsz=18,wght=400:-290 opsz=18,wght=700:-300 opsz=17,wght=400:-290 opsz=17,wght=700:-300)> @MC_bottom.meem_arabic;
+markClass kasraattachedright-ar <anchor (opsz=18,wght=400:40 opsz=18,wght=700:64 opsz=17,wght=400:40 opsz=17,wght=700:64) (opsz=18,wght=400:-185 opsz=18,wght=700:-203 opsz=17,wght=400:-185 opsz=17,wght=700:-203)> @MC_bottom.right_arabic;
+markClass dotcenter-ar <anchor (opsz=18,wght=400:52 opsz=18,wght=700:64 opsz=17,wght=400:78 opsz=17,wght=700:84) (opsz=18,wght=400:0 opsz=18,wght=700:0 opsz=17,wght=400:-1 opsz=17,wght=700:0)> @MC_center_arabic;
+markClass dotcenter-ar.alt <anchor (opsz=18,wght=400:52 opsz=18,wght=700:64 opsz=17,wght=400:78 opsz=17,wght=700:76) 0> @MC_center_arabic;
+markClass dotcenter_threedotsdownbelow-ar <anchor (opsz=18,wght=400:79 opsz=18,wght=700:97 opsz=17,wght=400:111 opsz=17,wght=700:116) (opsz=18,wght=400:0 opsz=18,wght=700:0 opsz=17,wght=400:-16 opsz=17,wght=700:-15)> @MC_center_arabic;
+markClass twodotshorizontalcenter-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:0 opsz=18,wght=700:0 opsz=17,wght=400:-1 opsz=17,wght=700:0)> @MC_center_arabic;
+markClass twodotshorizontalcenter_tahabove-ar <anchor (opsz=18,wght=400:104 opsz=18,wght=700:107 opsz=17,wght=400:109 opsz=17,wght=700:106) (opsz=18,wght=400:-4 opsz=18,wght=700:-5 opsz=17,wght=400:-3 opsz=17,wght=700:-3)> @MC_center_arabic;
+markClass twodotsverticalcenter-ar <anchor (opsz=18,wght=400:52 opsz=18,wght=700:63 opsz=17,wght=400:78 opsz=17,wght=700:84) (opsz=18,wght=400:0 opsz=18,wght=700:2 opsz=17,wght=400:0 opsz=17,wght=700:0)> @MC_center_arabic;
+markClass threedotsupcenter-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:0 opsz=18,wght=700:0 opsz=17,wght=400:-1 opsz=17,wght=700:5)> @MC_center_arabic;
+markClass threedotsdowncenter-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:113 opsz=17,wght=400:148 opsz=17,wght=700:135) (opsz=18,wght=400:0 opsz=18,wght=700:-1 opsz=17,wght=400:1 opsz=17,wght=700:0)> @MC_center_arabic;
+markClass fourdotscenter-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:0 opsz=18,wght=700:1 opsz=17,wght=400:-1 opsz=17,wght=700:1)> @MC_center_arabic;
+markClass vinvertedcenter-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) 0> @MC_center_arabic;
+markClass fourcenter-ar <anchor 97 (opsz=18,wght=400:-23 opsz=18,wght=700:-29 opsz=17,wght=400:-23 opsz=17,wght=700:-29)> @MC_center_arabic;
+markClass tahcenter-ar <anchor (opsz=18,wght=400:115 opsz=18,wght=700:121 opsz=17,wght=400:115 opsz=17,wght=700:121) 0> @MC_center_arabic;
+markClass gafsarkashcenter-ar <anchor (opsz=18,wght=400:112 opsz=18,wght=700:102 opsz=17,wght=400:112 opsz=17,wght=700:102) (opsz=18,wght=400:712 opsz=18,wght=700:725 opsz=17,wght=400:712 opsz=17,wght=700:725)> @MC_center_arabic;
+markClass zero.mark <anchor 0 0> @MC_digits_arabic;
+markClass one.mark <anchor 0 0> @MC_digits_arabic;
+markClass two.mark <anchor 0 0> @MC_digits_arabic;
+markClass three.mark <anchor 0 0> @MC_digits_arabic;
+markClass four.mark <anchor 0 0> @MC_digits_arabic;
+markClass five.mark <anchor 0 0> @MC_digits_arabic;
+markClass six.mark <anchor 0 0> @MC_digits_arabic;
+markClass seven.mark <anchor 0 0> @MC_digits_arabic;
+markClass eight.mark <anchor 0 0> @MC_digits_arabic;
+markClass nine.mark <anchor 0 0> @MC_digits_arabic;
+markClass zero-ar.mark <anchor 0 0> @MC_digits_arabic;
+markClass one-ar.mark <anchor 0 0> @MC_digits_arabic;
+markClass two-ar.mark <anchor 0 0> @MC_digits_arabic;
+markClass three-ar.mark <anchor 0 0> @MC_digits_arabic;
+markClass four-ar.mark <anchor 0 0> @MC_digits_arabic;
+markClass five-ar.mark <anchor 0 0> @MC_digits_arabic;
+markClass six-ar.mark <anchor 0 0> @MC_digits_arabic;
+markClass seven-ar.mark <anchor 0 0> @MC_digits_arabic;
+markClass eight-ar.mark <anchor 0 0> @MC_digits_arabic;
+markClass nine-ar.mark <anchor 0 0> @MC_digits_arabic;
+markClass zero-persian.alt.mark <anchor 0 0> @MC_digits_arabic;
+markClass two-persian.mark <anchor 0 0> @MC_digits_arabic;
+markClass four-persian.mark <anchor 0 0> @MC_digits_arabic;
+markClass four-persian.alt.mark <anchor 0 0> @MC_digits_arabic;
+markClass five-persian.mark <anchor 0 0> @MC_digits_arabic;
+markClass six-persian.mark <anchor 0 0> @MC_digits_arabic;
+markClass seven-persian.mark <anchor 0 0> @MC_digits_arabic;
+markClass seven-persian.alt.mark <anchor 0 0> @MC_digits_arabic;
+markClass zero.small <anchor 0 0> @MC_digits_arabic;
+markClass one.small <anchor 0 0> @MC_digits_arabic;
+markClass two.small <anchor 0 0> @MC_digits_arabic;
+markClass three.small <anchor 0 0> @MC_digits_arabic;
+markClass four.small <anchor 0 0> @MC_digits_arabic;
+markClass five.small <anchor 0 0> @MC_digits_arabic;
+markClass six.small <anchor 0 0> @MC_digits_arabic;
+markClass seven.small <anchor 0 0> @MC_digits_arabic;
+markClass eight.small <anchor 0 0> @MC_digits_arabic;
+markClass nine.small <anchor 0 0> @MC_digits_arabic;
+markClass zero-ar.small <anchor 0 0> @MC_digits_arabic;
+markClass one-ar.small <anchor 0 0> @MC_digits_arabic;
+markClass two-ar.small <anchor 0 0> @MC_digits_arabic;
+markClass three-ar.small <anchor 0 0> @MC_digits_arabic;
+markClass four-ar.small <anchor 0 0> @MC_digits_arabic;
+markClass five-ar.small <anchor 0 0> @MC_digits_arabic;
+markClass six-ar.small <anchor 0 0> @MC_digits_arabic;
+markClass seven-ar.small <anchor 0 0> @MC_digits_arabic;
+markClass eight-ar.small <anchor 0 0> @MC_digits_arabic;
+markClass nine-ar.small <anchor 0 0> @MC_digits_arabic;
+markClass zero-persian.alt.small <anchor 0 0> @MC_digits_arabic;
+markClass two-persian.small <anchor 0 0> @MC_digits_arabic;
+markClass four-persian.small <anchor 0 0> @MC_digits_arabic;
+markClass four-persian.alt.small <anchor 0 0> @MC_digits_arabic;
+markClass five-persian.small <anchor 0 0> @MC_digits_arabic;
+markClass six-persian.small <anchor 0 0> @MC_digits_arabic;
+markClass seven-persian.small <anchor 0 0> @MC_digits_arabic;
+markClass seven-persian.alt.small <anchor 0 0> @MC_digits_arabic;
+markClass hamzafloating-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:131 opsz=17,wght=400:117 opsz=17,wght=700:131) (opsz=18,wght=400:641 opsz=18,wght=700:638 opsz=17,wght=400:638 opsz=17,wght=700:628)> @MC_float_arabic;
+markClass ringcenter-ar <anchor (opsz=18,wght=400:97 opsz=18,wght=700:101 opsz=17,wght=400:97 opsz=17,wght=700:101) (opsz=18,wght=400:-1 opsz=18,wght=700:0 opsz=17,wght=400:-1 opsz=17,wght=700:0)> @MC_ring_arabic;
+markClass seenabove-ar <anchor 218 1060> @MC_seen_arabic;
+markClass rounddotattachedleft-ar <anchor (opsz=18,wght=400:169 opsz=18,wght=700:191 opsz=17,wght=400:169 opsz=17,wght=700:191) 431> @MC_stroke_arabic;
+markClass rounddotattachedright-ar <anchor (opsz=18,wght=400:-26 opsz=18,wght=700:-53 opsz=17,wght=400:-26 opsz=17,wght=700:-53) 431> @MC_stroke_arabic;
+markClass hamzaattachedleft-ar <anchor (opsz=18,wght=400:214 opsz=18,wght=700:301 opsz=17,wght=400:250 opsz=17,wght=700:301) (opsz=18,wght=400:421 opsz=18,wght=700:441 opsz=17,wght=400:428 opsz=17,wght=700:441)> @MC_stroke_arabic;
+markClass hamzaattachedright-ar <anchor -6 (opsz=18,wght=400:430 opsz=18,wght=700:441 opsz=17,wght=400:431 opsz=17,wght=700:441)> @MC_stroke_arabic;
+markClass ringattachedleft-ar <anchor 191 438> @MC_stroke_arabic;
+markClass strokeleft-ar <anchor (opsz=18,wght=400:165 opsz=18,wght=700:168 opsz=17,wght=400:165 opsz=17,wght=700:168) 471> @MC_stroke_arabic;
+markClass strokeright-ar <anchor (opsz=18,wght=400:31 opsz=18,wght=700:43 opsz=17,wght=400:31 opsz=17,wght=700:43) 471> @MC_stroke_arabic;
+markClass stroke-ar <anchor (opsz=18,wght=400:152 opsz=18,wght=700:213 opsz=17,wght=400:152 opsz=17,wght=700:213) (opsz=18,wght=400:547 opsz=18,wght=700:559 opsz=17,wght=400:547 opsz=17,wght=700:559)> @MC_stroke_arabic;
+markClass doublestroke-ar <anchor (opsz=18,wght=400:152 opsz=18,wght=700:213 opsz=17,wght=400:152 opsz=17,wght=700:213) (opsz=18,wght=400:599 opsz=18,wght=700:621 opsz=17,wght=400:599 opsz=17,wght=700:621)> @MC_stroke_arabic;
+markClass hamzaattachedleft-ar <anchor (opsz=18,wght=400:214 opsz=18,wght=700:300 opsz=17,wght=400:250 opsz=17,wght=700:301) (opsz=18,wght=400:421 opsz=18,wght=700:441 opsz=17,wght=400:428 opsz=17,wght=700:441)> @MC_stroke.left_arabic;
+markClass ringattachedleft-ar <anchor 191 438> @MC_stroke.left_arabic;
+markClass strokeleft-ar <anchor (opsz=18,wght=400:165 opsz=18,wght=700:168 opsz=17,wght=400:165 opsz=17,wght=700:168) 471> @MC_stroke.left_arabic;
+markClass tail-ar <anchor (opsz=18,wght=400:231 opsz=18,wght=700:274 opsz=17,wght=400:231 opsz=17,wght=700:274) 308> @MC_tail_arabic;
+markClass dotabove-ar <anchor (opsz=18,wght=400:52 opsz=18,wght=700:64 opsz=17,wght=400:78 opsz=17,wght=700:84) (opsz=18,wght=400:400 opsz=18,wght=700:400 opsz=17,wght=400:399 opsz=17,wght=700:400)> @MC_top_arabic;
+markClass dotabove_threedotsupabove-ar <anchor (opsz=18,wght=400:79 opsz=18,wght=700:97 opsz=17,wght=400:111 opsz=17,wght=700:116) 400> @MC_top_arabic;
+markClass dotabove_vabove-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) 400> @MC_top_arabic;
+markClass dotabove_vinvertedabove-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) 400> @MC_top_arabic;
+markClass dotabove_tahabove-ar <anchor (opsz=18,wght=400:115 opsz=18,wght=700:121 opsz=17,wght=400:115 opsz=17,wght=700:121) 400> @MC_top_arabic;
+markClass twodotshorizontalabove-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:129 opsz=17,wght=400:148 opsz=17,wght=700:155) 400> @MC_top_arabic;
+markClass twodotshorizontalabove_vabove-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) 400> @MC_top_arabic;
+markClass twodotshorizontalabove_tahabove-ar <anchor (opsz=18,wght=400:115 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) 400> @MC_top_arabic;
+markClass twodotsverticalabove-ar <anchor (opsz=18,wght=400:52 opsz=18,wght=700:63 opsz=17,wght=400:79 opsz=17,wght=700:84) 400> @MC_top_arabic;
+markClass threedotshorizontalabove-ar <anchor (opsz=18,wght=400:158 opsz=18,wght=700:195 opsz=17,wght=400:218 opsz=17,wght=700:227) 400> @MC_top_arabic;
+markClass threedotsupabove-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) 400> @MC_top_arabic;
+markClass threedotsdownabove-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:400 opsz=18,wght=700:400 opsz=17,wght=400:400 opsz=17,wght=700:390)> @MC_top_arabic;
+markClass fourdotsabove-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) 400> @MC_top_arabic;
+markClass hamzaabove-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:131 opsz=17,wght=400:110 opsz=17,wght=700:131) (opsz=18,wght=400:608 opsz=18,wght=700:608 opsz=17,wght=400:607 opsz=17,wght=700:608)> @MC_top_arabic;
+markClass wavyhamzaabove-ar <anchor (opsz=18,wght=400:124 opsz=18,wght=700:164 opsz=17,wght=400:146 opsz=17,wght=700:164) (opsz=18,wght=400:406 opsz=18,wght=700:409 opsz=17,wght=400:407 opsz=17,wght=700:409)> @MC_top_arabic;
+markClass wasla-ar <anchor (opsz=18,wght=400:141 opsz=18,wght=700:158 opsz=17,wght=400:141 opsz=17,wght=700:158) 402> @MC_top_arabic;
+markClass madda-ar <anchor (opsz=18,wght=400:136 opsz=18,wght=700:155 opsz=17,wght=400:136 opsz=17,wght=700:155) (opsz=18,wght=400:402 opsz=18,wght=700:429 opsz=17,wght=400:402 opsz=17,wght=700:429)> @MC_top_arabic;
+markClass vabove-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) 401> @MC_top_arabic;
+markClass vinvertedabove-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) 401> @MC_top_arabic;
+markClass gafsarkashabove-ar <anchor (opsz=18,wght=400:173 opsz=18,wght=700:199 opsz=17,wght=400:173 opsz=17,wght=700:199) (opsz=18,wght=400:497 opsz=18,wght=700:503 opsz=17,wght=400:497 opsz=17,wght=700:503)> @MC_top_arabic;
+markClass gafsarkashabove-ar.short <anchor (opsz=18,wght=400:163 opsz=18,wght=700:149 opsz=17,wght=400:163 opsz=17,wght=700:149) (opsz=18,wght=400:474 opsz=18,wght=700:453 opsz=17,wght=400:474 opsz=17,wght=700:453)> @MC_top_arabic;
+markClass grafsarkashabove-ar <anchor (opsz=18,wght=400:173 opsz=18,wght=700:199 opsz=17,wght=400:173 opsz=17,wght=700:199) (opsz=18,wght=400:497 opsz=18,wght=700:503 opsz=17,wght=400:497 opsz=17,wght=700:503)> @MC_top_arabic;
+markClass grafsarkashabove-ar.short <anchor (opsz=18,wght=400:163 opsz=18,wght=700:149 opsz=17,wght=400:163 opsz=17,wght=700:149) (opsz=18,wght=400:474 opsz=18,wght=700:453 opsz=17,wght=400:474 opsz=17,wght=700:453)> @MC_top_arabic;
+markClass commaabove-ar <anchor (opsz=18,wght=400:60 opsz=18,wght=700:77 opsz=17,wght=400:60 opsz=17,wght=700:77) 492> @MC_top_arabic;
+markClass twoabove-ar <anchor (opsz=18,wght=400:69 opsz=18,wght=700:75 opsz=17,wght=400:69 opsz=17,wght=700:75) 407> @MC_top_arabic;
+markClass threeabove-ar <anchor (opsz=18,wght=400:100 opsz=18,wght=700:105 opsz=17,wght=400:100 opsz=17,wght=700:105) 407> @MC_top_arabic;
+markClass fourabove-ar <anchor (opsz=18,wght=400:90 opsz=18,wght=700:94 opsz=17,wght=400:90 opsz=17,wght=700:94) 407> @MC_top_arabic;
+markClass tahabove-ar <anchor (opsz=18,wght=400:114 opsz=18,wght=700:121 opsz=17,wght=400:114 opsz=17,wght=700:121) 400> @MC_top_arabic;
+markClass tahabove_vabove-ar <anchor (opsz=18,wght=400:115 opsz=18,wght=700:95 opsz=17,wght=400:115 opsz=17,wght=700:95) (opsz=18,wght=400:419 opsz=18,wght=700:406 opsz=17,wght=400:419 opsz=17,wght=700:406)> @MC_top_arabic;
+markClass tehabove-ar <anchor (opsz=18,wght=400:138 opsz=18,wght=700:143 opsz=17,wght=400:138 opsz=17,wght=700:143) 408> @MC_top_arabic;
+markClass noonabove-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:110 opsz=17,wght=400:105 opsz=17,wght=700:110) 408> @MC_top_arabic;
+markClass dotbelow_threedotsdownbelow-ar <anchor (opsz=18,wght=400:79 opsz=18,wght=700:97 opsz=17,wght=400:111 opsz=17,wght=700:116) 0> @MC_top_arabic;
+markClass twodotshorizontalbelow_tahabove-ar <anchor (opsz=18,wght=400:115 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:-564 opsz=18,wght=700:-597 opsz=17,wght=400:-590 opsz=17,wght=700:-603)> @MC_top_arabic;
+markClass rounddotattachedabove-ar <anchor (opsz=18,wght=400:70 opsz=18,wght=700:73 opsz=17,wght=400:70 opsz=17,wght=700:73) (opsz=18,wght=400:680 opsz=18,wght=700:676 opsz=17,wght=400:680 opsz=17,wght=700:676)> @MC_top_arabic;
+markClass fathaattached-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 716> @MC_top_arabic;
+markClass fathaattachedright-ar <anchor (opsz=18,wght=400:40 opsz=18,wght=700:64 opsz=17,wght=400:40 opsz=17,wght=700:64) (opsz=18,wght=400:709 opsz=18,wght=700:731 opsz=17,wght=400:709 opsz=17,wght=700:731)> @MC_top_arabic;
+markClass miniKeheh-ar <anchor (opsz=18,wght=400:79 opsz=18,wght=700:93 opsz=17,wght=400:79 opsz=17,wght=700:93) (opsz=18,wght=400:512 opsz=18,wght=700:510 opsz=17,wght=400:512 opsz=17,wght=700:510)> @MC_top_arabic;
+markClass hamzaaboveMark-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:131 opsz=17,wght=400:117 opsz=17,wght=700:131) 608> @MC_top_arabic;
+markClass maddaMark-ar <anchor (opsz=18,wght=400:136 opsz=18,wght=700:155 opsz=17,wght=400:136 opsz=17,wght=700:155) (opsz=18,wght=400:608 opsz=18,wght=700:635 opsz=17,wght=400:608 opsz=17,wght=700:635)> @MC_top_arabic;
+markClass vaboveMark-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) 607> @MC_top_arabic;
+markClass vinvertedaboveMark-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) 607> @MC_top_arabic;
+markClass shadda-ar <anchor (opsz=18,wght=400:103 opsz=18,wght=700:119 opsz=17,wght=400:113 opsz=17,wght=700:131) (opsz=18,wght=400:594 opsz=18,wght=700:592 opsz=17,wght=400:582 opsz=17,wght=700:592)> @MC_top_arabic;
+markClass fatha-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 606> @MC_top_arabic;
+markClass damma-ar <anchor (opsz=18,wght=400:96 opsz=18,wght=700:107 opsz=17,wght=400:96 opsz=17,wght=700:107) (opsz=18,wght=400:607 opsz=18,wght=700:606 opsz=17,wght=400:607 opsz=17,wght=700:606)> @MC_top_arabic;
+markClass dammainverted-ar <anchor (opsz=18,wght=400:85 opsz=18,wght=700:107 opsz=17,wght=400:96 opsz=17,wght=700:107) 606> @MC_top_arabic;
+markClass dammainverted-ar.alt <anchor (opsz=18,wght=400:60 opsz=18,wght=700:77 opsz=17,wght=400:60 opsz=17,wght=700:77) 606> @MC_top_arabic;
+markClass dammareversed-ar <anchor (opsz=18,wght=400:96 opsz=18,wght=700:107 opsz=17,wght=400:84 opsz=17,wght=700:107) (opsz=18,wght=400:606 opsz=18,wght=700:581 opsz=17,wght=400:716 opsz=17,wght=700:581)> @MC_top_arabic;
+markClass fathatan-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 606> @MC_top_arabic;
+markClass dammatan-ar <anchor (opsz=18,wght=400:141 opsz=18,wght=700:149 opsz=17,wght=400:141 opsz=17,wght=700:149) (opsz=18,wght=400:607 opsz=18,wght=700:606 opsz=17,wght=400:607 opsz=17,wght=700:606)> @MC_top_arabic;
+markClass openfathatan-ar <anchor (opsz=18,wght=400:150 opsz=18,wght=700:159 opsz=17,wght=400:150 opsz=17,wght=700:159) 606> @MC_top_arabic;
+markClass opendammatan-ar <anchor (opsz=18,wght=400:183 opsz=18,wght=700:214 opsz=17,wght=400:183 opsz=17,wght=700:214) (opsz=18,wght=400:607 opsz=18,wght=700:606 opsz=17,wght=400:607 opsz=17,wght=700:606)> @MC_top_arabic;
+markClass sukun-ar <anchor (opsz=18,wght=400:84 opsz=18,wght=700:88 opsz=17,wght=400:84 opsz=17,wght=700:88) 606> @MC_top_arabic;
+markClass fathasmall-ar <anchor (opsz=18,wght=400:79 opsz=18,wght=700:84 opsz=17,wght=400:79 opsz=17,wght=700:84) 605> @MC_top_arabic;
+markClass dammasmall-ar <anchor (opsz=18,wght=400:76 opsz=18,wght=700:84 opsz=17,wght=400:76 opsz=17,wght=700:84) (opsz=18,wght=400:607 opsz=18,wght=700:603 opsz=17,wght=400:607 opsz=17,wght=700:603)> @MC_top_arabic;
+markClass fathaCurly-ar <anchor (opsz=18,wght=400:106 opsz=18,wght=700:122 opsz=17,wght=400:106 opsz=17,wght=700:122) 606> @MC_top_arabic;
+markClass dammaCurly-ar <anchor (opsz=18,wght=400:118 opsz=18,wght=700:130 opsz=17,wght=400:118 opsz=17,wght=700:130) (opsz=18,wght=400:590 opsz=18,wght=700:589 opsz=17,wght=400:590 opsz=17,wght=700:589)> @MC_top_arabic;
+markClass fathatanCurly-ar <anchor (opsz=18,wght=400:106 opsz=18,wght=700:122 opsz=17,wght=400:106 opsz=17,wght=700:122) 606> @MC_top_arabic;
+markClass dammatanCurly-ar <anchor (opsz=18,wght=400:164 opsz=18,wght=700:188 opsz=17,wght=400:164 opsz=17,wght=700:188) (opsz=18,wght=400:590 opsz=18,wght=700:589 opsz=17,wght=400:590 opsz=17,wght=700:589)> @MC_top_arabic;
+markClass dammaDot-ar <anchor (opsz=18,wght=400:137 opsz=18,wght=700:147 opsz=17,wght=400:137 opsz=17,wght=700:147) 606> @MC_top_arabic;
+markClass fathaHorizont-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 606> @MC_top_arabic;
+markClass fathatwodots-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 606> @MC_top_arabic;
+markClass fathaDotabove-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 606> @MC_top_arabic;
+markClass fathaRing-ar <anchor (opsz=18,wght=400:102 opsz=18,wght=700:120 opsz=17,wght=400:102 opsz=17,wght=700:107) 606> @MC_top_arabic;
+markClass noonghunnaabove-ar <anchor (opsz=18,wght=400:62 opsz=18,wght=700:70 opsz=17,wght=400:62 opsz=17,wght=700:70) 606> @MC_top_arabic;
+markClass noonghunnaabovesideways-ar <anchor (opsz=18,wght=400:65 opsz=18,wght=700:74 opsz=17,wght=400:65 opsz=17,wght=700:74) 606> @MC_top_arabic;
+markClass toneloopabove-ar <anchor (opsz=18,wght=400:102 opsz=18,wght=700:120 opsz=17,wght=400:102 opsz=17,wght=700:120) 606> @MC_top_arabic;
+markClass leftarrowheadabove-ar <anchor (opsz=18,wght=400:75 opsz=18,wght=700:74 opsz=17,wght=400:75 opsz=17,wght=700:74) 606> @MC_top_arabic;
+markClass rightarrowheadabove-ar <anchor (opsz=18,wght=400:75 opsz=18,wght=700:74 opsz=17,wght=400:75 opsz=17,wght=700:74) 606> @MC_top_arabic;
+markClass doublerightarrowheadabove-ar <anchor 151 606> @MC_top_arabic;
+markClass doublerightarrowheadDotabove-ar <anchor 208 606> @MC_top_arabic;
+markClass rightarrowheadDotabove-ar <anchor (opsz=18,wght=400:122 opsz=18,wght=700:126 opsz=17,wght=400:127 opsz=17,wght=700:130) 606> @MC_top_arabic;
+markClass toneonedotabove-ar <anchor (opsz=18,wght=400:38 opsz=18,wght=700:44 opsz=17,wght=400:38 opsz=17,wght=700:44) 606> @MC_top_arabic;
+markClass tonetwodotsabove-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 606> @MC_top_arabic;
+markClass sukunoval-ar <anchor (opsz=18,wght=400:84 opsz=18,wght=700:88 opsz=17,wght=400:84 opsz=17,wght=700:88) 666> @MC_top_arabic;
+markClass sukunround-ar <anchor (opsz=18,wght=400:84 opsz=18,wght=700:93 opsz=17,wght=400:84 opsz=17,wght=700:93) (opsz=18,wght=400:649 opsz=18,wght=700:643 opsz=17,wght=400:649 opsz=17,wght=700:643)> @MC_top_arabic;
+markClass jazm-ar <anchor (opsz=18,wght=400:100 opsz=18,wght=700:110 opsz=17,wght=400:100 opsz=17,wght=700:110) 606> @MC_top_arabic;
+markClass rhombusStopabove-ar <anchor (opsz=18,wght=400:85 opsz=18,wght=700:112 opsz=17,wght=400:85 opsz=17,wght=700:112) 606> @MC_top_arabic;
+markClass rounddotabove-ar <anchor (opsz=18,wght=400:70 opsz=18,wght=700:73 opsz=17,wght=400:70 opsz=17,wght=700:73) 606> @MC_top_arabic;
+markClass largerounddotabove-ar <anchor (opsz=18,wght=400:114 opsz=18,wght=700:126 opsz=17,wght=400:114 opsz=17,wght=700:126) 606> @MC_top_arabic;
+markClass maddalong-ar <anchor (opsz=18,wght=400:146 opsz=18,wght=700:165 opsz=17,wght=400:146 opsz=17,wght=700:165) 605> @MC_top_arabic;
+markClass doubleMadda-ar <anchor (opsz=18,wght=400:156 opsz=18,wght=700:185 opsz=17,wght=400:156 opsz=17,wght=700:185) 605> @MC_top_arabic;
+markClass doubleHafmadda-ar <anchor (opsz=18,wght=400:156 opsz=18,wght=700:185 opsz=17,wght=400:156 opsz=17,wght=700:185) 605> @MC_top_arabic;
+markClass maddaWaajib-ar <anchor (opsz=18,wght=400:150 opsz=18,wght=700:177 opsz=17,wght=400:150 opsz=17,wght=700:177) 605> @MC_top_arabic;
+markClass alefabove-ar <anchor (opsz=18,wght=400:33 opsz=18,wght=700:43 opsz=17,wght=400:22 opsz=17,wght=700:33) (opsz=18,wght=400:573 opsz=18,wght=700:579 opsz=17,wght=400:573 opsz=17,wght=700:579)> @MC_top_arabic;
+markClass alefMokhassas-ar <anchor (opsz=18,wght=400:180 opsz=18,wght=700:195 opsz=17,wght=400:180 opsz=17,wght=700:195) 573> @MC_top_arabic;
+markClass zahabove-ar <anchor (opsz=18,wght=400:115 opsz=18,wght=700:121 opsz=17,wght=400:115 opsz=17,wght=700:121) 606> @MC_top_arabic;
+markClass meemabove-ar <anchor (opsz=18,wght=400:91 opsz=18,wght=700:101 opsz=17,wght=400:91 opsz=17,wght=700:101) (opsz=18,wght=400:607 opsz=18,wght=700:603 opsz=17,wght=400:607 opsz=17,wght=700:603)> @MC_top_arabic;
+markClass wawabove-ar <anchor (opsz=18,wght=400:84 opsz=18,wght=700:94 opsz=17,wght=400:84 opsz=17,wght=700:107) (opsz=18,wght=400:607 opsz=18,wght=700:606 opsz=17,wght=400:607 opsz=17,wght=700:606)> @MC_top_arabic;
+markClass yehabove-farsi <anchor (opsz=18,wght=400:131 opsz=18,wght=700:138 opsz=17,wght=400:131 opsz=17,wght=700:138) 606> @MC_top_arabic;
+markClass yehabove-ar <anchor (opsz=18,wght=400:136 opsz=18,wght=700:142 opsz=17,wght=400:136 opsz=17,wght=700:136) 608> @MC_top_arabic;
+markClass barreyehabove-ar <anchor (opsz=18,wght=400:130 opsz=18,wght=700:140 opsz=17,wght=400:130 opsz=17,wght=700:140) (opsz=18,wght=400:706 opsz=18,wght=700:698 opsz=17,wght=400:706 opsz=17,wght=700:698)> @MC_top_arabic;
+markClass noonKasraabove-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:112 opsz=17,wght=400:105 opsz=17,wght=700:112) 606> @MC_top_arabic;
+markClass rehHahabove-ar <anchor (opsz=18,wght=400:154 opsz=18,wght=700:168 opsz=17,wght=400:154 opsz=17,wght=700:168) 392> @MC_top_arabic;
+markClass rehDadabove-ar <anchor (opsz=18,wght=400:160 opsz=18,wght=700:172 opsz=17,wght=400:160 opsz=17,wght=700:172) 392> @MC_top_arabic;
+markClass sallallahouAlayheWassallamcomb-ar <anchor (opsz=18,wght=400:119 opsz=18,wght=700:122 opsz=17,wght=400:119 opsz=17,wght=700:122) 392> @MC_top_arabic;
+markClass alayheAssallamcomb-ar <anchor (opsz=18,wght=400:118 opsz=18,wght=700:152 opsz=17,wght=400:118 opsz=17,wght=700:152) 392> @MC_top_arabic;
+markClass takhallusabove-ar <anchor (opsz=18,wght=400:120 opsz=18,wght=700:134 opsz=17,wght=400:120 opsz=17,wght=700:134) 392> @MC_top_arabic;
+markClass footnotemarkerabove-ar <anchor (opsz=18,wght=400:151 opsz=18,wght=700:173 opsz=17,wght=400:151 opsz=17,wght=700:173) 606> @MC_top_arabic;
+markClass safhaabove-ar <anchor (opsz=18,wght=400:174 opsz=18,wght=700:181 opsz=17,wght=400:174 opsz=17,wght=700:181) 392> @MC_top_arabic;
+markClass twoabove-ar <anchor (opsz=18,wght=400:129 opsz=18,wght=700:163 opsz=17,wght=400:129 opsz=17,wght=700:163) 510> @MC_top.digits_arabic;
+markClass threeabove-ar <anchor (opsz=18,wght=400:133 opsz=18,wght=700:156 opsz=17,wght=400:133 opsz=17,wght=700:156) 510> @MC_top.digits_arabic;
+markClass meemabove-ar <anchor (opsz=18,wght=400:181 opsz=18,wght=700:201 opsz=17,wght=400:181 opsz=17,wght=700:201) (opsz=18,wght=400:792 opsz=18,wght=700:802 opsz=17,wght=400:792 opsz=17,wght=700:802)> @MC_top.meem_arabic;
+markClass hamzaaboveMark-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:131 opsz=17,wght=400:117 opsz=17,wght=700:131) 708> @MC_top.tashkil_arabic;
+markClass maddaMark-ar <anchor (opsz=18,wght=400:136 opsz=18,wght=700:155 opsz=17,wght=400:136 opsz=17,wght=700:155) (opsz=18,wght=400:708 opsz=18,wght=700:735 opsz=17,wght=400:708 opsz=17,wght=700:735)> @MC_top.tashkil_arabic;
+markClass vaboveMark-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) 707> @MC_top.tashkil_arabic;
+markClass vinvertedaboveMark-ar <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) 707> @MC_top.tashkil_arabic;
+markClass shadda-ar <anchor (opsz=18,wght=400:103 opsz=18,wght=700:119 opsz=17,wght=400:113 opsz=17,wght=700:131) (opsz=18,wght=400:694 opsz=18,wght=700:692 opsz=17,wght=400:692 opsz=17,wght=700:692)> @MC_top.tashkil_arabic;
+markClass fatha-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 706> @MC_top.tashkil_arabic;
+markClass damma-ar <anchor (opsz=18,wght=400:96 opsz=18,wght=700:107 opsz=17,wght=400:96 opsz=17,wght=700:107) (opsz=18,wght=400:707 opsz=18,wght=700:706 opsz=17,wght=400:707 opsz=17,wght=700:706)> @MC_top.tashkil_arabic;
+markClass dammainverted-ar <anchor (opsz=18,wght=400:85 opsz=18,wght=700:107 opsz=17,wght=400:96 opsz=17,wght=700:107) 706> @MC_top.tashkil_arabic;
+markClass dammainverted-ar.alt <anchor (opsz=18,wght=400:60 opsz=18,wght=700:77 opsz=17,wght=400:60 opsz=17,wght=700:77) 706> @MC_top.tashkil_arabic;
+markClass dammareversed-ar <anchor (opsz=18,wght=400:96 opsz=18,wght=700:107 opsz=17,wght=400:84 opsz=17,wght=700:107) (opsz=18,wght=400:706 opsz=18,wght=700:681 opsz=17,wght=400:816 opsz=17,wght=700:681)> @MC_top.tashkil_arabic;
+markClass fathatan-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 706> @MC_top.tashkil_arabic;
+markClass dammatan-ar <anchor (opsz=18,wght=400:141 opsz=18,wght=700:149 opsz=17,wght=400:141 opsz=17,wght=700:149) (opsz=18,wght=400:707 opsz=18,wght=700:706 opsz=17,wght=400:707 opsz=17,wght=700:706)> @MC_top.tashkil_arabic;
+markClass openfathatan-ar <anchor (opsz=18,wght=400:150 opsz=18,wght=700:159 opsz=17,wght=400:150 opsz=17,wght=700:159) 706> @MC_top.tashkil_arabic;
+markClass opendammatan-ar <anchor (opsz=18,wght=400:183 opsz=18,wght=700:214 opsz=17,wght=400:183 opsz=17,wght=700:214) (opsz=18,wght=400:707 opsz=18,wght=700:706 opsz=17,wght=400:707 opsz=17,wght=700:706)> @MC_top.tashkil_arabic;
+markClass sukun-ar <anchor (opsz=18,wght=400:84 opsz=18,wght=700:88 opsz=17,wght=400:84 opsz=17,wght=700:88) 686> @MC_top.tashkil_arabic;
+markClass fathasmall-ar <anchor (opsz=18,wght=400:79 opsz=18,wght=700:84 opsz=17,wght=400:79 opsz=17,wght=700:84) 705> @MC_top.tashkil_arabic;
+markClass dammasmall-ar <anchor (opsz=18,wght=400:76 opsz=18,wght=700:84 opsz=17,wght=400:76 opsz=17,wght=700:84) (opsz=18,wght=400:707 opsz=18,wght=700:703 opsz=17,wght=400:707 opsz=17,wght=700:703)> @MC_top.tashkil_arabic;
+markClass fathaCurly-ar <anchor (opsz=18,wght=400:106 opsz=18,wght=700:122 opsz=17,wght=400:106 opsz=17,wght=700:122) 706> @MC_top.tashkil_arabic;
+markClass dammaCurly-ar <anchor (opsz=18,wght=400:118 opsz=18,wght=700:130 opsz=17,wght=400:118 opsz=17,wght=700:130) (opsz=18,wght=400:690 opsz=18,wght=700:689 opsz=17,wght=400:690 opsz=17,wght=700:689)> @MC_top.tashkil_arabic;
+markClass fathatanCurly-ar <anchor (opsz=18,wght=400:106 opsz=18,wght=700:122 opsz=17,wght=400:106 opsz=17,wght=700:122) 706> @MC_top.tashkil_arabic;
+markClass dammatanCurly-ar <anchor (opsz=18,wght=400:164 opsz=18,wght=700:188 opsz=17,wght=400:164 opsz=17,wght=700:188) (opsz=18,wght=400:690 opsz=18,wght=700:689 opsz=17,wght=400:690 opsz=17,wght=700:689)> @MC_top.tashkil_arabic;
+markClass dammaDot-ar <anchor (opsz=18,wght=400:137 opsz=18,wght=700:147 opsz=17,wght=400:137 opsz=17,wght=700:147) 706> @MC_top.tashkil_arabic;
+markClass fathaHorizont-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 706> @MC_top.tashkil_arabic;
+markClass fathatwodots-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 706> @MC_top.tashkil_arabic;
+markClass fathaDotabove-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 706> @MC_top.tashkil_arabic;
+markClass fathaRing-ar <anchor (opsz=18,wght=400:102 opsz=18,wght=700:120 opsz=17,wght=400:102 opsz=17,wght=700:107) 706> @MC_top.tashkil_arabic;
+markClass noonghunnaabove-ar <anchor (opsz=18,wght=400:62 opsz=18,wght=700:70 opsz=17,wght=400:62 opsz=17,wght=700:70) 706> @MC_top.tashkil_arabic;
+markClass noonghunnaabovesideways-ar <anchor (opsz=18,wght=400:65 opsz=18,wght=700:74 opsz=17,wght=400:65 opsz=17,wght=700:74) 706> @MC_top.tashkil_arabic;
+markClass toneloopabove-ar <anchor (opsz=18,wght=400:102 opsz=18,wght=700:120 opsz=17,wght=400:102 opsz=17,wght=700:120) 706> @MC_top.tashkil_arabic;
+markClass leftarrowheadabove-ar <anchor (opsz=18,wght=400:75 opsz=18,wght=700:74 opsz=17,wght=400:75 opsz=17,wght=700:74) 706> @MC_top.tashkil_arabic;
+markClass rightarrowheadabove-ar <anchor (opsz=18,wght=400:75 opsz=18,wght=700:74 opsz=17,wght=400:75 opsz=17,wght=700:74) 706> @MC_top.tashkil_arabic;
+markClass doublerightarrowheadabove-ar <anchor 151 706> @MC_top.tashkil_arabic;
+markClass doublerightarrowheadDotabove-ar <anchor 208 706> @MC_top.tashkil_arabic;
+markClass rightarrowheadDotabove-ar <anchor (opsz=18,wght=400:122 opsz=18,wght=700:126 opsz=17,wght=400:127 opsz=17,wght=700:130) 706> @MC_top.tashkil_arabic;
+markClass toneonedotabove-ar <anchor (opsz=18,wght=400:38 opsz=18,wght=700:44 opsz=17,wght=400:38 opsz=17,wght=700:44) 706> @MC_top.tashkil_arabic;
+markClass tonetwodotsabove-ar <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) 706> @MC_top.tashkil_arabic;
+markClass jazm-ar <anchor (opsz=18,wght=400:100 opsz=18,wght=700:110 opsz=17,wght=400:100 opsz=17,wght=700:110) 706> @MC_top.tashkil_arabic;
+markClass rhombusStopabove-ar <anchor (opsz=18,wght=400:85 opsz=18,wght=700:112 opsz=17,wght=400:85 opsz=17,wght=700:112) 706> @MC_top.tashkil_arabic;
+markClass rounddotabove-ar <anchor (opsz=18,wght=400:70 opsz=18,wght=700:73 opsz=17,wght=400:70 opsz=17,wght=700:73) 706> @MC_top.tashkil_arabic;
+markClass largerounddotabove-ar <anchor (opsz=18,wght=400:114 opsz=18,wght=700:126 opsz=17,wght=400:114 opsz=17,wght=700:126) 706> @MC_top.tashkil_arabic;
+markClass maddalong-ar <anchor (opsz=18,wght=400:146 opsz=18,wght=700:165 opsz=17,wght=400:146 opsz=17,wght=700:165) 705> @MC_top.tashkil_arabic;
+markClass doubleMadda-ar <anchor (opsz=18,wght=400:156 opsz=18,wght=700:185 opsz=17,wght=400:156 opsz=17,wght=700:185) 705> @MC_top.tashkil_arabic;
+markClass doubleHafmadda-ar <anchor (opsz=18,wght=400:156 opsz=18,wght=700:185 opsz=17,wght=400:156 opsz=17,wght=700:185) 705> @MC_top.tashkil_arabic;
+markClass maddaWaajib-ar <anchor (opsz=18,wght=400:150 opsz=18,wght=700:177 opsz=17,wght=400:150 opsz=17,wght=700:177) 705> @MC_top.tashkil_arabic;
+markClass alefabove-ar <anchor (opsz=18,wght=400:33 opsz=18,wght=700:43 opsz=17,wght=400:22 opsz=17,wght=700:33) (opsz=18,wght=400:673 opsz=18,wght=700:679 opsz=17,wght=400:673 opsz=17,wght=700:679)> @MC_top.tashkil_arabic;
+markClass alefMokhassas-ar <anchor (opsz=18,wght=400:180 opsz=18,wght=700:195 opsz=17,wght=400:180 opsz=17,wght=700:195) 673> @MC_top.tashkil_arabic;
+markClass zahabove-ar <anchor (opsz=18,wght=400:115 opsz=18,wght=700:121 opsz=17,wght=400:115 opsz=17,wght=700:121) 706> @MC_top.tashkil_arabic;
+markClass wawabove-ar <anchor (opsz=18,wght=400:84 opsz=18,wght=700:94 opsz=17,wght=400:84 opsz=17,wght=700:107) (opsz=18,wght=400:707 opsz=18,wght=700:706 opsz=17,wght=400:707 opsz=17,wght=700:706)> @MC_top.tashkil_arabic;
+markClass yehabove-farsi <anchor (opsz=18,wght=400:131 opsz=18,wght=700:138 opsz=17,wght=400:131 opsz=17,wght=700:138) 706> @MC_top.tashkil_arabic;
+markClass noonKasraabove-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:112 opsz=17,wght=400:105 opsz=17,wght=700:112) 706> @MC_top.tashkil_arabic;
+markClass footnotemarkerabove-ar <anchor (opsz=18,wght=400:151 opsz=18,wght=700:173 opsz=17,wght=400:151 opsz=17,wght=700:173) 706> @MC_top.tashkil_arabic;
+markClass barreyehabove-ar <anchor (opsz=18,wght=400:130 opsz=18,wght=700:140 opsz=17,wght=400:130 opsz=17,wght=700:140) (opsz=18,wght=400:639 opsz=18,wght=700:626 opsz=17,wght=400:635 opsz=17,wght=700:633)> @MC_waqf_arabic;
+markClass threedotsabove-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) 1070> @MC_waqf_arabic;
+markClass jeemabove-ar <anchor (opsz=18,wght=400:115 opsz=18,wght=700:130 opsz=17,wght=400:113 opsz=17,wght=700:125) 1070> @MC_waqf_arabic;
+markClass zainabove-ar <anchor (opsz=18,wght=400:73 opsz=18,wght=700:79 opsz=17,wght=400:73 opsz=17,wght=700:79) 1070> @MC_waqf_arabic;
+markClass seenabove-ar <anchor (opsz=18,wght=400:181 opsz=18,wght=700:194 opsz=17,wght=400:181 opsz=17,wght=700:194) 1070> @MC_waqf_arabic;
+markClass sadabove-ar <anchor (opsz=18,wght=400:189 opsz=18,wght=700:192 opsz=17,wght=400:189 opsz=17,wght=700:192) 1070> @MC_waqf_arabic;
+markClass tahStop-ar <anchor (opsz=18,wght=400:114 opsz=18,wght=700:121 opsz=17,wght=400:114 opsz=17,wght=700:121) 1070> @MC_waqf_arabic;
+markClass ainabove-ar <anchor (opsz=18,wght=400:109 opsz=18,wght=700:118 opsz=17,wght=400:109 opsz=17,wght=700:118) 1070> @MC_waqf_arabic;
+markClass qafabove-ar <anchor (opsz=18,wght=400:125 opsz=18,wght=700:136 opsz=17,wght=400:125 opsz=17,wght=700:136) 1070> @MC_waqf_arabic;
+markClass meemStopabove-ar <anchor (opsz=18,wght=400:138 opsz=18,wght=700:155 opsz=17,wght=400:138 opsz=17,wght=700:155) 1070> @MC_waqf_arabic;
+markClass noonStopabove-ar <anchor (opsz=18,wght=400:105 opsz=18,wght=700:112 opsz=17,wght=400:105 opsz=17,wght=700:112) 1070> @MC_waqf_arabic;
+markClass lamAlefabove-ar <anchor (opsz=18,wght=400:91 opsz=18,wght=700:96 opsz=17,wght=400:91 opsz=17,wght=700:96) 1070> @MC_waqf_arabic;
+markClass sahabove-ar <anchor (opsz=18,wght=400:194 opsz=18,wght=700:215 opsz=17,wght=400:194 opsz=17,wght=700:215) 1070> @MC_waqf_arabic;
+markClass assajdaabove-ar <anchor (opsz=18,wght=400:546 opsz=18,wght=700:609 opsz=17,wght=400:546 opsz=17,wght=700:609) 1070> @MC_waqf_arabic;
+markClass annisfabove-ar <anchor (opsz=18,wght=400:447 opsz=18,wght=700:484 opsz=17,wght=400:447 opsz=17,wght=700:484) 1070> @MC_waqf_arabic;
+markClass aththalathaabove-ar <anchor (opsz=18,wght=400:332 opsz=18,wght=700:371 opsz=17,wght=400:332 opsz=17,wght=700:371) 1070> @MC_waqf_arabic;
+markClass arrubabove-ar <anchor (opsz=18,wght=400:294 opsz=18,wght=700:328 opsz=17,wght=400:294 opsz=17,wght=700:328) 1070> @MC_waqf_arabic;
+markClass qifabove-ar <anchor (opsz=18,wght=400:243 opsz=18,wght=700:264 opsz=17,wght=400:243 opsz=17,wght=700:264) 1070> @MC_waqf_arabic;
+markClass saktaabove-ar <anchor (opsz=18,wght=400:372 opsz=18,wght=700:422 opsz=17,wght=400:372 opsz=17,wght=700:429) 1070> @MC_waqf_arabic;
+markClass waqfaabove-ar <anchor (opsz=18,wght=400:354 opsz=18,wght=700:396 opsz=17,wght=400:354 opsz=17,wght=700:396) 1070> @MC_waqf_arabic;
+markClass sadLamAlefMaksuraabove-ar <anchor (opsz=18,wght=400:243 opsz=18,wght=700:252 opsz=17,wght=400:243 opsz=17,wght=700:252) 1070> @MC_waqf_arabic;
+markClass qafLamAlefMaksuraabove-ar <anchor (opsz=18,wght=400:199 opsz=18,wght=700:215 opsz=17,wght=400:199 opsz=17,wght=700:215) 1070> @MC_waqf_arabic;
+markClass alefLamYehabove-ar <anchor (opsz=18,wght=400:199 opsz=18,wght=700:215 opsz=17,wght=400:199 opsz=17,wght=700:215) 1070> @MC_waqf_arabic;
+markClass aljuz-ar <anchor (opsz=18,wght=400:371 opsz=18,wght=700:426 opsz=17,wght=400:371 opsz=17,wght=700:426) 1070> @MC_waqf_arabic;
+@kern1.hahjoin_arabic = [hah-ar.medi hah-ar.init];
+@kern1.reh_arabic = [reh-ar reh-ar.fina behDotless_reh-ar.fina seen_reh-ar seen_reh-ar.fina seen_rehLoop-ar.fina sad_reh-ar sad_reh-ar.fina sad_rehLoop-ar sad_rehLoop-ar.fina];
+@kern1.seven_arabic = [seven];
+@kern1.sevenar_arabic = [seven-ar seven-persian];
+@kern1.space_arabic = [space];
+@kern1.waw_arabic = [waw-ar waw-ar.fina];
+@kern1.zero_arabic = [zero];
+@kern2.beh.init_arabic = [behDotless-ar.init behDotless-ar.init.high];
+@kern2.feh_arabic = [fehDotless-ar fehDotless-ar.init];
+@kern2.hahjoin_arabic = [hah-ar.fina hah-ar.medi];
+@kern2.heh_arabic = [heh-ar hehgoal-ar ae-ar];
+@kern2.heh.init_arabic = [heh-ar.init hehDoachashmee-ar];
+@kern2.hehgoal_arabic = [hehgoal-ar.init hehgoal-ar.init.ascending];
+@kern2.kaf.init_arabic = [kaf-ar.init kaf-ar.init.alt keheh-ar kaf_alef-ar kaf_alef-ar.short kaf_kafDotless-ar kaf_lam-ar kaf_lam-ar.init kaf_lam_alef-ar];
+@kern2.kafswash_arabic = [kafswash-ar kafswash-ar.init];
+@kern2.lam.init_arabic = [kafDotless-ar lam-ar.init];
+@kern2.sad_arabic = [sad-ar sad-ar.init tah-ar tah-ar.init sad_reh-ar sad_rehLoop-ar sad_alefMaksura-ar];
+@kern2.seen_arabic = [seen-ar seen-ar.init seen-ar.init.wide seen_reh-ar seen_rehLoop-ar seen_alefMaksura-ar];
+@kern2.seven_arabic = [seven];
+@kern2.sevenar_arabic = [seven-ar seven-persian];
+@kern2.yeh_arabic = [alefMaksura-ar.fina];
+@kern2.yeh2_arabic = [yehbarree-ar.fina];
+@kern2.yehbarree_arabic = [yehbarree-ar behDotless_yehbarree-ar hah_yehbarree-ar seen_yehbarree-ar sad_yehbarree-ar tah_yehbarree-ar ain_yehbarree-ar fehDotless_yehbarree-ar kaf_yehbarree-ar lam_yehbarree-ar meem_yehbarree-ar heh_yehbarree-ar hehgoal_yehbarree-ar];
+@kern2.zero_arabic = [zero];
+@dotcenter_arabic = [dotcenter-ar dotcenter_threedotsdownbelow-ar twodotshorizontalcenter-ar twodotshorizontalcenter_tahabove-ar twodotsverticalcenter-ar threedotsupcenter-ar threedotsdowncenter-ar fourdotscenter-ar fourcenter-ar tahcenter-ar vinvertedcenter-ar];
+@dotcenter.below_arabic = [dotbelow-ar dotbelow_threedotsdownbelow-ar twodotshorizontalbelow-ar twodotshorizontalbelow_tahabove-ar twodotsverticalbelow-ar threedotsupbelow-ar threedotsdownbelow-ar fourdotsbelow-ar fourbelow-ar tahbelow-ar vinvertedbelow-ar];
+@dots.above_arabic = [dotabove-ar dotabove_threedotsupabove-ar dotabove_vabove-ar dotabove_vinvertedabove-ar dotabove_tahabove-ar twodotshorizontalabove-ar twodotshorizontalabove_vabove-ar twodotshorizontalabove_tahabove-ar twodotsverticalabove-ar threedotshorizontalabove-ar threedotsupabove-ar threedotsdownabove-ar fourdotsabove-ar hamzaabove-ar wavyhamzaabove-ar wasla-ar madda-ar vabove-ar vinvertedabove-ar gafsarkashabove-ar gafsarkashabove-ar.short grafsarkashabove-ar grafsarkashabove-ar.short commaabove-ar twoabove-ar threeabove-ar fourabove-ar tahabove-ar tahabove_vabove-ar tehabove-ar noonabove-ar];
+@hehgoal.ascending_arabic = [alef-ar.fina alef-ar.short.fina behDotless-ar.medi behDotless-ar.medi.high behDotless_reh-ar.fina behDotless_noonghunna-ar.fina dal-ar.fina kafDotless-ar.fina kaf-ar.medi lam-ar.fina lam-ar.medi lam_alef-ar.fina lam_yehbarree-ar.fina kaf_alef-ar.fina kaf_lam-ar.fina kaf_lam-ar.medi kaf_kafDotless-ar.fina kaf_lam_alef-ar.fina kaf_yehbarree-ar.fina hehgoal-ar.medi hehgoal-ar.medi.yehbarree hehgoal_yehbarree-ar.fina];
+@digits_arabic = [zero one two three four five six seven eight nine zero-ar one-ar two-ar three-ar four-ar five-ar six-ar seven-ar eight-ar nine-ar zero-persian zero-persian.alt two-persian four-persian four-persian.alt five-persian six-persian seven-persian seven-persian.alt];
+@digits.small_arabic = [zero.small one.small two.small three.small four.small five.small six.small seven.small eight.small nine.small zero-ar.small one-ar.small two-ar.small three-ar.small four-ar.small five-ar.small six-ar.small seven-ar.small eight-ar.small nine-ar.small zero-ar.small zero-persian.alt.small two-persian.small four-persian.small four-persian.alt.small five-persian.small six-persian.small seven-persian.small seven-persian.alt.small];
+@digits.mark_arabic = [zero.mark one.mark two.mark three.mark four.mark five.mark six.mark seven.mark eight.mark nine.mark zero-ar.mark one-ar.mark two-ar.mark three-ar.mark four-ar.mark five-ar.mark six-ar.mark seven-ar.mark eight-ar.mark nine-ar.mark zero-ar.mark zero-persian.alt.mark two-persian.mark four-persian.mark four-persian.alt.mark five-persian.mark six-persian.mark seven-persian.mark seven-persian.alt.mark];
+@ArabicLetters_arabic = [ae-ar ain-ar ain-ar.fina ain-ar.init ain-ar.medi ain_yehbarree-ar ain_yehbarree-ar.fina alef-ar alef-ar.fina alef-ar.fina.kaf alef-ar.short alef-ar.short.fina alef-ar.short.fina.kaf alefMaksura-ar alefMaksura-ar.fina aleflow-ar behDotless-ar behDotless-ar.fina behDotless-ar.init behDotless-ar.init.high behDotless-ar.medi behDotless-ar.medi.high behDotless_alefMaksura-ar behDotless_alefMaksura-ar.fina behDotless_noonghunna-ar.fina behDotless_reh-ar.fina behDotless_rehLoop-ar.fina behDotless_yehbarree-ar behDotless_yehbarree-ar.fina dal-ar dal-ar.fina fehDotless-ar fehDotless-ar.fina fehDotless-ar.init fehDotless-ar.medi fehDotless_alefMaksura-ar fehDotless_yehbarree-ar fehDotless_yehbarree-ar.fina hah-ar hah-ar.fina hah-ar.init hah-ar.medi hah_yehbarree-ar hah_yehbarree-ar.fina hamza-ar heh-ar heh-ar.fina heh-ar.init heh-ar.medi hehDoachashmee-ar hehDoachashmee-ar.fina hehDoachashmee-ar.medi hehDoachashmee_yehbarree-ar.fina heh_yehbarree-ar heh_yehbarree-ar.fina hehgoal-ar hehgoal-ar.fina hehgoal-ar.init hehgoal-ar.init.ascending hehgoal-ar.medi hehgoal-ar.medi.yehbarree hehgoal_alefMaksura-ar.fina hehgoal_yehbarree-ar hehgoal_yehbarree-ar.fina highhamza-ar kaf-ar.init kaf-ar.init.alt kaf-ar.medi kaf-ar.medi.alt kafDotless-ar kafDotless-ar.fina kaf_alef-ar kaf_alef-ar.fina kaf_alef-ar.fina.short kaf_alef-ar.short kaf_alefMaksura-ar kaf_alefMaksura-ar.fina kaf_kafDotless-ar kaf_kafDotless-ar.fina kaf_lam-ar kaf_lam-ar.fina kaf_lam-ar.init kaf_lam-ar.medi kaf_lam_alef-ar kaf_lam_alef-ar.fina kaf_yehbarree-ar kaf_yehbarree-ar.fina kafswash-ar kafswash-ar.fina kafswash-ar.init kafswash-ar.medi kashida-ar kashida-ar.init kashida-ar.wide kashidaHamza-ar kashidaWaw-ar keheh-ar keheh-ar.fina lam-ar lam-ar.fina lam-ar.init lam-ar.medi lam_alef-ar lam_alef-ar.fina lam_alefMaksura-ar lam_yehbarree-ar lam_yehbarree-ar.fina meem-ar meem-ar.alt meem-ar.fina meem-ar.fina.alt meem-ar.init meem-ar.medi meem_yehbarree-ar meem_yehbarree-ar.fina noonghunna-ar noonghunna-ar.fina qafDotless-ar qafDotless-ar.fina raisedrounddot-ar reh-ar reh-ar.fina rehLoop-ar rehLoop-ar.fina rounddot-ar sad-ar sad-ar.fina sad-ar.init sad-ar.medi sad_alefMaksura-ar sad_alefMaksura-ar.fina sad_reh-ar sad_reh-ar.fina sad_rehLoop-ar sad_rehLoop-ar.fina sad_yehbarree-ar sad_yehbarree-ar.fina seen-ar seen-ar.fina seen-ar.init seen-ar.init.wide seen-ar.medi seen-ar.medi.wide seen_alefMaksura-ar seen_alefMaksura-ar.fina seen_reh-ar seen_reh-ar.fina seen_rehLoop-ar seen_rehLoop-ar.fina seen_yehbarree-ar seen_yehbarree-ar.fina tah-ar tah-ar.fina tah-ar.init tah-ar.medi tah_yehbarree-ar tah_yehbarree-ar.fina verticalTail-ar waw-ar waw-ar.fina wawSmall-ar wawStraight-ar wawStraight-ar.fina yehRohingya-ar yehRohingya-ar.fina yehSmall-ar yehSmall-farsi yehbarree-ar yehbarree-ar.fina yehthin-ar.init yehthin-ar.medi];
+# print "\n".join(sorted(g.name for g in Glyphs.font.glyphs if g.export and g.category == "Letter" and g.color != 0))
+# Prefix: Languagesystems
+languagesystem arab dflt;
+languagesystem arab FAR;
+languagesystem arab KSH;
+languagesystem arab RHG;
+languagesystem arab SND;
+languagesystem arab URD;
+# Prefix: Lookups
+lookup center_marks_arabic {
+    sub @dotcenter_arabic by @dotcenter.below_arabic;
+} center_marks_arabic;
+
+lookup mark_digits_arabic {
+    sub @digits_arabic by @digits.mark_arabic;
+} mark_digits_arabic;
+
+lookup small_digits_arabic {
+    sub @digits_arabic by @digits.small_arabic;
+} small_digits_arabic;
+
+lookup subtending_2_arabic {
+    sub samvat-ar by samvat-ar.2;
+    sub year-ar by year-ar.2;
+    sub pagenumber-ar by pagenumber-ar.2;
+    sub endofayah-ar by endofayah-ar.2;
+    sub disputedendofayah-ar by disputedendofayah-ar.2;
+    sub footnotemarker-ar by footnotemarker-ar.2;
+    sub number-ar by number-ar.2;
+    sub pound-ar by pound-ar.2;
+    sub piastre-ar by piastre-ar.2;
+} subtending_2_arabic;
+
+lookup subtending_3_arabic {
+    sub samvat-ar by samvat-ar.3;
+    sub year-ar by year-ar.3;
+    sub pagenumber-ar by pagenumber-ar.3;
+    sub endofayah-ar by endofayah-ar.3;
+    sub disputedendofayah-ar by disputedendofayah-ar.3;
+    sub number-ar by number-ar.3;
+    sub pound-ar by pound-ar.3;
+    sub piastre-ar by piastre-ar.3;
+} subtending_3_arabic;
+
+lookup subtending_4_arabic {
+    sub samvat-ar by samvat-ar.4;
+    sub year-ar by year-ar.4;
+} subtending_4_arabic;
+
+# Hack to be able to use the autogenerated mark class in
+# handwritten feature code when compiling with fontmake.
+markClass dummy <anchor 0 0> @MC_bottom_arabic;
+markClass dummy <anchor 0 0> @MC_top_arabic;
+@kern1.reh_arabic = [dummy];
+@kern1.reh_arabic = [reh-ar reh-ar.fina behDotless_reh-ar.fina seen_reh-ar seen_reh-ar.fina seen_rehLoop-ar.fina sad_reh-ar sad_reh-ar.fina sad_rehLoop-ar sad_rehLoop-ar.fina];
+feature rtlm {
+    # automatic
+    sub radical by radical.rtlm;
+} rtlm;
+
+feature locl {
+    script arab;
+    language FAR;
+    sub zero-persian by zero-persian.alt;
+    language URD;
+    sub four-persian by four-persian.alt;
+    sub six-persian by six-ar;
+    sub seven-persian by seven-persian.alt;
+    sub dammainverted-ar by dammainverted-ar.alt;
+    language KSH;
+    sub four-persian by four-persian.alt;
+    sub six-persian by six-ar;
+    sub seven-persian by seven-persian.alt;
+    language RHG;
+    sub four-persian by four-ar;
+    sub six-persian by six-ar;
+    sub seven-persian by seven-persian.alt;
+    language SND;
+    sub six-persian by six-ar;
+    sub seven-persian by seven-persian.alt;
+    sub comma-ar by commareversed;
+    sub semicolon-ar by semicolonreversed;
+    sub meem-ar by meem-ar.alt;
+    sub sindhipostpositionmen-ar by sindhipostpositionmen-ar.alt;
+} locl;
+
+feature ccmp {
+    lookup compose_arabic {
+        # Handle the few Arabic Unicode decompositions, by composing them first
+        # so that we have consistent renderinf since our encoded mark glyphs have
+        # sliughtly different positioning rules.
+        # HarfBuzz will compose for us, but other layout engines might not.
+        sub alef-ar maddaMark-ar by alefMadda-ar;
+        sub alef-ar hamzaaboveMark-ar by alefHamzaabove-ar;
+        sub waw-ar hamzaaboveMark-ar by wawHamzaabove-ar;
+        #sub alef-ar hamzabelow-ar				by alefHmazabelow-ar;
+        sub yeh-ar hamzaaboveMark-ar by yehHamzaabove-ar;
+        sub ae-ar hamzaaboveMark-ar by hehHamzaabove-ar;
+        sub hehgoal-ar hamzaaboveMark-ar by hehgoalHamzaabove-ar;
+        sub yehbarree-ar hamzaaboveMark-ar by yehbarreeHamzaabove-ar;
+        # Not a Unicode decomposition, but used in Persian.
+        sub heh-ar hamzaaboveMark-ar by hehHamzaabove-ar;
+    } compose_arabic;
+
+    lookup early_arabic {
+        # Decompose early so that u-ar gets decomposed after that.
+        # We do two step decomposition so that the comma above gets
+        # attached to the waw not the high hamza.
+        sub uHamzaabove-ar by highhamza-ar u-ar;
+    } early_arabic;
+
+    sub alefHamzaabove-ar by alef-ar.short hamzaabove-ar;
+    sub alefHamzabelow-ar by alef-ar hamzabelow-ar;
+    sub alefMadda-ar by alef-ar.short madda-ar;
+    sub alefWasla-ar by alef-ar.short wasla-ar;
+    sub alefWavyhamzaabove-ar by alef-ar.short wavyhamzaabove-ar;
+    sub alefWavyhamzabelow-ar by alef-ar wavyhamzabelow-ar;
+    sub alefTwoabove-ar by alef-ar.short twoabove-ar;
+    sub alefThreeabove-ar by alef-ar.short threeabove-ar;
+    sub alefFatha-ar by alef-ar fathaattached-ar;
+    sub alefRightFatha-ar by alef-ar fathaattachedright-ar;
+    sub alefRightMiddleStroke-ar by alef-ar strokeright-ar;
+    sub alefLeftMiddleStroke-ar by alef-ar strokeleft-ar;
+    sub alefKasra-ar by alef-ar kasraattached-ar;
+    sub alefRightKasra-ar by alef-ar kasraattachedright-ar;
+    sub alefRoundDotAbove-ar by alef-ar.short rounddotattachedabove-ar;
+    sub alefRightRoundDot-ar by alef-ar rounddotattachedright-ar;
+    sub alefLeftRoundDot-ar by alef-ar rounddotattachedleft-ar;
+    sub alefRoundDotBelow-ar by alef-ar rounddotattachedbelow-ar;
+    sub alefDotAbove-ar by alef-ar dotabove-ar;
+    sub alefRightFathaDotAbove-ar by alef-ar fathaattachedright-ar dotabove-ar;
+    sub alefRightMiddleStrokeDotAbove-ar by alef-ar strokeright-ar dotabove-ar;
+    sub alefRightKasraDotAbove-ar by alef-ar kasraattachedright-ar dotabove-ar;
+    sub alefRightFathaLeftRing-ar by alef-ar fathaattachedright-ar ringattachedleft-ar;
+    sub alefRightMiddleStrokeLeftRing-ar by alef-ar strokeright-ar ringattachedleft-ar;
+    sub alefRightKasraLeftRing-ar by alef-ar kasraattachedright-ar ringattachedleft-ar;
+    sub alefRightHamza-ar by alef-ar hamzaattachedright-ar;
+    sub alefLeftHamza-ar by alef-ar hamzaattachedleft-ar;
+    sub beh-ar by behDotless-ar dotbelow-ar;
+    sub teh-ar by behDotless-ar twodotshorizontalabove-ar;
+    sub tehVabove-ar by behDotless-ar twodotshorizontalabove_vabove-ar;
+    sub theh-ar by behDotless-ar threedotsupabove-ar;
+    sub peh-ar by behDotless-ar threedotsdownbelow-ar;
+    sub pehVabove-ar by behDotless-ar vabove-ar threedotsdownbelow-ar;
+    sub beeh-ar by behDotless-ar twodotsverticalbelow-ar;
+    sub beheh-ar by behDotless-ar fourdotsbelow-ar;
+    sub tehThreedotsdown-ar by behDotless-ar threedotsdownabove-ar;
+    sub tteh-ar by behDotless-ar tahabove-ar;
+    sub ttehVabove-ar by behDotless-ar tahabove_vabove-ar;
+    sub tteheh-ar by behDotless-ar twodotsverticalabove-ar;
+    sub teheh-ar by behDotless-ar fourdotsabove-ar;
+    sub behThreedotshorizontalbelow-ar by behDotless-ar threedotshorizontalbelow-ar;
+    sub behThreedotsupabove-ar by behDotless-ar threedotsupabove-ar dotbelow-ar;
+    sub behThreedotsupbelow-ar by behDotless-ar threedotsupbelow-ar;
+    sub tehThreedotsupbelow-ar by behDotless-ar twodotshorizontalabove-ar threedotsupbelow-ar;
+    sub behTwodotsbelowDotabove-ar by behDotless-ar dotabove-ar twodotshorizontalbelow-ar;
+    sub behVinvertedbelow-ar by behDotless-ar vinvertedbelow-ar;
+    sub behVabove-ar by behDotless-ar vabove-ar;
+    sub behVbelow-ar by behDotless-ar vbelow-ar;
+    sub behhamzaabove-ar by behDotless-ar hamzaabove-ar dotbelow-ar;
+    sub behMeemabove-ar by behDotless-ar dotbelow-ar meemabove-ar;
+    sub pehMeemabove-ar by behDotless-ar threedotsdownbelow-ar meemabove-ar;
+    sub tehTehabove-ar by behDotless-ar tehabove-ar;
+    sub tehRing-ar by behDotless-ar twodotshorizontalabove-ar ringbelow-ar;
+    sub jeem-ar by hah-ar dotcenter-ar;
+    sub khah-ar by hah-ar dotabove-ar;
+    sub tcheh-ar by hah-ar threedotsdowncenter-ar;
+    sub hahThreedotsabove-ar by hah-ar threedotsupabove-ar;
+    sub hahHamzaabove-ar by hah-ar hamzaabove-ar;
+    sub hahTwodotsverticalabove-ar by hah-ar twodotsverticalabove-ar;
+    sub hahTwodotshorizontalabove-ar by hah-ar twodotshorizontalabove-ar;
+    sub hahTahabove-ar by hah-ar tahabove-ar;
+    sub tcheheh-ar by hah-ar fourdotscenter-ar;
+    sub nyeh-ar by hah-ar twodotshorizontalcenter-ar;
+    sub dyeh-ar by hah-ar twodotsverticalcenter-ar;
+    sub hahThreedotsupbelow-ar by hah-ar threedotsupcenter-ar;
+    sub hahTahbelow-ar by hah-ar tahcenter-ar;
+    sub hahTahTwodotshorizontalbelow-ar by hah-ar twodotshorizontalcenter_tahabove-ar;
+    sub hahFourbelow-ar by hah-ar fourcenter-ar;
+    sub hahVinvertedbelow-ar by hah-ar vinvertedcenter-ar;
+    sub jeemThreedotsbelow-ar by hah-ar dotcenter_threedotsdownbelow-ar;
+    sub jeemTwodotsabove-ar by hah-ar dotcenter-ar twodotshorizontalabove-ar;
+    sub jeemThreedotsabove-ar by hah-ar dotcenter-ar threedotsupabove-ar;
+    sub tchehDotabove-ar by hah-ar threedotsdowncenter-ar dotabove-ar;
+    sub tchehVabove-ar by hah-ar threedotsdowncenter-ar vabove-ar;
+    sub thal-ar by dal-ar dotabove-ar;
+    sub ddal-ar by dal-ar tahabove-ar;
+    sub dahal-ar by dal-ar twodotshorizontalabove-ar;
+    sub ddahal-ar by dal-ar twodotshorizontalbelow-ar;
+    sub dul-ar by dal-ar threedotsupabove-ar;
+    sub dalRing-ar by dal-ar ringbelow-ar;
+    sub dalDotbelow-ar by dal-ar dotbelow-ar;
+    sub dalDotbelowTah-ar by dal-ar tahabove-ar dotbelow-ar;
+    sub dalThreedotsdown-ar by dal-ar threedotsdownabove-ar;
+    sub dalFourdots-ar by dal-ar fourdotsabove-ar;
+    sub dalVinvertedabove-ar by dal-ar vinvertedabove-ar;
+    sub dalTwodotsverticalbelowTah-ar by dal-ar tahabove-ar twodotsverticalbelow-ar;
+    sub dalVinvertedbelow-ar by dal-ar vinvertedbelow-ar;
+    sub dalThreedotsbelow-ar by dal-ar threedotsdownbelow-ar;
+    sub zain-ar by reh-ar dotabove-ar;
+    sub jeh-ar by reh-ar threedotsupabove-ar;
+    sub rreh-ar by reh-ar tahabove-ar;
+    sub rehv-ar by reh-ar vabove-ar;
+    sub rehRing-ar by reh-ar ringbelow-ar;
+    sub rehDotbelow-ar by reh-ar dotbelow-ar;
+    sub rehVbelow-ar by reh-ar vbelow-ar;
+    sub rehDotbelowdotabove-ar by reh-ar dotcenter-ar dotbelow-ar;
+    sub rehTwodots-ar by reh-ar twodotshorizontalabove-ar;
+    sub rehFourdots-ar by reh-ar fourdotsabove-ar;
+    sub rehVinvertedabove-ar by reh-ar vinvertedabove-ar;
+    sub rehStroke-ar by reh-ar stroke-ar;
+    sub rehTwodotsverticalabove-ar by reh-ar twodotsverticalabove-ar;
+    sub rehHamzaabove-ar by reh-ar hamzaabove-ar;
+    sub rehTwodotshorizontalaboveTahabove-ar by reh-ar twodotshorizontalabove_tahabove-ar;
+    sub zainVinvertedabove-ar by reh-ar dotabove_vinvertedabove-ar;
+    sub rehNoonabove-ar by reh-ar noonabove-ar;
+    sub sheen-ar by seen-ar threedotsupabove-ar;
+    sub seenDotbelowDotabove-ar by seen-ar dotabove-ar dotbelow-ar;
+    sub sheenDotbelow-ar by seen-ar threedotsupabove-ar dotbelow-ar;
+    sub sheenThreedotsbelow-ar by seen-ar threedotsupabove-ar threedotsdownbelow-ar;
+    sub seenFourdotsabove-ar by seen-ar fourdotsabove-ar;
+    sub seenTwodotsverticalabove-ar by seen-ar twodotsverticalabove-ar;
+    sub seenTahTwodotshorizontalabove-ar by seen-ar twodotshorizontalabove_tahabove-ar;
+    sub seenFourabove-ar by seen-ar fourabove-ar;
+    sub seenVinvertedabove-ar by seen-ar vinvertedabove-ar;
+    sub seenThreedotsbelow-ar by seen-ar threedotsdownbelow-ar;
+    sub dad-ar by sad-ar dotabove-ar;
+    sub dadDotbelow-ar by sad-ar dotabove-ar dotbelow-ar;
+    sub sadThreedots-ar by sad-ar threedotsupabove-ar;
+    sub sadTwodotsbelow-ar by sad-ar twodotshorizontalbelow-ar;
+    sub sadThreedotsbelow-ar by sad-ar threedotsdownbelow-ar;
+    sub zah-ar by tah-ar dotabove-ar;
+    sub tahThreedots-ar by tah-ar threedotsupabove-ar;
+    sub tahTwodotsabove-ar by tah-ar twodotshorizontalabove-ar;
+    sub tahDotbelow-ar by tah-ar dotbelow-ar;
+    sub tahThreedotsbelow-ar by tah-ar threedotsdownbelow-ar;
+    sub ghain-ar by ain-ar dotabove-ar;
+    sub ghainDotbelow-ar by ain-ar dotabove-ar dotcenter-ar;
+    sub ainThreedotsbelow-ar by ain-ar threedotsdowncenter-ar;
+    sub ainThreedots-ar by ain-ar threedotsupabove-ar;
+    sub ainTwodotshorizontalabove-ar by ain-ar twodotshorizontalabove-ar;
+    sub ainThreedotsdownabove-ar by ain-ar threedotsdownabove-ar;
+    sub ainTwodotsverticalabove-ar by ain-ar twodotsverticalabove-ar;
+    sub ghainThreedotsabove-ar by ain-ar dotabove_threedotsupabove-ar;
+    sub feh-ar by fehDotless-ar dotabove-ar;
+    sub veh-ar by fehDotless-ar threedotsupabove-ar;
+    sub fehDotmovedbelow-ar by fehDotless-ar dotbelow-ar;
+    sub fehDotbelow-ar by fehDotless-ar dotabove-ar dotbelow-ar;
+    sub fehThreedotsbelow-ar by fehDotless-ar threedotsdownbelow-ar;
+    sub peheh-ar by fehDotless-ar fourdotsabove-ar;
+    sub fehTwodotsbelow-ar by fehDotless-ar twodotshorizontalbelow-ar;
+    sub fehThreedotsupbelow-ar by fehDotless-ar threedotsupbelow-ar;
+    sub fehDotbelowThreedotsabove-ar by fehDotless-ar threedotsupabove-ar dotbelow-ar;
+    sub qaf-ar by qafDotless-ar twodotshorizontalabove-ar;
+    sub qafDotabove-ar by qafDotless-ar dotabove-ar;
+    sub qafThreedotsabove-ar by qafDotless-ar threedotsupabove-ar;
+    sub qafDotbelow-ar by qafDotless-ar twodotshorizontalabove-ar dotbelow-ar;
+    sub qafDotbelowNoDotAbove-ar by qafDotless-ar dotbelow-ar;
+    sub kafThreedotsbelow-ar by kaf-ar threedotsdownbelow-ar;
+    sub ng-ar by kaf-ar threedotsupabove-ar;
+    sub kafDotabove-ar by kaf-ar dotabove-ar;
+    sub kafTwodotshorizontalabove-ar by kaf-ar twodotshorizontalabove-ar;
+    sub kafDotbelow-ar by kaf-ar dotbelow-ar;
+    sub gaf-ar by keheh-ar gafsarkashabove-ar;
+    sub kafRing-ar by keheh-ar ringcenter-ar;
+    sub kehehDotabove-ar by keheh-ar dotabove-ar;
+    sub kehehTwodotshorizontalabove-ar by keheh-ar twodotshorizontalabove-ar;
+    sub kehehThreedotsabove-ar by keheh-ar threedotsupabove-ar;
+    sub kehehThreedotsupbelow-ar by keheh-ar threedotsupbelow-ar;
+    sub kehehThreedotsbelow-ar by keheh-ar threedotsdownbelow-ar;
+    sub kehehVabove-ar by keheh-ar vabove-ar;
+    sub kehehTwodotsverticalbelow-ar by keheh-ar twodotsverticalbelow-ar;
+    sub gafRing-ar by keheh-ar gafsarkashabove-ar ringcenter-ar;
+    sub gafThreedots-ar by keheh-ar gafsarkashabove-ar threedotsupabove-ar;
+    sub gafTwodotsbelow-ar by keheh-ar gafsarkashabove-ar twodotshorizontalbelow-ar;
+    sub ngoeh-ar by keheh-ar gafsarkashabove-ar twodotshorizontalabove-ar;
+    sub gueh-ar by keheh-ar gafsarkashabove-ar twodotsverticalbelow-ar;
+    sub gafInvertedstroke-ar by keheh-ar gafsarkashcenter-ar;
+    sub graf-ar by keheh-ar grafsarkashabove-ar;
+    sub lamVabove-ar by lam-ar vabove-ar;
+    sub lamDotabove-ar by lam-ar dotabove-ar;
+    sub lamThreedotsabove-ar by lam-ar threedotsupabove-ar;
+    sub lamThreedotsbelow-ar by lam-ar threedotsdownbelow-ar;
+    sub lamBar-ar by lam-ar stroke-ar;
+    sub lamDoublebar-ar by lam-ar doublestroke-ar;
+    sub lamTahabove-ar by lam-ar tahabove-ar;
+    sub meemDotabove-ar by meem-ar dotabove-ar;
+    sub meemDotbelow-ar by meem-ar dotbelow-ar;
+    sub meemThreedotsabove-ar by meem-ar threedotsupabove-ar;
+    sub noon-ar by noonghunna-ar dotabove-ar;
+    sub noonDotbelow-ar by noonghunna-ar dotabove-ar dotbelow-ar;
+    sub rnoon-ar by noonghunna-ar tahabove-ar;
+    sub noonRing-ar by noonghunna-ar dotabove-ar ringbelow-ar;
+    sub noonTwodotsbelow-ar by noonghunna-ar dotabove-ar twodotshorizontalbelow-ar;
+    sub noonTahabove-ar by noonghunna-ar dotabove_tahabove-ar;
+    sub noonVabove-ar by noonghunna-ar dotabove_vabove-ar;
+    sub noonVinvertedabove-ar by noonghunna-ar vinvertedabove-ar;
+    sub tehMarbuta-ar by ae-ar twodotshorizontalabove-ar;
+    sub hehHamzaabove-ar by ae-ar hamzaabove-ar;
+    sub hehgoalHamzaabove-ar by hehgoal-ar hamzaabove-ar;
+    sub tehMarbutagoal-ar by hehgoal-ar twodotshorizontalabove-ar;
+    sub hehVinvertedabove-ar by hehDoachashmee-ar vinvertedabove-ar;
+    sub wawHamzaabove-ar by waw-ar hamzaabove-ar;
+    sub wawring-ar by waw-ar ringcenter-ar;
+    sub wawTwodots-ar by waw-ar twodotshorizontalabove-ar;
+    sub wawDotabove-ar by waw-ar dotabove-ar;
+    sub kirghizoe-ar by waw-ar stroke-ar;
+    sub oe-ar by waw-ar vabove-ar;
+    sub u-ar by waw-ar commaabove-ar;
+    sub yu-ar by waw-ar alefabove-ar;
+    sub kirghizyu-ar by waw-ar vinvertedabove-ar;
+    sub ve-ar by waw-ar threedotsupabove-ar;
+    sub wawTwoabove-ar by waw-ar twoabove-ar;
+    sub wawThreeAbove-ar by waw-ar threeabove-ar;
+    sub wawDotcenter-ar by waw-ar dotcenter-ar.alt;
+    sub yeh-ar by alefMaksura-ar twodotshorizontalbelow-ar;
+    sub yehHamzaabove-ar by alefMaksura-ar hamzaabove-ar;
+    sub yehKashmiri-ar by alefMaksura-ar ring-ar;
+    sub yehVabove-ar by yeh-farsi vabove-ar;
+    sub yehVinverted-farsi by yeh-farsi vinvertedabove-ar;
+    sub yehTwodotsabove-farsi by yeh-farsi twodotshorizontalabove-ar;
+    sub yehThreedotsabove-farsi by yeh-farsi threedotsupabove-ar;
+    sub yehTwoabove-farsi by yeh-farsi twoabove-ar;
+    sub yehThreeabove-farsi by yeh-farsi threeabove-ar;
+    sub yehFourbelow-farsi by alefMaksura-ar fourbelow-ar;
+    sub yehTwodotsbelowNoonabove-ar by alefMaksura-ar twodotshorizontalbelow-ar noonabove-ar;
+    sub yehbarreeHamzaabove-ar by yehbarree-ar hamzaabove-ar;
+    sub yehbarreeTwoabove-ar by yehbarree-ar twoabove-ar;
+    sub yehbarreeThreeabove-ar by yehbarree-ar threeabove-ar;
+    sub e-ar by alefMaksura-ar twodotsverticalbelow-ar;
+    sub yehThreedotsbelow-ar by alefMaksura-ar threedotsdownbelow-ar;
+    sub yehTwodotsbelowHamzaabove-ar by alefMaksura-ar twodotshorizontalbelow-ar hamzaabove-ar;
+    sub yehTwodotsbelowDotabove-ar by alefMaksura-ar twodotshorizontalbelow-ar dotabove-ar;
+    sub kashidaTwodotsbelow-ar by kashida-ar twodotshorizontalbelow-ar;
+} ccmp;
+
+feature isol {
+    sub kaf-ar by kafDotless-ar miniKeheh-ar;
+    sub fehAfrican-ar by fehDotless-ar;
+    sub qafAfrican-ar by qafDotless-ar;
+    sub qafThreedotsaboveAfrican-ar by qafDotless-ar threedotsupabove-ar;
+    sub noonThreedotsabove-ar by noonghunna-ar threedotsupabove-ar;
+    sub noonAfrican-ar by noonghunna-ar;
+    sub ae-ar by hehgoal-ar;
+    sub yeh-farsi by alefMaksura-ar;
+    sub yehTail-ar by alefMaksura-ar tail-ar;
+    sub highhamzaAlef-ar by highhamza-ar alef-ar;
+    sub highhamzaWaw-ar by highhamza-ar waw-ar;
+    sub highhamzaYeh-ar by highhamza-ar alefMaksura-ar;
+} isol;
+
+feature init {
+    lookup center_marks_arabic;
+    sub behDotless-ar by behDotless-ar.init;
+    sub noonghunna-ar by behDotless-ar.init;
+    sub alefMaksura-ar by behDotless-ar.init;
+    sub hah-ar by hah-ar.init;
+    sub seen-ar by seen-ar.init;
+    sub sad-ar by sad-ar.init;
+    sub tah-ar by tah-ar.init;
+    sub ain-ar by ain-ar.init;
+    sub fehDotless-ar by fehDotless-ar.init;
+    sub qafDotless-ar by fehDotless-ar.init;
+    sub fehAfrican-ar by fehDotless-ar.init dotbelow-ar;
+    sub qafAfrican-ar by fehDotless-ar.init dotabove-ar;
+    sub qafThreedotsaboveAfrican-ar by fehDotless-ar.init dotabove_threedotsupabove-ar;
+    sub kaf-ar by kaf-ar.init;
+    sub keheh-ar by kaf-ar.init;
+    sub kafswash-ar by kafswash-ar.init;
+    sub lam-ar by lam-ar.init;
+    sub meem-ar by meem-ar.init;
+    sub meem-ar.alt by meem-ar.init;
+    sub noonThreedotsabove-ar by behDotless-ar.init threedotsdownbelow-ar;
+    sub noonAfrican-ar by behDotless-ar.init dotabove-ar;
+    sub heh-ar by heh-ar.init;
+    sub hehDoachashmee-ar by heh-ar.init;
+    sub hehgoal-ar by hehgoal-ar.init hehgoalMark-ar;
+    sub yeh-farsi by behDotless-ar.init twodotshorizontalbelow-ar;
+    sub yehbarree-ar by behDotless-ar.init twodotshorizontalbelow-ar;
+    sub kashida-ar by kashida-ar.init;
+    sub highhamzaYeh-ar by highhamza-ar behDotless-ar.init;
+} init;
+
+feature medi {
+    lookup center_marks_arabic;
+    sub behDotless-ar by behDotless-ar.medi;
+    sub noonghunna-ar by behDotless-ar.medi;
+    sub alefMaksura-ar by behDotless-ar.medi;
+    sub hah-ar by hah-ar.medi;
+    sub seen-ar by seen-ar.medi;
+    sub sad-ar by sad-ar.medi;
+    sub tah-ar by tah-ar.medi;
+    sub ain-ar by ain-ar.medi;
+    sub fehDotless-ar by fehDotless-ar.medi;
+    sub qafDotless-ar by fehDotless-ar.medi;
+    sub fehAfrican-ar by fehDotless-ar.medi dotbelow-ar;
+    sub qafAfrican-ar by fehDotless-ar.medi dotabove-ar;
+    sub qafThreedotsaboveAfrican-ar by fehDotless-ar.medi dotabove_threedotsupabove-ar;
+    sub kaf-ar by kaf-ar.medi;
+    sub keheh-ar by kaf-ar.medi;
+    sub kafswash-ar by kafswash-ar.medi;
+    sub lam-ar by lam-ar.medi;
+    sub meem-ar by meem-ar.medi;
+    sub meem-ar.alt by meem-ar.medi;
+    sub noonThreedotsabove-ar by behDotless-ar.medi threedotsdownbelow-ar;
+    sub noonAfrican-ar by behDotless-ar.medi dotabove-ar;
+    sub heh-ar by heh-ar.medi;
+    sub hehgoal-ar by hehgoal-ar.medi;
+    sub hehDoachashmee-ar by hehDoachashmee-ar.medi;
+    sub yeh-farsi by behDotless-ar.medi twodotshorizontalbelow-ar;
+    sub yehbarree-ar by behDotless-ar.medi twodotshorizontalbelow-ar;
+    sub yehthin-ar.init by yehthin-ar.medi;
+    sub highhamzaYeh-ar by highhamza-ar alefMaksura-ar;
+} medi;
+
+feature fina {
+    sub alef-ar by alef-ar.fina;
+    sub alef-ar.short by alef-ar.short.fina;
+    sub behDotless-ar by behDotless-ar.fina;
+    sub hah-ar by hah-ar.fina;
+    sub dal-ar by dal-ar.fina;
+    sub reh-ar by reh-ar.fina;
+    sub rehLoop-ar by rehLoop-ar.fina;
+    sub seen-ar by seen-ar.fina;
+    sub sad-ar by sad-ar.fina;
+    sub tah-ar by tah-ar.fina;
+    sub ain-ar by ain-ar.fina;
+    sub fehDotless-ar by fehDotless-ar.fina;
+    sub fehAfrican-ar by fehDotless-ar.fina;
+    sub qafDotless-ar by qafDotless-ar.fina;
+    sub qafAfrican-ar by qafDotless-ar.fina;
+    sub qafThreedotsaboveAfrican-ar by qafDotless-ar.fina threedotsupabove-ar;
+    sub kafDotless-ar by kafDotless-ar.fina;
+    sub kaf-ar by kafDotless-ar.fina miniKeheh-ar;
+    sub keheh-ar by keheh-ar.fina;
+    sub kafswash-ar by kafswash-ar.fina;
+    sub lam-ar by lam-ar.fina;
+    sub meem-ar by meem-ar.fina;
+    sub meem-ar.alt by meem-ar.fina.alt;
+    sub noonghunna-ar by noonghunna-ar.fina;
+    sub noonAfrican-ar by noonghunna-ar.fina;
+    sub noonThreedotsabove-ar by noonghunna-ar.fina threedotsupabove-ar;
+    sub heh-ar by heh-ar.fina;
+    sub hehgoal-ar by hehgoal-ar.fina;
+    sub hehDoachashmee-ar by hehDoachashmee-ar.fina;
+    sub ae-ar by heh-ar.fina;
+    sub waw-ar by waw-ar.fina;
+    sub wawStraight-ar by wawStraight-ar.fina;
+    sub yeh-farsi by alefMaksura-ar.fina;
+    sub alefMaksura-ar by alefMaksura-ar.fina;
+    sub yehTail-ar by alefMaksura-ar.fina tail-ar;
+    sub yehbarreeHamzaabove-ar by yehbarree-ar.fina hamzaabove-ar;
+    sub yehbarree-ar by yehbarree-ar.fina;
+    sub yehRohingya-ar by yehRohingya-ar.fina;
+    sub highhamzaAlef-ar by highhamza-ar alef-ar;
+    sub highhamzaWaw-ar by highhamza-ar waw-ar;
+    sub uHamzaabove-ar by highhamza-ar waw-ar commaabove-ar;
+    sub highhamzaYeh-ar by highhamza-ar alefMaksura-ar;
+} fina;
+
+feature rlig {
+    lookup short_alef_arabic {
+        lookupflag UseMarkFilteringSet @MC_top_arabic;
+        sub [alef-ar alef-ar.fina]' @MC_top_arabic by [alef-ar.short alef-ar.short.fina];
+    } short_alef_arabic;
+
+    lookup subtending_marks_arabic {
+        lookupflag 0;
+        # Subtending with small digits.
+        sub [endofayah-ar disputedendofayah-ar number-ar]' lookup subtending_3_arabic @digits_arabic' lookup small_digits_arabic @digits_arabic' lookup small_digits_arabic @digits_arabic' lookup small_digits_arabic;
+        sub [endofayah-ar disputedendofayah-ar number-ar]' lookup subtending_2_arabic @digits_arabic' lookup small_digits_arabic @digits_arabic' lookup small_digits_arabic;
+        sub [endofayah-ar disputedendofayah-ar number-ar footnotemarker-ar] @digits_arabic' lookup small_digits_arabic;
+        # Subtending with full-size digits.
+        sub [year-ar samvat-ar]' lookup subtending_4_arabic @digits_arabic' lookup mark_digits_arabic @digits_arabic' lookup mark_digits_arabic @digits_arabic' lookup mark_digits_arabic @digits_arabic' lookup mark_digits_arabic;
+        sub [year-ar samvat-ar pagenumber-ar piastre-ar pound-ar]' lookup subtending_3_arabic @digits_arabic' lookup mark_digits_arabic @digits_arabic' lookup mark_digits_arabic @digits_arabic' lookup mark_digits_arabic;
+        sub [year-ar samvat-ar pagenumber-ar piastre-ar pound-ar footnotemarker-ar]' lookup subtending_2_arabic @digits_arabic' lookup mark_digits_arabic @digits_arabic' lookup mark_digits_arabic;
+        sub [year-ar samvat-ar pagenumber-ar piastre-ar pound-ar footnotemarker-ar] @digits_arabic' lookup mark_digits_arabic;
+    } subtending_marks_arabic;
+
+    lookup isolated_heh_arabic {
+        lookupflag IgnoreMarks;
+        ignore sub @ArabicLetters_arabic heh-ar';
+        sub heh-ar' by hehDoachashmee-ar;
+        ignore sub heh-ar.init' kashida-ar' @ArabicLetters_arabic;
+        sub heh-ar.init' kashida-ar' by hehDoachashmee-ar;
+    } isolated_heh_arabic;
+
+    lookup high_tooth_arabic {
+        lookupflag IgnoreMarks;
+        sub [behDotless-ar.init behDotless-ar.medi]' [seen-ar.medi seen-ar.fina] by [behDotless-ar.init.high behDotless-ar.medi.high];
+        sub [behDotless-ar.init behDotless-ar.medi] [behDotless-ar.medi]' [behDotless-ar.medi behDotless-ar.fina seen-ar.medi seen-ar.fina] by behDotless-ar.medi.high;
+        ignore sub [seen-ar.init seen-ar.medi] behDotless-ar.medi' [behDotless-ar.medi behDotless-ar.fina] [behDotless-ar.medi behDotless-ar.fina seen-ar.medi seen-ar.fina];
+        sub [seen-ar.init seen-ar.medi] behDotless-ar.medi' [behDotless-ar.medi behDotless-ar.fina] by behDotless-ar.medi.high;
+    } high_tooth_arabic;
+
+    lookup wide_seen_arabic {
+        lookupflag IgnoreMarks;
+        sub [seen-ar.init seen-ar.medi]' behDotless-ar.medi by [seen-ar.init.wide seen-ar.medi.wide];
+    } wide_seen_arabic;
+
+    lookup yeh_arabic {
+        lookupflag IgnoreMarks;
+        sub behDotless-ar.init alefMaksura-ar.fina by behDotless_alefMaksura-ar;
+        sub [behDotless-ar.medi behDotless-ar.medi.high] alefMaksura-ar.fina by behDotless_alefMaksura-ar.fina;
+        sub seen-ar.init alefMaksura-ar.fina by seen_alefMaksura-ar;
+        sub seen-ar.medi alefMaksura-ar.fina by seen_alefMaksura-ar.fina;
+        sub sad-ar.init alefMaksura-ar.fina by sad_alefMaksura-ar;
+        sub sad-ar.medi alefMaksura-ar.fina by sad_alefMaksura-ar.fina;
+        sub fehDotless-ar.init alefMaksura-ar.fina by fehDotless_alefMaksura-ar;
+        sub kaf-ar.init alefMaksura-ar.fina by kaf_alefMaksura-ar;
+        sub kaf-ar.medi alefMaksura-ar.fina by kaf_alefMaksura-ar.fina;
+        sub lam-ar.init alefMaksura-ar.fina by lam_alefMaksura-ar;
+        sub hehgoal-ar.init alefMaksura-ar.fina by hehgoal_alefMaksura-ar.fina;
+    } yeh_arabic;
+
+    lookup yehbarree_arabic {
+        lookupflag IgnoreMarks;
+        sub behDotless-ar.init yehbarree-ar.fina by behDotless_yehbarree-ar;
+        sub hah-ar.init yehbarree-ar.fina by hah_yehbarree-ar;
+        sub seen-ar.init yehbarree-ar.fina by seen_yehbarree-ar;
+        sub sad-ar.init yehbarree-ar.fina by sad_yehbarree-ar;
+        sub tah-ar.init yehbarree-ar.fina by tah_yehbarree-ar;
+        sub ain-ar.init yehbarree-ar.fina by ain_yehbarree-ar;
+        sub fehDotless-ar.init yehbarree-ar.fina by fehDotless_yehbarree-ar;
+        sub kaf-ar.init yehbarree-ar.fina by kaf_yehbarree-ar;
+        sub lam-ar.init yehbarree-ar.fina by lam_yehbarree-ar;
+        sub lam-ar.init yehbarree-ar.fina by lam_yehbarree-ar;
+        sub meem-ar.init yehbarree-ar.fina by meem_yehbarree-ar;
+        sub heh-ar.init yehbarree-ar.fina by heh_yehbarree-ar;
+        sub hehgoal-ar.init yehbarree-ar.fina by hehgoal_yehbarree-ar;
+        sub [behDotless-ar.medi behDotless-ar.medi.high] yehbarree-ar.fina by behDotless_yehbarree-ar.fina;
+        sub hah-ar.medi yehbarree-ar.fina by hah_yehbarree-ar.fina;
+        sub seen-ar.medi yehbarree-ar.fina by seen_yehbarree-ar.fina;
+        sub sad-ar.medi yehbarree-ar.fina by sad_yehbarree-ar.fina;
+        sub tah-ar.medi yehbarree-ar.fina by tah_yehbarree-ar.fina;
+        sub ain-ar.medi yehbarree-ar.fina by ain_yehbarree-ar.fina;
+        sub fehDotless-ar.medi yehbarree-ar.fina by fehDotless_yehbarree-ar.fina;
+        sub kaf-ar.medi yehbarree-ar.fina by kaf_yehbarree-ar.fina;
+        sub lam-ar.medi yehbarree-ar.fina by lam_yehbarree-ar.fina;
+        sub lam-ar.medi yehbarree-ar.fina by lam_yehbarree-ar.fina;
+        sub meem-ar.medi yehbarree-ar.fina by meem_yehbarree-ar.fina;
+        sub heh-ar.medi yehbarree-ar.fina by heh_yehbarree-ar.fina;
+        sub hehDoachashmee-ar.medi yehbarree-ar.fina by hehDoachashmee_yehbarree-ar.fina;
+        sub hehgoal-ar.medi yehbarree-ar.fina by hehgoal_yehbarree-ar.fina;
+    } yehbarree_arabic;
+
+    lookup hehgoal_yehbarree_arabic {
+        lookupflag IgnoreMarks;
+        sub hehgoal-ar.medi' [behDotless_yehbarree-ar.fina hah_yehbarree-ar.fina ain_yehbarree-ar.fina fehDotless_yehbarree-ar.fina kaf_yehbarree-ar.fina lam_yehbarree-ar.fina heh_yehbarree-ar.fina hehgoal_yehbarree-ar.fina] by hehgoal-ar.medi.yehbarree;
+    } hehgoal_yehbarree_arabic;
+
+    lookup floating_hamza_arabic {
+        lookupflag UseMarkFilteringSet [hamzaaboveMark-ar];
+        sub [lam-ar.init lam-ar.medi] kashida-ar' hamzaaboveMark-ar' by hamzafloating-ar;
+    } floating_hamza_arabic;
+
+    lookup lam_alef_arabic {
+        lookupflag IgnoreMarks;
+        sub lam-ar.init alef-ar.fina by lam_alef-ar;
+        sub lam-ar.medi alef-ar.fina by lam_alef-ar.fina;
+        sub lam-ar.init alef-ar.short.fina by lam_alef-ar;
+        sub lam-ar.medi alef-ar.short.fina by lam_alef-ar.fina;
+    } lam_alef_arabic;
+
+    # Hack.
+    # In mark feature we want to move dots over beh to the right if the reh is dotless, but since
+    # it is a ligature we can’t detect that e.g. "behDotless-ar dotabove-ar reh-ar.fina" and
+    # "behDotless-ar reh-ar.fina dotabove-ar" both become "behDotless_reh-ar.fina dotabove-ar",
+    # but we want to move the dots only in the first case.
+    # So, here we insert a "dummy" glyph before the dots if they are on thre reh and the beh is dotless.
+    lookup teh_dots_sub_arabic {
+        lookupflag UseMarkFilteringSet @dots.above_arabic;
+        sub behDotless-ar.medi' [reh-ar.fina rehLoop-ar.fina] @dots.above_arabic by behDotless-ar.medi dummy;
+    } teh_dots_sub_arabic;
+
+    lookup standard_ligatures_arabic {
+        lookupflag IgnoreMarks;
+        #sub behDotless-ar.init	hah-ar.medi			by behDotless_hah-ar.init;
+        #sub behDotless-ar.init	hah-ar.fina			by behDotless_hah-ar;
+        sub [behDotless-ar.medi behDotless-ar.medi.high] reh-ar.fina by behDotless_reh-ar.fina;
+        sub [behDotless-ar.medi behDotless-ar.medi.high] rehLoop-ar.fina by behDotless_rehLoop-ar.fina;
+        sub [behDotless-ar.medi behDotless-ar.medi.high] noonghunna-ar.fina by behDotless_noonghunna-ar.fina;
+        sub seen-ar.init reh-ar.fina by seen_reh-ar;
+        sub seen-ar.medi reh-ar.fina by seen_reh-ar.fina;
+        sub seen-ar.init rehLoop-ar.fina by seen_rehLoop-ar;
+        sub seen-ar.medi rehLoop-ar.fina by seen_rehLoop-ar.fina;
+        sub sad-ar.init reh-ar.fina by sad_reh-ar;
+        sub sad-ar.medi reh-ar.fina by sad_reh-ar.fina;
+        sub sad-ar.init rehLoop-ar.fina by sad_rehLoop-ar;
+        sub sad-ar.medi rehLoop-ar.fina by sad_rehLoop-ar.fina;
+        #sub lam-ar.init		hah-ar.medi			by lam_hah-ar.init;
+        sub kaf-ar.init alef-ar.fina by kaf_alef-ar;
+        sub kaf-ar.medi alef-ar.fina by kaf_alef-ar.fina;
+        sub kaf-ar.init alef-ar.short.fina by kaf_alef-ar.short;
+        sub kaf-ar.medi alef-ar.short.fina by kaf_alef-ar.fina.short;
+        sub kaf-ar.init lam-ar.fina by kaf_lam-ar;
+        sub kaf-ar.init lam-ar.medi by kaf_lam-ar.init;
+        sub kaf-ar.medi lam-ar.fina by kaf_lam-ar.fina;
+        sub kaf-ar.medi lam-ar.medi by kaf_lam-ar.medi;
+        sub kaf-ar.init kafDotless-ar.fina by kaf_kafDotless-ar;
+        sub kaf-ar.medi kafDotless-ar.fina by kaf_kafDotless-ar.fina;
+        sub kaf-ar.init lam_alef-ar.fina by kaf_lam_alef-ar;
+        sub kaf-ar.medi lam_alef-ar.fina by kaf_lam_alef-ar.fina;
+    } standard_ligatures_arabic;
+
+    lookup hehgoal_arabic {
+        lookupflag IgnoreMarks;
+        sub hehgoal-ar.init' @hehgoal.ascending_arabic by hehgoal-ar.init.ascending;
+    } hehgoal_arabic;
+
+    @sarkash_arabic = [gafsarkashabove-ar grafsarkashabove-ar];
+    lookup short_sarkash_arabic {
+        lookupflag UseMarkFilteringSet @sarkash_arabic;
+        sub [kaf_alef-ar kaf_alef-ar.fina kaf_alef-ar.short kaf_alef-ar.fina.short kaf_lam-ar kaf_lam-ar.fina kaf_lam-ar.medi kaf_lam-ar.init kaf_kafDotless-ar kaf_kafDotless-ar.fina kaf_lam_alef-ar kaf_lam_alef-ar.fina] @sarkash_arabic' by [gafsarkashabove-ar.short grafsarkashabove-ar.short];
+    } short_sarkash_arabic;
+
+    lookup small_alef_arabic {
+        lookupflag 0;
+        sub thinspace' alefabove-ar by space;
+    } small_alef_arabic;
+
+    lookup allah_arabic {
+        lookupflag 0;
+        sub alef-ar lam-ar.init lam-ar.medi shadda-ar alefabove-ar [heh-ar.fina hehgoal-ar.fina] by allah-ar;
+        sub lam-ar.init lam-ar.medi shadda-ar alefabove-ar [heh-ar.fina hehgoal-ar.fina] by lellah-ar;
+        sub lam-ar.medi lam-ar.medi shadda-ar alefabove-ar [heh-ar.fina hehgoal-ar.fina] by lellah-ar.fina;
+    } allah_arabic;
+
+} rlig;
+
+feature tnum {
+    # automatic
+    sub zero by zero.tf;
+    sub one by one.tf;
+    sub two by two.tf;
+    sub three by three.tf;
+    sub four by four.tf;
+    sub five by five.tf;
+    sub six by six.tf;
+    sub seven by seven.tf;
+    sub eight by eight.tf;
+    sub nine by nine.tf;
+    sub zero-ar by zero-ar.tf;
+    sub one-ar by one-ar.tf;
+    sub two-ar by two-ar.tf;
+    sub three-ar by three-ar.tf;
+    sub four-ar by four-ar.tf;
+    sub five-ar by five-ar.tf;
+    sub six-ar by six-ar.tf;
+    sub seven-ar by seven-ar.tf;
+    sub eight-ar by eight-ar.tf;
+    sub nine-ar by nine-ar.tf;
+    sub zero-persian.alt by zero-persian.alt.tf;
+    sub two-persian by two-persian.tf;
+    sub four-persian by four-persian.tf;
+    sub four-persian.alt by four-persian.alt.tf;
+    sub five-persian by five-persian.tf;
+    sub six-persian by six-persian.tf;
+    sub seven-persian by seven-persian.tf;
+    sub seven-persian.alt by seven-persian.alt.tf;
+} tnum;
+
+feature pnum {
+    # automatic
+    sub zero.tf by zero;
+    sub one.tf by one;
+    sub two.tf by two;
+    sub three.tf by three;
+    sub four.tf by four;
+    sub five.tf by five;
+    sub six.tf by six;
+    sub seven.tf by seven;
+    sub eight.tf by eight;
+    sub nine.tf by nine;
+    sub zero-ar.tf by zero-ar;
+    sub one-ar.tf by one-ar;
+    sub two-ar.tf by two-ar;
+    sub three-ar.tf by three-ar;
+    sub four-ar.tf by four-ar;
+    sub five-ar.tf by five-ar;
+    sub six-ar.tf by six-ar;
+    sub seven-ar.tf by seven-ar;
+    sub eight-ar.tf by eight-ar;
+    sub nine-ar.tf by nine-ar;
+    sub zero-persian.alt.tf by zero-persian.alt;
+    sub two-persian.tf by two-persian;
+    sub four-persian.tf by four-persian;
+    sub four-persian.alt.tf by four-persian.alt;
+    sub five-persian.tf by five-persian;
+    sub six-persian.tf by six-persian;
+    sub seven-persian.tf by seven-persian;
+    sub seven-persian.alt.tf by seven-persian.alt;
+} pnum;
+
+lookup kern_rtl_arabic {
+    lookupflag IgnoreMarks;
+    pos eight-ar nine-ar (opsz=18,wght=400:-80 opsz=18,wght=700:-60 opsz=17,wght=400:-80 opsz=17,wght=700:-60);
+    pos eight-ar six-ar (opsz=18,wght=400:-100 opsz=18,wght=700:-90 opsz=17,wght=400:-100 opsz=17,wght=700:-90);
+    pos five-ar six-ar (opsz=18,wght=400:-70 opsz=18,wght=700:-30 opsz=17,wght=400:-70 opsz=17,wght=700:-30);
+    pos five-persian six-ar (opsz=18,wght=400:-70 opsz=18,wght=700:-40 opsz=17,wght=400:-70 opsz=17,wght=700:-40);
+    pos four-ar six-ar (opsz=18,wght=400:-20 opsz=18,wght=700:0 opsz=17,wght=400:-20 opsz=17,wght=700:0);
+    pos four-ar three-ar (opsz=18,wght=400:-40 opsz=18,wght=700:0 opsz=17,wght=400:-40 opsz=17,wght=700:0);
+    pos four-persian eight-ar (opsz=18,wght=400:-80 opsz=18,wght=700:-50 opsz=17,wght=400:-80 opsz=17,wght=700:-50);
+    pos four-persian.alt eight-ar (opsz=18,wght=400:-120 opsz=18,wght=700:-100 opsz=17,wght=400:-120 opsz=17,wght=700:-100);
+    pos one-ar six-ar (opsz=18,wght=400:-30 opsz=18,wght=700:0 opsz=17,wght=400:-30 opsz=17,wght=700:0);
+    pos seven-persian.alt eight-ar (opsz=18,wght=400:-20 opsz=18,wght=700:-40 opsz=17,wght=400:-20 opsz=17,wght=700:-40);
+    pos six-ar eight-ar (opsz=18,wght=400:0 opsz=18,wght=700:20 opsz=17,wght=400:0 opsz=17,wght=700:20);
+    pos six-persian eight-ar (opsz=18,wght=400:-70 opsz=18,wght=700:-60 opsz=17,wght=400:-70 opsz=17,wght=700:-60);
+    pos three-ar eight-ar (opsz=18,wght=400:-80 opsz=18,wght=700:-90 opsz=17,wght=400:-80 opsz=17,wght=700:-90);
+    pos two-ar eight-ar (opsz=18,wght=400:-110 opsz=18,wght=700:-100 opsz=17,wght=400:-110 opsz=17,wght=700:-100);
+    pos two-persian eight-ar (opsz=18,wght=400:-110 opsz=18,wght=700:-80 opsz=17,wght=400:-110 opsz=17,wght=700:-80);
+    enum pos dal-ar @kern2.kaf.init_arabic <(opsz=18,wght=400:-90 opsz=18,wght=700:-70 opsz=17,wght=400:-50 opsz=17,wght=700:-70) 0 (opsz=18,wght=400:-90 opsz=18,wght=700:-70 opsz=17,wght=400:-50 opsz=17,wght=700:-70) 0>;
+    enum pos dal-ar.fina @kern2.kaf.init_arabic <(opsz=18,wght=400:-90 opsz=18,wght=700:-70 opsz=17,wght=400:-70 opsz=17,wght=700:-80) 0 (opsz=18,wght=400:-90 opsz=18,wght=700:-70 opsz=17,wght=400:-70 opsz=17,wght=700:-80) 0>;
+    enum pos eight-ar @kern2.sevenar_arabic -120;
+    enum pos five-ar @kern2.sevenar_arabic (opsz=18,wght=400:-30 opsz=18,wght=700:-10 opsz=17,wght=400:-30 opsz=17,wght=700:-10);
+    enum pos five-persian @kern2.sevenar_arabic (opsz=18,wght=400:-60 opsz=18,wght=700:-50 opsz=17,wght=400:-60 opsz=17,wght=700:-50);
+    enum pos four-ar @kern2.sevenar_arabic (opsz=18,wght=400:-50 opsz=18,wght=700:-20 opsz=17,wght=400:-50 opsz=17,wght=700:-20);
+    enum pos nine-ar @kern2.sevenar_arabic (opsz=18,wght=400:-30 opsz=18,wght=700:0 opsz=17,wght=400:-30 opsz=17,wght=700:0);
+    enum pos @kern1.reh_arabic ain-ar <(opsz=18,wght=400:90 opsz=18,wght=700:70 opsz=17,wght=400:90 opsz=17,wght=700:70) 0 (opsz=18,wght=400:90 opsz=18,wght=700:70 opsz=17,wght=400:90 opsz=17,wght=700:70) 0>;
+    enum pos @kern1.reh_arabic ain-ar.init <(opsz=18,wght=400:-30 opsz=18,wght=700:-40 opsz=17,wght=400:-30 opsz=17,wght=700:-40) 0 (opsz=18,wght=400:-30 opsz=18,wght=700:-40 opsz=17,wght=400:-30 opsz=17,wght=700:-40) 0>;
+    enum pos @kern1.reh_arabic behDotless-ar <(opsz=18,wght=400:-50 opsz=18,wght=700:-30 opsz=17,wght=400:-50 opsz=17,wght=700:-30) 0 (opsz=18,wght=400:-50 opsz=18,wght=700:-30 opsz=17,wght=400:-50 opsz=17,wght=700:-30) 0>;
+    enum pos @kern1.reh_arabic behDotless_alefMaksura-ar <(opsz=18,wght=400:60 opsz=18,wght=700:50 opsz=17,wght=400:60 opsz=17,wght=700:50) 0 (opsz=18,wght=400:60 opsz=18,wght=700:50 opsz=17,wght=400:60 opsz=17,wght=700:50) 0>;
+    enum pos @kern1.reh_arabic fehDotless_alefMaksura-ar <(opsz=18,wght=400:60 opsz=18,wght=700:50 opsz=17,wght=400:60 opsz=17,wght=700:50) 0 (opsz=18,wght=400:60 opsz=18,wght=700:50 opsz=17,wght=400:60 opsz=17,wght=700:50) 0>;
+    enum pos @kern1.reh_arabic hah-ar <(opsz=18,wght=400:60 opsz=18,wght=700:70 opsz=17,wght=400:60 opsz=17,wght=700:70) 0 (opsz=18,wght=400:60 opsz=18,wght=700:70 opsz=17,wght=400:60 opsz=17,wght=700:70) 0>;
+    enum pos @kern1.reh_arabic hah-ar.init <(opsz=18,wght=400:-80 opsz=18,wght=700:-70 opsz=17,wght=400:-80 opsz=17,wght=700:-70) 0 (opsz=18,wght=400:-80 opsz=18,wght=700:-70 opsz=17,wght=400:-80 opsz=17,wght=700:-70) 0>;
+    enum pos @kern1.reh_arabic highhamza-ar <-30 0 -30 0>;
+    enum pos @kern1.reh_arabic lam-ar <(opsz=18,wght=400:50 opsz=18,wght=700:0 opsz=17,wght=400:50 opsz=17,wght=700:0) 0 (opsz=18,wght=400:50 opsz=18,wght=700:0 opsz=17,wght=400:50 opsz=17,wght=700:0) 0>;
+    enum pos @kern1.reh_arabic lam_alef-ar <(opsz=18,wght=400:-50 opsz=18,wght=700:-40 opsz=17,wght=400:-50 opsz=17,wght=700:-40) 0 (opsz=18,wght=400:-50 opsz=18,wght=700:-40 opsz=17,wght=400:-50 opsz=17,wght=700:-40) 0>;
+    enum pos @kern1.reh_arabic lam_alefMaksura-ar <(opsz=18,wght=400:60 opsz=18,wght=700:50 opsz=17,wght=400:60 opsz=17,wght=700:50) 0 (opsz=18,wght=400:60 opsz=18,wght=700:50 opsz=17,wght=400:60 opsz=17,wght=700:50) 0>;
+    enum pos @kern1.reh_arabic meem-ar <(opsz=18,wght=400:-60 opsz=18,wght=700:-50 opsz=17,wght=400:-60 opsz=17,wght=700:-50) 0 (opsz=18,wght=400:-60 opsz=18,wght=700:-50 opsz=17,wght=400:-60 opsz=17,wght=700:-50) 0>;
+    enum pos @kern1.reh_arabic meem-ar.init <(opsz=18,wght=400:-50 opsz=18,wght=700:-40 opsz=17,wght=400:-50 opsz=17,wght=700:-40) 0 (opsz=18,wght=400:-50 opsz=18,wght=700:-40 opsz=17,wght=400:-50 opsz=17,wght=700:-40) 0>;
+    enum pos @kern1.reh_arabic waw-ar <(opsz=18,wght=400:40 opsz=18,wght=700:0 opsz=17,wght=400:40 opsz=17,wght=700:0) 0 (opsz=18,wght=400:40 opsz=18,wght=700:0 opsz=17,wght=400:40 opsz=17,wght=700:0) 0>;
+    enum pos @kern1.sevenar_arabic eight-ar -120;
+    enum pos @kern1.sevenar_arabic five-ar (opsz=18,wght=400:-30 opsz=18,wght=700:-10 opsz=17,wght=400:-30 opsz=17,wght=700:-10);
+    enum pos @kern1.sevenar_arabic five-persian -40;
+    enum pos @kern1.sevenar_arabic nine-ar (opsz=18,wght=400:-40 opsz=18,wght=700:0 opsz=17,wght=400:-40 opsz=17,wght=700:0);
+    enum pos @kern1.sevenar_arabic seven-persian.alt (opsz=18,wght=400:-40 opsz=18,wght=700:0 opsz=17,wght=400:-40 opsz=17,wght=700:0);
+    pos @kern1.reh_arabic @kern2.beh.init_arabic <(opsz=18,wght=400:-30 opsz=18,wght=700:-40 opsz=17,wght=400:-30 opsz=17,wght=700:-40) 0 (opsz=18,wght=400:-30 opsz=18,wght=700:-40 opsz=17,wght=400:-30 opsz=17,wght=700:-40) 0>;
+    pos @kern1.reh_arabic @kern2.feh_arabic <(opsz=18,wght=400:-40 opsz=18,wght=700:-30 opsz=17,wght=400:-40 opsz=17,wght=700:-30) 0 (opsz=18,wght=400:-40 opsz=18,wght=700:-30 opsz=17,wght=400:-40 opsz=17,wght=700:-30) 0>;
+    pos @kern1.reh_arabic @kern2.heh_arabic <(opsz=18,wght=400:-60 opsz=18,wght=700:-50 opsz=17,wght=400:-60 opsz=17,wght=700:-50) 0 (opsz=18,wght=400:-60 opsz=18,wght=700:-50 opsz=17,wght=400:-60 opsz=17,wght=700:-50) 0>;
+    pos @kern1.reh_arabic @kern2.heh.init_arabic <(opsz=18,wght=400:-40 opsz=18,wght=700:-30 opsz=17,wght=400:-40 opsz=17,wght=700:-30) 0 (opsz=18,wght=400:-40 opsz=18,wght=700:-30 opsz=17,wght=400:-40 opsz=17,wght=700:-30) 0>;
+    pos @kern1.reh_arabic @kern2.kaf.init_arabic <(opsz=18,wght=400:-140 opsz=18,wght=700:-120 opsz=17,wght=400:-140 opsz=17,wght=700:-120) 0 (opsz=18,wght=400:-140 opsz=18,wght=700:-120 opsz=17,wght=400:-140 opsz=17,wght=700:-120) 0>;
+    pos @kern1.reh_arabic @kern2.kafswash_arabic <(opsz=18,wght=400:-50 opsz=18,wght=700:-40 opsz=17,wght=400:-50 opsz=17,wght=700:-40) 0 (opsz=18,wght=400:-50 opsz=18,wght=700:-40 opsz=17,wght=400:-50 opsz=17,wght=700:-40) 0>;
+    pos @kern1.reh_arabic @kern2.lam.init_arabic <(opsz=18,wght=400:-40 opsz=18,wght=700:-30 opsz=17,wght=400:-40 opsz=17,wght=700:-30) 0 (opsz=18,wght=400:-40 opsz=18,wght=700:-30 opsz=17,wght=400:-40 opsz=17,wght=700:-30) 0>;
+    pos @kern1.reh_arabic @kern2.sad_arabic <(opsz=18,wght=400:-50 opsz=18,wght=700:-40 opsz=17,wght=400:-50 opsz=17,wght=700:-40) 0 (opsz=18,wght=400:-50 opsz=18,wght=700:-40 opsz=17,wght=400:-50 opsz=17,wght=700:-40) 0>;
+    pos @kern1.reh_arabic @kern2.seen_arabic <(opsz=18,wght=400:-50 opsz=18,wght=700:-40 opsz=17,wght=400:-50 opsz=17,wght=700:-40) 0 (opsz=18,wght=400:-50 opsz=18,wght=700:-40 opsz=17,wght=400:-50 opsz=17,wght=700:-40) 0>;
+    pos @kern1.reh_arabic @kern2.yehbarree_arabic <(opsz=18,wght=400:-50 opsz=18,wght=700:-40 opsz=17,wght=400:-50 opsz=17,wght=700:-40) 0 (opsz=18,wght=400:-50 opsz=18,wght=700:-40 opsz=17,wght=400:-50 opsz=17,wght=700:-40) 0>;
+    pos @kern1.waw_arabic @kern2.kaf.init_arabic <(opsz=18,wght=400:-90 opsz=18,wght=700:-70 opsz=17,wght=400:-50 opsz=17,wght=700:-70) 0 (opsz=18,wght=400:-90 opsz=18,wght=700:-70 opsz=17,wght=400:-50 opsz=17,wght=700:-70) 0>;
+} kern_rtl_arabic;
+
+lookup kern_contextual_0_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> hamzabelow-ar ain-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> hamzabelow-ar hamzabelow-ar ain-ar;
+} kern_contextual_0_arabic;
+
+lookup kern_contextual_1_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar hamzabelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:20 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:20 opsz=17,wght=700:40) 0> hamzabelow-ar alef-ar hamzabelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:20 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:20 opsz=17,wght=700:40) 0> hamzabelow-ar hamzabelow-ar hamzabelow-ar alef-ar hamzabelow-ar;
+} kern_contextual_1_arabic;
+
+lookup kern_contextual_2_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar madda-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0> hamzabelow-ar alef-ar.short madda-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0> hamzabelow-ar madda-ar hamzabelow-ar alef-ar.short madda-ar;
+} kern_contextual_2_arabic;
+
+lookup kern_contextual_3_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar wavyhamzaabove-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0> hamzabelow-ar alef-ar.short wavyhamzaabove-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0> hamzabelow-ar wavyhamzaabove-ar hamzabelow-ar alef-ar.short wavyhamzaabove-ar;
+} kern_contextual_3_arabic;
+
+lookup kern_contextual_4_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar wavyhamzabelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> hamzabelow-ar alef-ar wavyhamzabelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> hamzabelow-ar wavyhamzabelow-ar hamzabelow-ar alef-ar wavyhamzabelow-ar;
+} kern_contextual_4_arabic;
+
+lookup kern_contextual_5_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> hamzabelow-ar behDotless_alefMaksura-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> hamzabelow-ar hamzabelow-ar behDotless_alefMaksura-ar;
+} kern_contextual_5_arabic;
+
+lookup kern_contextual_6_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar threedotshorizontalbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:40 opsz=18,wght=700:110 opsz=17,wght=400:40 opsz=17,wght=700:110) 0 (opsz=18,wght=400:40 opsz=18,wght=700:110 opsz=17,wght=400:40 opsz=17,wght=700:110) 0> hamzabelow-ar behDotless-ar.init threedotshorizontalbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:40 opsz=18,wght=700:110 opsz=17,wght=400:40 opsz=17,wght=700:110) 0 (opsz=18,wght=400:40 opsz=18,wght=700:110 opsz=17,wght=400:40 opsz=17,wght=700:110) 0> hamzabelow-ar threedotshorizontalbelow-ar hamzabelow-ar behDotless-ar.init threedotshorizontalbelow-ar;
+} kern_contextual_6_arabic;
+
+lookup kern_contextual_7_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar threedotsupbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> hamzabelow-ar behDotless-ar.init threedotsupbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> hamzabelow-ar threedotsupbelow-ar hamzabelow-ar behDotless-ar.init threedotsupbelow-ar;
+} kern_contextual_7_arabic;
+
+lookup kern_contextual_8_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar vinvertedbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0> hamzabelow-ar behDotless-ar.init vinvertedbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0> hamzabelow-ar vinvertedbelow-ar hamzabelow-ar behDotless-ar.init vinvertedbelow-ar;
+} kern_contextual_8_arabic;
+
+lookup kern_contextual_9_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar fourdotsbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0> hamzabelow-ar behDotless-ar.init fourdotsbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0> hamzabelow-ar fourdotsbelow-ar hamzabelow-ar behDotless-ar.init fourdotsbelow-ar;
+} kern_contextual_9_arabic;
+
+lookup kern_contextual_10_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> hamzabelow-ar hah-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> hamzabelow-ar hamzabelow-ar hah-ar;
+} kern_contextual_10_arabic;
+
+lookup kern_contextual_11_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar threedotsdownbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0> hamzabelow-ar lam-ar.init threedotsdownbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0> hamzabelow-ar threedotsdownbelow-ar hamzabelow-ar lam-ar.init threedotsdownbelow-ar;
+} kern_contextual_11_arabic;
+
+lookup kern_contextual_12_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar threedotsdownbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0> hamzabelow-ar behDotless-ar.init threedotsdownbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0> hamzabelow-ar threedotsdownbelow-ar hamzabelow-ar behDotless-ar.init threedotsdownbelow-ar;
+} kern_contextual_12_arabic;
+
+lookup kern_contextual_13_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar twodotshorizontalbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> hamzabelow-ar behDotless-ar.init twodotshorizontalbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> hamzabelow-ar twodotshorizontalbelow-ar hamzabelow-ar behDotless-ar.init twodotshorizontalbelow-ar;
+} kern_contextual_13_arabic;
+
+lookup kern_contextual_14_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar fourbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> hamzabelow-ar behDotless-ar.init fourbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> hamzabelow-ar fourbelow-ar hamzabelow-ar behDotless-ar.init fourbelow-ar;
+} kern_contextual_14_arabic;
+
+lookup kern_contextual_15_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar ring-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> hamzabelow-ar behDotless-ar.init ring-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> hamzabelow-ar ring-ar hamzabelow-ar behDotless-ar.init ring-ar;
+} kern_contextual_15_arabic;
+
+lookup kern_contextual_16_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar hamzabelow-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0> hamzabelow-ar alef-ar hamzabelow-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:1 opsz=17,wght=700:50) 0> hamzabelow-ar hamzabelow-ar hamzabelow-ar alef-ar hamzabelow-ar;
+} kern_contextual_16_arabic;
+
+lookup kern_contextual_17_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar madda-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> hamzabelow-ar alef-ar.short madda-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> hamzabelow-ar madda-ar hamzabelow-ar alef-ar.short madda-ar;
+} kern_contextual_17_arabic;
+
+lookup kern_contextual_18_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar wasla-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0> hamzabelow-ar alef-ar.short wasla-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0> hamzabelow-ar wasla-ar hamzabelow-ar alef-ar.short wasla-ar;
+} kern_contextual_18_arabic;
+
+lookup kern_contextual_19_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar wavyhamzaabove-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> hamzabelow-ar alef-ar.short wavyhamzaabove-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> hamzabelow-ar wavyhamzaabove-ar hamzabelow-ar alef-ar.short wavyhamzaabove-ar;
+} kern_contextual_19_arabic;
+
+lookup kern_contextual_20_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar wavyhamzabelow-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> hamzabelow-ar alef-ar wavyhamzabelow-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> hamzabelow-ar wavyhamzabelow-ar hamzabelow-ar alef-ar wavyhamzabelow-ar;
+} kern_contextual_20_arabic;
+
+lookup kern_contextual_21_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar threedotshorizontalbelow-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:40 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:40 opsz=17,wght=700:50) 0> hamzabelow-ar behDotless-ar.init threedotshorizontalbelow-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:40 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:40 opsz=17,wght=400:40 opsz=17,wght=700:50) 0> hamzabelow-ar threedotshorizontalbelow-ar hamzabelow-ar behDotless-ar.init threedotshorizontalbelow-ar;
+} kern_contextual_21_arabic;
+
+lookup kern_contextual_22_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar threedotsupbelow-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0> hamzabelow-ar behDotless-ar.init threedotsupbelow-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0> hamzabelow-ar threedotsupbelow-ar hamzabelow-ar behDotless-ar.init threedotsupbelow-ar;
+} kern_contextual_22_arabic;
+
+lookup kern_contextual_23_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar fourdotsbelow-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0> hamzabelow-ar behDotless-ar.init fourdotsbelow-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0> hamzabelow-ar fourdotsbelow-ar hamzabelow-ar behDotless-ar.init fourdotsbelow-ar;
+} kern_contextual_23_arabic;
+
+lookup kern_contextual_24_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar threedotsdownbelow-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> hamzabelow-ar lam-ar.init threedotsdownbelow-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> hamzabelow-ar threedotsdownbelow-ar hamzabelow-ar lam-ar.init threedotsdownbelow-ar;
+} kern_contextual_24_arabic;
+
+lookup kern_contextual_25_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar threedotsdownbelow-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0> hamzabelow-ar behDotless-ar.init threedotsdownbelow-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:20) 0> hamzabelow-ar threedotsdownbelow-ar hamzabelow-ar behDotless-ar.init threedotsdownbelow-ar;
+} kern_contextual_25_arabic;
+
+lookup kern_contextual_26_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar twodotshorizontalbelow-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> hamzabelow-ar behDotless-ar.init twodotshorizontalbelow-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> hamzabelow-ar twodotshorizontalbelow-ar hamzabelow-ar behDotless-ar.init twodotshorizontalbelow-ar;
+} kern_contextual_26_arabic;
+
+lookup kern_contextual_27_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:40 opsz=18,wght=700:70 opsz=17,wght=400:40 opsz=17,wght=700:70) 0 (opsz=18,wght=400:40 opsz=18,wght=700:70 opsz=17,wght=400:40 opsz=17,wght=700:70) 0> wavyhamzabelow-ar ain-ar;
+    pos alef-ar' <(opsz=18,wght=400:40 opsz=18,wght=700:70 opsz=17,wght=400:40 opsz=17,wght=700:70) 0 (opsz=18,wght=400:40 opsz=18,wght=700:70 opsz=17,wght=400:40 opsz=17,wght=700:70) 0> wavyhamzabelow-ar wavyhamzabelow-ar ain-ar;
+} kern_contextual_27_arabic;
+
+lookup kern_contextual_28_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar hamzabelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:50 opsz=18,wght=700:110 opsz=17,wght=400:50 opsz=17,wght=700:110) 0 (opsz=18,wght=400:50 opsz=18,wght=700:110 opsz=17,wght=400:50 opsz=17,wght=700:110) 0> wavyhamzabelow-ar alef-ar hamzabelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:50 opsz=18,wght=700:110 opsz=17,wght=400:50 opsz=17,wght=700:110) 0 (opsz=18,wght=400:50 opsz=18,wght=700:110 opsz=17,wght=400:50 opsz=17,wght=700:110) 0> wavyhamzabelow-ar hamzabelow-ar wavyhamzabelow-ar alef-ar hamzabelow-ar;
+} kern_contextual_28_arabic;
+
+lookup kern_contextual_29_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar wavyhamzabelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:40 opsz=18,wght=700:120 opsz=17,wght=400:40 opsz=17,wght=700:120) 0 (opsz=18,wght=400:40 opsz=18,wght=700:120 opsz=17,wght=400:40 opsz=17,wght=700:120) 0> wavyhamzabelow-ar alef-ar wavyhamzabelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:40 opsz=18,wght=700:120 opsz=17,wght=400:40 opsz=17,wght=700:120) 0 (opsz=18,wght=400:40 opsz=18,wght=700:120 opsz=17,wght=400:40 opsz=17,wght=700:120) 0> wavyhamzabelow-ar wavyhamzabelow-ar wavyhamzabelow-ar alef-ar wavyhamzabelow-ar;
+} kern_contextual_29_arabic;
+
+lookup kern_contextual_30_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar threedotshorizontalbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:80 opsz=17,wght=400:70 opsz=17,wght=700:110) 0 (opsz=18,wght=400:1 opsz=18,wght=700:80 opsz=17,wght=400:70 opsz=17,wght=700:110) 0> wavyhamzabelow-ar behDotless-ar.init threedotshorizontalbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:80 opsz=17,wght=400:70 opsz=17,wght=700:110) 0 (opsz=18,wght=400:1 opsz=18,wght=700:80 opsz=17,wght=400:70 opsz=17,wght=700:110) 0> wavyhamzabelow-ar threedotshorizontalbelow-ar wavyhamzabelow-ar behDotless-ar.init threedotshorizontalbelow-ar;
+} kern_contextual_30_arabic;
+
+lookup kern_contextual_31_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar threedotsupbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:90) 0 (opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:90) 0> wavyhamzabelow-ar behDotless-ar.init threedotsupbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:90) 0 (opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:90) 0> wavyhamzabelow-ar threedotsupbelow-ar wavyhamzabelow-ar behDotless-ar.init threedotsupbelow-ar;
+} kern_contextual_31_arabic;
+
+lookup kern_contextual_32_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar fourdotsbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:60 opsz=17,wght=700:90) 0 (opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:60 opsz=17,wght=700:90) 0> wavyhamzabelow-ar behDotless-ar.init fourdotsbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:60 opsz=17,wght=700:90) 0 (opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:60 opsz=17,wght=700:90) 0> wavyhamzabelow-ar fourdotsbelow-ar wavyhamzabelow-ar behDotless-ar.init fourdotsbelow-ar;
+} kern_contextual_32_arabic;
+
+lookup kern_contextual_33_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar twodotsverticalbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:1 opsz=17,wght=700:60) 0 (opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:1 opsz=17,wght=700:60) 0> wavyhamzabelow-ar behDotless-ar.init twodotsverticalbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:1 opsz=17,wght=700:60) 0 (opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:1 opsz=17,wght=700:60) 0> wavyhamzabelow-ar twodotsverticalbelow-ar wavyhamzabelow-ar behDotless-ar.init twodotsverticalbelow-ar;
+} kern_contextual_33_arabic;
+
+lookup kern_contextual_34_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> wavyhamzabelow-ar hah-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:1 opsz=17,wght=700:30) 0> wavyhamzabelow-ar wavyhamzabelow-ar hah-ar;
+} kern_contextual_34_arabic;
+
+lookup kern_contextual_35_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar threedotsdownbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:40 opsz=17,wght=700:60) 0 (opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:40 opsz=17,wght=700:60) 0> wavyhamzabelow-ar lam-ar.init threedotsdownbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:40 opsz=17,wght=700:60) 0 (opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:40 opsz=17,wght=700:60) 0> wavyhamzabelow-ar threedotsdownbelow-ar wavyhamzabelow-ar lam-ar.init threedotsdownbelow-ar;
+} kern_contextual_35_arabic;
+
+lookup kern_contextual_36_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar threedotsdownbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> wavyhamzabelow-ar behDotless-ar.init threedotsdownbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> wavyhamzabelow-ar threedotsdownbelow-ar wavyhamzabelow-ar behDotless-ar.init threedotsdownbelow-ar;
+} kern_contextual_36_arabic;
+
+lookup kern_contextual_37_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar twodotshorizontalbelow-ar];
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:1 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:1 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> wavyhamzabelow-ar behDotless-ar.init twodotshorizontalbelow-ar;
+    pos alef-ar' <(opsz=18,wght=400:1 opsz=18,wght=700:1 opsz=17,wght=400:1 opsz=17,wght=700:40) 0 (opsz=18,wght=400:1 opsz=18,wght=700:1 opsz=17,wght=400:1 opsz=17,wght=700:40) 0> wavyhamzabelow-ar twodotshorizontalbelow-ar wavyhamzabelow-ar behDotless-ar.init twodotshorizontalbelow-ar;
+} kern_contextual_37_arabic;
+
+lookup kern_contextual_38_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar hamzabelow-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:20 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:20 opsz=17,wght=700:50) 0> wavyhamzabelow-ar alef-ar hamzabelow-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:20 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:20 opsz=17,wght=700:50) 0> wavyhamzabelow-ar hamzabelow-ar wavyhamzabelow-ar alef-ar hamzabelow-ar;
+} kern_contextual_38_arabic;
+
+lookup kern_contextual_39_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar wavyhamzabelow-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:30 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:30 opsz=17,wght=700:50) 0> wavyhamzabelow-ar alef-ar wavyhamzabelow-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:30 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:50 opsz=17,wght=400:30 opsz=17,wght=700:50) 0> wavyhamzabelow-ar wavyhamzabelow-ar wavyhamzabelow-ar alef-ar wavyhamzabelow-ar;
+} kern_contextual_39_arabic;
+
+lookup kern_contextual_40_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar threedotshorizontalbelow-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:40 opsz=17,wght=700:60) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:40 opsz=17,wght=700:60) 0> wavyhamzabelow-ar behDotless-ar.init threedotshorizontalbelow-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:40 opsz=17,wght=700:60) 0 (opsz=18,wght=400:1 opsz=18,wght=700:30 opsz=17,wght=400:40 opsz=17,wght=700:60) 0> wavyhamzabelow-ar threedotshorizontalbelow-ar wavyhamzabelow-ar behDotless-ar.init threedotshorizontalbelow-ar;
+} kern_contextual_40_arabic;
+
+lookup kern_contextual_41_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar threedotsupbelow-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:80 opsz=17,wght=400:1 opsz=17,wght=700:80) 0 (opsz=18,wght=400:1 opsz=18,wght=700:80 opsz=17,wght=400:1 opsz=17,wght=700:80) 0> wavyhamzabelow-ar behDotless-ar.init threedotsupbelow-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:80 opsz=17,wght=400:1 opsz=17,wght=700:80) 0 (opsz=18,wght=400:1 opsz=18,wght=700:80 opsz=17,wght=400:1 opsz=17,wght=700:80) 0> wavyhamzabelow-ar threedotsupbelow-ar wavyhamzabelow-ar behDotless-ar.init threedotsupbelow-ar;
+} kern_contextual_41_arabic;
+
+lookup kern_contextual_42_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar fourdotsbelow-ar];
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:20 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:20 opsz=17,wght=700:50) 0> wavyhamzabelow-ar behDotless-ar.init fourdotsbelow-ar;
+    pos alef-ar.fina' <(opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:20 opsz=17,wght=700:50) 0 (opsz=18,wght=400:1 opsz=18,wght=700:20 opsz=17,wght=400:20 opsz=17,wght=700:50) 0> wavyhamzabelow-ar fourdotsbelow-ar wavyhamzabelow-ar behDotless-ar.init fourdotsbelow-ar;
+} kern_contextual_42_arabic;
+
+lookup kern_contextual_43_arabic {
+    lookupflag UseMarkFilteringSet [hamzabelow-ar];
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:100 opsz=18,wght=700:130 opsz=17,wght=400:100 opsz=17,wght=700:130) 0 (opsz=18,wght=400:100 opsz=18,wght=700:130 opsz=17,wght=400:100 opsz=17,wght=700:130) 0> alef-ar hamzabelow-ar;
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:100 opsz=18,wght=700:130 opsz=17,wght=400:100 opsz=17,wght=700:130) 0 (opsz=18,wght=400:100 opsz=18,wght=700:130 opsz=17,wght=400:100 opsz=17,wght=700:130) 0> hamzabelow-ar alef-ar hamzabelow-ar;
+} kern_contextual_43_arabic;
+
+lookup kern_contextual_44_arabic {
+    lookupflag UseMarkFilteringSet [wavyhamzabelow-ar];
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:100 opsz=18,wght=700:120 opsz=17,wght=400:100 opsz=17,wght=700:120) 0 (opsz=18,wght=400:100 opsz=18,wght=700:120 opsz=17,wght=400:100 opsz=17,wght=700:120) 0> alef-ar wavyhamzabelow-ar;
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:100 opsz=18,wght=700:120 opsz=17,wght=400:100 opsz=17,wght=700:120) 0 (opsz=18,wght=400:100 opsz=18,wght=700:120 opsz=17,wght=400:100 opsz=17,wght=700:120) 0> wavyhamzabelow-ar alef-ar wavyhamzabelow-ar;
+} kern_contextual_44_arabic;
+
+lookup kern_contextual_45_arabic {
+    lookupflag UseMarkFilteringSet [dotbelow-ar];
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:20 opsz=18,wght=700:30 opsz=17,wght=400:40 opsz=17,wght=700:40) 0 (opsz=18,wght=400:20 opsz=18,wght=700:30 opsz=17,wght=400:40 opsz=17,wght=700:40) 0> @kern2.beh.init_arabic dotbelow-ar;
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:20 opsz=18,wght=700:30 opsz=17,wght=400:40 opsz=17,wght=700:40) 0 (opsz=18,wght=400:20 opsz=18,wght=700:30 opsz=17,wght=400:40 opsz=17,wght=700:40) 0> dotbelow-ar @kern2.beh.init_arabic dotbelow-ar;
+} kern_contextual_45_arabic;
+
+lookup kern_contextual_46_arabic {
+    lookupflag UseMarkFilteringSet [ringbelow-ar];
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:30 opsz=18,wght=700:40 opsz=17,wght=400:30 opsz=17,wght=700:40) 0 (opsz=18,wght=400:30 opsz=18,wght=700:40 opsz=17,wght=400:30 opsz=17,wght=700:40) 0> @kern2.beh.init_arabic ringbelow-ar;
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:30 opsz=18,wght=700:40 opsz=17,wght=400:30 opsz=17,wght=700:40) 0 (opsz=18,wght=400:30 opsz=18,wght=700:40 opsz=17,wght=400:30 opsz=17,wght=700:40) 0> ringbelow-ar @kern2.beh.init_arabic ringbelow-ar;
+} kern_contextual_46_arabic;
+
+lookup kern_contextual_47_arabic {
+    lookupflag UseMarkFilteringSet [threedotshorizontalbelow-ar];
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:120 opsz=18,wght=700:150 opsz=17,wght=400:180 opsz=17,wght=700:180) 0 (opsz=18,wght=400:120 opsz=18,wght=700:150 opsz=17,wght=400:180 opsz=17,wght=700:180) 0> @kern2.beh.init_arabic threedotshorizontalbelow-ar;
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:120 opsz=18,wght=700:150 opsz=17,wght=400:180 opsz=17,wght=700:180) 0 (opsz=18,wght=400:120 opsz=18,wght=700:150 opsz=17,wght=400:180 opsz=17,wght=700:180) 0> threedotshorizontalbelow-ar @kern2.beh.init_arabic threedotshorizontalbelow-ar;
+} kern_contextual_47_arabic;
+
+lookup kern_contextual_48_arabic {
+    lookupflag UseMarkFilteringSet [threedotsupbelow-ar];
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:80 opsz=18,wght=700:50 opsz=17,wght=400:50 opsz=17,wght=700:40) 0 (opsz=18,wght=400:80 opsz=18,wght=700:50 opsz=17,wght=400:50 opsz=17,wght=700:40) 0> @kern2.beh.init_arabic threedotsupbelow-ar;
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:80 opsz=18,wght=700:50 opsz=17,wght=400:50 opsz=17,wght=700:40) 0 (opsz=18,wght=400:80 opsz=18,wght=700:50 opsz=17,wght=400:50 opsz=17,wght=700:40) 0> threedotsupbelow-ar @kern2.beh.init_arabic threedotsupbelow-ar;
+} kern_contextual_48_arabic;
+
+lookup kern_contextual_49_arabic {
+    lookupflag UseMarkFilteringSet [vbelow-ar];
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:40 opsz=18,wght=700:40 opsz=17,wght=400:30 opsz=17,wght=700:40) 0 (opsz=18,wght=400:40 opsz=18,wght=700:40 opsz=17,wght=400:30 opsz=17,wght=700:40) 0> @kern2.beh.init_arabic vbelow-ar;
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:40 opsz=18,wght=700:40 opsz=17,wght=400:30 opsz=17,wght=700:40) 0 (opsz=18,wght=400:40 opsz=18,wght=700:40 opsz=17,wght=400:30 opsz=17,wght=700:40) 0> vbelow-ar @kern2.beh.init_arabic vbelow-ar;
+} kern_contextual_49_arabic;
+
+lookup kern_contextual_50_arabic {
+    lookupflag UseMarkFilteringSet [vinvertedbelow-ar];
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:60 opsz=18,wght=700:50 opsz=17,wght=400:60 opsz=17,wght=700:50) 0 (opsz=18,wght=400:60 opsz=18,wght=700:50 opsz=17,wght=400:60 opsz=17,wght=700:50) 0> @kern2.beh.init_arabic vinvertedbelow-ar;
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:60 opsz=18,wght=700:50 opsz=17,wght=400:60 opsz=17,wght=700:50) 0 (opsz=18,wght=400:60 opsz=18,wght=700:50 opsz=17,wght=400:60 opsz=17,wght=700:50) 0> vinvertedbelow-ar @kern2.beh.init_arabic vinvertedbelow-ar;
+} kern_contextual_50_arabic;
+
+lookup kern_contextual_51_arabic {
+    lookupflag UseMarkFilteringSet [fourdotsbelow-ar];
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:70 opsz=18,wght=700:90 opsz=17,wght=400:110 opsz=17,wght=700:110) 0 (opsz=18,wght=400:70 opsz=18,wght=700:90 opsz=17,wght=400:110 opsz=17,wght=700:110) 0> @kern2.beh.init_arabic fourdotsbelow-ar;
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:70 opsz=18,wght=700:90 opsz=17,wght=400:110 opsz=17,wght=700:110) 0 (opsz=18,wght=400:70 opsz=18,wght=700:90 opsz=17,wght=400:110 opsz=17,wght=700:110) 0> fourdotsbelow-ar @kern2.beh.init_arabic fourdotsbelow-ar;
+} kern_contextual_51_arabic;
+
+lookup kern_contextual_52_arabic {
+    lookupflag UseMarkFilteringSet [twodotsverticalbelow-ar];
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:30 opsz=18,wght=700:40 opsz=17,wght=400:40 opsz=17,wght=700:40) 0 (opsz=18,wght=400:30 opsz=18,wght=700:40 opsz=17,wght=400:40 opsz=17,wght=700:40) 0> @kern2.beh.init_arabic twodotsverticalbelow-ar;
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:30 opsz=18,wght=700:40 opsz=17,wght=400:40 opsz=17,wght=700:40) 0 (opsz=18,wght=400:30 opsz=18,wght=700:40 opsz=17,wght=400:40 opsz=17,wght=700:40) 0> twodotsverticalbelow-ar @kern2.beh.init_arabic twodotsverticalbelow-ar;
+} kern_contextual_52_arabic;
+
+lookup kern_contextual_53_arabic {
+    lookupflag UseMarkFilteringSet [threedotsdownbelow-ar];
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:120 opsz=18,wght=700:110 opsz=17,wght=400:160 opsz=17,wght=700:130) 0 (opsz=18,wght=400:120 opsz=18,wght=700:110 opsz=17,wght=400:160 opsz=17,wght=700:130) 0> @kern2.lam.init_arabic threedotsdownbelow-ar;
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:120 opsz=18,wght=700:110 opsz=17,wght=400:160 opsz=17,wght=700:130) 0 (opsz=18,wght=400:120 opsz=18,wght=700:110 opsz=17,wght=400:160 opsz=17,wght=700:130) 0> threedotsdownbelow-ar @kern2.lam.init_arabic threedotsdownbelow-ar;
+} kern_contextual_53_arabic;
+
+lookup kern_contextual_54_arabic {
+    lookupflag UseMarkFilteringSet [threedotsdownbelow-ar];
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:70 opsz=18,wght=700:90 opsz=17,wght=400:110 opsz=17,wght=700:110) 0 (opsz=18,wght=400:70 opsz=18,wght=700:90 opsz=17,wght=400:110 opsz=17,wght=700:110) 0> @kern2.beh.init_arabic threedotsdownbelow-ar;
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:70 opsz=18,wght=700:90 opsz=17,wght=400:110 opsz=17,wght=700:110) 0 (opsz=18,wght=400:70 opsz=18,wght=700:90 opsz=17,wght=400:110 opsz=17,wght=700:110) 0> threedotsdownbelow-ar @kern2.beh.init_arabic threedotsdownbelow-ar;
+} kern_contextual_54_arabic;
+
+lookup kern_contextual_55_arabic {
+    lookupflag UseMarkFilteringSet [twodotshorizontalbelow-ar];
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:70 opsz=18,wght=700:90 opsz=17,wght=400:110 opsz=17,wght=700:110) 0 (opsz=18,wght=400:70 opsz=18,wght=700:90 opsz=17,wght=400:110 opsz=17,wght=700:110) 0> @kern2.beh.init_arabic twodotshorizontalbelow-ar;
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:70 opsz=18,wght=700:90 opsz=17,wght=400:110 opsz=17,wght=700:110) 0 (opsz=18,wght=400:70 opsz=18,wght=700:90 opsz=17,wght=400:110 opsz=17,wght=700:110) 0> twodotshorizontalbelow-ar @kern2.beh.init_arabic twodotshorizontalbelow-ar;
+} kern_contextual_55_arabic;
+
+lookup kern_contextual_56_arabic {
+    lookupflag UseMarkFilteringSet [fourbelow-ar];
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:50 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:60) 0 (opsz=18,wght=400:50 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:60) 0> @kern2.beh.init_arabic fourbelow-ar;
+    pos @kern1.reh_arabic' <(opsz=18,wght=400:50 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:60) 0 (opsz=18,wght=400:50 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:60) 0> fourbelow-ar @kern2.beh.init_arabic fourbelow-ar;
+} kern_contextual_56_arabic;
+
+lookup kern_contextual_57_arabic {
+    lookupflag UseMarkFilteringSet [ring-ar];
+    pos @kern1.reh_arabic' <70 0 70 0> @kern2.beh.init_arabic ring-ar;
+    pos @kern1.reh_arabic' <70 0 70 0> ring-ar @kern2.beh.init_arabic ring-ar;
+} kern_contextual_57_arabic;
+
+lookup kern_contextual_58_arabic {
+    lookupflag UseMarkFilteringSet [threedotshorizontalbelow-ar];
+    pos @kern1.waw_arabic' <(opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:80) 0 (opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:80) 0> behDotless-ar.init threedotshorizontalbelow-ar;
+    pos @kern1.waw_arabic' <(opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:80) 0 (opsz=18,wght=400:1 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:80) 0> threedotshorizontalbelow-ar behDotless-ar.init threedotshorizontalbelow-ar;
+} kern_contextual_58_arabic;
+
+feature kern {
+    script DFLT;
+    language dflt;
+    lookup kern_rtl_arabic;
+    lookup kern_contextual_0_arabic;
+    lookup kern_contextual_1_arabic;
+    lookup kern_contextual_2_arabic;
+    lookup kern_contextual_3_arabic;
+    lookup kern_contextual_4_arabic;
+    lookup kern_contextual_5_arabic;
+    lookup kern_contextual_6_arabic;
+    lookup kern_contextual_7_arabic;
+    lookup kern_contextual_8_arabic;
+    lookup kern_contextual_9_arabic;
+    lookup kern_contextual_10_arabic;
+    lookup kern_contextual_11_arabic;
+    lookup kern_contextual_12_arabic;
+    lookup kern_contextual_13_arabic;
+    lookup kern_contextual_14_arabic;
+    lookup kern_contextual_15_arabic;
+    lookup kern_contextual_16_arabic;
+    lookup kern_contextual_17_arabic;
+    lookup kern_contextual_18_arabic;
+    lookup kern_contextual_19_arabic;
+    lookup kern_contextual_20_arabic;
+    lookup kern_contextual_21_arabic;
+    lookup kern_contextual_22_arabic;
+    lookup kern_contextual_23_arabic;
+    lookup kern_contextual_24_arabic;
+    lookup kern_contextual_25_arabic;
+    lookup kern_contextual_26_arabic;
+    lookup kern_contextual_27_arabic;
+    lookup kern_contextual_28_arabic;
+    lookup kern_contextual_29_arabic;
+    lookup kern_contextual_30_arabic;
+    lookup kern_contextual_31_arabic;
+    lookup kern_contextual_32_arabic;
+    lookup kern_contextual_33_arabic;
+    lookup kern_contextual_34_arabic;
+    lookup kern_contextual_35_arabic;
+    lookup kern_contextual_36_arabic;
+    lookup kern_contextual_37_arabic;
+    lookup kern_contextual_38_arabic;
+    lookup kern_contextual_39_arabic;
+    lookup kern_contextual_40_arabic;
+    lookup kern_contextual_41_arabic;
+    lookup kern_contextual_42_arabic;
+    lookup kern_contextual_43_arabic;
+    lookup kern_contextual_44_arabic;
+    lookup kern_contextual_45_arabic;
+    lookup kern_contextual_46_arabic;
+    lookup kern_contextual_47_arabic;
+    lookup kern_contextual_48_arabic;
+    lookup kern_contextual_49_arabic;
+    lookup kern_contextual_50_arabic;
+    lookup kern_contextual_51_arabic;
+    lookup kern_contextual_52_arabic;
+    lookup kern_contextual_53_arabic;
+    lookup kern_contextual_54_arabic;
+    lookup kern_contextual_55_arabic;
+    lookup kern_contextual_56_arabic;
+    lookup kern_contextual_57_arabic;
+    lookup kern_contextual_58_arabic;
+    script arab;
+    language dflt;
+    lookup kern_rtl_arabic;
+    lookup kern_contextual_0_arabic;
+    lookup kern_contextual_1_arabic;
+    lookup kern_contextual_2_arabic;
+    lookup kern_contextual_3_arabic;
+    lookup kern_contextual_4_arabic;
+    lookup kern_contextual_5_arabic;
+    lookup kern_contextual_6_arabic;
+    lookup kern_contextual_7_arabic;
+    lookup kern_contextual_8_arabic;
+    lookup kern_contextual_9_arabic;
+    lookup kern_contextual_10_arabic;
+    lookup kern_contextual_11_arabic;
+    lookup kern_contextual_12_arabic;
+    lookup kern_contextual_13_arabic;
+    lookup kern_contextual_14_arabic;
+    lookup kern_contextual_15_arabic;
+    lookup kern_contextual_16_arabic;
+    lookup kern_contextual_17_arabic;
+    lookup kern_contextual_18_arabic;
+    lookup kern_contextual_19_arabic;
+    lookup kern_contextual_20_arabic;
+    lookup kern_contextual_21_arabic;
+    lookup kern_contextual_22_arabic;
+    lookup kern_contextual_23_arabic;
+    lookup kern_contextual_24_arabic;
+    lookup kern_contextual_25_arabic;
+    lookup kern_contextual_26_arabic;
+    lookup kern_contextual_27_arabic;
+    lookup kern_contextual_28_arabic;
+    lookup kern_contextual_29_arabic;
+    lookup kern_contextual_30_arabic;
+    lookup kern_contextual_31_arabic;
+    lookup kern_contextual_32_arabic;
+    lookup kern_contextual_33_arabic;
+    lookup kern_contextual_34_arabic;
+    lookup kern_contextual_35_arabic;
+    lookup kern_contextual_36_arabic;
+    lookup kern_contextual_37_arabic;
+    lookup kern_contextual_38_arabic;
+    lookup kern_contextual_39_arabic;
+    lookup kern_contextual_40_arabic;
+    lookup kern_contextual_41_arabic;
+    lookup kern_contextual_42_arabic;
+    lookup kern_contextual_43_arabic;
+    lookup kern_contextual_44_arabic;
+    lookup kern_contextual_45_arabic;
+    lookup kern_contextual_46_arabic;
+    lookup kern_contextual_47_arabic;
+    lookup kern_contextual_48_arabic;
+    lookup kern_contextual_49_arabic;
+    lookup kern_contextual_50_arabic;
+    lookup kern_contextual_51_arabic;
+    lookup kern_contextual_52_arabic;
+    lookup kern_contextual_53_arabic;
+    lookup kern_contextual_54_arabic;
+    lookup kern_contextual_55_arabic;
+    lookup kern_contextual_56_arabic;
+    lookup kern_contextual_57_arabic;
+    lookup kern_contextual_58_arabic;
+    language FAR;
+    language KSH;
+    language RHG;
+    language SND;
+    language URD;
+} kern;
+
+feature kern {
+    # Kern ٢٠٢ but not ٢٠٦, and don’t cheange the zero advance width to maintain balanced spacing.
+    ignore pos [two-ar four-persian.alt] [zero-ar zero-persian]' [six-ar zero-ar];
+    pos [two-ar four-persian.alt] [zero-ar zero-persian]' <-80 0 0 0>;
+    # Do smilarly but for decimal seperator.
+    ignore pos [two-ar two-persian three-ar four-persian four-persian.alt] [decimalseparator-ar]' [six-ar nine-ar];
+    pos [two-ar two-persian three-ar four-persian four-persian.alt] [decimalseparator-ar]' <-80 0 0 0>;
+    lookup kern_contextual_yehbarree_arabic {
+        lookupflag IgnoreMarks;
+        pos behDotless-ar.init' <0 0 (opsz=18,wght=400:257 opsz=18,wght=700:275 opsz=17,wght=400:257 opsz=17,wght=700:275) 0> behDotless_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init' <0 0 (opsz=18,wght=400:151 opsz=18,wght=700:121 opsz=17,wght=400:151 opsz=17,wght=700:121) 0> hah_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init' <0 0 (opsz=18,wght=400:137 opsz=18,wght=700:140 opsz=17,wght=400:137 opsz=17,wght=700:140) 0> ain_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init' <0 0 (opsz=18,wght=400:203 opsz=18,wght=700:186 opsz=17,wght=400:203 opsz=17,wght=700:186) 0> fehDotless_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init' <0 0 (opsz=18,wght=400:96 opsz=18,wght=700:92 opsz=17,wght=400:96 opsz=17,wght=700:92) 0> kaf_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init' <0 0 (opsz=18,wght=400:257 opsz=18,wght=700:276 opsz=17,wght=400:257 opsz=17,wght=700:276) 0> lam_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init' <0 0 (opsz=18,wght=400:129 opsz=18,wght=700:113 opsz=17,wght=400:129 opsz=17,wght=700:113) 0> heh_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init' <0 0 (opsz=18,wght=400:159 opsz=18,wght=700:152 opsz=17,wght=400:159 opsz=17,wght=700:152) 0> hehgoal_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init.high' <0 0 (opsz=18,wght=400:257 opsz=18,wght=700:275 opsz=17,wght=400:257 opsz=17,wght=700:275) 0> behDotless_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init.high' <0 0 (opsz=18,wght=400:151 opsz=18,wght=700:121 opsz=17,wght=400:151 opsz=17,wght=700:121) 0> hah_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init.high' <0 0 (opsz=18,wght=400:137 opsz=18,wght=700:140 opsz=17,wght=400:137 opsz=17,wght=700:140) 0> ain_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init.high' <0 0 (opsz=18,wght=400:203 opsz=18,wght=700:186 opsz=17,wght=400:203 opsz=17,wght=700:186) 0> fehDotless_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init.high' <0 0 (opsz=18,wght=400:96 opsz=18,wght=700:92 opsz=17,wght=400:96 opsz=17,wght=700:92) 0> kaf_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init.high' <0 0 (opsz=18,wght=400:257 opsz=18,wght=700:276 opsz=17,wght=400:257 opsz=17,wght=700:276) 0> lam_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init.high' <0 0 (opsz=18,wght=400:129 opsz=18,wght=700:113 opsz=17,wght=400:129 opsz=17,wght=700:113) 0> heh_yehbarree-ar.fina;
+        subtable;
+        pos behDotless-ar.init.high' <0 0 (opsz=18,wght=400:159 opsz=18,wght=700:152 opsz=17,wght=400:159 opsz=17,wght=700:152) 0> hehgoal_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:317 opsz=18,wght=700:315 opsz=17,wght=400:317 opsz=17,wght=700:315) 0> behDotless_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:211 opsz=18,wght=700:161 opsz=17,wght=400:211 opsz=17,wght=700:161) 0> hah_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:52 opsz=18,wght=700:1 opsz=17,wght=400:52 opsz=17,wght=700:1) 0> tah_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:197 opsz=18,wght=700:180 opsz=17,wght=400:197 opsz=17,wght=700:180) 0> ain_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:263 opsz=18,wght=700:226 opsz=17,wght=400:263 opsz=17,wght=700:226) 0> fehDotless_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:156 opsz=18,wght=700:132 opsz=17,wght=400:156 opsz=17,wght=700:132) 0> kaf_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:317 opsz=18,wght=700:316 opsz=17,wght=400:317 opsz=17,wght=700:316) 0> lam_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:189 opsz=18,wght=700:153 opsz=17,wght=400:189 opsz=17,wght=700:153) 0> heh_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:219 opsz=18,wght=700:192 opsz=17,wght=400:219 opsz=17,wght=700:192) 0> hehgoal_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:6 opsz=18,wght=700:1 opsz=17,wght=400:6 opsz=17,wght=700:1) 0> hehDoachashmee_yehbarree-ar.fina;
+        subtable;
+        pos fehDotless-ar.init' <0 0 (opsz=18,wght=400:44 opsz=18,wght=700:53 opsz=17,wght=400:44 opsz=17,wght=700:53) 0> behDotless_yehbarree-ar.fina;
+        subtable;
+        pos fehDotless-ar.init' <0 0 (opsz=18,wght=400:44 opsz=18,wght=700:54 opsz=17,wght=400:44 opsz=17,wght=700:54) 0> lam_yehbarree-ar.fina;
+        subtable;
+        pos kaf-ar.init' <0 0 (opsz=18,wght=400:20 opsz=18,wght=700:62 opsz=17,wght=400:20 opsz=17,wght=700:62) 0> behDotless_yehbarree-ar.fina;
+        subtable;
+        pos kaf-ar.init' <0 0 (opsz=18,wght=400:20 opsz=18,wght=700:63 opsz=17,wght=400:20 opsz=17,wght=700:63) 0> lam_yehbarree-ar.fina;
+        subtable;
+        pos kaf-ar.init.alt' <0 0 (opsz=18,wght=400:46 opsz=18,wght=700:60 opsz=17,wght=400:46 opsz=17,wght=700:60) 0> behDotless_yehbarree-ar.fina;
+        subtable;
+        pos kaf-ar.init.alt' <0 0 (opsz=18,wght=400:46 opsz=18,wght=700:61 opsz=17,wght=400:46 opsz=17,wght=700:61) 0> lam_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:305 opsz=18,wght=700:322 opsz=17,wght=400:305 opsz=17,wght=700:322) 0> behDotless_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:199 opsz=18,wght=700:168 opsz=17,wght=400:199 opsz=17,wght=700:168) 0> hah_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:40 opsz=18,wght=700:4 opsz=17,wght=400:40 opsz=17,wght=700:4) 0> tah_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:185 opsz=18,wght=700:187 opsz=17,wght=400:185 opsz=17,wght=700:187) 0> ain_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:251 opsz=18,wght=700:233 opsz=17,wght=400:251 opsz=17,wght=700:233) 0> fehDotless_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:144 opsz=18,wght=700:139 opsz=17,wght=400:144 opsz=17,wght=700:139) 0> kaf_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:305 opsz=18,wght=700:323 opsz=17,wght=400:305 opsz=17,wght=700:323) 0> lam_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:177 opsz=18,wght=700:160 opsz=17,wght=400:177 opsz=17,wght=700:160) 0> heh_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:207 opsz=18,wght=700:199 opsz=17,wght=400:207 opsz=17,wght=700:199) 0> hehgoal_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init' <0 0 (opsz=18,wght=400:99 opsz=18,wght=700:68 opsz=17,wght=400:99 opsz=17,wght=700:68) 0> behDotless_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init' <0 0 (opsz=18,wght=400:45 opsz=18,wght=700:1 opsz=17,wght=400:45 opsz=17,wght=700:1) 0> fehDotless_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init' <0 0 (opsz=18,wght=400:99 opsz=18,wght=700:69 opsz=17,wght=400:99 opsz=17,wght=700:69) 0> lam_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init' <0 0 1 0> hehgoal_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:317 opsz=18,wght=700:315 opsz=17,wght=400:317 opsz=17,wght=700:315) 0> behDotless_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:211 opsz=18,wght=700:161 opsz=17,wght=400:211 opsz=17,wght=700:161) 0> hah_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:52 opsz=18,wght=700:1 opsz=17,wght=400:52 opsz=17,wght=700:1) 0> tah_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:197 opsz=18,wght=700:180 opsz=17,wght=400:197 opsz=17,wght=700:180) 0> ain_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:263 opsz=18,wght=700:226 opsz=17,wght=400:263 opsz=17,wght=700:226) 0> fehDotless_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:156 opsz=18,wght=700:132 opsz=17,wght=400:156 opsz=17,wght=700:132) 0> kaf_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:317 opsz=18,wght=700:316 opsz=17,wght=400:317 opsz=17,wght=700:316) 0> lam_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:189 opsz=18,wght=700:153 opsz=17,wght=400:189 opsz=17,wght=700:153) 0> heh_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:219 opsz=18,wght=700:192 opsz=17,wght=400:219 opsz=17,wght=700:192) 0> hehgoal_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:6 opsz=18,wght=700:1 opsz=17,wght=400:6 opsz=17,wght=700:1) 0> hehDoachashmee_yehbarree-ar.fina;
+        subtable;
+        pos kashida-ar.init' <0 0 (opsz=18,wght=400:209 opsz=18,wght=700:231 opsz=17,wght=400:209 opsz=17,wght=700:231) 0> behDotless_yehbarree-ar.fina;
+        subtable;
+        pos kashida-ar.init' <0 0 (opsz=18,wght=400:103 opsz=18,wght=700:77 opsz=17,wght=400:103 opsz=17,wght=700:77) 0> hah_yehbarree-ar.fina;
+        subtable;
+        pos kashida-ar.init' <0 0 (opsz=18,wght=400:89 opsz=18,wght=700:96 opsz=17,wght=400:89 opsz=17,wght=700:96) 0> ain_yehbarree-ar.fina;
+        subtable;
+        pos kashida-ar.init' <0 0 (opsz=18,wght=400:155 opsz=18,wght=700:142 opsz=17,wght=400:155 opsz=17,wght=700:142) 0> fehDotless_yehbarree-ar.fina;
+        subtable;
+        pos kashida-ar.init' <0 0 48 0> kaf_yehbarree-ar.fina;
+        subtable;
+        pos kashida-ar.init' <0 0 (opsz=18,wght=400:209 opsz=18,wght=700:232 opsz=17,wght=400:209 opsz=17,wght=700:232) 0> lam_yehbarree-ar.fina;
+        subtable;
+        pos kashida-ar.init' <0 0 (opsz=18,wght=400:81 opsz=18,wght=700:69 opsz=17,wght=400:81 opsz=17,wght=700:69) 0> heh_yehbarree-ar.fina;
+        subtable;
+        pos kashida-ar.init' <0 0 (opsz=18,wght=400:111 opsz=18,wght=700:108 opsz=17,wght=400:111 opsz=17,wght=700:108) 0> hehgoal_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:39 opsz=18,wght=700:15 opsz=17,wght=400:1 opsz=17,wght=700:1) 0> yehthin-ar.medi behDotless_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:39 opsz=18,wght=700:16 opsz=17,wght=400:1 opsz=17,wght=700:1) 0> yehthin-ar.medi lam_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:39 opsz=18,wght=700:15 opsz=17,wght=400:39 opsz=17,wght=700:15) 0> lam-ar.medi behDotless_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:39 opsz=18,wght=700:16 opsz=17,wght=400:39 opsz=17,wght=700:16) 0> lam-ar.medi lam_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:31 opsz=18,wght=700:9 opsz=17,wght=400:31 opsz=17,wght=700:9) 0> kashida-ar behDotless_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:31 opsz=18,wght=700:10 opsz=17,wght=400:31 opsz=17,wght=700:10) 0> kashida-ar lam_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:27 opsz=18,wght=700:22 opsz=17,wght=400:1 opsz=17,wght=700:1) 0> yehthin-ar.medi behDotless_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:27 opsz=18,wght=700:23 opsz=17,wght=400:1 opsz=17,wght=700:1) 0> yehthin-ar.medi lam_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:27 opsz=18,wght=700:22 opsz=17,wght=400:27 opsz=17,wght=700:22) 0> lam-ar.medi behDotless_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:27 opsz=18,wght=700:23 opsz=17,wght=400:27 opsz=17,wght=700:23) 0> lam-ar.medi lam_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:19 opsz=18,wght=700:16 opsz=17,wght=400:19 opsz=17,wght=700:16) 0> kashida-ar behDotless_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:19 opsz=18,wght=700:17 opsz=17,wght=400:19 opsz=17,wght=700:17) 0> kashida-ar lam_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:39 opsz=18,wght=700:15 opsz=17,wght=400:1 opsz=17,wght=700:1) 0> yehthin-ar.medi behDotless_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:39 opsz=18,wght=700:16 opsz=17,wght=400:1 opsz=17,wght=700:1) 0> yehthin-ar.medi lam_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:39 opsz=18,wght=700:15 opsz=17,wght=400:39 opsz=17,wght=700:15) 0> lam-ar.medi behDotless_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:39 opsz=18,wght=700:16 opsz=17,wght=400:39 opsz=17,wght=700:16) 0> lam-ar.medi lam_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:31 opsz=18,wght=700:9 opsz=17,wght=400:31 opsz=17,wght=700:9) 0> kashida-ar behDotless_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:31 opsz=18,wght=700:10 opsz=17,wght=400:31 opsz=17,wght=700:10) 0> kashida-ar lam_yehbarree-ar.fina;
+        subtable;
+        pos yehthin-ar.init' <0 0 (opsz=18,wght=400:1 opsz=18,wght=700:7 opsz=17,wght=400:1 opsz=17,wght=700:7) 0> meem_yehbarree-ar.fina;
+        subtable;
+        pos lam-ar.init' <0 0 (opsz=18,wght=400:1 opsz=18,wght=700:14 opsz=17,wght=400:1 opsz=17,wght=700:14) 0> meem_yehbarree-ar.fina;
+        subtable;
+        pos hehgoal-ar.init.ascending' <0 0 (opsz=18,wght=400:1 opsz=18,wght=700:7 opsz=17,wght=400:1 opsz=17,wght=700:7) 0> meem_yehbarree-ar.fina;
+        subtable;
+    } kern_contextual_yehbarree_arabic;
+
+} kern;
+
+feature mark {
+    lookup mark2base_top_arabic {
+        pos base hamza-ar
+            <anchor (opsz=18,wght=400:251 opsz=18,wght=700:260 opsz=17,wght=400:251 opsz=17,wght=700:260) (opsz=18,wght=400:337 opsz=18,wght=700:391 opsz=17,wght=400:337 opsz=17,wght=700:391)> mark @MC_top_arabic;
+        pos base highhamza-ar
+            <anchor (opsz=18,wght=400:251 opsz=18,wght=700:260 opsz=17,wght=400:251 opsz=17,wght=700:260) (opsz=18,wght=400:584 opsz=18,wght=700:638 opsz=17,wght=400:584 opsz=17,wght=700:638)> mark @MC_top_arabic;
+        pos base rounddot-ar
+            <anchor (opsz=18,wght=400:103 opsz=18,wght=700:97 opsz=17,wght=400:103 opsz=17,wght=700:97) (opsz=18,wght=400:155 opsz=18,wght=700:161 opsz=17,wght=400:155 opsz=17,wght=700:161)> mark @MC_top_arabic;
+        pos base raisedrounddot-ar
+            <anchor (opsz=18,wght=400:103 opsz=18,wght=700:97 opsz=17,wght=400:103 opsz=17,wght=700:97) (opsz=18,wght=400:466 opsz=18,wght=700:481 opsz=17,wght=400:466 opsz=17,wght=700:481)> mark @MC_top_arabic;
+        pos base alef-ar
+            <anchor (opsz=18,wght=400:122 opsz=18,wght=700:131 opsz=17,wght=400:122 opsz=17,wght=700:131) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic;
+        pos base alef-ar.fina
+            <anchor (opsz=18,wght=400:123 opsz=18,wght=700:131 opsz=17,wght=400:123 opsz=17,wght=700:131) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic;
+        pos base alef-ar.fina.kaf
+            <anchor (opsz=18,wght=400:123 opsz=18,wght=700:131 opsz=17,wght=400:123 opsz=17,wght=700:131) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic;
+        pos base alef-ar.short
+            <anchor (opsz=18,wght=400:122 opsz=18,wght=700:131 opsz=17,wght=400:122 opsz=17,wght=700:131) (opsz=18,wght=400:671 opsz=18,wght=700:691 opsz=17,wght=400:671 opsz=17,wght=700:691)> mark @MC_top_arabic;
+        pos base alef-ar.short.fina
+            <anchor (opsz=18,wght=400:123 opsz=18,wght=700:142 opsz=17,wght=400:123 opsz=17,wght=700:142) (opsz=18,wght=400:671 opsz=18,wght=700:691 opsz=17,wght=400:671 opsz=17,wght=700:691)> mark @MC_top_arabic;
+        pos base alef-ar.short.fina.kaf
+            <anchor (opsz=18,wght=400:123 opsz=18,wght=700:142 opsz=17,wght=400:123 opsz=17,wght=700:142) (opsz=18,wght=400:671 opsz=18,wght=700:691 opsz=17,wght=400:671 opsz=17,wght=700:691)> mark @MC_top_arabic;
+        pos base behDotless-ar
+            <anchor (opsz=18,wght=400:423 opsz=18,wght=700:430 opsz=17,wght=400:423 opsz=17,wght=700:430) (opsz=18,wght=400:189 opsz=18,wght=700:239 opsz=17,wght=400:189 opsz=17,wght=700:239)> mark @MC_top_arabic;
+        pos base behDotless-ar.fina
+            <anchor (opsz=18,wght=400:439 opsz=18,wght=700:444 opsz=17,wght=400:439 opsz=17,wght=700:444) 189> mark @MC_top_arabic;
+        pos base behDotless-ar.medi
+            <anchor (opsz=18,wght=400:165 opsz=18,wght=700:181 opsz=17,wght=400:165 opsz=17,wght=700:181) (opsz=18,wght=400:283 opsz=18,wght=700:307 opsz=17,wght=400:283 opsz=17,wght=700:307)> mark @MC_top_arabic;
+        pos base behDotless-ar.medi.high
+            <anchor (opsz=18,wght=400:165 opsz=18,wght=700:181 opsz=17,wght=400:165 opsz=17,wght=700:181) 391> mark @MC_top_arabic;
+        pos base behDotless-ar.init
+            <anchor (opsz=18,wght=400:146 opsz=18,wght=700:148 opsz=17,wght=400:146 opsz=17,wght=700:148) (opsz=18,wght=400:279 opsz=18,wght=700:302 opsz=17,wght=400:279 opsz=17,wght=700:302)> mark @MC_top_arabic;
+        pos base behDotless-ar.init.high
+            <anchor (opsz=18,wght=400:140 opsz=18,wght=700:151 opsz=17,wght=400:140 opsz=17,wght=700:151) (opsz=18,wght=400:391 opsz=18,wght=700:386 opsz=17,wght=400:391 opsz=17,wght=700:386)> mark @MC_top_arabic;
+        pos base yehthin-ar.init
+            <anchor (opsz=18,wght=400:125 opsz=18,wght=700:138 opsz=17,wght=400:125 opsz=17,wght=700:138) (opsz=18,wght=400:279 opsz=18,wght=700:302 opsz=17,wght=400:279 opsz=17,wght=700:302)> mark @MC_top_arabic;
+        pos base yehthin-ar.medi
+            <anchor (opsz=18,wght=400:135 opsz=18,wght=700:151 opsz=17,wght=400:155 opsz=17,wght=700:171) (opsz=18,wght=400:283 opsz=18,wght=700:307 opsz=17,wght=400:283 opsz=17,wght=700:307)> mark @MC_top_arabic;
+        pos base hah-ar
+            <anchor (opsz=18,wght=400:309 opsz=18,wght=700:367 opsz=17,wght=400:309 opsz=17,wght=700:369) (opsz=18,wght=400:426 opsz=18,wght=700:456 opsz=17,wght=400:426 opsz=17,wght=700:510)> mark @MC_top_arabic;
+        pos base hah-ar.fina
+            <anchor (opsz=18,wght=400:309 opsz=18,wght=700:367 opsz=17,wght=400:309 opsz=17,wght=700:369) (opsz=18,wght=400:426 opsz=18,wght=700:456 opsz=17,wght=400:426 opsz=17,wght=700:510)> mark @MC_top_arabic;
+        pos base hah-ar.medi
+            <anchor (opsz=18,wght=400:338 opsz=18,wght=700:399 opsz=17,wght=400:340 opsz=17,wght=700:372) (opsz=18,wght=400:349 opsz=18,wght=700:384 opsz=17,wght=400:349 opsz=17,wght=700:397)> mark @MC_top_arabic;
+        pos base hah-ar.init
+            <anchor (opsz=18,wght=400:338 opsz=18,wght=700:399 opsz=17,wght=400:340 opsz=17,wght=700:372) (opsz=18,wght=400:349 opsz=18,wght=700:384 opsz=17,wght=400:349 opsz=17,wght=700:397)> mark @MC_top_arabic;
+        pos base dal-ar
+            <anchor (opsz=18,wght=400:198 opsz=18,wght=700:207 opsz=17,wght=400:198 opsz=17,wght=700:207) (opsz=18,wght=400:475 opsz=18,wght=700:524 opsz=17,wght=400:475 opsz=17,wght=700:524)> mark @MC_top_arabic;
+        pos base dal-ar.fina
+            <anchor (opsz=18,wght=400:316 opsz=18,wght=700:324 opsz=17,wght=400:288 opsz=17,wght=700:282) (opsz=18,wght=400:455 opsz=18,wght=700:480 opsz=17,wght=400:455 opsz=17,wght=700:480)> mark @MC_top_arabic;
+        pos base reh-ar
+            <anchor (opsz=18,wght=400:204 opsz=18,wght=700:234 opsz=17,wght=400:204 opsz=17,wght=700:234) (opsz=18,wght=400:300 opsz=18,wght=700:319 opsz=17,wght=400:300 opsz=17,wght=700:319)> mark @MC_top_arabic;
+        pos base reh-ar.fina
+            <anchor (opsz=18,wght=400:204 opsz=18,wght=700:234 opsz=17,wght=400:204 opsz=17,wght=700:234) (opsz=18,wght=400:300 opsz=18,wght=700:319 opsz=17,wght=400:300 opsz=17,wght=700:319)> mark @MC_top_arabic;
+        pos base rehLoop-ar
+            <anchor 368 (opsz=18,wght=400:300 opsz=18,wght=700:319 opsz=17,wght=400:300 opsz=17,wght=700:319)> mark @MC_top_arabic;
+        pos base rehLoop-ar.fina
+            <anchor 368 (opsz=18,wght=400:300 opsz=18,wght=700:319 opsz=17,wght=400:300 opsz=17,wght=700:319)> mark @MC_top_arabic;
+        pos base seen-ar
+            <anchor (opsz=18,wght=400:780 opsz=18,wght=700:787 opsz=17,wght=400:780 opsz=17,wght=700:787) (opsz=18,wght=400:286 opsz=18,wght=700:319 opsz=17,wght=400:286 opsz=17,wght=700:319)> mark @MC_top_arabic;
+        pos base seen-ar.fina
+            <anchor (opsz=18,wght=400:780 opsz=18,wght=700:787 opsz=17,wght=400:780 opsz=17,wght=700:787) (opsz=18,wght=400:286 opsz=18,wght=700:319 opsz=17,wght=400:286 opsz=17,wght=700:319)> mark @MC_top_arabic;
+        pos base seen-ar.medi
+            <anchor (opsz=18,wght=400:387 opsz=18,wght=700:445 opsz=17,wght=400:387 opsz=17,wght=700:445) (opsz=18,wght=400:286 opsz=18,wght=700:319 opsz=17,wght=400:286 opsz=17,wght=700:319)> mark @MC_top_arabic;
+        pos base seen-ar.medi.wide
+            <anchor (opsz=18,wght=400:544 opsz=18,wght=700:592 opsz=17,wght=400:544 opsz=17,wght=700:592) (opsz=18,wght=400:286 opsz=18,wght=700:319 opsz=17,wght=400:286 opsz=17,wght=700:319)> mark @MC_top_arabic;
+        pos base seen-ar.init
+            <anchor (opsz=18,wght=400:387 opsz=18,wght=700:445 opsz=17,wght=400:387 opsz=17,wght=700:445) (opsz=18,wght=400:286 opsz=18,wght=700:319 opsz=17,wght=400:286 opsz=17,wght=700:319)> mark @MC_top_arabic;
+        pos base seen-ar.init.wide
+            <anchor (opsz=18,wght=400:544 opsz=18,wght=700:592 opsz=17,wght=400:544 opsz=17,wght=700:592) (opsz=18,wght=400:286 opsz=18,wght=700:319 opsz=17,wght=400:286 opsz=17,wght=700:319)> mark @MC_top_arabic;
+        pos base sad-ar
+            <anchor (opsz=18,wght=400:829 opsz=18,wght=700:802 opsz=17,wght=400:829 opsz=17,wght=700:802) (opsz=18,wght=400:397 opsz=18,wght=700:451 opsz=17,wght=400:397 opsz=17,wght=700:451)> mark @MC_top_arabic;
+        pos base sad-ar.fina
+            <anchor (opsz=18,wght=400:829 opsz=18,wght=700:802 opsz=17,wght=400:829 opsz=17,wght=700:802) (opsz=18,wght=400:397 opsz=18,wght=700:451 opsz=17,wght=400:397 opsz=17,wght=700:451)> mark @MC_top_arabic;
+        pos base sad-ar.medi
+            <anchor (opsz=18,wght=400:450 opsz=18,wght=700:457 opsz=17,wght=400:450 opsz=17,wght=700:457) (opsz=18,wght=400:397 opsz=18,wght=700:445 opsz=17,wght=400:397 opsz=17,wght=700:445)> mark @MC_top_arabic;
+        pos base sad-ar.init
+            <anchor (opsz=18,wght=400:450 opsz=18,wght=700:457 opsz=17,wght=400:450 opsz=17,wght=700:457) (opsz=18,wght=400:397 opsz=18,wght=700:445 opsz=17,wght=400:397 opsz=17,wght=700:445)> mark @MC_top_arabic;
+        pos base tah-ar
+            <anchor (opsz=18,wght=400:476 opsz=18,wght=700:475 opsz=17,wght=400:476 opsz=17,wght=700:475) (opsz=18,wght=400:399 opsz=18,wght=700:452 opsz=17,wght=400:399 opsz=17,wght=700:452)> mark @MC_top_arabic;
+        pos base tah-ar.fina
+            <anchor (opsz=18,wght=400:476 opsz=18,wght=700:475 opsz=17,wght=400:476 opsz=17,wght=700:475) (opsz=18,wght=400:399 opsz=18,wght=700:452 opsz=17,wght=400:399 opsz=17,wght=700:452)> mark @MC_top_arabic;
+        pos base tah-ar.medi
+            <anchor (opsz=18,wght=400:434 opsz=18,wght=700:449 opsz=17,wght=400:434 opsz=17,wght=700:449) (opsz=18,wght=400:399 opsz=18,wght=700:451 opsz=17,wght=400:399 opsz=17,wght=700:451)> mark @MC_top_arabic;
+        pos base tah-ar.init
+            <anchor (opsz=18,wght=400:434 opsz=18,wght=700:449 opsz=17,wght=400:434 opsz=17,wght=700:449) (opsz=18,wght=400:399 opsz=18,wght=700:451 opsz=17,wght=400:399 opsz=17,wght=700:451)> mark @MC_top_arabic;
+        pos base ain-ar
+            <anchor (opsz=18,wght=400:297 opsz=18,wght=700:303 opsz=17,wght=400:297 opsz=17,wght=700:303) (opsz=18,wght=400:540 opsz=18,wght=700:582 opsz=17,wght=400:540 opsz=17,wght=700:582)> mark @MC_top_arabic;
+        pos base ain-ar.fina
+            <anchor (opsz=18,wght=400:315 opsz=18,wght=700:334 opsz=17,wght=400:315 opsz=17,wght=700:334) (opsz=18,wght=400:403 opsz=18,wght=700:451 opsz=17,wght=400:403 opsz=17,wght=700:451)> mark @MC_top_arabic;
+        pos base ain-ar.medi
+            <anchor (opsz=18,wght=400:283 opsz=18,wght=700:303 opsz=17,wght=400:283 opsz=17,wght=700:303) (opsz=18,wght=400:403 opsz=18,wght=700:451 opsz=17,wght=400:403 opsz=17,wght=700:451)> mark @MC_top_arabic;
+        pos base ain-ar.init
+            <anchor (opsz=18,wght=400:286 opsz=18,wght=700:294 opsz=17,wght=400:286 opsz=17,wght=700:294) (opsz=18,wght=400:400 opsz=18,wght=700:432 opsz=17,wght=400:400 opsz=17,wght=700:432)> mark @MC_top_arabic;
+        pos base fehDotless-ar
+            <anchor (opsz=18,wght=400:630 opsz=18,wght=700:645 opsz=17,wght=400:630 opsz=17,wght=700:645) (opsz=18,wght=400:527 opsz=18,wght=700:559 opsz=17,wght=400:527 opsz=17,wght=700:559)> mark @MC_top_arabic;
+        pos base fehDotless-ar.fina
+            <anchor (opsz=18,wght=400:718 opsz=18,wght=700:736 opsz=17,wght=400:718 opsz=17,wght=700:736) (opsz=18,wght=400:456 opsz=18,wght=700:510 opsz=17,wght=400:456 opsz=17,wght=700:510)> mark @MC_top_arabic;
+        pos base fehDotless-ar.medi
+            <anchor (opsz=18,wght=400:264 opsz=18,wght=700:294 opsz=17,wght=400:264 opsz=17,wght=700:294) (opsz=18,wght=400:456 opsz=18,wght=700:510 opsz=17,wght=400:456 opsz=17,wght=700:510)> mark @MC_top_arabic;
+        pos base fehDotless-ar.init
+            <anchor (opsz=18,wght=400:255 opsz=18,wght=700:267 opsz=17,wght=400:255 opsz=17,wght=700:267) (opsz=18,wght=400:511 opsz=18,wght=700:569 opsz=17,wght=400:511 opsz=17,wght=700:569)> mark @MC_top_arabic;
+        pos base qafDotless-ar
+            <anchor (opsz=18,wght=400:513 opsz=18,wght=700:531 opsz=17,wght=400:513 opsz=17,wght=700:531) (opsz=18,wght=400:459 opsz=18,wght=700:513 opsz=17,wght=400:459 opsz=17,wght=700:513)> mark @MC_top_arabic;
+        pos base qafDotless-ar.fina
+            <anchor (opsz=18,wght=400:513 opsz=18,wght=700:530 opsz=17,wght=400:513 opsz=17,wght=700:530) (opsz=18,wght=400:363 opsz=18,wght=700:411 opsz=17,wght=400:363 opsz=17,wght=700:411)> mark @MC_top_arabic;
+        pos base yehRohingya-ar
+            <anchor (opsz=18,wght=400:324 opsz=18,wght=700:371 opsz=17,wght=400:324 opsz=17,wght=700:371) (opsz=18,wght=400:456 opsz=18,wght=700:510 opsz=17,wght=400:456 opsz=17,wght=700:510)> mark @MC_top_arabic;
+        pos base yehRohingya-ar.fina
+            <anchor (opsz=18,wght=400:373 opsz=18,wght=700:449 opsz=17,wght=400:373 opsz=17,wght=700:449) (opsz=18,wght=400:456 opsz=18,wght=700:510 opsz=17,wght=400:456 opsz=17,wght=700:510)> mark @MC_top_arabic;
+        pos base kafDotless-ar
+            <anchor (opsz=18,wght=400:421 opsz=18,wght=700:422 opsz=17,wght=400:421 opsz=17,wght=700:422) 276> mark @MC_top_arabic;
+        pos base kafDotless-ar.fina
+            <anchor (opsz=18,wght=400:394 opsz=18,wght=700:410 opsz=17,wght=400:394 opsz=17,wght=700:410) 276> mark @MC_top_arabic;
+        pos base kaf-ar.medi
+            <anchor (opsz=18,wght=400:229 opsz=18,wght=700:210 opsz=17,wght=400:229 opsz=17,wght=700:210) (opsz=18,wght=400:716 opsz=18,wght=700:746 opsz=17,wght=400:716 opsz=17,wght=700:746)> mark @MC_top_arabic;
+        pos base kaf-ar.medi.alt
+            <anchor (opsz=18,wght=400:237 opsz=18,wght=700:218 opsz=17,wght=400:237 opsz=17,wght=700:218) (opsz=18,wght=400:642 opsz=18,wght=700:695 opsz=17,wght=400:642 opsz=17,wght=700:695)> mark @MC_top_arabic;
+        pos base kaf-ar.init
+            <anchor (opsz=18,wght=400:217 opsz=18,wght=700:216 opsz=17,wght=400:217 opsz=17,wght=700:216) (opsz=18,wght=400:729 opsz=18,wght=700:758 opsz=17,wght=400:729 opsz=17,wght=700:758)> mark @MC_top_arabic;
+        pos base kaf-ar.init.alt
+            <anchor (opsz=18,wght=400:231 opsz=18,wght=700:251 opsz=17,wght=400:231 opsz=17,wght=700:251) (opsz=18,wght=400:638 opsz=18,wght=700:694 opsz=17,wght=400:638 opsz=17,wght=700:694)> mark @MC_top_arabic;
+        pos base keheh-ar
+            <anchor (opsz=18,wght=400:626 opsz=18,wght=700:640 opsz=17,wght=400:626 opsz=17,wght=700:640) (opsz=18,wght=400:710 opsz=18,wght=700:712 opsz=17,wght=400:710 opsz=17,wght=700:712)> mark @MC_top_arabic;
+        pos base keheh-ar.fina
+            <anchor (opsz=18,wght=400:634 opsz=18,wght=700:687 opsz=17,wght=400:634 opsz=17,wght=700:687) (opsz=18,wght=400:694 opsz=18,wght=700:696 opsz=17,wght=400:694 opsz=17,wght=700:696)> mark @MC_top_arabic;
+        pos base kafswash-ar
+            <anchor (opsz=18,wght=400:433 opsz=18,wght=700:408 opsz=17,wght=400:433 opsz=17,wght=700:408) (opsz=18,wght=400:477 opsz=18,wght=700:577 opsz=17,wght=400:477 opsz=17,wght=700:577)> mark @MC_top_arabic;
+        pos base kafswash-ar.fina
+            <anchor (opsz=18,wght=400:433 opsz=18,wght=700:408 opsz=17,wght=400:433 opsz=17,wght=700:408) (opsz=18,wght=400:477 opsz=18,wght=700:577 opsz=17,wght=400:477 opsz=17,wght=700:577)> mark @MC_top_arabic;
+        pos base kafswash-ar.medi
+            <anchor (opsz=18,wght=400:15 opsz=18,wght=700:12 opsz=17,wght=400:15 opsz=17,wght=700:12) (opsz=18,wght=400:510 opsz=18,wght=700:561 opsz=17,wght=400:510 opsz=17,wght=700:561)> mark @MC_top_arabic;
+        pos base kafswash-ar.init
+            <anchor (opsz=18,wght=400:15 opsz=18,wght=700:12 opsz=17,wght=400:15 opsz=17,wght=700:12) (opsz=18,wght=400:510 opsz=18,wght=700:561 opsz=17,wght=400:510 opsz=17,wght=700:561)> mark @MC_top_arabic;
+        pos base lam-ar
+            <anchor (opsz=18,wght=400:571 opsz=18,wght=700:570 opsz=17,wght=400:571 opsz=17,wght=700:570) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic;
+        pos base lam-ar.fina
+            <anchor (opsz=18,wght=400:571 opsz=18,wght=700:570 opsz=17,wght=400:571 opsz=17,wght=700:570) (opsz=18,wght=400:775 opsz=18,wght=700:799 opsz=17,wght=400:775 opsz=17,wght=700:799)> mark @MC_top_arabic;
+        pos base lam-ar.medi
+            <anchor (opsz=18,wght=400:135 opsz=18,wght=700:155 opsz=17,wght=400:135 opsz=17,wght=700:155) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic;
+        pos base lam-ar.init
+            <anchor 134 (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic;
+        pos base meem-ar
+            <anchor (opsz=18,wght=400:306 opsz=18,wght=700:312 opsz=17,wght=400:306 opsz=17,wght=700:312) (opsz=18,wght=400:384 opsz=18,wght=700:438 opsz=17,wght=400:384 opsz=17,wght=700:438)> mark @MC_top_arabic;
+        pos base meem-ar.alt
+            <anchor (opsz=18,wght=400:567 opsz=18,wght=700:607 opsz=17,wght=400:567 opsz=17,wght=700:607) (opsz=18,wght=400:371 opsz=18,wght=700:414 opsz=17,wght=400:371 opsz=17,wght=700:414)> mark @MC_top_arabic;
+        pos base meem-ar.fina
+            <anchor (opsz=18,wght=400:268 opsz=18,wght=700:299 opsz=17,wght=400:268 opsz=17,wght=700:299) (opsz=18,wght=400:370 opsz=18,wght=700:412 opsz=17,wght=400:370 opsz=17,wght=700:412)> mark @MC_top_arabic;
+        pos base meem-ar.fina.alt
+            <anchor (opsz=18,wght=400:574 opsz=18,wght=700:619 opsz=17,wght=400:574 opsz=17,wght=700:619) (opsz=18,wght=400:370 opsz=18,wght=700:412 opsz=17,wght=400:370 opsz=17,wght=700:412)> mark @MC_top_arabic;
+        pos base meem-ar.medi
+            <anchor 334 (opsz=18,wght=400:370 opsz=18,wght=700:412 opsz=17,wght=400:370 opsz=17,wght=700:412)> mark @MC_top_arabic;
+        pos base meem-ar.init
+            <anchor (opsz=18,wght=400:336 opsz=18,wght=700:332 opsz=17,wght=400:336 opsz=17,wght=700:332) (opsz=18,wght=400:371 opsz=18,wght=700:414 opsz=17,wght=400:371 opsz=17,wght=700:414)> mark @MC_top_arabic;
+        pos base noonghunna-ar
+            <anchor (opsz=18,wght=400:328 opsz=18,wght=700:334 opsz=17,wght=400:328 opsz=17,wght=700:334) 306> mark @MC_top_arabic;
+        pos base noonghunna-ar.fina
+            <anchor (opsz=18,wght=400:328 opsz=18,wght=700:334 opsz=17,wght=400:328 opsz=17,wght=700:334) 236> mark @MC_top_arabic;
+        pos base heh-ar
+            <anchor (opsz=18,wght=400:267 opsz=18,wght=700:285 opsz=17,wght=400:267 opsz=17,wght=700:285) (opsz=18,wght=400:504 opsz=18,wght=700:537 opsz=17,wght=400:504 opsz=17,wght=700:537)> mark @MC_top_arabic;
+        pos base heh-ar.fina
+            <anchor (opsz=18,wght=400:197 opsz=18,wght=700:203 opsz=17,wght=400:197 opsz=17,wght=700:203) (opsz=18,wght=400:510 opsz=18,wght=700:533 opsz=17,wght=400:510 opsz=17,wght=700:533)> mark @MC_top_arabic;
+        pos base heh-ar.medi
+            <anchor (opsz=18,wght=400:310 opsz=18,wght=700:307 opsz=17,wght=400:310 opsz=17,wght=700:307) (opsz=18,wght=400:422 opsz=18,wght=700:460 opsz=17,wght=400:422 opsz=17,wght=700:460)> mark @MC_top_arabic;
+        pos base heh-ar.init
+            <anchor (opsz=18,wght=400:149 opsz=18,wght=700:176 opsz=17,wght=400:149 opsz=17,wght=700:176) (opsz=18,wght=400:518 opsz=18,wght=700:590 opsz=17,wght=400:518 opsz=17,wght=700:590)> mark @MC_top_arabic;
+        pos base hehgoal-ar
+            <anchor (opsz=18,wght=400:267 opsz=18,wght=700:285 opsz=17,wght=400:267 opsz=17,wght=700:285) (opsz=18,wght=400:504 opsz=18,wght=700:537 opsz=17,wght=400:504 opsz=17,wght=700:537)> mark @MC_top_arabic;
+        pos base hehgoal-ar.fina
+            <anchor (opsz=18,wght=400:322 opsz=18,wght=700:370 opsz=17,wght=400:322 opsz=17,wght=700:370) (opsz=18,wght=400:269 opsz=18,wght=700:311 opsz=17,wght=400:269 opsz=17,wght=700:311)> mark @MC_top_arabic;
+        pos base hehgoal-ar.medi
+            <anchor (opsz=18,wght=400:220 opsz=18,wght=700:222 opsz=17,wght=400:220 opsz=17,wght=700:222) (opsz=18,wght=400:337 opsz=18,wght=700:413 opsz=17,wght=400:337 opsz=17,wght=700:413)> mark @MC_top_arabic;
+        pos base hehgoal-ar.medi.yehbarree
+            <anchor (opsz=18,wght=400:220 opsz=18,wght=700:222 opsz=17,wght=400:220 opsz=17,wght=700:222) (opsz=18,wght=400:337 opsz=18,wght=700:413 opsz=17,wght=400:337 opsz=17,wght=700:413)> mark @MC_top_arabic;
+        pos base hehgoal-ar.init
+            <anchor (opsz=18,wght=400:293 opsz=18,wght=700:312 opsz=17,wght=400:293 opsz=17,wght=700:312) (opsz=18,wght=400:279 opsz=18,wght=700:302 opsz=17,wght=400:279 opsz=17,wght=700:302)> mark @MC_top_arabic;
+        pos base hehgoal-ar.init.ascending
+            <anchor (opsz=18,wght=400:125 opsz=18,wght=700:138 opsz=17,wght=400:125 opsz=17,wght=700:138) (opsz=18,wght=400:279 opsz=18,wght=700:302 opsz=17,wght=400:279 opsz=17,wght=700:302)> mark @MC_top_arabic;
+        pos base ae-ar
+            <anchor (opsz=18,wght=400:267 opsz=18,wght=700:285 opsz=17,wght=400:267 opsz=17,wght=700:285) (opsz=18,wght=400:504 opsz=18,wght=700:537 opsz=17,wght=400:504 opsz=17,wght=700:537)> mark @MC_top_arabic;
+        pos base hehDoachashmee-ar
+            <anchor (opsz=18,wght=400:516 opsz=18,wght=700:479 opsz=17,wght=400:516 opsz=17,wght=700:479) (opsz=18,wght=400:466 opsz=18,wght=700:575 opsz=17,wght=400:466 opsz=17,wght=700:575)> mark @MC_top_arabic;
+        pos base hehDoachashmee-ar.fina
+            <anchor (opsz=18,wght=400:516 opsz=18,wght=700:479 opsz=17,wght=400:516 opsz=17,wght=700:479) (opsz=18,wght=400:466 opsz=18,wght=700:575 opsz=17,wght=400:466 opsz=17,wght=700:575)> mark @MC_top_arabic;
+        pos base hehDoachashmee-ar.medi
+            <anchor (opsz=18,wght=400:149 opsz=18,wght=700:176 opsz=17,wght=400:149 opsz=17,wght=700:176) (opsz=18,wght=400:518 opsz=18,wght=700:590 opsz=17,wght=400:518 opsz=17,wght=700:590)> mark @MC_top_arabic;
+        pos base waw-ar
+            <anchor (opsz=18,wght=400:248 opsz=18,wght=700:272 opsz=17,wght=400:248 opsz=17,wght=700:271) (opsz=18,wght=400:388 opsz=18,wght=700:436 opsz=17,wght=400:388 opsz=17,wght=700:436)> mark @MC_top_arabic;
+        pos base waw-ar.fina
+            <anchor (opsz=18,wght=400:248 opsz=18,wght=700:271 opsz=17,wght=400:248 opsz=17,wght=700:271) (opsz=18,wght=400:363 opsz=18,wght=700:411 opsz=17,wght=400:363 opsz=17,wght=700:411)> mark @MC_top_arabic;
+        pos base wawStraight-ar
+            <anchor (opsz=18,wght=400:211 opsz=18,wght=700:223 opsz=17,wght=400:211 opsz=17,wght=700:223) (opsz=18,wght=400:388 opsz=18,wght=700:436 opsz=17,wght=400:388 opsz=17,wght=700:436)> mark @MC_top_arabic;
+        pos base wawStraight-ar.fina
+            <anchor (opsz=18,wght=400:211 opsz=18,wght=700:223 opsz=17,wght=400:211 opsz=17,wght=700:223) (opsz=18,wght=400:363 opsz=18,wght=700:411 opsz=17,wght=400:363 opsz=17,wght=700:411)> mark @MC_top_arabic;
+        pos base alefMaksura-ar
+            <anchor (opsz=18,wght=400:97 opsz=18,wght=700:108 opsz=17,wght=400:97 opsz=17,wght=700:108) (opsz=18,wght=400:296 opsz=18,wght=700:322 opsz=17,wght=400:296 opsz=17,wght=700:322)> mark @MC_top_arabic;
+        pos base alefMaksura-ar.fina
+            <anchor (opsz=18,wght=400:96 opsz=18,wght=700:108 opsz=17,wght=400:96 opsz=17,wght=700:108) (opsz=18,wght=400:140 opsz=18,wght=700:169 opsz=17,wght=400:140 opsz=17,wght=700:169)> mark @MC_top_arabic;
+        pos base yehbarree-ar
+            <anchor (opsz=18,wght=400:152 opsz=18,wght=700:204 opsz=17,wght=400:152 opsz=17,wght=700:204) (opsz=18,wght=400:384 opsz=18,wght=700:413 opsz=17,wght=400:384 opsz=17,wght=700:413)> mark @MC_top_arabic;
+        pos base yehbarree-ar.fina
+            <anchor (opsz=18,wght=400:142 opsz=18,wght=700:156 opsz=17,wght=400:142 opsz=17,wght=700:156) (opsz=18,wght=400:136 opsz=18,wght=700:203 opsz=17,wght=400:136 opsz=17,wght=700:203)> mark @MC_top_arabic;
+        pos base kashida-ar
+            <anchor (opsz=18,wght=400:143 opsz=18,wght=700:148 opsz=17,wght=400:143 opsz=17,wght=700:148) 287> mark @MC_top_arabic;
+        pos base kashida-ar.init
+            <anchor (opsz=18,wght=400:143 opsz=18,wght=700:148 opsz=17,wght=400:143 opsz=17,wght=700:148) 287> mark @MC_top_arabic;
+        pos base kashida-ar.wide
+            <anchor (opsz=18,wght=400:193 opsz=18,wght=700:218 opsz=17,wght=400:193 opsz=17,wght=700:218) 287> mark @MC_top_arabic;
+        pos base kashidaHamza-ar
+            <anchor (opsz=18,wght=400:193 opsz=18,wght=700:218 opsz=17,wght=400:193 opsz=17,wght=700:218) (opsz=18,wght=400:287 opsz=18,wght=700:341 opsz=17,wght=400:287 opsz=17,wght=700:341)> mark @MC_top_arabic;
+        pos base aleflow-ar
+            <anchor (opsz=18,wght=400:125 opsz=18,wght=700:127 opsz=17,wght=400:125 opsz=17,wght=700:127) (opsz=18,wght=400:10 opsz=18,wght=700:9 opsz=17,wght=400:10 opsz=17,wght=700:9)> mark @MC_top_arabic;
+        pos base wawSmall-ar
+            <anchor (opsz=18,wght=400:115 opsz=18,wght=700:126 opsz=17,wght=400:115 opsz=17,wght=700:126) (opsz=18,wght=400:153 opsz=18,wght=700:175 opsz=17,wght=400:153 opsz=17,wght=700:175)> mark @MC_top_arabic;
+        pos base yehSmall-ar
+            <anchor (opsz=18,wght=400:162 opsz=18,wght=700:163 opsz=17,wght=400:162 opsz=17,wght=700:163) (opsz=18,wght=400:162 opsz=18,wght=700:172 opsz=17,wght=400:162 opsz=17,wght=700:172)> mark @MC_top_arabic;
+        pos base yehSmall-farsi
+            <anchor 162 (opsz=18,wght=400:185 opsz=18,wght=700:196 opsz=17,wght=400:185 opsz=17,wght=700:196)> mark @MC_top_arabic;
+        pos base hairspace
+            <anchor 36 337> mark @MC_top_arabic;
+        pos base space
+            <anchor (opsz=18,wght=400:106 opsz=18,wght=700:107 opsz=17,wght=400:106 opsz=17,wght=700:107) 337> mark @MC_top_arabic;
+        pos base thinspace
+            <anchor (opsz=18,wght=400:53 opsz=18,wght=700:54 opsz=17,wght=400:53 opsz=17,wght=700:54) 337> mark @MC_top_arabic;
+        pos base lellah-ar
+            <anchor (opsz=18,wght=400:197 opsz=18,wght=700:746 opsz=17,wght=400:197 opsz=17,wght=700:746) (opsz=18,wght=400:510 opsz=18,wght=700:1107 opsz=17,wght=400:510 opsz=17,wght=700:1107)> mark @MC_top_arabic;
+        pos base lellah-ar.fina
+            <anchor (opsz=18,wght=400:197 opsz=18,wght=700:746 opsz=17,wght=400:197 opsz=17,wght=700:746) (opsz=18,wght=400:510 opsz=18,wght=700:1107 opsz=17,wght=400:510 opsz=17,wght=700:1107)> mark @MC_top_arabic;
+        pos base afghani-ar
+            <anchor (opsz=18,wght=400:289 opsz=18,wght=700:316 opsz=17,wght=400:289 opsz=17,wght=700:316) (opsz=18,wght=400:-70 opsz=18,wght=700:-71 opsz=17,wght=400:-70 opsz=17,wght=700:-71)> mark @MC_top_arabic;
+        pos base misraComma-ar
+            <anchor (opsz=18,wght=400:289 opsz=18,wght=700:303 opsz=17,wght=400:289 opsz=17,wght=700:303) (opsz=18,wght=400:540 opsz=18,wght=700:582 opsz=17,wght=400:540 opsz=17,wght=700:582)> mark @MC_top_arabic;
+        pos base sindhipostpositionmen-ar
+            <anchor (opsz=18,wght=400:306 opsz=18,wght=700:312 opsz=17,wght=400:306 opsz=17,wght=700:312) (opsz=18,wght=400:384 opsz=18,wght=700:438 opsz=17,wght=400:384 opsz=17,wght=700:438)> mark @MC_top_arabic;
+        pos base sindhipostpositionmen-ar.alt
+            <anchor (opsz=18,wght=400:567 opsz=18,wght=700:607 opsz=17,wght=400:567 opsz=17,wght=700:607) (opsz=18,wght=400:371 opsz=18,wght=700:414 opsz=17,wght=400:371 opsz=17,wght=700:414)> mark @MC_top_arabic;
+        pos base sindhiampersand-ar
+            <anchor (opsz=18,wght=400:251 opsz=18,wght=700:260 opsz=17,wght=400:251 opsz=17,wght=700:260) (opsz=18,wght=400:337 opsz=18,wght=700:391 opsz=17,wght=400:337 opsz=17,wght=700:391)> mark @MC_top_arabic;
+    } mark2base_top_arabic;
+
+    lookup mark2base_top.digits_arabic {
+        pos base alef-ar.short
+            <anchor (opsz=18,wght=400:112 opsz=18,wght=700:107 opsz=17,wght=400:112 opsz=17,wght=700:107) (opsz=18,wght=400:591 opsz=18,wght=700:631 opsz=17,wght=400:591 opsz=17,wght=700:631)> mark @MC_top.digits_arabic;
+        pos base alef-ar.short.fina
+            <anchor (opsz=18,wght=400:112 opsz=18,wght=700:107 opsz=17,wght=400:112 opsz=17,wght=700:107) (opsz=18,wght=400:591 opsz=18,wght=700:631 opsz=17,wght=400:591 opsz=17,wght=700:631)> mark @MC_top.digits_arabic;
+        pos base alef-ar.short.fina.kaf
+            <anchor (opsz=18,wght=400:112 opsz=18,wght=700:107 opsz=17,wght=400:112 opsz=17,wght=700:107) (opsz=18,wght=400:591 opsz=18,wght=700:631 opsz=17,wght=400:591 opsz=17,wght=700:631)> mark @MC_top.digits_arabic;
+    } mark2base_top.digits_arabic;
+
+    lookup mark2base_top.tashkil_arabic {
+        pos base hamza-ar
+            <anchor (opsz=18,wght=400:251 opsz=18,wght=700:260 opsz=17,wght=400:251 opsz=17,wght=700:260) (opsz=18,wght=400:487 opsz=18,wght=700:541 opsz=17,wght=400:537 opsz=17,wght=700:591)> mark @MC_top.tashkil_arabic;
+        pos base highhamza-ar
+            <anchor (opsz=18,wght=400:251 opsz=18,wght=700:260 opsz=17,wght=400:251 opsz=17,wght=700:260) (opsz=18,wght=400:734 opsz=18,wght=700:788 opsz=17,wght=400:784 opsz=17,wght=700:838)> mark @MC_top.tashkil_arabic;
+        pos base rounddot-ar
+            <anchor (opsz=18,wght=400:103 opsz=18,wght=700:97 opsz=17,wght=400:103 opsz=17,wght=700:97) (opsz=18,wght=400:305 opsz=18,wght=700:311 opsz=17,wght=400:355 opsz=17,wght=700:361)> mark @MC_top.tashkil_arabic;
+        pos base raisedrounddot-ar
+            <anchor (opsz=18,wght=400:103 opsz=18,wght=700:97 opsz=17,wght=400:103 opsz=17,wght=700:97) (opsz=18,wght=400:616 opsz=18,wght=700:631 opsz=17,wght=400:666 opsz=17,wght=700:681)> mark @MC_top.tashkil_arabic;
+        pos base behDotless-ar
+            <anchor (opsz=18,wght=400:423 opsz=18,wght=700:430 opsz=17,wght=400:423 opsz=17,wght=700:430) (opsz=18,wght=400:339 opsz=18,wght=700:389 opsz=17,wght=400:389 opsz=17,wght=700:439)> mark @MC_top.tashkil_arabic;
+        pos base behDotless-ar.fina
+            <anchor (opsz=18,wght=400:439 opsz=18,wght=700:444 opsz=17,wght=400:439 opsz=17,wght=700:444) (opsz=18,wght=400:339 opsz=18,wght=700:339 opsz=17,wght=400:389 opsz=17,wght=700:389)> mark @MC_top.tashkil_arabic;
+        pos base behDotless-ar.medi
+            <anchor (opsz=18,wght=400:165 opsz=18,wght=700:181 opsz=17,wght=400:165 opsz=17,wght=700:181) (opsz=18,wght=400:433 opsz=18,wght=700:457 opsz=17,wght=400:483 opsz=17,wght=700:507)> mark @MC_top.tashkil_arabic;
+        pos base behDotless-ar.medi.high
+            <anchor (opsz=18,wght=400:165 opsz=18,wght=700:181 opsz=17,wght=400:165 opsz=17,wght=700:181) (opsz=18,wght=400:541 opsz=18,wght=700:541 opsz=17,wght=400:591 opsz=17,wght=700:591)> mark @MC_top.tashkil_arabic;
+        pos base behDotless-ar.init
+            <anchor (opsz=18,wght=400:146 opsz=18,wght=700:148 opsz=17,wght=400:146 opsz=17,wght=700:148) (opsz=18,wght=400:479 opsz=18,wght=700:502 opsz=17,wght=400:529 opsz=17,wght=700:552)> mark @MC_top.tashkil_arabic;
+        pos base behDotless-ar.init.high
+            <anchor (opsz=18,wght=400:140 opsz=18,wght=700:151 opsz=17,wght=400:140 opsz=17,wght=700:151) (opsz=18,wght=400:591 opsz=18,wght=700:586 opsz=17,wght=400:641 opsz=17,wght=700:636)> mark @MC_top.tashkil_arabic;
+        pos base yehthin-ar.init
+            <anchor (opsz=18,wght=400:125 opsz=18,wght=700:138 opsz=17,wght=400:125 opsz=17,wght=700:138) (opsz=18,wght=400:429 opsz=18,wght=700:452 opsz=17,wght=400:479 opsz=17,wght=700:502)> mark @MC_top.tashkil_arabic;
+        pos base yehthin-ar.medi
+            <anchor (opsz=18,wght=400:135 opsz=18,wght=700:151 opsz=17,wght=400:155 opsz=17,wght=700:171) (opsz=18,wght=400:433 opsz=18,wght=700:457 opsz=17,wght=400:483 opsz=17,wght=700:507)> mark @MC_top.tashkil_arabic;
+        pos base hah-ar
+            <anchor (opsz=18,wght=400:309 opsz=18,wght=700:367 opsz=17,wght=400:309 opsz=17,wght=700:369) (opsz=18,wght=400:576 opsz=18,wght=700:606 opsz=17,wght=400:626 opsz=17,wght=700:710)> mark @MC_top.tashkil_arabic;
+        pos base hah-ar.fina
+            <anchor (opsz=18,wght=400:309 opsz=18,wght=700:367 opsz=17,wght=400:309 opsz=17,wght=700:369) (opsz=18,wght=400:576 opsz=18,wght=700:606 opsz=17,wght=400:626 opsz=17,wght=700:710)> mark @MC_top.tashkil_arabic;
+        pos base hah-ar.medi
+            <anchor (opsz=18,wght=400:338 opsz=18,wght=700:399 opsz=17,wght=400:340 opsz=17,wght=700:372) (opsz=18,wght=400:499 opsz=18,wght=700:534 opsz=17,wght=400:549 opsz=17,wght=700:597)> mark @MC_top.tashkil_arabic;
+        pos base hah-ar.init
+            <anchor (opsz=18,wght=400:338 opsz=18,wght=700:399 opsz=17,wght=400:340 opsz=17,wght=700:372) (opsz=18,wght=400:499 opsz=18,wght=700:534 opsz=17,wght=400:549 opsz=17,wght=700:597)> mark @MC_top.tashkil_arabic;
+        pos base dal-ar
+            <anchor (opsz=18,wght=400:198 opsz=18,wght=700:207 opsz=17,wght=400:198 opsz=17,wght=700:207) (opsz=18,wght=400:625 opsz=18,wght=700:674 opsz=17,wght=400:675 opsz=17,wght=700:724)> mark @MC_top.tashkil_arabic;
+        pos base dal-ar.fina
+            <anchor (opsz=18,wght=400:316 opsz=18,wght=700:324 opsz=17,wght=400:288 opsz=17,wght=700:282) (opsz=18,wght=400:605 opsz=18,wght=700:630 opsz=17,wght=400:655 opsz=17,wght=700:680)> mark @MC_top.tashkil_arabic;
+        pos base reh-ar
+            <anchor (opsz=18,wght=400:204 opsz=18,wght=700:234 opsz=17,wght=400:204 opsz=17,wght=700:234) (opsz=18,wght=400:450 opsz=18,wght=700:469 opsz=17,wght=400:500 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic;
+        pos base reh-ar.fina
+            <anchor (opsz=18,wght=400:204 opsz=18,wght=700:234 opsz=17,wght=400:204 opsz=17,wght=700:234) (opsz=18,wght=400:450 opsz=18,wght=700:469 opsz=17,wght=400:500 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic;
+        pos base rehLoop-ar
+            <anchor 368 (opsz=18,wght=400:450 opsz=18,wght=700:469 opsz=17,wght=400:500 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic;
+        pos base rehLoop-ar.fina
+            <anchor 368 (opsz=18,wght=400:450 opsz=18,wght=700:469 opsz=17,wght=400:500 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic;
+        pos base seen-ar
+            <anchor (opsz=18,wght=400:780 opsz=18,wght=700:787 opsz=17,wght=400:780 opsz=17,wght=700:787) (opsz=18,wght=400:436 opsz=18,wght=700:469 opsz=17,wght=400:486 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic;
+        pos base seen-ar.fina
+            <anchor (opsz=18,wght=400:780 opsz=18,wght=700:787 opsz=17,wght=400:780 opsz=17,wght=700:787) (opsz=18,wght=400:436 opsz=18,wght=700:469 opsz=17,wght=400:486 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic;
+        pos base seen-ar.medi
+            <anchor (opsz=18,wght=400:387 opsz=18,wght=700:445 opsz=17,wght=400:387 opsz=17,wght=700:445) (opsz=18,wght=400:436 opsz=18,wght=700:469 opsz=17,wght=400:486 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic;
+        pos base seen-ar.medi.wide
+            <anchor (opsz=18,wght=400:544 opsz=18,wght=700:592 opsz=17,wght=400:544 opsz=17,wght=700:592) (opsz=18,wght=400:436 opsz=18,wght=700:469 opsz=17,wght=400:486 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic;
+        pos base seen-ar.init
+            <anchor (opsz=18,wght=400:387 opsz=18,wght=700:445 opsz=17,wght=400:387 opsz=17,wght=700:445) (opsz=18,wght=400:436 opsz=18,wght=700:469 opsz=17,wght=400:486 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic;
+        pos base seen-ar.init.wide
+            <anchor (opsz=18,wght=400:544 opsz=18,wght=700:592 opsz=17,wght=400:544 opsz=17,wght=700:592) (opsz=18,wght=400:436 opsz=18,wght=700:469 opsz=17,wght=400:486 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic;
+        pos base sad-ar
+            <anchor (opsz=18,wght=400:829 opsz=18,wght=700:802 opsz=17,wght=400:829 opsz=17,wght=700:802) (opsz=18,wght=400:547 opsz=18,wght=700:601 opsz=17,wght=400:597 opsz=17,wght=700:651)> mark @MC_top.tashkil_arabic;
+        pos base sad-ar.fina
+            <anchor (opsz=18,wght=400:829 opsz=18,wght=700:802 opsz=17,wght=400:829 opsz=17,wght=700:802) (opsz=18,wght=400:547 opsz=18,wght=700:601 opsz=17,wght=400:597 opsz=17,wght=700:651)> mark @MC_top.tashkil_arabic;
+        pos base sad-ar.medi
+            <anchor (opsz=18,wght=400:450 opsz=18,wght=700:457 opsz=17,wght=400:450 opsz=17,wght=700:457) (opsz=18,wght=400:547 opsz=18,wght=700:595 opsz=17,wght=400:597 opsz=17,wght=700:645)> mark @MC_top.tashkil_arabic;
+        pos base sad-ar.init
+            <anchor (opsz=18,wght=400:450 opsz=18,wght=700:457 opsz=17,wght=400:450 opsz=17,wght=700:457) (opsz=18,wght=400:547 opsz=18,wght=700:595 opsz=17,wght=400:597 opsz=17,wght=700:645)> mark @MC_top.tashkil_arabic;
+        pos base tah-ar
+            <anchor (opsz=18,wght=400:476 opsz=18,wght=700:475 opsz=17,wght=400:476 opsz=17,wght=700:475) (opsz=18,wght=400:549 opsz=18,wght=700:602 opsz=17,wght=400:599 opsz=17,wght=700:652)> mark @MC_top.tashkil_arabic;
+        pos base tah-ar.fina
+            <anchor (opsz=18,wght=400:476 opsz=18,wght=700:475 opsz=17,wght=400:476 opsz=17,wght=700:475) (opsz=18,wght=400:549 opsz=18,wght=700:602 opsz=17,wght=400:599 opsz=17,wght=700:652)> mark @MC_top.tashkil_arabic;
+        pos base tah-ar.medi
+            <anchor (opsz=18,wght=400:434 opsz=18,wght=700:449 opsz=17,wght=400:434 opsz=17,wght=700:449) (opsz=18,wght=400:549 opsz=18,wght=700:601 opsz=17,wght=400:599 opsz=17,wght=700:651)> mark @MC_top.tashkil_arabic;
+        pos base tah-ar.init
+            <anchor (opsz=18,wght=400:434 opsz=18,wght=700:449 opsz=17,wght=400:434 opsz=17,wght=700:449) (opsz=18,wght=400:549 opsz=18,wght=700:601 opsz=17,wght=400:599 opsz=17,wght=700:651)> mark @MC_top.tashkil_arabic;
+        pos base ain-ar
+            <anchor (opsz=18,wght=400:297 opsz=18,wght=700:303 opsz=17,wght=400:297 opsz=17,wght=700:303) (opsz=18,wght=400:690 opsz=18,wght=700:732 opsz=17,wght=400:740 opsz=17,wght=700:782)> mark @MC_top.tashkil_arabic;
+        pos base ain-ar.fina
+            <anchor (opsz=18,wght=400:315 opsz=18,wght=700:334 opsz=17,wght=400:315 opsz=17,wght=700:334) (opsz=18,wght=400:553 opsz=18,wght=700:601 opsz=17,wght=400:603 opsz=17,wght=700:651)> mark @MC_top.tashkil_arabic;
+        pos base ain-ar.medi
+            <anchor (opsz=18,wght=400:283 opsz=18,wght=700:303 opsz=17,wght=400:283 opsz=17,wght=700:303) (opsz=18,wght=400:553 opsz=18,wght=700:601 opsz=17,wght=400:603 opsz=17,wght=700:651)> mark @MC_top.tashkil_arabic;
+        pos base ain-ar.init
+            <anchor (opsz=18,wght=400:286 opsz=18,wght=700:294 opsz=17,wght=400:286 opsz=17,wght=700:294) (opsz=18,wght=400:550 opsz=18,wght=700:582 opsz=17,wght=400:600 opsz=17,wght=700:632)> mark @MC_top.tashkil_arabic;
+        pos base fehDotless-ar
+            <anchor (opsz=18,wght=400:630 opsz=18,wght=700:645 opsz=17,wght=400:630 opsz=17,wght=700:645) (opsz=18,wght=400:677 opsz=18,wght=700:709 opsz=17,wght=400:727 opsz=17,wght=700:759)> mark @MC_top.tashkil_arabic;
+        pos base fehDotless-ar.fina
+            <anchor (opsz=18,wght=400:718 opsz=18,wght=700:736 opsz=17,wght=400:718 opsz=17,wght=700:736) (opsz=18,wght=400:606 opsz=18,wght=700:660 opsz=17,wght=400:656 opsz=17,wght=700:710)> mark @MC_top.tashkil_arabic;
+        pos base fehDotless-ar.medi
+            <anchor (opsz=18,wght=400:264 opsz=18,wght=700:294 opsz=17,wght=400:264 opsz=17,wght=700:294) (opsz=18,wght=400:606 opsz=18,wght=700:660 opsz=17,wght=400:656 opsz=17,wght=700:710)> mark @MC_top.tashkil_arabic;
+        pos base fehDotless-ar.init
+            <anchor (opsz=18,wght=400:255 opsz=18,wght=700:267 opsz=17,wght=400:255 opsz=17,wght=700:267) (opsz=18,wght=400:661 opsz=18,wght=700:719 opsz=17,wght=400:711 opsz=17,wght=700:769)> mark @MC_top.tashkil_arabic;
+        pos base qafDotless-ar
+            <anchor (opsz=18,wght=400:513 opsz=18,wght=700:531 opsz=17,wght=400:513 opsz=17,wght=700:531) (opsz=18,wght=400:609 opsz=18,wght=700:663 opsz=17,wght=400:659 opsz=17,wght=700:713)> mark @MC_top.tashkil_arabic;
+        pos base qafDotless-ar.fina
+            <anchor (opsz=18,wght=400:513 opsz=18,wght=700:530 opsz=17,wght=400:513 opsz=17,wght=700:530) (opsz=18,wght=400:513 opsz=18,wght=700:561 opsz=17,wght=400:563 opsz=17,wght=700:611)> mark @MC_top.tashkil_arabic;
+        pos base yehRohingya-ar
+            <anchor (opsz=18,wght=400:324 opsz=18,wght=700:371 opsz=17,wght=400:324 opsz=17,wght=700:371) (opsz=18,wght=400:606 opsz=18,wght=700:660 opsz=17,wght=400:656 opsz=17,wght=700:710)> mark @MC_top.tashkil_arabic;
+        pos base yehRohingya-ar.fina
+            <anchor (opsz=18,wght=400:373 opsz=18,wght=700:449 opsz=17,wght=400:373 opsz=17,wght=700:449) (opsz=18,wght=400:606 opsz=18,wght=700:660 opsz=17,wght=400:656 opsz=17,wght=700:710)> mark @MC_top.tashkil_arabic;
+        pos base kafDotless-ar
+            <anchor (opsz=18,wght=400:421 opsz=18,wght=700:422 opsz=17,wght=400:421 opsz=17,wght=700:422) (opsz=18,wght=400:426 opsz=18,wght=700:426 opsz=17,wght=400:476 opsz=17,wght=700:476)> mark @MC_top.tashkil_arabic;
+        pos base kafDotless-ar.fina
+            <anchor (opsz=18,wght=400:394 opsz=18,wght=700:410 opsz=17,wght=400:394 opsz=17,wght=700:410) (opsz=18,wght=400:426 opsz=18,wght=700:426 opsz=17,wght=400:476 opsz=17,wght=700:476)> mark @MC_top.tashkil_arabic;
+        pos base kafswash-ar
+            <anchor (opsz=18,wght=400:433 opsz=18,wght=700:408 opsz=17,wght=400:433 opsz=17,wght=700:408) (opsz=18,wght=400:627 opsz=18,wght=700:727 opsz=17,wght=400:627 opsz=17,wght=700:727)> mark @MC_top.tashkil_arabic;
+        pos base kafswash-ar.fina
+            <anchor (opsz=18,wght=400:433 opsz=18,wght=700:408 opsz=17,wght=400:433 opsz=17,wght=700:408) (opsz=18,wght=400:627 opsz=18,wght=700:727 opsz=17,wght=400:627 opsz=17,wght=700:727)> mark @MC_top.tashkil_arabic;
+        pos base kafswash-ar.medi
+            <anchor (opsz=18,wght=400:15 opsz=18,wght=700:12 opsz=17,wght=400:15 opsz=17,wght=700:12) (opsz=18,wght=400:660 opsz=18,wght=700:711 opsz=17,wght=400:710 opsz=17,wght=700:761)> mark @MC_top.tashkil_arabic;
+        pos base kafswash-ar.init
+            <anchor (opsz=18,wght=400:15 opsz=18,wght=700:12 opsz=17,wght=400:15 opsz=17,wght=700:12) (opsz=18,wght=400:660 opsz=18,wght=700:711 opsz=17,wght=400:710 opsz=17,wght=700:761)> mark @MC_top.tashkil_arabic;
+        pos base lam-ar
+            <anchor (opsz=18,wght=400:291 opsz=18,wght=700:270 opsz=17,wght=400:291 opsz=17,wght=700:270) (opsz=18,wght=400:576 opsz=18,wght=700:590 opsz=17,wght=400:626 opsz=17,wght=700:640)> mark @MC_top.tashkil_arabic;
+        pos base lam-ar.fina
+            <anchor (opsz=18,wght=400:291 opsz=18,wght=700:270 opsz=17,wght=400:291 opsz=17,wght=700:270) (opsz=18,wght=400:575 opsz=18,wght=700:589 opsz=17,wght=400:625 opsz=17,wght=700:639)> mark @MC_top.tashkil_arabic;
+        pos base meem-ar
+            <anchor (opsz=18,wght=400:306 opsz=18,wght=700:312 opsz=17,wght=400:306 opsz=17,wght=700:312) (opsz=18,wght=400:534 opsz=18,wght=700:588 opsz=17,wght=400:584 opsz=17,wght=700:638)> mark @MC_top.tashkil_arabic;
+        pos base meem-ar.alt
+            <anchor (opsz=18,wght=400:566 opsz=18,wght=700:607 opsz=17,wght=400:566 opsz=17,wght=700:607) (opsz=18,wght=400:521 opsz=18,wght=700:564 opsz=17,wght=400:571 opsz=17,wght=700:614)> mark @MC_top.tashkil_arabic;
+        pos base meem-ar.fina
+            <anchor (opsz=18,wght=400:268 opsz=18,wght=700:299 opsz=17,wght=400:268 opsz=17,wght=700:299) (opsz=18,wght=400:520 opsz=18,wght=700:562 opsz=17,wght=400:570 opsz=17,wght=700:612)> mark @MC_top.tashkil_arabic;
+        pos base meem-ar.fina.alt
+            <anchor (opsz=18,wght=400:574 opsz=18,wght=700:619 opsz=17,wght=400:574 opsz=17,wght=700:619) (opsz=18,wght=400:520 opsz=18,wght=700:562 opsz=17,wght=400:570 opsz=17,wght=700:612)> mark @MC_top.tashkil_arabic;
+        pos base meem-ar.medi
+            <anchor 334 (opsz=18,wght=400:520 opsz=18,wght=700:562 opsz=17,wght=400:570 opsz=17,wght=700:612)> mark @MC_top.tashkil_arabic;
+        pos base meem-ar.init
+            <anchor (opsz=18,wght=400:336 opsz=18,wght=700:332 opsz=17,wght=400:336 opsz=17,wght=700:332) (opsz=18,wght=400:521 opsz=18,wght=700:564 opsz=17,wght=400:571 opsz=17,wght=700:614)> mark @MC_top.tashkil_arabic;
+        pos base noonghunna-ar
+            <anchor (opsz=18,wght=400:328 opsz=18,wght=700:334 opsz=17,wght=400:328 opsz=17,wght=700:334) (opsz=18,wght=400:456 opsz=18,wght=700:456 opsz=17,wght=400:506 opsz=17,wght=700:506)> mark @MC_top.tashkil_arabic;
+        pos base noonghunna-ar.fina
+            <anchor (opsz=18,wght=400:328 opsz=18,wght=700:334 opsz=17,wght=400:328 opsz=17,wght=700:334) (opsz=18,wght=400:386 opsz=18,wght=700:386 opsz=17,wght=400:436 opsz=17,wght=700:436)> mark @MC_top.tashkil_arabic;
+        pos base heh-ar
+            <anchor (opsz=18,wght=400:267 opsz=18,wght=700:285 opsz=17,wght=400:267 opsz=17,wght=700:285) (opsz=18,wght=400:660 opsz=18,wght=700:704 opsz=17,wght=400:710 opsz=17,wght=700:754)> mark @MC_top.tashkil_arabic;
+        pos base heh-ar.fina
+            <anchor (opsz=18,wght=400:197 opsz=18,wght=700:203 opsz=17,wght=400:197 opsz=17,wght=700:203) (opsz=18,wght=400:660 opsz=18,wght=700:683 opsz=17,wght=400:710 opsz=17,wght=700:733)> mark @MC_top.tashkil_arabic;
+        pos base heh-ar.medi
+            <anchor (opsz=18,wght=400:310 opsz=18,wght=700:307 opsz=17,wght=400:310 opsz=17,wght=700:307) (opsz=18,wght=400:572 opsz=18,wght=700:610 opsz=17,wght=400:622 opsz=17,wght=700:660)> mark @MC_top.tashkil_arabic;
+        pos base heh-ar.init
+            <anchor (opsz=18,wght=400:149 opsz=18,wght=700:176 opsz=17,wght=400:149 opsz=17,wght=700:176) (opsz=18,wght=400:668 opsz=18,wght=700:740 opsz=17,wght=400:718 opsz=17,wght=700:790)> mark @MC_top.tashkil_arabic;
+        pos base hehgoal-ar
+            <anchor (opsz=18,wght=400:267 opsz=18,wght=700:285 opsz=17,wght=400:267 opsz=17,wght=700:285) (opsz=18,wght=400:660 opsz=18,wght=700:704 opsz=17,wght=400:710 opsz=17,wght=700:754)> mark @MC_top.tashkil_arabic;
+        pos base hehgoal-ar.fina
+            <anchor (opsz=18,wght=400:322 opsz=18,wght=700:370 opsz=17,wght=400:322 opsz=17,wght=700:370) (opsz=18,wght=400:419 opsz=18,wght=700:461 opsz=17,wght=400:469 opsz=17,wght=700:511)> mark @MC_top.tashkil_arabic;
+        pos base hehgoal-ar.medi
+            <anchor (opsz=18,wght=400:220 opsz=18,wght=700:222 opsz=17,wght=400:220 opsz=17,wght=700:222) (opsz=18,wght=400:487 opsz=18,wght=700:563 opsz=17,wght=400:537 opsz=17,wght=700:613)> mark @MC_top.tashkil_arabic;
+        pos base hehgoal-ar.medi.yehbarree
+            <anchor (opsz=18,wght=400:220 opsz=18,wght=700:222 opsz=17,wght=400:220 opsz=17,wght=700:222) (opsz=18,wght=400:487 opsz=18,wght=700:563 opsz=17,wght=400:537 opsz=17,wght=700:613)> mark @MC_top.tashkil_arabic;
+        pos base hehgoal-ar.init
+            <anchor (opsz=18,wght=400:293 opsz=18,wght=700:312 opsz=17,wght=400:293 opsz=17,wght=700:312) (opsz=18,wght=400:429 opsz=18,wght=700:452 opsz=17,wght=400:479 opsz=17,wght=700:502)> mark @MC_top.tashkil_arabic;
+        pos base hehgoal-ar.init.ascending
+            <anchor (opsz=18,wght=400:125 opsz=18,wght=700:138 opsz=17,wght=400:125 opsz=17,wght=700:138) (opsz=18,wght=400:429 opsz=18,wght=700:452 opsz=17,wght=400:479 opsz=17,wght=700:502)> mark @MC_top.tashkil_arabic;
+        pos base ae-ar
+            <anchor (opsz=18,wght=400:267 opsz=18,wght=700:285 opsz=17,wght=400:267 opsz=17,wght=700:285) (opsz=18,wght=400:660 opsz=18,wght=700:704 opsz=17,wght=400:710 opsz=17,wght=700:754)> mark @MC_top.tashkil_arabic;
+        pos base hehDoachashmee-ar
+            <anchor (opsz=18,wght=400:516 opsz=18,wght=700:479 opsz=17,wght=400:516 opsz=17,wght=700:479) (opsz=18,wght=400:616 opsz=18,wght=700:725 opsz=17,wght=400:666 opsz=17,wght=700:775)> mark @MC_top.tashkil_arabic;
+        pos base hehDoachashmee-ar.fina
+            <anchor (opsz=18,wght=400:516 opsz=18,wght=700:479 opsz=17,wght=400:516 opsz=17,wght=700:479) (opsz=18,wght=400:616 opsz=18,wght=700:725 opsz=17,wght=400:666 opsz=17,wght=700:775)> mark @MC_top.tashkil_arabic;
+        pos base hehDoachashmee-ar.medi
+            <anchor (opsz=18,wght=400:149 opsz=18,wght=700:176 opsz=17,wght=400:149 opsz=17,wght=700:176) (opsz=18,wght=400:668 opsz=18,wght=700:740 opsz=17,wght=400:718 opsz=17,wght=700:790)> mark @MC_top.tashkil_arabic;
+        pos base waw-ar
+            <anchor (opsz=18,wght=400:248 opsz=18,wght=700:272 opsz=17,wght=400:248 opsz=17,wght=700:271) (opsz=18,wght=400:538 opsz=18,wght=700:586 opsz=17,wght=400:588 opsz=17,wght=700:636)> mark @MC_top.tashkil_arabic;
+        pos base waw-ar.fina
+            <anchor (opsz=18,wght=400:248 opsz=18,wght=700:271 opsz=17,wght=400:248 opsz=17,wght=700:271) (opsz=18,wght=400:513 opsz=18,wght=700:561 opsz=17,wght=400:563 opsz=17,wght=700:611)> mark @MC_top.tashkil_arabic;
+        pos base wawStraight-ar
+            <anchor (opsz=18,wght=400:211 opsz=18,wght=700:223 opsz=17,wght=400:211 opsz=17,wght=700:223) (opsz=18,wght=400:538 opsz=18,wght=700:586 opsz=17,wght=400:588 opsz=17,wght=700:636)> mark @MC_top.tashkil_arabic;
+        pos base wawStraight-ar.fina
+            <anchor (opsz=18,wght=400:211 opsz=18,wght=700:223 opsz=17,wght=400:211 opsz=17,wght=700:223) (opsz=18,wght=400:513 opsz=18,wght=700:561 opsz=17,wght=400:563 opsz=17,wght=700:611)> mark @MC_top.tashkil_arabic;
+        pos base alefMaksura-ar
+            <anchor (opsz=18,wght=400:340 opsz=18,wght=700:338 opsz=17,wght=400:340 opsz=17,wght=700:338) (opsz=18,wght=400:556 opsz=18,wght=700:622 opsz=17,wght=400:599 opsz=17,wght=700:672)> mark @MC_top.tashkil_arabic;
+        pos base alefMaksura-ar.fina
+            <anchor (opsz=18,wght=400:346 opsz=18,wght=700:378 opsz=17,wght=400:346 opsz=17,wght=700:378) (opsz=18,wght=400:290 opsz=18,wght=700:319 opsz=17,wght=400:340 opsz=17,wght=700:369)> mark @MC_top.tashkil_arabic;
+        pos base yehbarree-ar
+            <anchor (opsz=18,wght=400:352 opsz=18,wght=700:414 opsz=17,wght=400:352 opsz=17,wght=700:394) (opsz=18,wght=400:534 opsz=18,wght=700:563 opsz=17,wght=400:584 opsz=17,wght=700:613)> mark @MC_top.tashkil_arabic;
+        pos base yehbarree-ar.fina
+            <anchor (opsz=18,wght=400:142 opsz=18,wght=700:156 opsz=17,wght=400:142 opsz=17,wght=700:156) (opsz=18,wght=400:286 opsz=18,wght=700:353 opsz=17,wght=400:336 opsz=17,wght=700:403)> mark @MC_top.tashkil_arabic;
+        pos base kashidaHamza-ar
+            <anchor (opsz=18,wght=400:193 opsz=18,wght=700:218 opsz=17,wght=400:193 opsz=17,wght=700:218) (opsz=18,wght=400:437 opsz=18,wght=700:491 opsz=17,wght=400:487 opsz=17,wght=700:541)> mark @MC_top.tashkil_arabic;
+        pos base kashidaWaw-ar
+            <anchor (opsz=18,wght=400:223 opsz=18,wght=700:253 opsz=17,wght=400:192 opsz=17,wght=700:217) (opsz=18,wght=400:413 opsz=18,wght=700:465 opsz=17,wght=400:453 opsz=17,wght=700:505)> mark @MC_top.tashkil_arabic;
+        pos base lellah-ar
+            <anchor (opsz=18,wght=400:671 opsz=18,wght=700:707 opsz=17,wght=400:660 opsz=17,wght=700:697) (opsz=18,wght=400:1054 opsz=18,wght=700:1110 opsz=17,wght=400:1054 opsz=17,wght=700:1110)> mark @MC_top.tashkil_arabic;
+        pos base lellah-ar.fina
+            <anchor (opsz=18,wght=400:671 opsz=18,wght=700:707 opsz=17,wght=400:660 opsz=17,wght=700:697) (opsz=18,wght=400:1054 opsz=18,wght=700:1110 opsz=17,wght=400:1054 opsz=17,wght=700:1110)> mark @MC_top.tashkil_arabic;
+        pos base sindhipostpositionmen-ar
+            <anchor (opsz=18,wght=400:306 opsz=18,wght=700:312 opsz=17,wght=400:306 opsz=17,wght=700:312) (opsz=18,wght=400:534 opsz=18,wght=700:588 opsz=17,wght=400:584 opsz=17,wght=700:638)> mark @MC_top.tashkil_arabic;
+        pos base sindhipostpositionmen-ar.alt
+            <anchor (opsz=18,wght=400:566 opsz=18,wght=700:607 opsz=17,wght=400:566 opsz=17,wght=700:607) (opsz=18,wght=400:521 opsz=18,wght=700:564 opsz=17,wght=400:571 opsz=17,wght=700:614)> mark @MC_top.tashkil_arabic;
+        pos base sindhiampersand-ar
+            <anchor (opsz=18,wght=400:251 opsz=18,wght=700:260 opsz=17,wght=400:251 opsz=17,wght=700:260) (opsz=18,wght=400:487 opsz=18,wght=700:541 opsz=17,wght=400:537 opsz=17,wght=700:591)> mark @MC_top.tashkil_arabic;
+    } mark2base_top.tashkil_arabic;
+
+    lookup mark2base_digits_arabic {
+        pos base endofayah-ar
+            <anchor (opsz=18,wght=400:660 opsz=18,wght=700:828 opsz=17,wght=400:660 opsz=17,wght=700:828) (opsz=18,wght=400:107 opsz=18,wght=700:137 opsz=17,wght=400:107 opsz=17,wght=700:137)> mark @MC_digits_arabic;
+        pos base endofayah-ar.2
+            <anchor (opsz=18,wght=400:445 opsz=18,wght=700:596 opsz=17,wght=400:445 opsz=17,wght=700:628) (opsz=18,wght=400:107 opsz=18,wght=700:137 opsz=17,wght=400:107 opsz=17,wght=700:137)> mark @MC_digits_arabic;
+        pos base endofayah-ar.3
+            <anchor (opsz=18,wght=400:232 opsz=18,wght=700:367 opsz=17,wght=400:232 opsz=17,wght=700:367) (opsz=18,wght=400:107 opsz=18,wght=700:137 opsz=17,wght=400:107 opsz=17,wght=700:137)> mark @MC_digits_arabic;
+        pos base disputedendofayah-ar
+            <anchor 108 0> mark @MC_digits_arabic;
+        pos base disputedendofayah-ar.2
+            <anchor 0 0> mark @MC_digits_arabic;
+        pos base disputedendofayah-ar.3
+            <anchor 0 0> mark @MC_digits_arabic;
+        pos base year-ar
+            <anchor (opsz=18,wght=400:1102 opsz=18,wght=700:1163 opsz=17,wght=400:1102 opsz=17,wght=700:1163) 0> mark @MC_digits_arabic;
+        pos base year-ar.2
+            <anchor (opsz=18,wght=400:750 opsz=18,wght=700:853 opsz=17,wght=400:750 opsz=17,wght=700:853) 0> mark @MC_digits_arabic;
+        pos base year-ar.3
+            <anchor (opsz=18,wght=400:459 opsz=18,wght=700:460 opsz=17,wght=400:459 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos base year-ar.4
+            <anchor (opsz=18,wght=400:154 opsz=18,wght=700:77 opsz=17,wght=400:154 opsz=17,wght=700:77) (opsz=18,wght=400:20 opsz=18,wght=700:80 opsz=17,wght=400:20 opsz=17,wght=700:80)> mark @MC_digits_arabic;
+        pos base samvat-ar
+            <anchor (opsz=18,wght=400:532 opsz=18,wght=700:462 opsz=17,wght=400:532 opsz=17,wght=700:462) 0> mark @MC_digits_arabic;
+        pos base samvat-ar.2
+            <anchor (opsz=18,wght=400:172 opsz=18,wght=700:52 opsz=17,wght=400:172 opsz=17,wght=700:52) 0> mark @MC_digits_arabic;
+        pos base samvat-ar.3
+            <anchor (opsz=18,wght=400:172 opsz=18,wght=700:52 opsz=17,wght=400:172 opsz=17,wght=700:52) 0> mark @MC_digits_arabic;
+        pos base samvat-ar.4
+            <anchor (opsz=18,wght=400:172 opsz=18,wght=700:52 opsz=17,wght=400:172 opsz=17,wght=700:52) 0> mark @MC_digits_arabic;
+        pos base pagenumber-ar
+            <anchor (opsz=18,wght=400:137 opsz=18,wght=700:123 opsz=17,wght=400:137 opsz=17,wght=700:123) (opsz=18,wght=400:176 opsz=18,wght=700:236 opsz=17,wght=400:176 opsz=17,wght=700:236)> mark @MC_digits_arabic;
+        pos base pagenumber-ar.2
+            <anchor (opsz=18,wght=400:236 opsz=18,wght=700:126 opsz=17,wght=400:236 opsz=17,wght=700:126) (opsz=18,wght=400:206 opsz=18,wght=700:236 opsz=17,wght=400:206 opsz=17,wght=700:236)> mark @MC_digits_arabic;
+        pos base pagenumber-ar.3
+            <anchor (opsz=18,wght=400:86 opsz=18,wght=700:29 opsz=17,wght=400:86 opsz=17,wght=700:29) (opsz=18,wght=400:206 opsz=18,wght=700:236 opsz=17,wght=400:206 opsz=17,wght=700:236)> mark @MC_digits_arabic;
+        pos base number-ar
+            <anchor (opsz=18,wght=400:670 opsz=18,wght=700:640 opsz=17,wght=400:670 opsz=17,wght=700:640) (opsz=18,wght=400:134 opsz=18,wght=700:164 opsz=17,wght=400:134 opsz=17,wght=700:164)> mark @MC_digits_arabic;
+        pos base number-ar.2
+            <anchor (opsz=18,wght=400:460 opsz=18,wght=700:350 opsz=17,wght=400:460 opsz=17,wght=700:350) (opsz=18,wght=400:134 opsz=18,wght=700:164 opsz=17,wght=400:134 opsz=17,wght=700:164)> mark @MC_digits_arabic;
+        pos base number-ar.3
+            <anchor (opsz=18,wght=400:210 opsz=18,wght=700:80 opsz=17,wght=400:210 opsz=17,wght=700:80) (opsz=18,wght=400:134 opsz=18,wght=700:164 opsz=17,wght=400:134 opsz=17,wght=700:164)> mark @MC_digits_arabic;
+        pos base footnotemarker-ar
+            <anchor (opsz=18,wght=400:657 opsz=18,wght=700:677 opsz=17,wght=400:657 opsz=17,wght=700:677) (opsz=18,wght=400:213 opsz=18,wght=700:263 opsz=17,wght=400:213 opsz=17,wght=700:263)> mark @MC_digits_arabic;
+        pos base footnotemarker-ar.2
+            <anchor (opsz=18,wght=400:487 opsz=18,wght=700:457 opsz=17,wght=400:487 opsz=17,wght=700:457) (opsz=18,wght=400:213 opsz=18,wght=700:263 opsz=17,wght=400:213 opsz=17,wght=700:263)> mark @MC_digits_arabic;
+        pos base piastre-ar
+            <anchor (opsz=18,wght=400:680 opsz=18,wght=700:760 opsz=17,wght=400:678 opsz=17,wght=700:786) 0> mark @MC_digits_arabic;
+        pos base piastre-ar.2
+            <anchor (opsz=18,wght=400:340 opsz=18,wght=700:371 opsz=17,wght=400:340 opsz=17,wght=700:371) 0> mark @MC_digits_arabic;
+        pos base piastre-ar.3
+            <anchor (opsz=18,wght=400:9 opsz=18,wght=700:-4 opsz=17,wght=400:9 opsz=17,wght=700:-4) 0> mark @MC_digits_arabic;
+        pos base pound-ar
+            <anchor (opsz=18,wght=400:680 opsz=18,wght=700:760 opsz=17,wght=400:679 opsz=17,wght=700:773) 0> mark @MC_digits_arabic;
+        pos base pound-ar.2
+            <anchor (opsz=18,wght=400:340 opsz=18,wght=700:371 opsz=17,wght=400:340 opsz=17,wght=700:371) 0> mark @MC_digits_arabic;
+        pos base pound-ar.3
+            <anchor (opsz=18,wght=400:9 opsz=18,wght=700:-4 opsz=17,wght=400:9 opsz=17,wght=700:-4) 0> mark @MC_digits_arabic;
+    } mark2base_digits_arabic;
+
+    lookup mark2base_seen_arabic {
+        pos base sad-ar.medi
+            <anchor (opsz=18,wght=400:450 opsz=18,wght=700:457 opsz=17,wght=400:450 opsz=17,wght=700:457) (opsz=18,wght=400:487 opsz=18,wght=700:510 opsz=17,wght=400:510 opsz=17,wght=700:510)> mark @MC_seen_arabic;
+        pos base sad-ar.init
+            <anchor (opsz=18,wght=400:450 opsz=18,wght=700:457 opsz=17,wght=400:450 opsz=17,wght=700:457) (opsz=18,wght=400:487 opsz=18,wght=700:510 opsz=17,wght=400:510 opsz=17,wght=700:510)> mark @MC_seen_arabic;
+    } mark2base_seen_arabic;
+
+    lookup mark2base_bottom_arabic {
+        pos base hamza-ar
+            <anchor (opsz=18,wght=400:239 opsz=18,wght=700:250 opsz=17,wght=400:239 opsz=17,wght=700:250) 0> mark @MC_bottom_arabic;
+        pos base highhamza-ar
+            <anchor (opsz=18,wght=400:239 opsz=18,wght=700:250 opsz=17,wght=400:239 opsz=17,wght=700:250) 247> mark @MC_bottom_arabic;
+        pos base rounddot-ar
+            <anchor (opsz=18,wght=400:104 opsz=18,wght=700:97 opsz=17,wght=400:104 opsz=17,wght=700:97) 0> mark @MC_bottom_arabic;
+        pos base raisedrounddot-ar
+            <anchor (opsz=18,wght=400:104 opsz=18,wght=700:97 opsz=17,wght=400:104 opsz=17,wght=700:97) (opsz=18,wght=400:311 opsz=18,wght=700:320 opsz=17,wght=400:311 opsz=17,wght=700:320)> mark @MC_bottom_arabic;
+        pos base alef-ar
+            <anchor (opsz=18,wght=400:122 opsz=18,wght=700:131 opsz=17,wght=400:122 opsz=17,wght=700:131) 0> mark @MC_bottom_arabic;
+        pos base alef-ar.fina
+            <anchor (opsz=18,wght=400:149 opsz=18,wght=700:170 opsz=17,wght=400:149 opsz=17,wght=700:170) 0> mark @MC_bottom_arabic;
+        pos base alef-ar.fina.kaf
+            <anchor (opsz=18,wght=400:149 opsz=18,wght=700:170 opsz=17,wght=400:149 opsz=17,wght=700:170) 0> mark @MC_bottom_arabic;
+        pos base alef-ar.short
+            <anchor (opsz=18,wght=400:122 opsz=18,wght=700:131 opsz=17,wght=400:122 opsz=17,wght=700:131) 0> mark @MC_bottom_arabic;
+        pos base alef-ar.short.fina
+            <anchor (opsz=18,wght=400:149 opsz=18,wght=700:170 opsz=17,wght=400:149 opsz=17,wght=700:170) 0> mark @MC_bottom_arabic;
+        pos base alef-ar.short.fina.kaf
+            <anchor (opsz=18,wght=400:149 opsz=18,wght=700:170 opsz=17,wght=400:149 opsz=17,wght=700:170) 0> mark @MC_bottom_arabic;
+        pos base behDotless-ar
+            <anchor (opsz=18,wght=400:426 opsz=18,wght=700:433 opsz=17,wght=400:426 opsz=17,wght=700:433) -16> mark @MC_bottom_arabic;
+        pos base behDotless-ar.fina
+            <anchor (opsz=18,wght=400:367 opsz=18,wght=700:378 opsz=17,wght=400:367 opsz=17,wght=700:378) -16> mark @MC_bottom_arabic;
+        pos base behDotless-ar.medi
+            <anchor (opsz=18,wght=400:165 opsz=18,wght=700:173 opsz=17,wght=400:165 opsz=17,wght=700:173) (opsz=18,wght=400:6 opsz=18,wght=700:0 opsz=17,wght=400:6 opsz=17,wght=700:0)> mark @MC_bottom_arabic;
+        pos base behDotless-ar.medi.high
+            <anchor (opsz=18,wght=400:165 opsz=18,wght=700:173 opsz=17,wght=400:165 opsz=17,wght=700:173) 0> mark @MC_bottom_arabic;
+        pos base behDotless-ar.init
+            <anchor (opsz=18,wght=400:146 opsz=18,wght=700:153 opsz=17,wght=400:146 opsz=17,wght=700:153) (opsz=18,wght=400:6 opsz=18,wght=700:0 opsz=17,wght=400:6 opsz=17,wght=700:0)> mark @MC_bottom_arabic;
+        pos base behDotless-ar.init.high
+            <anchor (opsz=18,wght=400:146 opsz=18,wght=700:153 opsz=17,wght=400:146 opsz=17,wght=700:153) (opsz=18,wght=400:6 opsz=18,wght=700:0 opsz=17,wght=400:6 opsz=17,wght=700:0)> mark @MC_bottom_arabic;
+        pos base hah-ar
+            <anchor (opsz=18,wght=400:395 opsz=18,wght=700:450 opsz=17,wght=400:395 opsz=17,wght=700:437) (opsz=18,wght=400:-307 opsz=18,wght=700:-309 opsz=17,wght=400:-307 opsz=17,wght=700:-309)> mark @MC_bottom_arabic;
+        pos base hah-ar.fina
+            <anchor (opsz=18,wght=400:395 opsz=18,wght=700:450 opsz=17,wght=400:395 opsz=17,wght=700:437) (opsz=18,wght=400:-307 opsz=18,wght=700:-309 opsz=17,wght=400:-307 opsz=17,wght=700:-309)> mark @MC_bottom_arabic;
+        pos base hah-ar.medi
+            <anchor (opsz=18,wght=400:356 opsz=18,wght=700:390 opsz=17,wght=400:358 opsz=17,wght=700:360) 0> mark @MC_bottom_arabic;
+        pos base hah-ar.init
+            <anchor (opsz=18,wght=400:356 opsz=18,wght=700:390 opsz=17,wght=400:358 opsz=17,wght=700:360) 0> mark @MC_bottom_arabic;
+        pos base dal-ar
+            <anchor (opsz=18,wght=400:166 opsz=18,wght=700:176 opsz=17,wght=400:166 opsz=17,wght=700:176) (opsz=18,wght=400:-16 opsz=18,wght=700:-13 opsz=17,wght=400:-16 opsz=17,wght=700:-13)> mark @MC_bottom_arabic;
+        pos base dal-ar.fina
+            <anchor (opsz=18,wght=400:256 opsz=18,wght=700:262 opsz=17,wght=400:246 opsz=17,wght=700:249) 0> mark @MC_bottom_arabic;
+        pos base reh-ar
+            <anchor (opsz=18,wght=400:136 opsz=18,wght=700:165 opsz=17,wght=400:136 opsz=17,wght=700:165) (opsz=18,wght=400:-247 opsz=18,wght=700:-248 opsz=17,wght=400:-247 opsz=17,wght=700:-248)> mark @MC_bottom_arabic;
+        pos base reh-ar.fina
+            <anchor (opsz=18,wght=400:136 opsz=18,wght=700:165 opsz=17,wght=400:136 opsz=17,wght=700:165) (opsz=18,wght=400:-247 opsz=18,wght=700:-248 opsz=17,wght=400:-247 opsz=17,wght=700:-248)> mark @MC_bottom_arabic;
+        pos base rehLoop-ar
+            <anchor (opsz=18,wght=400:227 opsz=18,wght=700:212 opsz=17,wght=400:227 opsz=17,wght=700:212) (opsz=18,wght=400:-332 opsz=18,wght=700:-345 opsz=17,wght=400:-332 opsz=17,wght=700:-345)> mark @MC_bottom_arabic;
+        pos base rehLoop-ar.fina
+            <anchor (opsz=18,wght=400:227 opsz=18,wght=700:212 opsz=17,wght=400:227 opsz=17,wght=700:212) (opsz=18,wght=400:-332 opsz=18,wght=700:-345 opsz=17,wght=400:-332 opsz=17,wght=700:-345)> mark @MC_bottom_arabic;
+        pos base seen-ar
+            <anchor (opsz=18,wght=400:780 opsz=18,wght=700:787 opsz=17,wght=400:780 opsz=17,wght=700:787) 0> mark @MC_bottom_arabic;
+        pos base seen-ar.fina
+            <anchor (opsz=18,wght=400:780 opsz=18,wght=700:787 opsz=17,wght=400:780 opsz=17,wght=700:787) 0> mark @MC_bottom_arabic;
+        pos base seen-ar.medi
+            <anchor (opsz=18,wght=400:387 opsz=18,wght=700:445 opsz=17,wght=400:387 opsz=17,wght=700:445) 0> mark @MC_bottom_arabic;
+        pos base seen-ar.medi.wide
+            <anchor (opsz=18,wght=400:544 opsz=18,wght=700:592 opsz=17,wght=400:544 opsz=17,wght=700:592) 0> mark @MC_bottom_arabic;
+        pos base seen-ar.init
+            <anchor (opsz=18,wght=400:387 opsz=18,wght=700:445 opsz=17,wght=400:387 opsz=17,wght=700:445) 0> mark @MC_bottom_arabic;
+        pos base seen-ar.init.wide
+            <anchor (opsz=18,wght=400:544 opsz=18,wght=700:592 opsz=17,wght=400:544 opsz=17,wght=700:592) 0> mark @MC_bottom_arabic;
+        pos base sad-ar
+            <anchor (opsz=18,wght=400:773 opsz=18,wght=700:755 opsz=17,wght=400:773 opsz=17,wght=700:755) 0> mark @MC_bottom_arabic;
+        pos base sad-ar.fina
+            <anchor (opsz=18,wght=400:773 opsz=18,wght=700:755 opsz=17,wght=400:773 opsz=17,wght=700:755) 0> mark @MC_bottom_arabic;
+        pos base sad-ar.medi
+            <anchor (opsz=18,wght=400:406 opsz=18,wght=700:410 opsz=17,wght=400:406 opsz=17,wght=700:410) 0> mark @MC_bottom_arabic;
+        pos base sad-ar.init
+            <anchor (opsz=18,wght=400:406 opsz=18,wght=700:410 opsz=17,wght=400:406 opsz=17,wght=700:410) 0> mark @MC_bottom_arabic;
+        pos base tah-ar
+            <anchor (opsz=18,wght=400:333 opsz=18,wght=700:309 opsz=17,wght=400:333 opsz=17,wght=700:309) 0> mark @MC_bottom_arabic;
+        pos base tah-ar.fina
+            <anchor (opsz=18,wght=400:333 opsz=18,wght=700:309 opsz=17,wght=400:333 opsz=17,wght=700:309) 0> mark @MC_bottom_arabic;
+        pos base tah-ar.medi
+            <anchor (opsz=18,wght=400:291 opsz=18,wght=700:283 opsz=17,wght=400:291 opsz=17,wght=700:283) 0> mark @MC_bottom_arabic;
+        pos base tah-ar.init
+            <anchor (opsz=18,wght=400:291 opsz=18,wght=700:283 opsz=17,wght=400:291 opsz=17,wght=700:283) 0> mark @MC_bottom_arabic;
+        pos base ain-ar
+            <anchor (opsz=18,wght=400:386 opsz=18,wght=700:373 opsz=17,wght=400:386 opsz=17,wght=700:373) (opsz=18,wght=400:-307 opsz=18,wght=700:-309 opsz=17,wght=400:-307 opsz=17,wght=700:-309)> mark @MC_bottom_arabic;
+        pos base ain-ar.fina
+            <anchor (opsz=18,wght=400:386 opsz=18,wght=700:373 opsz=17,wght=400:386 opsz=17,wght=700:373) -404> mark @MC_bottom_arabic;
+        pos base ain-ar.medi
+            <anchor (opsz=18,wght=400:283 opsz=18,wght=700:303 opsz=17,wght=400:283 opsz=17,wght=700:303) 0> mark @MC_bottom_arabic;
+        pos base ain-ar.init
+            <anchor (opsz=18,wght=400:286 opsz=18,wght=700:317 opsz=17,wght=400:286 opsz=17,wght=700:317) 0> mark @MC_bottom_arabic;
+        pos base fehDotless-ar
+            <anchor (opsz=18,wght=400:630 opsz=18,wght=700:645 opsz=17,wght=400:630 opsz=17,wght=700:645) 0> mark @MC_bottom_arabic;
+        pos base fehDotless-ar.fina
+            <anchor (opsz=18,wght=400:701 opsz=18,wght=700:704 opsz=17,wght=400:701 opsz=17,wght=700:704) 0> mark @MC_bottom_arabic;
+        pos base fehDotless-ar.medi
+            <anchor (opsz=18,wght=400:242 opsz=18,wght=700:272 opsz=17,wght=400:242 opsz=17,wght=700:272) 0> mark @MC_bottom_arabic;
+        pos base fehDotless-ar.init
+            <anchor (opsz=18,wght=400:256 opsz=18,wght=700:280 opsz=17,wght=400:256 opsz=17,wght=700:280) 0> mark @MC_bottom_arabic;
+        pos base qafDotless-ar
+            <anchor (opsz=18,wght=400:361 opsz=18,wght=700:384 opsz=17,wght=400:361 opsz=17,wght=700:384) (opsz=18,wght=400:-194 opsz=18,wght=700:-213 opsz=17,wght=400:-194 opsz=17,wght=700:-213)> mark @MC_bottom_arabic;
+        pos base qafDotless-ar.fina
+            <anchor (opsz=18,wght=400:376 opsz=18,wght=700:380 opsz=17,wght=400:376 opsz=17,wght=700:380) (opsz=18,wght=400:-290 opsz=18,wght=700:-335 opsz=17,wght=400:-290 opsz=17,wght=700:-335)> mark @MC_bottom_arabic;
+        pos base yehRohingya-ar
+            <anchor (opsz=18,wght=400:302 opsz=18,wght=700:349 opsz=17,wght=400:302 opsz=17,wght=700:349) (opsz=18,wght=400:-216 opsz=18,wght=700:-240 opsz=17,wght=400:-216 opsz=17,wght=700:-240)> mark @MC_bottom_arabic;
+        pos base yehRohingya-ar.fina
+            <anchor (opsz=18,wght=400:351 opsz=18,wght=700:427 opsz=17,wght=400:351 opsz=17,wght=700:427) (opsz=18,wght=400:-216 opsz=18,wght=700:-240 opsz=17,wght=400:-216 opsz=17,wght=700:-240)> mark @MC_bottom_arabic;
+        pos base kafDotless-ar
+            <anchor (opsz=18,wght=400:421 opsz=18,wght=700:422 opsz=17,wght=400:421 opsz=17,wght=700:422) (opsz=18,wght=400:0 opsz=18,wght=700:-16 opsz=17,wght=400:0 opsz=17,wght=700:-16)> mark @MC_bottom_arabic;
+        pos base kafDotless-ar.fina
+            <anchor (opsz=18,wght=400:412 opsz=18,wght=700:410 opsz=17,wght=400:412 opsz=17,wght=700:410) -16> mark @MC_bottom_arabic;
+        pos base kaf-ar.medi
+            <anchor (opsz=18,wght=400:127 opsz=18,wght=700:117 opsz=17,wght=400:127 opsz=17,wght=700:117) 0> mark @MC_bottom_arabic;
+        pos base kaf-ar.medi.alt
+            <anchor (opsz=18,wght=400:136 opsz=18,wght=700:137 opsz=17,wght=400:136 opsz=17,wght=700:137) 0> mark @MC_bottom_arabic;
+        pos base kaf-ar.init
+            <anchor (opsz=18,wght=400:174 opsz=18,wght=700:184 opsz=17,wght=400:174 opsz=17,wght=700:184) 0> mark @MC_bottom_arabic;
+        pos base kaf-ar.init.alt
+            <anchor (opsz=18,wght=400:148 opsz=18,wght=700:186 opsz=17,wght=400:148 opsz=17,wght=700:186) 0> mark @MC_bottom_arabic;
+        pos base keheh-ar
+            <anchor (opsz=18,wght=400:426 opsz=18,wght=700:433 opsz=17,wght=400:426 opsz=17,wght=700:433) 0> mark @MC_bottom_arabic;
+        pos base keheh-ar.fina
+            <anchor (opsz=18,wght=400:376 opsz=18,wght=700:397 opsz=17,wght=400:376 opsz=17,wght=700:397) 0> mark @MC_bottom_arabic;
+        pos base kafswash-ar
+            <anchor (opsz=18,wght=400:670 opsz=18,wght=700:713 opsz=17,wght=400:670 opsz=17,wght=700:713) (opsz=18,wght=400:0 opsz=18,wght=700:-1 opsz=17,wght=400:0 opsz=17,wght=700:-1)> mark @MC_bottom_arabic;
+        pos base kafswash-ar.fina
+            <anchor (opsz=18,wght=400:670 opsz=18,wght=700:713 opsz=17,wght=400:670 opsz=17,wght=700:713) (opsz=18,wght=400:0 opsz=18,wght=700:-1 opsz=17,wght=400:0 opsz=17,wght=700:-1)> mark @MC_bottom_arabic;
+        pos base kafswash-ar.medi
+            <anchor (opsz=18,wght=400:398 opsz=18,wght=700:497 opsz=17,wght=400:398 opsz=17,wght=700:497) (opsz=18,wght=400:0 opsz=18,wght=700:-1 opsz=17,wght=400:0 opsz=17,wght=700:-1)> mark @MC_bottom_arabic;
+        pos base kafswash-ar.init
+            <anchor (opsz=18,wght=400:398 opsz=18,wght=700:497 opsz=17,wght=400:398 opsz=17,wght=700:497) (opsz=18,wght=400:0 opsz=18,wght=700:-1 opsz=17,wght=400:0 opsz=17,wght=700:-1)> mark @MC_bottom_arabic;
+        pos base lam-ar
+            <anchor (opsz=18,wght=400:327 opsz=18,wght=700:333 opsz=17,wght=400:327 opsz=17,wght=700:333) -263> mark @MC_bottom_arabic;
+        pos base lam-ar.fina
+            <anchor (opsz=18,wght=400:327 opsz=18,wght=700:333 opsz=17,wght=400:327 opsz=17,wght=700:333) -264> mark @MC_bottom_arabic;
+        pos base lam-ar.medi
+            <anchor (opsz=18,wght=400:135 opsz=18,wght=700:155 opsz=17,wght=400:135 opsz=17,wght=700:155) 0> mark @MC_bottom_arabic;
+        pos base lam-ar.init
+            <anchor 134 0> mark @MC_bottom_arabic;
+        pos base meem-ar
+            <anchor (opsz=18,wght=400:324 opsz=18,wght=700:330 opsz=17,wght=400:324 opsz=17,wght=700:330) 0> mark @MC_bottom_arabic;
+        pos base meem-ar.alt
+            <anchor (opsz=18,wght=400:577 opsz=18,wght=700:624 opsz=17,wght=400:577 opsz=17,wght=700:624) -13> mark @MC_bottom_arabic;
+        pos base meem-ar.fina
+            <anchor (opsz=18,wght=400:300 opsz=18,wght=700:349 opsz=17,wght=400:300 opsz=17,wght=700:349) 0> mark @MC_bottom_arabic;
+        pos base meem-ar.fina.alt
+            <anchor (opsz=18,wght=400:566 opsz=18,wght=700:618 opsz=17,wght=400:566 opsz=17,wght=700:618) -14> mark @MC_bottom_arabic;
+        pos base meem-ar.medi
+            <anchor (opsz=18,wght=400:334 opsz=18,wght=700:333 opsz=17,wght=400:334 opsz=17,wght=700:333) (opsz=18,wght=400:0 opsz=18,wght=700:-14 opsz=17,wght=400:0 opsz=17,wght=700:-14)> mark @MC_bottom_arabic;
+        pos base meem-ar.init
+            <anchor (opsz=18,wght=400:344 opsz=18,wght=700:349 opsz=17,wght=400:344 opsz=17,wght=700:349) 0> mark @MC_bottom_arabic;
+        pos base noonghunna-ar
+            <anchor (opsz=18,wght=400:328 opsz=18,wght=700:334 opsz=17,wght=400:328 opsz=17,wght=700:333) (opsz=18,wght=400:-124 opsz=18,wght=700:-143 opsz=17,wght=400:-124 opsz=17,wght=700:-143)> mark @MC_bottom_arabic;
+        pos base noonghunna-ar.fina
+            <anchor (opsz=18,wght=400:328 opsz=18,wght=700:334 opsz=17,wght=400:328 opsz=17,wght=700:333) (opsz=18,wght=400:-194 opsz=18,wght=700:-213 opsz=17,wght=400:-194 opsz=17,wght=700:-213)> mark @MC_bottom_arabic;
+        pos base heh-ar
+            <anchor (opsz=18,wght=400:269 opsz=18,wght=700:285 opsz=17,wght=400:269 opsz=17,wght=700:285) 0> mark @MC_bottom_arabic;
+        pos base heh-ar.fina
+            <anchor (opsz=18,wght=400:264 opsz=18,wght=700:280 opsz=17,wght=400:264 opsz=17,wght=700:280) 0> mark @MC_bottom_arabic;
+        pos base heh-ar.medi
+            <anchor (opsz=18,wght=400:307 opsz=18,wght=700:309 opsz=17,wght=400:307 opsz=17,wght=700:309) (opsz=18,wght=400:-239 opsz=18,wght=700:-241 opsz=17,wght=400:-239 opsz=17,wght=700:-241)> mark @MC_bottom_arabic;
+        pos base heh-ar.init
+            <anchor (opsz=18,wght=400:400 opsz=18,wght=700:415 opsz=17,wght=400:400 opsz=17,wght=700:415) 0> mark @MC_bottom_arabic;
+        pos base hehgoal-ar
+            <anchor (opsz=18,wght=400:269 opsz=18,wght=700:285 opsz=17,wght=400:269 opsz=17,wght=700:285) 0> mark @MC_bottom_arabic;
+        pos base hehgoal-ar.fina
+            <anchor (opsz=18,wght=400:248 opsz=18,wght=700:306 opsz=17,wght=400:248 opsz=17,wght=700:306) 0> mark @MC_bottom_arabic;
+        pos base hehgoal-ar.medi
+            <anchor (opsz=18,wght=400:220 opsz=18,wght=700:222 opsz=17,wght=400:220 opsz=17,wght=700:222) (opsz=18,wght=400:-245 opsz=18,wght=700:-244 opsz=17,wght=400:-245 opsz=17,wght=700:-244)> mark @MC_bottom_arabic;
+        pos base hehgoal-ar.medi.yehbarree
+            <anchor (opsz=18,wght=400:220 opsz=18,wght=700:222 opsz=17,wght=400:220 opsz=17,wght=700:222) (opsz=18,wght=400:-335 opsz=18,wght=700:-367 opsz=17,wght=400:-335 opsz=17,wght=700:-367)> mark @MC_bottom_arabic;
+        pos base hehgoal-ar.init
+            <anchor (opsz=18,wght=400:329 opsz=18,wght=700:380 opsz=17,wght=400:329 opsz=17,wght=700:380) (opsz=18,wght=400:6 opsz=18,wght=700:0 opsz=17,wght=400:6 opsz=17,wght=700:0)> mark @MC_bottom_arabic;
+        pos base hehgoal-ar.init.ascending
+            <anchor (opsz=18,wght=400:111 opsz=18,wght=700:133 opsz=17,wght=400:111 opsz=17,wght=700:133) (opsz=18,wght=400:6 opsz=18,wght=700:0 opsz=17,wght=400:6 opsz=17,wght=700:0)> mark @MC_bottom_arabic;
+        pos base ae-ar
+            <anchor (opsz=18,wght=400:269 opsz=18,wght=700:285 opsz=17,wght=400:269 opsz=17,wght=700:285) 0> mark @MC_bottom_arabic;
+        pos base hehDoachashmee-ar
+            <anchor (opsz=18,wght=400:461 opsz=18,wght=700:494 opsz=17,wght=400:461 opsz=17,wght=700:494) 0> mark @MC_bottom_arabic;
+        pos base hehDoachashmee-ar.fina
+            <anchor (opsz=18,wght=400:461 opsz=18,wght=700:494 opsz=17,wght=400:461 opsz=17,wght=700:494) 0> mark @MC_bottom_arabic;
+        pos base hehDoachashmee-ar.medi
+            <anchor (opsz=18,wght=400:400 opsz=18,wght=700:415 opsz=17,wght=400:400 opsz=17,wght=700:415) 0> mark @MC_bottom_arabic;
+        pos base waw-ar
+            <anchor (opsz=18,wght=400:248 opsz=18,wght=700:272 opsz=17,wght=400:248 opsz=17,wght=700:271) (opsz=18,wght=400:-263 opsz=18,wght=700:-262 opsz=17,wght=400:-263 opsz=17,wght=700:-262)> mark @MC_bottom_arabic;
+        pos base waw-ar.fina
+            <anchor (opsz=18,wght=400:248 opsz=18,wght=700:271 opsz=17,wght=400:248 opsz=17,wght=700:271) (opsz=18,wght=400:-288 opsz=18,wght=700:-287 opsz=17,wght=400:-288 opsz=17,wght=700:-287)> mark @MC_bottom_arabic;
+        pos base wawStraight-ar
+            <anchor (opsz=18,wght=400:230 opsz=18,wght=700:233 opsz=17,wght=400:230 opsz=17,wght=700:233) (opsz=18,wght=400:-260 opsz=18,wght=700:-262 opsz=17,wght=400:-260 opsz=17,wght=700:-262)> mark @MC_bottom_arabic;
+        pos base wawStraight-ar.fina
+            <anchor (opsz=18,wght=400:230 opsz=18,wght=700:233 opsz=17,wght=400:230 opsz=17,wght=700:233) (opsz=18,wght=400:-285 opsz=18,wght=700:-287 opsz=17,wght=400:-285 opsz=17,wght=700:-287)> mark @MC_bottom_arabic;
+        pos base alefMaksura-ar
+            <anchor (opsz=18,wght=400:371 opsz=18,wght=700:377 opsz=17,wght=400:371 opsz=17,wght=700:377) (opsz=18,wght=400:-150 opsz=18,wght=700:-169 opsz=17,wght=400:-150 opsz=17,wght=700:-169)> mark @MC_bottom_arabic;
+        pos base alefMaksura-ar.fina
+            <anchor (opsz=18,wght=400:370 opsz=18,wght=700:377 opsz=17,wght=400:370 opsz=17,wght=700:377) (opsz=18,wght=400:-306 opsz=18,wght=700:-322 opsz=17,wght=400:-306 opsz=17,wght=700:-322)> mark @MC_bottom_arabic;
+        pos base yehbarree-ar
+            <anchor (opsz=18,wght=400:643 opsz=18,wght=700:650 opsz=17,wght=400:643 opsz=17,wght=700:650) 0> mark @MC_bottom_arabic;
+        pos base yehbarree-ar.fina
+            <anchor (opsz=18,wght=400:294 opsz=18,wght=700:300 opsz=17,wght=400:294 opsz=17,wght=700:300) (opsz=18,wght=400:-251 opsz=18,wght=700:-247 opsz=17,wght=400:-251 opsz=17,wght=700:-247)> mark @MC_bottom_arabic;
+        pos base kashida-ar
+            <anchor (opsz=18,wght=400:143 opsz=18,wght=700:148 opsz=17,wght=400:143 opsz=17,wght=700:148) 0> mark @MC_bottom_arabic;
+        pos base kashida-ar.init
+            <anchor (opsz=18,wght=400:143 opsz=18,wght=700:148 opsz=17,wght=400:143 opsz=17,wght=700:148) 0> mark @MC_bottom_arabic;
+        pos base kashida-ar.wide
+            <anchor (opsz=18,wght=400:193 opsz=18,wght=700:218 opsz=17,wght=400:193 opsz=17,wght=700:218) 0> mark @MC_bottom_arabic;
+        pos base kashidaHamza-ar
+            <anchor (opsz=18,wght=400:193 opsz=18,wght=700:218 opsz=17,wght=400:193 opsz=17,wght=700:218) 0> mark @MC_bottom_arabic;
+        pos base space
+            <anchor (opsz=18,wght=400:106 opsz=18,wght=700:107 opsz=17,wght=400:106 opsz=17,wght=700:107) 0> mark @MC_bottom_arabic;
+        pos base lellah-ar
+            <anchor (opsz=18,wght=400:264 opsz=18,wght=700:280 opsz=17,wght=400:264 opsz=17,wght=700:280) 0> mark @MC_bottom_arabic;
+        pos base lellah-ar.fina
+            <anchor (opsz=18,wght=400:264 opsz=18,wght=700:280 opsz=17,wght=400:264 opsz=17,wght=700:280) 0> mark @MC_bottom_arabic;
+        pos base misraComma-ar
+            <anchor (opsz=18,wght=400:361 opsz=18,wght=700:365 opsz=17,wght=400:361 opsz=17,wght=700:365) (opsz=18,wght=400:-311 opsz=18,wght=700:-312 opsz=17,wght=400:-311 opsz=17,wght=700:-312)> mark @MC_bottom_arabic;
+        pos base sindhipostpositionmen-ar
+            <anchor (opsz=18,wght=400:324 opsz=18,wght=700:330 opsz=17,wght=400:324 opsz=17,wght=700:330) 0> mark @MC_bottom_arabic;
+        pos base sindhipostpositionmen-ar.alt
+            <anchor (opsz=18,wght=400:577 opsz=18,wght=700:624 opsz=17,wght=400:577 opsz=17,wght=700:624) -13> mark @MC_bottom_arabic;
+        pos base sindhiampersand-ar
+            <anchor (opsz=18,wght=400:239 opsz=18,wght=700:250 opsz=17,wght=400:239 opsz=17,wght=700:250) 0> mark @MC_bottom_arabic;
+    } mark2base_bottom_arabic;
+
+    lookup mark2base_bottom.right_arabic {
+        pos base alef-ar.fina
+            <anchor (opsz=18,wght=400:149 opsz=18,wght=700:190 opsz=17,wght=400:149 opsz=17,wght=700:190) (opsz=18,wght=400:100 opsz=18,wght=700:150 opsz=17,wght=400:100 opsz=17,wght=700:150)> mark @MC_bottom.right_arabic;
+        pos base alef-ar.fina.kaf
+            <anchor (opsz=18,wght=400:149 opsz=18,wght=700:190 opsz=17,wght=400:149 opsz=17,wght=700:190) (opsz=18,wght=400:100 opsz=18,wght=700:150 opsz=17,wght=400:100 opsz=17,wght=700:150)> mark @MC_bottom.right_arabic;
+        pos base alef-ar.short.fina
+            <anchor (opsz=18,wght=400:149 opsz=18,wght=700:190 opsz=17,wght=400:149 opsz=17,wght=700:190) (opsz=18,wght=400:100 opsz=18,wght=700:150 opsz=17,wght=400:100 opsz=17,wght=700:150)> mark @MC_bottom.right_arabic;
+        pos base alef-ar.short.fina.kaf
+            <anchor (opsz=18,wght=400:149 opsz=18,wght=700:190 opsz=17,wght=400:149 opsz=17,wght=700:190) (opsz=18,wght=400:100 opsz=18,wght=700:150 opsz=17,wght=400:100 opsz=17,wght=700:150)> mark @MC_bottom.right_arabic;
+        pos base rial
+            <anchor (opsz=18,wght=400:791 opsz=18,wght=700:874 opsz=17,wght=400:791 opsz=17,wght=700:874) (opsz=18,wght=400:100 opsz=18,wght=700:150 opsz=17,wght=400:100 opsz=17,wght=700:150)> mark @MC_bottom.right_arabic;
+    } mark2base_bottom.right_arabic;
+
+    lookup mark2base_center_arabic {
+        pos base alef-ar.fina.kaf
+            <anchor (opsz=18,wght=400:12 opsz=18,wght=700:16 opsz=17,wght=400:12 opsz=17,wght=700:16) 0> mark @MC_center_arabic;
+        pos base hah-ar
+            <anchor (opsz=18,wght=400:374 opsz=18,wght=700:394 opsz=17,wght=400:374 opsz=17,wght=700:394) (opsz=18,wght=400:-20 opsz=18,wght=700:0 opsz=17,wght=400:-20 opsz=17,wght=700:0)> mark @MC_center_arabic;
+        pos base hah-ar.fina
+            <anchor (opsz=18,wght=400:374 opsz=18,wght=700:394 opsz=17,wght=400:374 opsz=17,wght=700:394) (opsz=18,wght=400:-20 opsz=18,wght=700:0 opsz=17,wght=400:-20 opsz=17,wght=700:0)> mark @MC_center_arabic;
+        pos base reh-ar
+            <anchor (opsz=18,wght=400:60 opsz=18,wght=700:78 opsz=17,wght=400:60 opsz=17,wght=700:78) (opsz=18,wght=400:20 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:70)> mark @MC_center_arabic;
+        pos base reh-ar.fina
+            <anchor (opsz=18,wght=400:60 opsz=18,wght=700:78 opsz=17,wght=400:60 opsz=17,wght=700:78) (opsz=18,wght=400:20 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:70)> mark @MC_center_arabic;
+        pos base ain-ar
+            <anchor (opsz=18,wght=400:357 opsz=18,wght=700:371 opsz=17,wght=400:357 opsz=17,wght=700:371) (opsz=18,wght=400:-50 opsz=18,wght=700:-18 opsz=17,wght=400:-50 opsz=17,wght=700:-18)> mark @MC_center_arabic;
+        pos base ain-ar.fina
+            <anchor (opsz=18,wght=400:323 opsz=18,wght=700:345 opsz=17,wght=400:323 opsz=17,wght=700:345) (opsz=18,wght=400:-140 opsz=18,wght=700:-116 opsz=17,wght=400:-140 opsz=17,wght=700:-116)> mark @MC_center_arabic;
+        pos base kafDotless-ar.fina
+            <anchor 0 0> mark @MC_center_arabic;
+        pos base kaf-ar.medi
+            <anchor (opsz=18,wght=400:355 opsz=18,wght=700:370 opsz=17,wght=400:355 opsz=17,wght=700:370) (opsz=18,wght=400:673 opsz=18,wght=700:674 opsz=17,wght=400:673 opsz=17,wght=700:674)> mark @MC_center_arabic;
+        pos base kaf-ar.medi.alt
+            <anchor (opsz=18,wght=400:323 opsz=18,wght=700:318 opsz=17,wght=400:323 opsz=17,wght=700:318) (opsz=18,wght=400:578 opsz=18,wght=700:601 opsz=17,wght=400:578 opsz=17,wght=700:601)> mark @MC_center_arabic;
+        pos base kaf-ar.init
+            <anchor (opsz=18,wght=400:343 opsz=18,wght=700:376 opsz=17,wght=400:343 opsz=17,wght=700:376) 690> mark @MC_center_arabic;
+        pos base kaf-ar.init.alt
+            <anchor (opsz=18,wght=400:317 opsz=18,wght=700:350 opsz=17,wght=400:317 opsz=17,wght=700:350) (opsz=18,wght=400:578 opsz=18,wght=700:601 opsz=17,wght=400:578 opsz=17,wght=700:601)> mark @MC_center_arabic;
+        pos base keheh-ar
+            <anchor (opsz=18,wght=400:752 opsz=18,wght=700:800 opsz=17,wght=400:752 opsz=17,wght=700:800) 690> mark @MC_center_arabic;
+        pos base keheh-ar.fina
+            <anchor (opsz=18,wght=400:760 opsz=18,wght=700:847 opsz=17,wght=400:760 opsz=17,wght=700:847) (opsz=18,wght=400:673 opsz=18,wght=700:674 opsz=17,wght=400:673 opsz=17,wght=700:674)> mark @MC_center_arabic;
+        pos base waw-ar
+            <anchor (opsz=18,wght=400:194 opsz=18,wght=700:177 opsz=17,wght=400:159 opsz=17,wght=700:176) (opsz=18,wght=400:-61 opsz=18,wght=700:-41 opsz=17,wght=400:-59 opsz=17,wght=700:-43)> mark @MC_center_arabic;
+        pos base waw-ar.fina
+            <anchor (opsz=18,wght=400:195 opsz=18,wght=700:150 opsz=17,wght=400:195 opsz=17,wght=700:160) (opsz=18,wght=400:-73 opsz=18,wght=700:-69 opsz=17,wght=400:-91 opsz=17,wght=700:-64)> mark @MC_center_arabic;
+        pos base wawStraight-ar
+            <anchor (opsz=18,wght=400:158 opsz=18,wght=700:96 opsz=17,wght=400:158 opsz=17,wght=700:96) (opsz=18,wght=400:-48 opsz=18,wght=700:-44 opsz=17,wght=400:-48 opsz=17,wght=700:-44)> mark @MC_center_arabic;
+        pos base wawStraight-ar.fina
+            <anchor (opsz=18,wght=400:158 opsz=18,wght=700:96 opsz=17,wght=400:158 opsz=17,wght=700:96) (opsz=18,wght=400:-48 opsz=18,wght=700:-44 opsz=17,wght=400:-48 opsz=17,wght=700:-44)> mark @MC_center_arabic;
+        pos base kashidaWaw-ar
+            <anchor (opsz=18,wght=400:180 opsz=18,wght=700:177 opsz=17,wght=400:121 opsz=17,wght=700:141) (opsz=18,wght=400:-66 opsz=18,wght=700:-37 opsz=17,wght=400:-64 opsz=17,wght=700:-38)> mark @MC_center_arabic;
+    } mark2base_center_arabic;
+
+    lookup mark2base_ring_arabic {
+        pos base kafDotless-ar
+            <anchor (opsz=18,wght=400:396 opsz=18,wght=700:422 opsz=17,wght=400:396 opsz=17,wght=700:422) 0> mark @MC_ring_arabic;
+        pos base kaf-ar.medi
+            <anchor (opsz=18,wght=400:327 opsz=18,wght=700:321 opsz=17,wght=400:327 opsz=17,wght=700:321) (opsz=18,wght=400:600 opsz=18,wght=700:596 opsz=17,wght=400:600 opsz=17,wght=700:596)> mark @MC_ring_arabic;
+        pos base kaf-ar.medi.alt
+            <anchor (opsz=18,wght=400:296 opsz=18,wght=700:270 opsz=17,wght=400:296 opsz=17,wght=700:270) (opsz=18,wght=400:507 opsz=18,wght=700:524 opsz=17,wght=400:507 opsz=17,wght=700:524)> mark @MC_ring_arabic;
+        pos base kaf-ar.init
+            <anchor (opsz=18,wght=400:320 opsz=18,wght=700:326 opsz=17,wght=400:320 opsz=17,wght=700:326) (opsz=18,wght=400:619 opsz=18,wght=700:613 opsz=17,wght=400:619 opsz=17,wght=700:613)> mark @MC_ring_arabic;
+        pos base kaf-ar.init.alt
+            <anchor (opsz=18,wght=400:289 opsz=18,wght=700:301 opsz=17,wght=400:289 opsz=17,wght=700:301) (opsz=18,wght=400:505 opsz=18,wght=700:523 opsz=17,wght=400:505 opsz=17,wght=700:523)> mark @MC_ring_arabic;
+        pos base keheh-ar
+            <anchor (opsz=18,wght=400:729 opsz=18,wght=700:750 opsz=17,wght=400:729 opsz=17,wght=700:750) (opsz=18,wght=400:619 opsz=18,wght=700:613 opsz=17,wght=400:619 opsz=17,wght=700:613)> mark @MC_ring_arabic;
+        pos base keheh-ar.fina
+            <anchor (opsz=18,wght=400:737 opsz=18,wght=700:796 opsz=17,wght=400:737 opsz=17,wght=700:796) (opsz=18,wght=400:602 opsz=18,wght=700:597 opsz=17,wght=400:602 opsz=17,wght=700:597)> mark @MC_ring_arabic;
+        pos base waw-ar
+            <anchor (opsz=18,wght=400:192 opsz=18,wght=700:178 opsz=17,wght=400:192 opsz=17,wght=700:177) (opsz=18,wght=400:-106 opsz=18,wght=700:-78 opsz=17,wght=400:-106 opsz=17,wght=700:-78)> mark @MC_ring_arabic;
+        pos base waw-ar.fina
+            <anchor (opsz=18,wght=400:192 opsz=18,wght=700:177 opsz=17,wght=400:192 opsz=17,wght=700:177) (opsz=18,wght=400:-129 opsz=18,wght=700:-102 opsz=17,wght=400:-129 opsz=17,wght=700:-102)> mark @MC_ring_arabic;
+        pos base kashidaWaw-ar
+            <anchor (opsz=18,wght=400:179 opsz=18,wght=700:177 opsz=17,wght=400:148 opsz=17,wght=700:142) (opsz=18,wght=400:-102 opsz=18,wght=700:-66 opsz=17,wght=400:-102 opsz=17,wght=700:-66)> mark @MC_ring_arabic;
+    } mark2base_ring_arabic;
+
+    lookup mark2base_stroke_arabic {
+        pos base alef-ar
+            <anchor (opsz=18,wght=400:125 opsz=18,wght=700:128 opsz=17,wght=400:125 opsz=17,wght=700:128) (opsz=18,wght=400:431 opsz=18,wght=700:441 opsz=17,wght=400:431 opsz=17,wght=700:441)> mark @MC_stroke_arabic;
+        pos base alef-ar.fina
+            <anchor (opsz=18,wght=400:125 opsz=18,wght=700:128 opsz=17,wght=400:125 opsz=17,wght=700:128) (opsz=18,wght=400:431 opsz=18,wght=700:441 opsz=17,wght=400:431 opsz=17,wght=700:441)> mark @MC_stroke_arabic;
+        pos base alef-ar.fina.kaf
+            <anchor (opsz=18,wght=400:125 opsz=18,wght=700:128 opsz=17,wght=400:125 opsz=17,wght=700:128) (opsz=18,wght=400:431 opsz=18,wght=700:441 opsz=17,wght=400:431 opsz=17,wght=700:441)> mark @MC_stroke_arabic;
+        pos base alef-ar.short
+            <anchor (opsz=18,wght=400:125 opsz=18,wght=700:128 opsz=17,wght=400:125 opsz=17,wght=700:128) (opsz=18,wght=400:431 opsz=18,wght=700:441 opsz=17,wght=400:431 opsz=17,wght=700:441)> mark @MC_stroke_arabic;
+        pos base alef-ar.short.fina
+            <anchor (opsz=18,wght=400:125 opsz=18,wght=700:128 opsz=17,wght=400:125 opsz=17,wght=700:128) (opsz=18,wght=400:431 opsz=18,wght=700:441 opsz=17,wght=400:431 opsz=17,wght=700:441)> mark @MC_stroke_arabic;
+        pos base alef-ar.short.fina.kaf
+            <anchor (opsz=18,wght=400:125 opsz=18,wght=700:128 opsz=17,wght=400:125 opsz=17,wght=700:128) (opsz=18,wght=400:431 opsz=18,wght=700:441 opsz=17,wght=400:431 opsz=17,wght=700:441)> mark @MC_stroke_arabic;
+        pos base reh-ar
+            <anchor (opsz=18,wght=400:229 opsz=18,wght=700:267 opsz=17,wght=400:229 opsz=17,wght=700:267) (opsz=18,wght=400:-44 opsz=18,wght=700:-14 opsz=17,wght=400:-44 opsz=17,wght=700:-14)> mark @MC_stroke_arabic;
+        pos base reh-ar.fina
+            <anchor (opsz=18,wght=400:229 opsz=18,wght=700:267 opsz=17,wght=400:229 opsz=17,wght=700:267) (opsz=18,wght=400:-44 opsz=18,wght=700:-14 opsz=17,wght=400:-44 opsz=17,wght=700:-14)> mark @MC_stroke_arabic;
+        pos base lam-ar
+            <anchor (opsz=18,wght=400:573 opsz=18,wght=700:575 opsz=17,wght=400:573 opsz=17,wght=700:575) 471> mark @MC_stroke_arabic;
+        pos base lam-ar.fina
+            <anchor (opsz=18,wght=400:573 opsz=18,wght=700:575 opsz=17,wght=400:573 opsz=17,wght=700:575) 470> mark @MC_stroke_arabic;
+        pos base lam-ar.medi
+            <anchor (opsz=18,wght=400:137 opsz=18,wght=700:160 opsz=17,wght=400:137 opsz=17,wght=700:160) 471> mark @MC_stroke_arabic;
+        pos base lam-ar.init
+            <anchor (opsz=18,wght=400:136 opsz=18,wght=700:141 opsz=17,wght=400:136 opsz=17,wght=700:141) 471> mark @MC_stroke_arabic;
+        pos base waw-ar
+            <anchor (opsz=18,wght=400:340 opsz=18,wght=700:386 opsz=17,wght=400:340 opsz=17,wght=700:385) (opsz=18,wght=400:-53 opsz=18,wght=700:-43 opsz=17,wght=400:-53 opsz=17,wght=700:-43)> mark @MC_stroke_arabic;
+        pos base waw-ar.fina
+            <anchor (opsz=18,wght=400:340 opsz=18,wght=700:385 opsz=17,wght=400:340 opsz=17,wght=700:385) (opsz=18,wght=400:-83 opsz=18,wght=700:-65 opsz=17,wght=400:-83 opsz=17,wght=700:-65)> mark @MC_stroke_arabic;
+        pos base kashidaWaw-ar
+            <anchor (opsz=18,wght=400:297 opsz=18,wght=700:344 opsz=17,wght=400:266 opsz=17,wght=700:308) (opsz=18,wght=400:-59 opsz=18,wght=700:-38 opsz=17,wght=400:-59 opsz=17,wght=700:-38)> mark @MC_stroke_arabic;
+    } mark2base_stroke_arabic;
+
+    lookup mark2base_tail_arabic {
+        pos base alefMaksura-ar
+            <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:291 opsz=18,wght=700:308 opsz=17,wght=400:291 opsz=17,wght=700:308)> mark @MC_tail_arabic;
+        pos base alefMaksura-ar.fina
+            <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:135 opsz=18,wght=700:155 opsz=17,wght=400:135 opsz=17,wght=700:155)> mark @MC_tail_arabic;
+    } mark2base_tail_arabic;
+
+    lookup mark2base_below_arabic {
+        pos base space
+            <anchor 106 0> mark @MC_below_arabic;
+    } mark2base_below_arabic;
+
+    lookup mark2base_waqf_arabic {
+        pos base kashida-ar
+            <anchor (opsz=18,wght=400:143 opsz=18,wght=700:153 opsz=17,wght=400:143 opsz=17,wght=700:153) 287> mark @MC_waqf_arabic;
+        pos base endofayah-ar
+            <anchor (opsz=18,wght=400:870 opsz=18,wght=700:1056 opsz=17,wght=400:870 opsz=17,wght=700:1056) (opsz=18,wght=400:1168 opsz=18,wght=700:1335 opsz=17,wght=400:1168 opsz=17,wght=700:1335)> mark @MC_waqf_arabic;
+        pos base endofayah-ar.2
+            <anchor (opsz=18,wght=400:870 opsz=18,wght=700:1056 opsz=17,wght=400:870 opsz=17,wght=700:1056) (opsz=18,wght=400:1168 opsz=18,wght=700:1335 opsz=17,wght=400:1168 opsz=17,wght=700:1335)> mark @MC_waqf_arabic;
+        pos base endofayah-ar.3
+            <anchor (opsz=18,wght=400:870 opsz=18,wght=700:1056 opsz=17,wght=400:870 opsz=17,wght=700:1056) (opsz=18,wght=400:1168 opsz=18,wght=700:1335 opsz=17,wght=400:1168 opsz=17,wght=700:1335)> mark @MC_waqf_arabic;
+        pos base disputedendofayah-ar
+            <anchor (opsz=18,wght=400:277 opsz=18,wght=700:299 opsz=17,wght=400:277 opsz=17,wght=700:299) (opsz=18,wght=400:1283 opsz=18,wght=700:1328 opsz=17,wght=400:1283 opsz=17,wght=700:1328)> mark @MC_waqf_arabic;
+        pos base space
+            <anchor 0 600> mark @MC_waqf_arabic;
+    } mark2base_waqf_arabic;
+
+    lookup mark2liga_top_arabic {
+        pos ligature behDotless_reh-ar.fina
+                <anchor (opsz=18,wght=400:482 opsz=18,wght=700:541 opsz=17,wght=400:482 opsz=17,wght=700:541) (opsz=18,wght=400:356 opsz=18,wght=700:413 opsz=17,wght=400:396 opsz=17,wght=700:423)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:213 opsz=18,wght=700:219 opsz=17,wght=400:213 opsz=17,wght=700:219) (opsz=18,wght=400:252 opsz=18,wght=700:282 opsz=17,wght=400:252 opsz=17,wght=700:282)> mark @MC_top_arabic;
+        pos ligature behDotless_rehLoop-ar.fina
+                <anchor (opsz=18,wght=400:666 opsz=18,wght=700:695 opsz=17,wght=400:666 opsz=17,wght=700:695) (opsz=18,wght=400:356 opsz=18,wght=700:413 opsz=17,wght=400:396 opsz=17,wght=700:423)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:377 opsz=18,wght=700:353 opsz=17,wght=400:377 opsz=17,wght=700:353) (opsz=18,wght=400:252 opsz=18,wght=700:282 opsz=17,wght=400:252 opsz=17,wght=700:282)> mark @MC_top_arabic;
+        pos ligature behDotless_noonghunna-ar.fina
+                <anchor (opsz=18,wght=400:695 opsz=18,wght=700:716 opsz=17,wght=400:695 opsz=17,wght=700:716) (opsz=18,wght=400:283 opsz=18,wght=700:313 opsz=17,wght=400:283 opsz=17,wght=700:313)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:328 opsz=18,wght=700:334 opsz=17,wght=400:328 opsz=17,wght=700:334) 236> mark @MC_top_arabic;
+        pos ligature behDotless_alefMaksura-ar
+                <anchor (opsz=18,wght=400:659 opsz=18,wght=700:650 opsz=17,wght=400:659 opsz=17,wght=700:650) (opsz=18,wght=400:399 opsz=18,wght=700:394 opsz=17,wght=400:399 opsz=17,wght=700:394)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:135 opsz=18,wght=700:155 opsz=17,wght=400:135 opsz=17,wght=700:155)> mark @MC_top_arabic;
+        pos ligature behDotless_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:560 opsz=18,wght=700:571 opsz=17,wght=400:560 opsz=17,wght=700:571) (opsz=18,wght=400:394 opsz=18,wght=700:421 opsz=17,wght=400:394 opsz=17,wght=700:421)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:56 opsz=18,wght=700:50 opsz=17,wght=400:56 opsz=17,wght=700:50) (opsz=18,wght=400:146 opsz=18,wght=700:167 opsz=17,wght=400:146 opsz=17,wght=700:167)> mark @MC_top_arabic;
+        pos ligature seen_reh-ar
+                <anchor (opsz=18,wght=400:741 opsz=18,wght=700:771 opsz=17,wght=400:741 opsz=17,wght=700:771) (opsz=18,wght=400:286 opsz=18,wght=700:319 opsz=17,wght=400:286 opsz=17,wght=700:319)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:213 opsz=18,wght=700:219 opsz=17,wght=400:213 opsz=17,wght=700:219) (opsz=18,wght=400:252 opsz=18,wght=700:282 opsz=17,wght=400:252 opsz=17,wght=700:282)> mark @MC_top_arabic;
+        pos ligature seen_reh-ar.fina
+                <anchor (opsz=18,wght=400:741 opsz=18,wght=700:771 opsz=17,wght=400:741 opsz=17,wght=700:771) (opsz=18,wght=400:286 opsz=18,wght=700:319 opsz=17,wght=400:286 opsz=17,wght=700:319)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:213 opsz=18,wght=700:219 opsz=17,wght=400:213 opsz=17,wght=700:219) (opsz=18,wght=400:252 opsz=18,wght=700:282 opsz=17,wght=400:252 opsz=17,wght=700:282)> mark @MC_top_arabic;
+        pos ligature seen_rehLoop-ar
+                <anchor 905 (opsz=18,wght=400:286 opsz=18,wght=700:319 opsz=17,wght=400:286 opsz=17,wght=700:319)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:377 opsz=18,wght=700:353 opsz=17,wght=400:379 opsz=17,wght=700:353) (opsz=18,wght=400:252 opsz=18,wght=700:282 opsz=17,wght=400:255 opsz=17,wght=700:282)> mark @MC_top_arabic;
+        pos ligature seen_rehLoop-ar.fina
+                <anchor 905 (opsz=18,wght=400:286 opsz=18,wght=700:319 opsz=17,wght=400:286 opsz=17,wght=700:319)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:377 opsz=18,wght=700:353 opsz=17,wght=400:379 opsz=17,wght=700:353) (opsz=18,wght=400:252 opsz=18,wght=700:282 opsz=17,wght=400:255 opsz=17,wght=700:282)> mark @MC_top_arabic;
+        pos ligature seen_alefMaksura-ar
+                <anchor (opsz=18,wght=400:1066 opsz=18,wght=700:1135 opsz=17,wght=400:1066 opsz=17,wght=700:1135) (opsz=18,wght=400:286 opsz=18,wght=700:319 opsz=17,wght=400:286 opsz=17,wght=700:319)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:56 opsz=18,wght=700:50 opsz=17,wght=400:56 opsz=17,wght=700:50) (opsz=18,wght=400:146 opsz=18,wght=700:167 opsz=17,wght=400:146 opsz=17,wght=700:167)> mark @MC_top_arabic;
+        pos ligature seen_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:1066 opsz=18,wght=700:1135 opsz=17,wght=400:1066 opsz=17,wght=700:1135) (opsz=18,wght=400:286 opsz=18,wght=700:319 opsz=17,wght=400:286 opsz=17,wght=700:319)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:56 opsz=18,wght=700:50 opsz=17,wght=400:56 opsz=17,wght=700:50) (opsz=18,wght=400:146 opsz=18,wght=700:167 opsz=17,wght=400:146 opsz=17,wght=700:167)> mark @MC_top_arabic;
+        pos ligature sad_reh-ar
+                <anchor (opsz=18,wght=400:779 opsz=18,wght=700:797 opsz=17,wght=400:779 opsz=17,wght=700:797) (opsz=18,wght=400:397 opsz=18,wght=700:445 opsz=17,wght=400:397 opsz=17,wght=700:445)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:213 opsz=18,wght=700:219 opsz=17,wght=400:213 opsz=17,wght=700:219) (opsz=18,wght=400:252 opsz=18,wght=700:282 opsz=17,wght=400:252 opsz=17,wght=700:282)> mark @MC_top_arabic;
+        pos ligature sad_reh-ar.fina
+                <anchor (opsz=18,wght=400:779 opsz=18,wght=700:797 opsz=17,wght=400:779 opsz=17,wght=700:797) (opsz=18,wght=400:397 opsz=18,wght=700:445 opsz=17,wght=400:397 opsz=17,wght=700:445)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:213 opsz=18,wght=700:219 opsz=17,wght=400:213 opsz=17,wght=700:219) (opsz=18,wght=400:252 opsz=18,wght=700:282 opsz=17,wght=400:252 opsz=17,wght=700:282)> mark @MC_top_arabic;
+        pos ligature sad_rehLoop-ar
+                <anchor (opsz=18,wght=400:943 opsz=18,wght=700:931 opsz=17,wght=400:943 opsz=17,wght=700:931) (opsz=18,wght=400:397 opsz=18,wght=700:445 opsz=17,wght=400:397 opsz=17,wght=700:445)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:377 opsz=18,wght=700:353 opsz=17,wght=400:377 opsz=17,wght=700:353) (opsz=18,wght=400:252 opsz=18,wght=700:282 opsz=17,wght=400:252 opsz=17,wght=700:282)> mark @MC_top_arabic;
+        pos ligature sad_rehLoop-ar.fina
+                <anchor (opsz=18,wght=400:943 opsz=18,wght=700:931 opsz=17,wght=400:943 opsz=17,wght=700:931) (opsz=18,wght=400:397 opsz=18,wght=700:445 opsz=17,wght=400:397 opsz=17,wght=700:445)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:377 opsz=18,wght=700:353 opsz=17,wght=400:377 opsz=17,wght=700:353) (opsz=18,wght=400:252 opsz=18,wght=700:282 opsz=17,wght=400:252 opsz=17,wght=700:282)> mark @MC_top_arabic;
+        pos ligature sad_alefMaksura-ar
+                <anchor (opsz=18,wght=400:1048 opsz=18,wght=700:1146 opsz=17,wght=400:1048 opsz=17,wght=700:1146) (opsz=18,wght=400:399 opsz=18,wght=700:453 opsz=17,wght=400:399 opsz=17,wght=700:453)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:98 opsz=18,wght=700:50 opsz=17,wght=400:98 opsz=17,wght=700:50) (opsz=18,wght=400:140 opsz=18,wght=700:167 opsz=17,wght=400:140 opsz=17,wght=700:167)> mark @MC_top_arabic;
+        pos ligature sad_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:1048 opsz=18,wght=700:1146 opsz=17,wght=400:1048 opsz=17,wght=700:1146) (opsz=18,wght=400:399 opsz=18,wght=700:453 opsz=17,wght=400:399 opsz=17,wght=700:453)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:98 opsz=18,wght=700:50 opsz=17,wght=400:98 opsz=17,wght=700:50) (opsz=18,wght=400:140 opsz=18,wght=700:167 opsz=17,wght=400:140 opsz=17,wght=700:167)> mark @MC_top_arabic;
+        pos ligature fehDotless_alefMaksura-ar
+                <anchor (opsz=18,wght=400:549 opsz=18,wght=700:550 opsz=17,wght=400:549 opsz=17,wght=700:550) (opsz=18,wght=400:523 opsz=18,wght=700:584 opsz=17,wght=400:523 opsz=17,wght=700:584)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:135 opsz=18,wght=700:155 opsz=17,wght=400:135 opsz=17,wght=700:155)> mark @MC_top_arabic;
+        pos ligature kaf_alef-ar
+                <anchor (opsz=18,wght=400:359 opsz=18,wght=700:372 opsz=17,wght=400:359 opsz=17,wght=700:372) (opsz=18,wght=400:638 opsz=18,wght=700:694 opsz=17,wght=400:638 opsz=17,wght=700:694)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:123 opsz=18,wght=700:131 opsz=17,wght=400:123 opsz=17,wght=700:131) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic;
+        pos ligature kaf_alef-ar.short
+                <anchor (opsz=18,wght=400:359 opsz=18,wght=700:371 opsz=17,wght=400:359 opsz=17,wght=700:371) (opsz=18,wght=400:638 opsz=18,wght=700:694 opsz=17,wght=400:638 opsz=17,wght=700:694)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:123 opsz=18,wght=700:142 opsz=17,wght=400:123 opsz=17,wght=700:142) (opsz=18,wght=400:671 opsz=18,wght=700:691 opsz=17,wght=400:671 opsz=17,wght=700:691)> mark @MC_top_arabic;
+        pos ligature kaf_alef-ar.fina
+                <anchor (opsz=18,wght=400:359 opsz=18,wght=700:378 opsz=17,wght=400:359 opsz=17,wght=700:378) (opsz=18,wght=400:642 opsz=18,wght=700:695 opsz=17,wght=400:642 opsz=17,wght=700:695)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:123 opsz=18,wght=700:131 opsz=17,wght=400:123 opsz=17,wght=700:131) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic;
+        pos ligature kaf_alef-ar.fina.short
+                <anchor (opsz=18,wght=400:359 opsz=18,wght=700:378 opsz=17,wght=400:359 opsz=17,wght=700:378) (opsz=18,wght=400:642 opsz=18,wght=700:695 opsz=17,wght=400:642 opsz=17,wght=700:695)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:123 opsz=18,wght=700:142 opsz=17,wght=400:123 opsz=17,wght=700:142) (opsz=18,wght=400:671 opsz=18,wght=700:691 opsz=17,wght=400:671 opsz=17,wght=700:691)> mark @MC_top_arabic;
+        pos ligature kaf_kafDotless-ar
+                <anchor (opsz=18,wght=400:941 opsz=18,wght=700:987 opsz=17,wght=400:941 opsz=17,wght=700:987) (opsz=18,wght=400:638 opsz=18,wght=700:694 opsz=17,wght=400:638 opsz=17,wght=700:694)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:394 opsz=18,wght=700:410 opsz=17,wght=400:394 opsz=17,wght=700:410) 276> mark @MC_top_arabic;
+        pos ligature kaf_kafDotless-ar.fina
+                <anchor (opsz=18,wght=400:941 opsz=18,wght=700:986 opsz=17,wght=400:941 opsz=17,wght=700:986) (opsz=18,wght=400:642 opsz=18,wght=700:695 opsz=17,wght=400:642 opsz=17,wght=700:695)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:394 opsz=18,wght=700:410 opsz=17,wght=400:394 opsz=17,wght=700:410) 276> mark @MC_top_arabic;
+        pos ligature kaf_lam-ar
+                <anchor (opsz=18,wght=400:819 opsz=18,wght=700:827 opsz=17,wght=400:819 opsz=17,wght=700:827) (opsz=18,wght=400:638 opsz=18,wght=700:694 opsz=17,wght=400:638 opsz=17,wght=700:694)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:571 opsz=18,wght=700:570 opsz=17,wght=400:571 opsz=17,wght=700:570) (opsz=18,wght=400:775 opsz=18,wght=700:799 opsz=17,wght=400:775 opsz=17,wght=700:799)> mark @MC_top_arabic;
+        pos ligature kaf_lam-ar.fina
+                <anchor (opsz=18,wght=400:819 opsz=18,wght=700:826 opsz=17,wght=400:819 opsz=17,wght=700:826) (opsz=18,wght=400:642 opsz=18,wght=700:695 opsz=17,wght=400:642 opsz=17,wght=700:695)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:571 opsz=18,wght=700:570 opsz=17,wght=400:571 opsz=17,wght=700:570) (opsz=18,wght=400:775 opsz=18,wght=700:799 opsz=17,wght=400:775 opsz=17,wght=700:799)> mark @MC_top_arabic;
+        pos ligature kaf_lam-ar.medi
+                <anchor (opsz=18,wght=400:383 opsz=18,wght=700:411 opsz=17,wght=400:383 opsz=17,wght=700:411) (opsz=18,wght=400:642 opsz=18,wght=700:695 opsz=17,wght=400:642 opsz=17,wght=700:695)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:135 opsz=18,wght=700:155 opsz=17,wght=400:135 opsz=17,wght=700:155) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic;
+        pos ligature kaf_lam-ar.init
+                <anchor (opsz=18,wght=400:383 opsz=18,wght=700:411 opsz=17,wght=400:383 opsz=17,wght=700:412) (opsz=18,wght=400:638 opsz=18,wght=700:694 opsz=17,wght=400:638 opsz=17,wght=700:694)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:135 opsz=18,wght=700:155 opsz=17,wght=400:135 opsz=17,wght=700:155) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic;
+        pos ligature kaf_lam_alef-ar
+                <anchor (opsz=18,wght=400:756 opsz=18,wght=700:791 opsz=17,wght=400:756 opsz=17,wght=700:791) (opsz=18,wght=400:640 opsz=18,wght=700:697 opsz=17,wght=400:640 opsz=17,wght=700:697)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:482 opsz=18,wght=700:504 opsz=17,wght=400:482 opsz=17,wght=700:504) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:166 opsz=18,wght=700:183 opsz=17,wght=400:166 opsz=17,wght=700:183) (opsz=18,wght=400:532 opsz=18,wght=700:575 opsz=17,wght=400:532 opsz=17,wght=700:575)> mark @MC_top_arabic;
+        pos ligature kaf_lam_alef-ar.fina
+                <anchor (opsz=18,wght=400:756 opsz=18,wght=700:790 opsz=17,wght=400:756 opsz=17,wght=700:790) (opsz=18,wght=400:639 opsz=18,wght=700:696 opsz=17,wght=400:639 opsz=17,wght=700:696)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:482 opsz=18,wght=700:504 opsz=17,wght=400:482 opsz=17,wght=700:504) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:166 opsz=18,wght=700:183 opsz=17,wght=400:166 opsz=17,wght=700:183) (opsz=18,wght=400:532 opsz=18,wght=700:575 opsz=17,wght=400:532 opsz=17,wght=700:575)> mark @MC_top_arabic;
+        pos ligature kaf_alefMaksura-ar
+                <anchor (opsz=18,wght=400:579 opsz=18,wght=700:566 opsz=17,wght=400:579 opsz=17,wght=700:566) (opsz=18,wght=400:629 opsz=18,wght=700:680 opsz=17,wght=400:629 opsz=17,wght=700:680)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:96 opsz=18,wght=700:108 opsz=17,wght=400:96 opsz=17,wght=700:108) (opsz=18,wght=400:140 opsz=18,wght=700:169 opsz=17,wght=400:140 opsz=17,wght=700:169)> mark @MC_top_arabic;
+        pos ligature kaf_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:566 opsz=18,wght=700:561 opsz=17,wght=400:566 opsz=17,wght=700:561) (opsz=18,wght=400:627 opsz=18,wght=700:682 opsz=17,wght=400:627 opsz=17,wght=700:682)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:96 opsz=18,wght=700:108 opsz=17,wght=400:96 opsz=17,wght=700:108) (opsz=18,wght=400:140 opsz=18,wght=700:169 opsz=17,wght=400:140 opsz=17,wght=700:169)> mark @MC_top_arabic;
+        pos ligature hehgoal_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:1027 opsz=18,wght=700:1055 opsz=17,wght=400:1027 opsz=17,wght=700:1055) (opsz=18,wght=400:274 opsz=18,wght=700:293 opsz=17,wght=400:274 opsz=17,wght=700:293)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:56 opsz=18,wght=700:50 opsz=17,wght=400:56 opsz=17,wght=700:50) (opsz=18,wght=400:146 opsz=18,wght=700:167 opsz=17,wght=400:146 opsz=17,wght=700:167)> mark @MC_top_arabic;
+        pos ligature lam_alef-ar
+                <anchor (opsz=18,wght=400:425 opsz=18,wght=700:412 opsz=17,wght=400:425 opsz=17,wght=700:412) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:103 opsz=18,wght=700:124 opsz=17,wght=400:103 opsz=17,wght=700:124) (opsz=18,wght=400:605 opsz=18,wght=700:644 opsz=17,wght=400:605 opsz=17,wght=700:644)> mark @MC_top_arabic;
+        pos ligature lam_alef-ar.fina
+                <anchor (opsz=18,wght=400:518 opsz=18,wght=700:542 opsz=17,wght=400:518 opsz=17,wght=700:542) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:166 opsz=18,wght=700:183 opsz=17,wght=400:166 opsz=17,wght=700:183) (opsz=18,wght=400:586 opsz=18,wght=700:635 opsz=17,wght=400:586 opsz=17,wght=700:635)> mark @MC_top_arabic;
+        pos ligature lam_alefMaksura-ar
+                <anchor 688 (opsz=18,wght=400:782 opsz=18,wght=700:806 opsz=17,wght=400:782 opsz=17,wght=700:806)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:135 opsz=18,wght=700:155 opsz=17,wght=400:135 opsz=17,wght=700:155)> mark @MC_top_arabic;
+        pos ligature behDotless_yehbarree-ar
+                <anchor (opsz=18,wght=400:445 opsz=18,wght=700:421 opsz=17,wght=400:445 opsz=17,wght=700:421) (opsz=18,wght=400:650 opsz=18,wght=700:649 opsz=17,wght=400:650 opsz=17,wght=700:649)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:204 opsz=17,wght=400:152 opsz=17,wght=700:204) (opsz=18,wght=400:384 opsz=18,wght=700:413 opsz=17,wght=400:384 opsz=17,wght=700:413)> mark @MC_top_arabic;
+        pos ligature behDotless_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:490 opsz=18,wght=700:499 opsz=17,wght=400:490 opsz=17,wght=700:499) (opsz=18,wght=400:283 opsz=18,wght=700:307 opsz=17,wght=400:283 opsz=17,wght=700:307)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:174 opsz=17,wght=400:152 opsz=17,wght=700:174) (opsz=18,wght=400:124 opsz=18,wght=700:153 opsz=17,wght=400:124 opsz=17,wght=700:153)> mark @MC_top_arabic;
+        pos ligature hah_yehbarree-ar
+                <anchor (opsz=18,wght=400:568 opsz=18,wght=700:606 opsz=17,wght=400:573 opsz=17,wght=700:606) (opsz=18,wght=400:540 opsz=18,wght=700:578 opsz=17,wght=400:540 opsz=17,wght=700:585)> mark @MC_top_arabic
+            ligComponent
+                <anchor 152 544> mark @MC_top_arabic;
+        pos ligature hah_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:568 opsz=18,wght=700:606 opsz=17,wght=400:573 opsz=17,wght=700:606) (opsz=18,wght=400:280 opsz=18,wght=700:318 opsz=17,wght=400:280 opsz=17,wght=700:325)> mark @MC_top_arabic
+            ligComponent
+                <anchor 152 284> mark @MC_top_arabic;
+        pos ligature seen_yehbarree-ar
+                <anchor (opsz=18,wght=400:733 opsz=18,wght=700:791 opsz=17,wght=400:733 opsz=17,wght=700:791) (opsz=18,wght=400:557 opsz=18,wght=700:587 opsz=17,wght=400:554 opsz=17,wght=700:587)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:204 opsz=17,wght=400:152 opsz=17,wght=700:204) (opsz=18,wght=400:387 opsz=18,wght=700:413 opsz=17,wght=400:384 opsz=17,wght=700:413)> mark @MC_top_arabic;
+        pos ligature seen_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:733 opsz=18,wght=700:791 opsz=17,wght=400:733 opsz=17,wght=700:791) (opsz=18,wght=400:289 opsz=18,wght=700:319 opsz=17,wght=400:286 opsz=17,wght=700:319)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:204 opsz=17,wght=400:152 opsz=17,wght=700:204) (opsz=18,wght=400:119 opsz=18,wght=700:145 opsz=17,wght=400:116 opsz=17,wght=700:145)> mark @MC_top_arabic;
+        pos ligature sad_yehbarree-ar
+                <anchor (opsz=18,wght=400:739 opsz=18,wght=700:706 opsz=17,wght=400:739 opsz=17,wght=700:706) (opsz=18,wght=400:645 opsz=18,wght=700:693 opsz=17,wght=400:645 opsz=17,wght=700:693)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:204 opsz=17,wght=400:152 opsz=17,wght=700:204) (opsz=18,wght=400:387 opsz=18,wght=700:413 opsz=17,wght=400:387 opsz=17,wght=700:413)> mark @MC_top_arabic;
+        pos ligature sad_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:739 opsz=18,wght=700:706 opsz=17,wght=400:739 opsz=17,wght=700:706) (opsz=18,wght=400:385 opsz=18,wght=700:433 opsz=17,wght=400:385 opsz=17,wght=700:433)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:204 opsz=17,wght=400:152 opsz=17,wght=700:204) (opsz=18,wght=400:127 opsz=18,wght=700:153 opsz=17,wght=400:127 opsz=17,wght=700:153)> mark @MC_top_arabic;
+        pos ligature tah_yehbarree-ar
+                <anchor (opsz=18,wght=400:648 opsz=18,wght=700:671 opsz=17,wght=400:648 opsz=17,wght=700:671) (opsz=18,wght=400:665 opsz=18,wght=700:717 opsz=17,wght=400:665 opsz=17,wght=700:717)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:154 opsz=17,wght=400:152 opsz=17,wght=700:154) (opsz=18,wght=400:387 opsz=18,wght=700:413 opsz=17,wght=400:387 opsz=17,wght=700:413)> mark @MC_top_arabic;
+        pos ligature tah_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:648 opsz=18,wght=700:671 opsz=17,wght=400:648 opsz=17,wght=700:671) (opsz=18,wght=400:405 opsz=18,wght=700:457 opsz=17,wght=400:405 opsz=17,wght=700:457)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:154 opsz=17,wght=400:152 opsz=17,wght=700:154) (opsz=18,wght=400:127 opsz=18,wght=700:153 opsz=17,wght=400:127 opsz=17,wght=700:153)> mark @MC_top_arabic;
+        pos ligature ain_yehbarree-ar
+                <anchor (opsz=18,wght=400:394 opsz=18,wght=700:421 opsz=17,wght=400:394 opsz=17,wght=700:421) (opsz=18,wght=400:690 opsz=18,wght=700:736 opsz=17,wght=400:690 opsz=17,wght=700:736)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:102 opsz=18,wght=700:94 opsz=17,wght=400:102 opsz=17,wght=700:94) (opsz=18,wght=400:217 opsz=18,wght=700:363 opsz=17,wght=400:217 opsz=17,wght=700:363)> mark @MC_top_arabic;
+        pos ligature ain_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:483 opsz=18,wght=700:503 opsz=17,wght=400:483 opsz=17,wght=700:503) (opsz=18,wght=400:403 opsz=18,wght=700:451 opsz=17,wght=400:403 opsz=17,wght=700:451)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:102 opsz=18,wght=700:94 opsz=17,wght=400:102 opsz=17,wght=700:94) (opsz=18,wght=400:-43 opsz=18,wght=700:103 opsz=17,wght=400:-43 opsz=17,wght=700:103)> mark @MC_top_arabic;
+        pos ligature fehDotless_yehbarree-ar
+                <anchor (opsz=18,wght=400:339 opsz=18,wght=700:362 opsz=17,wght=400:339 opsz=17,wght=700:362) (opsz=18,wght=400:779 opsz=18,wght=700:837 opsz=17,wght=400:779 opsz=17,wght=700:837)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:22 opsz=18,wght=700:24 opsz=17,wght=400:22 opsz=17,wght=700:24) (opsz=18,wght=400:197 opsz=18,wght=700:223 opsz=17,wght=400:197 opsz=17,wght=700:223)> mark @MC_top_arabic;
+        pos ligature fehDotless_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:477 opsz=18,wght=700:507 opsz=17,wght=400:477 opsz=17,wght=700:507) (opsz=18,wght=400:456 opsz=18,wght=700:510 opsz=17,wght=400:456 opsz=17,wght=700:510)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:22 opsz=18,wght=700:24 opsz=17,wght=400:22 opsz=17,wght=700:24) (opsz=18,wght=400:-63 opsz=18,wght=700:-37 opsz=17,wght=400:-63 opsz=17,wght=700:-37)> mark @MC_top_arabic;
+        pos ligature kaf_yehbarree-ar
+                <anchor (opsz=18,wght=400:368 opsz=18,wght=700:367 opsz=17,wght=400:368 opsz=17,wght=700:367) (opsz=18,wght=400:984 opsz=18,wght=700:1013 opsz=17,wght=400:984 opsz=17,wght=700:1013)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:114 opsz=17,wght=400:152 opsz=17,wght=700:114) (opsz=18,wght=400:387 opsz=18,wght=700:333 opsz=17,wght=400:387 opsz=17,wght=700:333)> mark @MC_top_arabic;
+        pos ligature kaf_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:512 opsz=18,wght=700:493 opsz=17,wght=400:512 opsz=17,wght=700:493) (opsz=18,wght=400:713 opsz=18,wght=700:743 opsz=17,wght=400:713 opsz=17,wght=700:743)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:114 opsz=17,wght=400:152 opsz=17,wght=700:114) (opsz=18,wght=400:127 opsz=18,wght=700:73 opsz=17,wght=400:127 opsz=17,wght=700:73)> mark @MC_top_arabic;
+        pos ligature lam_yehbarree-ar
+                <anchor 458 (opsz=18,wght=400:896 opsz=18,wght=700:970 opsz=17,wght=400:896 opsz=17,wght=700:970)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:124 opsz=17,wght=400:152 opsz=17,wght=700:124) (opsz=18,wght=400:387 opsz=18,wght=700:413 opsz=17,wght=400:387 opsz=17,wght=700:413)> mark @MC_top_arabic;
+        pos ligature lam_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:490 opsz=18,wght=700:502 opsz=17,wght=400:490 opsz=17,wght=700:502) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:124 opsz=17,wght=400:152 opsz=17,wght=700:124) (opsz=18,wght=400:127 opsz=18,wght=700:153 opsz=17,wght=400:127 opsz=17,wght=700:153)> mark @MC_top_arabic;
+        pos ligature meem_yehbarree-ar
+                <anchor (opsz=18,wght=400:696 opsz=18,wght=700:686 opsz=17,wght=400:696 opsz=17,wght=700:686) (opsz=18,wght=400:643 opsz=18,wght=700:686 opsz=17,wght=400:643 opsz=17,wght=700:686)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:204 opsz=17,wght=400:152 opsz=17,wght=700:204) (opsz=18,wght=400:384 opsz=18,wght=700:413 opsz=17,wght=400:384 opsz=17,wght=700:413)> mark @MC_top_arabic;
+        pos ligature meem_yehbarree-ar.fina
+                <anchor 665 (opsz=18,wght=400:370 opsz=18,wght=700:412 opsz=17,wght=400:370 opsz=17,wght=700:412)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:232 opsz=18,wght=700:199 opsz=17,wght=400:232 opsz=17,wght=700:199) (opsz=18,wght=400:124 opsz=18,wght=700:142 opsz=17,wght=400:124 opsz=17,wght=700:142)> mark @MC_top_arabic;
+        pos ligature heh_yehbarree-ar
+                <anchor (opsz=18,wght=400:539 opsz=18,wght=700:550 opsz=17,wght=400:539 opsz=17,wght=700:550) (opsz=18,wght=400:683 opsz=18,wght=700:767 opsz=17,wght=400:683 opsz=17,wght=700:767)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:132 opsz=18,wght=700:94 opsz=17,wght=400:132 opsz=17,wght=700:94) (opsz=18,wght=400:384 opsz=18,wght=700:363 opsz=17,wght=400:384 opsz=17,wght=700:363)> mark @MC_top_arabic;
+        pos ligature heh_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:524 opsz=18,wght=700:523 opsz=17,wght=400:524 opsz=17,wght=700:523) (opsz=18,wght=400:422 opsz=18,wght=700:460 opsz=17,wght=400:422 opsz=17,wght=700:460)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:172 opsz=18,wght=700:94 opsz=17,wght=400:172 opsz=17,wght=700:94) (opsz=18,wght=400:124 opsz=18,wght=700:103 opsz=17,wght=400:124 opsz=17,wght=700:103)> mark @MC_top_arabic;
+        pos ligature hehgoal_yehbarree-ar
+                <anchor (opsz=18,wght=400:691 opsz=18,wght=700:729 opsz=17,wght=400:691 opsz=17,wght=700:729) (opsz=18,wght=400:543 opsz=18,wght=700:560 opsz=17,wght=400:543 opsz=17,wght=700:560)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:252 opsz=18,wght=700:236 opsz=17,wght=400:252 opsz=17,wght=700:236) (opsz=18,wght=400:384 opsz=18,wght=700:413 opsz=17,wght=400:384 opsz=17,wght=700:413)> mark @MC_top_arabic;
+        pos ligature hehgoal_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:560 opsz=18,wght=700:562 opsz=17,wght=400:560 opsz=17,wght=700:562) (opsz=18,wght=400:337 opsz=18,wght=700:413 opsz=17,wght=400:337 opsz=17,wght=700:413)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:232 opsz=18,wght=700:199 opsz=17,wght=400:232 opsz=17,wght=700:199) (opsz=18,wght=400:124 opsz=18,wght=700:142 opsz=17,wght=400:124 opsz=17,wght=700:142)> mark @MC_top_arabic;
+        pos ligature hehDoachashmee_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:539 opsz=18,wght=700:550 opsz=17,wght=400:539 opsz=17,wght=700:550) (opsz=18,wght=400:423 opsz=18,wght=700:507 opsz=17,wght=400:423 opsz=17,wght=700:507)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:132 opsz=18,wght=700:94 opsz=17,wght=400:132 opsz=17,wght=700:94) (opsz=18,wght=400:124 opsz=18,wght=700:103 opsz=17,wght=400:124 opsz=17,wght=700:103)> mark @MC_top_arabic;
+        pos ligature allah-ar
+                <anchor (opsz=18,wght=400:1200 opsz=18,wght=700:1248 opsz=17,wght=400:1200 opsz=17,wght=700:1248) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:197 opsz=18,wght=700:746 opsz=17,wght=400:197 opsz=17,wght=700:746) (opsz=18,wght=400:510 opsz=18,wght=700:1107 opsz=17,wght=400:510 opsz=17,wght=700:1107)> mark @MC_top_arabic;
+        pos ligature basmalah-ar
+                <anchor (opsz=18,wght=400:6287 opsz=18,wght=700:6792 opsz=17,wght=400:6287 opsz=17,wght=700:6792) (opsz=18,wght=400:510 opsz=18,wght=700:533 opsz=17,wght=400:510 opsz=17,wght=700:533)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:3447 opsz=18,wght=700:3703 opsz=17,wght=400:3447 opsz=17,wght=700:3703) (opsz=18,wght=400:671 opsz=18,wght=700:691 opsz=17,wght=400:671 opsz=17,wght=700:691)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:5957 opsz=18,wght=700:6389 opsz=17,wght=400:5957 opsz=17,wght=700:6389) (opsz=18,wght=400:671 opsz=18,wght=700:691 opsz=17,wght=400:671 opsz=17,wght=700:691)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:4952 opsz=18,wght=700:5362 opsz=17,wght=400:4954 opsz=17,wght=700:5335) (opsz=18,wght=400:349 opsz=18,wght=700:384 opsz=17,wght=400:349 opsz=17,wght=700:397)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:2441 opsz=18,wght=700:2656 opsz=17,wght=400:2443 opsz=17,wght=700:2629) (opsz=18,wght=400:349 opsz=18,wght=700:384 opsz=17,wght=400:349 opsz=17,wght=700:397)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:3214 opsz=18,wght=700:3426 opsz=17,wght=400:3214 opsz=17,wght=700:3426) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:5724 opsz=18,wght=700:6132 opsz=17,wght=400:5724 opsz=17,wght=700:6132) (opsz=18,wght=400:776 opsz=18,wght=700:800 opsz=17,wght=400:776 opsz=17,wght=700:800)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:5377 opsz=18,wght=700:5772 opsz=17,wght=400:5377 opsz=17,wght=700:5772) (opsz=18,wght=400:300 opsz=18,wght=700:319 opsz=17,wght=400:300 opsz=17,wght=700:319)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:4323 opsz=18,wght=700:4673 opsz=17,wght=400:4323 opsz=17,wght=700:4673) (opsz=18,wght=400:370 opsz=18,wght=700:412 opsz=17,wght=400:370 opsz=17,wght=700:412)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:13604 opsz=18,wght=700:14274 opsz=17,wght=400:13604 opsz=17,wght=700:14274) (opsz=18,wght=400:391 opsz=18,wght=700:386 opsz=17,wght=400:391 opsz=17,wght=700:386)> mark @MC_top_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:2867 opsz=18,wght=700:3070 opsz=17,wght=400:2867 opsz=17,wght=700:3070) (opsz=18,wght=400:300 opsz=18,wght=700:319 opsz=17,wght=400:300 opsz=17,wght=700:319)> mark @MC_top_arabic;
+    } mark2liga_top_arabic;
+
+    lookup mark2liga_top.digits_arabic {
+        pos ligature kaf_alef-ar.short
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:112 opsz=18,wght=700:107 opsz=17,wght=400:112 opsz=17,wght=700:107) (opsz=18,wght=400:591 opsz=18,wght=700:631 opsz=17,wght=400:591 opsz=17,wght=700:631)> mark @MC_top.digits_arabic;
+        pos ligature kaf_alef-ar.fina.short
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:112 opsz=18,wght=700:107 opsz=17,wght=400:112 opsz=17,wght=700:107) (opsz=18,wght=400:591 opsz=18,wght=700:631 opsz=17,wght=400:591 opsz=17,wght=700:631)> mark @MC_top.digits_arabic;
+        pos ligature basmalah-ar
+                <anchor (opsz=18,wght=400:3437 opsz=18,wght=700:3679 opsz=17,wght=400:3437 opsz=17,wght=700:3679) (opsz=18,wght=400:591 opsz=18,wght=700:631 opsz=17,wght=400:591 opsz=17,wght=700:631)> mark @MC_top.digits_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:5947 opsz=18,wght=700:6365 opsz=17,wght=400:5947 opsz=17,wght=700:6365) (opsz=18,wght=400:591 opsz=18,wght=700:631 opsz=17,wght=400:591 opsz=17,wght=700:631)> mark @MC_top.digits_arabic
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>;
+    } mark2liga_top.digits_arabic;
+
+    lookup mark2liga_top.tashkil_arabic {
+        pos ligature behDotless_reh-ar.fina
+                <anchor (opsz=18,wght=400:522 opsz=18,wght=700:581 opsz=17,wght=400:522 opsz=17,wght=700:581) (opsz=18,wght=400:436 opsz=18,wght=700:463 opsz=17,wght=400:486 opsz=17,wght=700:513)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:143 opsz=18,wght=700:149 opsz=17,wght=400:143 opsz=17,wght=700:149) (opsz=18,wght=400:442 opsz=18,wght=700:472 opsz=17,wght=400:512 opsz=17,wght=700:522)> mark @MC_top.tashkil_arabic;
+        pos ligature behDotless_rehLoop-ar.fina
+                <anchor (opsz=18,wght=400:686 opsz=18,wght=700:715 opsz=17,wght=400:686 opsz=17,wght=700:715) (opsz=18,wght=400:436 opsz=18,wght=700:463 opsz=17,wght=400:486 opsz=17,wght=700:513)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:327 opsz=18,wght=700:303 opsz=17,wght=400:327 opsz=17,wght=700:303) (opsz=18,wght=400:472 opsz=18,wght=700:502 opsz=17,wght=400:522 opsz=17,wght=700:552)> mark @MC_top.tashkil_arabic;
+        pos ligature behDotless_noonghunna-ar.fina
+                <anchor (opsz=18,wght=400:695 opsz=18,wght=700:716 opsz=17,wght=400:695 opsz=17,wght=700:716) (opsz=18,wght=400:433 opsz=18,wght=700:463 opsz=17,wght=400:483 opsz=17,wght=700:513)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:328 opsz=18,wght=700:334 opsz=17,wght=400:328 opsz=17,wght=700:334) (opsz=18,wght=400:386 opsz=18,wght=700:386 opsz=17,wght=400:436 opsz=17,wght=700:436)> mark @MC_top.tashkil_arabic;
+        pos ligature behDotless_alefMaksura-ar
+                <anchor (opsz=18,wght=400:659 opsz=18,wght=700:650 opsz=17,wght=400:659 opsz=17,wght=700:650) (opsz=18,wght=400:549 opsz=18,wght=700:544 opsz=17,wght=400:599 opsz=17,wght=700:594)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:272 opsz=18,wght=700:286 opsz=17,wght=400:272 opsz=17,wght=700:286) (opsz=18,wght=400:285 opsz=18,wght=700:305 opsz=17,wght=400:335 opsz=17,wght=700:355)> mark @MC_top.tashkil_arabic;
+        pos ligature behDotless_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:560 opsz=18,wght=700:571 opsz=17,wght=400:560 opsz=17,wght=700:571) (opsz=18,wght=400:544 opsz=18,wght=700:571 opsz=17,wght=400:594 opsz=17,wght=700:571)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:256 opsz=18,wght=700:240 opsz=17,wght=400:256 opsz=17,wght=700:240) (opsz=18,wght=400:396 opsz=18,wght=700:417 opsz=17,wght=400:446 opsz=17,wght=700:417)> mark @MC_top.tashkil_arabic;
+        pos ligature seen_reh-ar
+                <anchor (opsz=18,wght=400:741 opsz=18,wght=700:771 opsz=17,wght=400:741 opsz=17,wght=700:771) (opsz=18,wght=400:436 opsz=18,wght=700:469 opsz=17,wght=400:486 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:213 opsz=18,wght=700:219 opsz=17,wght=400:213 opsz=17,wght=700:219) (opsz=18,wght=400:402 opsz=18,wght=700:432 opsz=17,wght=400:452 opsz=17,wght=700:482)> mark @MC_top.tashkil_arabic;
+        pos ligature seen_reh-ar.fina
+                <anchor (opsz=18,wght=400:741 opsz=18,wght=700:771 opsz=17,wght=400:741 opsz=17,wght=700:771) (opsz=18,wght=400:436 opsz=18,wght=700:469 opsz=17,wght=400:486 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:213 opsz=18,wght=700:219 opsz=17,wght=400:213 opsz=17,wght=700:219) (opsz=18,wght=400:402 opsz=18,wght=700:432 opsz=17,wght=400:452 opsz=17,wght=700:482)> mark @MC_top.tashkil_arabic;
+        pos ligature seen_rehLoop-ar
+                <anchor 905 (opsz=18,wght=400:436 opsz=18,wght=700:469 opsz=17,wght=400:486 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:377 opsz=18,wght=700:353 opsz=17,wght=400:379 opsz=17,wght=700:353) (opsz=18,wght=400:402 opsz=18,wght=700:432 opsz=17,wght=400:455 opsz=17,wght=700:482)> mark @MC_top.tashkil_arabic;
+        pos ligature seen_rehLoop-ar.fina
+                <anchor 905 (opsz=18,wght=400:436 opsz=18,wght=700:469 opsz=17,wght=400:486 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:377 opsz=18,wght=700:353 opsz=17,wght=400:379 opsz=17,wght=700:353) (opsz=18,wght=400:402 opsz=18,wght=700:432 opsz=17,wght=400:455 opsz=17,wght=700:482)> mark @MC_top.tashkil_arabic;
+        pos ligature seen_alefMaksura-ar
+                <anchor (opsz=18,wght=400:1066 opsz=18,wght=700:1135 opsz=17,wght=400:1066 opsz=17,wght=700:1135) (opsz=18,wght=400:436 opsz=18,wght=700:469 opsz=17,wght=400:486 opsz=17,wght=700:469)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:398 opsz=18,wght=700:400 opsz=17,wght=400:398 opsz=17,wght=700:400) (opsz=18,wght=400:490 opsz=18,wght=700:517 opsz=17,wght=400:540 opsz=17,wght=700:517)> mark @MC_top.tashkil_arabic;
+        pos ligature seen_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:1066 opsz=18,wght=700:1135 opsz=17,wght=400:1066 opsz=17,wght=700:1135) (opsz=18,wght=400:436 opsz=18,wght=700:469 opsz=17,wght=400:486 opsz=17,wght=700:469)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:398 opsz=18,wght=700:400 opsz=17,wght=400:398 opsz=17,wght=700:400) (opsz=18,wght=400:490 opsz=18,wght=700:517 opsz=17,wght=400:540 opsz=17,wght=700:517)> mark @MC_top.tashkil_arabic;
+        pos ligature sad_reh-ar
+                <anchor (opsz=18,wght=400:779 opsz=18,wght=700:797 opsz=17,wght=400:779 opsz=17,wght=700:797) (opsz=18,wght=400:547 opsz=18,wght=700:595 opsz=17,wght=400:597 opsz=17,wght=700:645)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:213 opsz=18,wght=700:219 opsz=17,wght=400:213 opsz=17,wght=700:219) (opsz=18,wght=400:402 opsz=18,wght=700:432 opsz=17,wght=400:452 opsz=17,wght=700:482)> mark @MC_top.tashkil_arabic;
+        pos ligature sad_reh-ar.fina
+                <anchor (opsz=18,wght=400:779 opsz=18,wght=700:797 opsz=17,wght=400:779 opsz=17,wght=700:797) (opsz=18,wght=400:547 opsz=18,wght=700:595 opsz=17,wght=400:597 opsz=17,wght=700:645)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:213 opsz=18,wght=700:219 opsz=17,wght=400:213 opsz=17,wght=700:219) (opsz=18,wght=400:402 opsz=18,wght=700:432 opsz=17,wght=400:452 opsz=17,wght=700:482)> mark @MC_top.tashkil_arabic;
+        pos ligature sad_rehLoop-ar
+                <anchor (opsz=18,wght=400:943 opsz=18,wght=700:931 opsz=17,wght=400:943 opsz=17,wght=700:931) (opsz=18,wght=400:547 opsz=18,wght=700:595 opsz=17,wght=400:597 opsz=17,wght=700:645)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:377 opsz=18,wght=700:353 opsz=17,wght=400:377 opsz=17,wght=700:353) (opsz=18,wght=400:402 opsz=18,wght=700:432 opsz=17,wght=400:452 opsz=17,wght=700:482)> mark @MC_top.tashkil_arabic;
+        pos ligature sad_rehLoop-ar.fina
+                <anchor (opsz=18,wght=400:943 opsz=18,wght=700:931 opsz=17,wght=400:943 opsz=17,wght=700:931) (opsz=18,wght=400:547 opsz=18,wght=700:595 opsz=17,wght=400:597 opsz=17,wght=700:645)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:377 opsz=18,wght=700:353 opsz=17,wght=400:377 opsz=17,wght=700:353) (opsz=18,wght=400:402 opsz=18,wght=700:432 opsz=17,wght=400:452 opsz=17,wght=700:482)> mark @MC_top.tashkil_arabic;
+        pos ligature sad_alefMaksura-ar
+                <anchor (opsz=18,wght=400:1048 opsz=18,wght=700:1146 opsz=17,wght=400:1048 opsz=17,wght=700:1146) (opsz=18,wght=400:549 opsz=18,wght=700:603 opsz=17,wght=400:599 opsz=17,wght=700:603)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:398 opsz=18,wght=700:400 opsz=17,wght=400:398 opsz=17,wght=700:400) (opsz=18,wght=400:490 opsz=18,wght=700:517 opsz=17,wght=400:540 opsz=17,wght=700:517)> mark @MC_top.tashkil_arabic;
+        pos ligature sad_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:1048 opsz=18,wght=700:1146 opsz=17,wght=400:1048 opsz=17,wght=700:1146) (opsz=18,wght=400:549 opsz=18,wght=700:603 opsz=17,wght=400:599 opsz=17,wght=700:603)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:398 opsz=18,wght=700:400 opsz=17,wght=400:398 opsz=17,wght=700:400) (opsz=18,wght=400:490 opsz=18,wght=700:517 opsz=17,wght=400:540 opsz=17,wght=700:517)> mark @MC_top.tashkil_arabic;
+        pos ligature fehDotless_alefMaksura-ar
+                <anchor (opsz=18,wght=400:549 opsz=18,wght=700:550 opsz=17,wght=400:549 opsz=17,wght=700:550) (opsz=18,wght=400:673 opsz=18,wght=700:734 opsz=17,wght=400:723 opsz=17,wght=700:784)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:182 opsz=18,wght=700:176 opsz=17,wght=400:182 opsz=17,wght=700:176) (opsz=18,wght=400:285 opsz=18,wght=700:305 opsz=17,wght=400:335 opsz=17,wght=700:355)> mark @MC_top.tashkil_arabic;
+        pos ligature kaf_alefMaksura-ar
+                <anchor (opsz=18,wght=400:579 opsz=18,wght=700:566 opsz=17,wght=400:579 opsz=17,wght=700:566) (opsz=18,wght=400:757 opsz=18,wght=700:783 opsz=17,wght=400:807 opsz=17,wght=700:833)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:216 opsz=18,wght=700:188 opsz=17,wght=400:196 opsz=17,wght=700:178) (opsz=18,wght=400:290 opsz=18,wght=700:319 opsz=17,wght=400:340 opsz=17,wght=700:369)> mark @MC_top.tashkil_arabic;
+        pos ligature kaf_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:566 opsz=18,wght=700:561 opsz=17,wght=400:566 opsz=17,wght=700:561) (opsz=18,wght=400:755 opsz=18,wght=700:787 opsz=17,wght=400:805 opsz=17,wght=700:837)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:196 opsz=18,wght=700:188 opsz=17,wght=400:176 opsz=17,wght=700:178) (opsz=18,wght=400:290 opsz=18,wght=700:319 opsz=17,wght=400:340 opsz=17,wght=700:369)> mark @MC_top.tashkil_arabic;
+        pos ligature hehgoal_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:1027 opsz=18,wght=700:1055 opsz=17,wght=400:1027 opsz=17,wght=700:1055) (opsz=18,wght=400:424 opsz=18,wght=700:443 opsz=17,wght=400:474 opsz=17,wght=700:493)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:398 opsz=18,wght=700:400 opsz=17,wght=400:398 opsz=17,wght=700:400) (opsz=18,wght=400:490 opsz=18,wght=700:517 opsz=17,wght=400:540 opsz=17,wght=700:567)> mark @MC_top.tashkil_arabic;
+        pos ligature lam_alefMaksura-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:272 opsz=18,wght=700:286 opsz=17,wght=400:272 opsz=17,wght=700:286) (opsz=18,wght=400:285 opsz=18,wght=700:305 opsz=17,wght=400:335 opsz=17,wght=700:355)> mark @MC_top.tashkil_arabic;
+        pos ligature behDotless_yehbarree-ar
+                <anchor (opsz=18,wght=400:445 opsz=18,wght=700:421 opsz=17,wght=400:445 opsz=17,wght=700:421) (opsz=18,wght=400:800 opsz=18,wght=700:799 opsz=17,wght=400:850 opsz=17,wght=700:849)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:204 opsz=17,wght=400:152 opsz=17,wght=700:204) (opsz=18,wght=400:534 opsz=18,wght=700:563 opsz=17,wght=400:584 opsz=17,wght=700:613)> mark @MC_top.tashkil_arabic;
+        pos ligature behDotless_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:490 opsz=18,wght=700:499 opsz=17,wght=400:490 opsz=17,wght=700:499) (opsz=18,wght=400:433 opsz=18,wght=700:457 opsz=17,wght=400:483 opsz=17,wght=700:507)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:174 opsz=17,wght=400:152 opsz=17,wght=700:174) (opsz=18,wght=400:274 opsz=18,wght=700:303 opsz=17,wght=400:324 opsz=17,wght=700:353)> mark @MC_top.tashkil_arabic;
+        pos ligature hah_yehbarree-ar
+                <anchor (opsz=18,wght=400:568 opsz=18,wght=700:606 opsz=17,wght=400:573 opsz=17,wght=700:606) (opsz=18,wght=400:690 opsz=18,wght=700:728 opsz=17,wght=400:740 opsz=17,wght=700:785)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor 152 (opsz=18,wght=400:694 opsz=18,wght=700:694 opsz=17,wght=400:744 opsz=17,wght=700:744)> mark @MC_top.tashkil_arabic;
+        pos ligature hah_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:568 opsz=18,wght=700:606 opsz=17,wght=400:573 opsz=17,wght=700:606) (opsz=18,wght=400:430 opsz=18,wght=700:468 opsz=17,wght=400:480 opsz=17,wght=700:525)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor 152 (opsz=18,wght=400:434 opsz=18,wght=700:434 opsz=17,wght=400:484 opsz=17,wght=700:484)> mark @MC_top.tashkil_arabic;
+        pos ligature seen_yehbarree-ar
+                <anchor (opsz=18,wght=400:733 opsz=18,wght=700:791 opsz=17,wght=400:733 opsz=17,wght=700:791) (opsz=18,wght=400:707 opsz=18,wght=700:737 opsz=17,wght=400:754 opsz=17,wght=700:787)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:204 opsz=17,wght=400:152 opsz=17,wght=700:204) (opsz=18,wght=400:537 opsz=18,wght=700:563 opsz=17,wght=400:584 opsz=17,wght=700:613)> mark @MC_top.tashkil_arabic;
+        pos ligature seen_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:733 opsz=18,wght=700:791 opsz=17,wght=400:733 opsz=17,wght=700:791) (opsz=18,wght=400:439 opsz=18,wght=700:469 opsz=17,wght=400:486 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:204 opsz=17,wght=400:152 opsz=17,wght=700:204) (opsz=18,wght=400:269 opsz=18,wght=700:295 opsz=17,wght=400:316 opsz=17,wght=700:345)> mark @MC_top.tashkil_arabic;
+        pos ligature sad_yehbarree-ar
+                <anchor (opsz=18,wght=400:739 opsz=18,wght=700:706 opsz=17,wght=400:739 opsz=17,wght=700:706) (opsz=18,wght=400:795 opsz=18,wght=700:843 opsz=17,wght=400:845 opsz=17,wght=700:893)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:204 opsz=17,wght=400:152 opsz=17,wght=700:204) (opsz=18,wght=400:537 opsz=18,wght=700:563 opsz=17,wght=400:587 opsz=17,wght=700:613)> mark @MC_top.tashkil_arabic;
+        pos ligature sad_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:739 opsz=18,wght=700:706 opsz=17,wght=400:739 opsz=17,wght=700:706) (opsz=18,wght=400:535 opsz=18,wght=700:583 opsz=17,wght=400:585 opsz=17,wght=700:633)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:204 opsz=17,wght=400:152 opsz=17,wght=700:204) (opsz=18,wght=400:277 opsz=18,wght=700:303 opsz=17,wght=400:327 opsz=17,wght=700:353)> mark @MC_top.tashkil_arabic;
+        pos ligature tah_yehbarree-ar
+                <anchor (opsz=18,wght=400:648 opsz=18,wght=700:671 opsz=17,wght=400:648 opsz=17,wght=700:671) (opsz=18,wght=400:815 opsz=18,wght=700:867 opsz=17,wght=400:865 opsz=17,wght=700:917)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:154 opsz=17,wght=400:152 opsz=17,wght=700:154) (opsz=18,wght=400:537 opsz=18,wght=700:563 opsz=17,wght=400:587 opsz=17,wght=700:613)> mark @MC_top.tashkil_arabic;
+        pos ligature tah_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:648 opsz=18,wght=700:671 opsz=17,wght=400:648 opsz=17,wght=700:671) (opsz=18,wght=400:555 opsz=18,wght=700:607 opsz=17,wght=400:605 opsz=17,wght=700:657)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:154 opsz=17,wght=400:152 opsz=17,wght=700:154) (opsz=18,wght=400:277 opsz=18,wght=700:303 opsz=17,wght=400:327 opsz=17,wght=700:353)> mark @MC_top.tashkil_arabic;
+        pos ligature ain_yehbarree-ar
+                <anchor (opsz=18,wght=400:394 opsz=18,wght=700:421 opsz=17,wght=400:394 opsz=17,wght=700:421) (opsz=18,wght=400:840 opsz=18,wght=700:886 opsz=17,wght=400:890 opsz=17,wght=700:936)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:102 opsz=18,wght=700:94 opsz=17,wght=400:102 opsz=17,wght=700:94) (opsz=18,wght=400:367 opsz=18,wght=700:513 opsz=17,wght=400:417 opsz=17,wght=700:563)> mark @MC_top.tashkil_arabic;
+        pos ligature ain_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:483 opsz=18,wght=700:503 opsz=17,wght=400:483 opsz=17,wght=700:503) (opsz=18,wght=400:553 opsz=18,wght=700:601 opsz=17,wght=400:603 opsz=17,wght=700:651)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:102 opsz=18,wght=700:94 opsz=17,wght=400:102 opsz=17,wght=700:94) (opsz=18,wght=400:107 opsz=18,wght=700:253 opsz=17,wght=400:157 opsz=17,wght=700:303)> mark @MC_top.tashkil_arabic;
+        pos ligature fehDotless_yehbarree-ar
+                <anchor (opsz=18,wght=400:339 opsz=18,wght=700:362 opsz=17,wght=400:339 opsz=17,wght=700:362) (opsz=18,wght=400:929 opsz=18,wght=700:987 opsz=17,wght=400:979 opsz=17,wght=700:1037)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:22 opsz=18,wght=700:24 opsz=17,wght=400:22 opsz=17,wght=700:24) (opsz=18,wght=400:347 opsz=18,wght=700:373 opsz=17,wght=400:397 opsz=17,wght=700:423)> mark @MC_top.tashkil_arabic;
+        pos ligature fehDotless_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:477 opsz=18,wght=700:507 opsz=17,wght=400:477 opsz=17,wght=700:507) (opsz=18,wght=400:606 opsz=18,wght=700:660 opsz=17,wght=400:656 opsz=17,wght=700:710)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:22 opsz=18,wght=700:24 opsz=17,wght=400:22 opsz=17,wght=700:24) (opsz=18,wght=400:87 opsz=18,wght=700:113 opsz=17,wght=400:137 opsz=17,wght=700:163)> mark @MC_top.tashkil_arabic;
+        pos ligature kaf_yehbarree-ar
+                <anchor (opsz=18,wght=400:368 opsz=18,wght=700:367 opsz=17,wght=400:368 opsz=17,wght=700:367) (opsz=18,wght=400:1115 opsz=18,wght=700:1117 opsz=17,wght=400:1165 opsz=17,wght=700:1167)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:114 opsz=17,wght=400:152 opsz=17,wght=700:114) (opsz=18,wght=400:537 opsz=18,wght=700:483 opsz=17,wght=400:587 opsz=17,wght=700:533)> mark @MC_top.tashkil_arabic;
+        pos ligature kaf_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:512 opsz=18,wght=700:493 opsz=17,wght=400:512 opsz=17,wght=700:493) (opsz=18,wght=400:844 opsz=18,wght=700:846 opsz=17,wght=400:894 opsz=17,wght=700:896)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:114 opsz=17,wght=400:152 opsz=17,wght=700:114) (opsz=18,wght=400:277 opsz=18,wght=700:223 opsz=17,wght=400:327 opsz=17,wght=700:273)> mark @MC_top.tashkil_arabic;
+        pos ligature lam_yehbarree-ar
+                <anchor 458 (opsz=18,wght=400:1046 opsz=18,wght=700:1120 opsz=17,wght=400:1096 opsz=17,wght=700:1170)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:124 opsz=17,wght=400:152 opsz=17,wght=700:124) (opsz=18,wght=400:537 opsz=18,wght=700:563 opsz=17,wght=400:587 opsz=17,wght=700:613)> mark @MC_top.tashkil_arabic;
+        pos ligature lam_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:490 opsz=18,wght=700:502 opsz=17,wght=400:490 opsz=17,wght=700:502) (opsz=18,wght=400:926 opsz=18,wght=700:950 opsz=17,wght=400:976 opsz=17,wght=700:1000)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:124 opsz=17,wght=400:152 opsz=17,wght=700:124) (opsz=18,wght=400:277 opsz=18,wght=700:303 opsz=17,wght=400:327 opsz=17,wght=700:353)> mark @MC_top.tashkil_arabic;
+        pos ligature meem_yehbarree-ar
+                <anchor (opsz=18,wght=400:696 opsz=18,wght=700:686 opsz=17,wght=400:696 opsz=17,wght=700:686) (opsz=18,wght=400:793 opsz=18,wght=700:836 opsz=17,wght=400:843 opsz=17,wght=700:886)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:152 opsz=18,wght=700:204 opsz=17,wght=400:152 opsz=17,wght=700:204) (opsz=18,wght=400:534 opsz=18,wght=700:563 opsz=17,wght=400:584 opsz=17,wght=700:613)> mark @MC_top.tashkil_arabic;
+        pos ligature meem_yehbarree-ar.fina
+                <anchor 665 (opsz=18,wght=400:520 opsz=18,wght=700:562 opsz=17,wght=400:570 opsz=17,wght=700:612)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:232 opsz=18,wght=700:199 opsz=17,wght=400:232 opsz=17,wght=700:199) (opsz=18,wght=400:274 opsz=18,wght=700:342 opsz=17,wght=400:274 opsz=17,wght=700:342)> mark @MC_top.tashkil_arabic;
+        pos ligature heh_yehbarree-ar
+                <anchor (opsz=18,wght=400:539 opsz=18,wght=700:550 opsz=17,wght=400:539 opsz=17,wght=700:550) (opsz=18,wght=400:833 opsz=18,wght=700:917 opsz=17,wght=400:883 opsz=17,wght=700:967)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:132 opsz=18,wght=700:94 opsz=17,wght=400:132 opsz=17,wght=700:94) (opsz=18,wght=400:534 opsz=18,wght=700:513 opsz=17,wght=400:584 opsz=17,wght=700:563)> mark @MC_top.tashkil_arabic;
+        pos ligature heh_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:524 opsz=18,wght=700:523 opsz=17,wght=400:524 opsz=17,wght=700:523) (opsz=18,wght=400:572 opsz=18,wght=700:610 opsz=17,wght=400:622 opsz=17,wght=700:660)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:172 opsz=18,wght=700:94 opsz=17,wght=400:172 opsz=17,wght=700:94) (opsz=18,wght=400:274 opsz=18,wght=700:253 opsz=17,wght=400:324 opsz=17,wght=700:303)> mark @MC_top.tashkil_arabic;
+        pos ligature hehgoal_yehbarree-ar
+                <anchor (opsz=18,wght=400:691 opsz=18,wght=700:729 opsz=17,wght=400:691 opsz=17,wght=700:729) (opsz=18,wght=400:693 opsz=18,wght=700:710 opsz=17,wght=400:743 opsz=17,wght=700:760)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:252 opsz=18,wght=700:236 opsz=17,wght=400:252 opsz=17,wght=700:236) (opsz=18,wght=400:534 opsz=18,wght=700:563 opsz=17,wght=400:584 opsz=17,wght=700:613)> mark @MC_top.tashkil_arabic;
+        pos ligature hehgoal_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:560 opsz=18,wght=700:562 opsz=17,wght=400:560 opsz=17,wght=700:562) (opsz=18,wght=400:487 opsz=18,wght=700:563 opsz=17,wght=400:537 opsz=17,wght=700:613)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:232 opsz=18,wght=700:199 opsz=17,wght=400:232 opsz=17,wght=700:199) (opsz=18,wght=400:274 opsz=18,wght=700:292 opsz=17,wght=400:324 opsz=17,wght=700:342)> mark @MC_top.tashkil_arabic;
+        pos ligature hehDoachashmee_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:539 opsz=18,wght=700:550 opsz=17,wght=400:539 opsz=17,wght=700:550) (opsz=18,wght=400:573 opsz=18,wght=700:657 opsz=17,wght=400:623 opsz=17,wght=700:707)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:132 opsz=18,wght=700:94 opsz=17,wght=400:132 opsz=17,wght=700:94) (opsz=18,wght=400:274 opsz=18,wght=700:253 opsz=17,wght=400:324 opsz=17,wght=700:303)> mark @MC_top.tashkil_arabic;
+        pos ligature basmalah-ar
+                <anchor (opsz=18,wght=400:6287 opsz=18,wght=700:6792 opsz=17,wght=400:6287 opsz=17,wght=700:6792) (opsz=18,wght=400:660 opsz=18,wght=700:683 opsz=17,wght=400:710 opsz=17,wght=700:733)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:4952 opsz=18,wght=700:5362 opsz=17,wght=400:4954 opsz=17,wght=700:5335) (opsz=18,wght=400:499 opsz=18,wght=700:534 opsz=17,wght=400:549 opsz=17,wght=700:597)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:2441 opsz=18,wght=700:2656 opsz=17,wght=400:2443 opsz=17,wght=700:2629) (opsz=18,wght=400:499 opsz=18,wght=700:534 opsz=17,wght=400:549 opsz=17,wght=700:597)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:5377 opsz=18,wght=700:5772 opsz=17,wght=400:5377 opsz=17,wght=700:5772) (opsz=18,wght=400:450 opsz=18,wght=700:469 opsz=17,wght=400:500 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:4323 opsz=18,wght=700:4673 opsz=17,wght=400:4323 opsz=17,wght=700:4673) (opsz=18,wght=400:520 opsz=18,wght=700:562 opsz=17,wght=400:570 opsz=17,wght=700:612)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:13604 opsz=18,wght=700:14274 opsz=17,wght=400:13604 opsz=17,wght=700:14274) (opsz=18,wght=400:591 opsz=18,wght=700:586 opsz=17,wght=400:641 opsz=17,wght=700:636)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:2867 opsz=18,wght=700:3070 opsz=17,wght=400:2867 opsz=17,wght=700:3070) (opsz=18,wght=400:450 opsz=18,wght=700:469 opsz=17,wght=400:500 opsz=17,wght=700:519)> mark @MC_top.tashkil_arabic
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>;
+    } mark2liga_top.tashkil_arabic;
+
+    lookup mark2liga_float_arabic {
+        pos ligature kaf_lam_alef-ar
+                <anchor (opsz=18,wght=400:319 opsz=18,wght=700:299 opsz=17,wght=400:319 opsz=17,wght=700:299) (opsz=18,wght=400:504 opsz=18,wght=700:554 opsz=17,wght=400:504 opsz=17,wght=700:554)> mark @MC_float_arabic
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>;
+        pos ligature kaf_lam_alef-ar.fina
+                <anchor (opsz=18,wght=400:319 opsz=18,wght=700:299 opsz=17,wght=400:319 opsz=17,wght=700:299) (opsz=18,wght=400:504 opsz=18,wght=700:554 opsz=17,wght=400:504 opsz=17,wght=700:554)> mark @MC_float_arabic
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>;
+        pos ligature lam_alef-ar
+                <anchor (opsz=18,wght=400:249 opsz=18,wght=700:199 opsz=17,wght=400:244 opsz=17,wght=700:199) (opsz=18,wght=400:534 opsz=18,wght=700:584 opsz=17,wght=400:534 opsz=17,wght=700:584)> mark @MC_float_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature lam_alef-ar.fina
+                <anchor (opsz=18,wght=400:319 opsz=18,wght=700:299 opsz=17,wght=400:319 opsz=17,wght=700:299) (opsz=18,wght=400:504 opsz=18,wght=700:554 opsz=17,wght=400:504 opsz=17,wght=700:554)> mark @MC_float_arabic
+            ligComponent
+                <anchor NULL>;
+    } mark2liga_float_arabic;
+
+    lookup mark2liga_bottom_arabic {
+        pos ligature behDotless_reh-ar.fina
+                <anchor (opsz=18,wght=400:462 opsz=18,wght=700:500 opsz=17,wght=400:462 opsz=17,wght=700:500) (opsz=18,wght=400:40 opsz=18,wght=700:20 opsz=17,wght=400:40 opsz=17,wght=700:20)> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:58 opsz=18,wght=700:87 opsz=17,wght=400:58 opsz=17,wght=700:87) -262> mark @MC_bottom_arabic;
+        pos ligature behDotless_rehLoop-ar.fina
+                <anchor (opsz=18,wght=400:626 opsz=18,wght=700:634 opsz=17,wght=400:626 opsz=17,wght=700:634) (opsz=18,wght=400:40 opsz=18,wght=700:20 opsz=17,wght=400:40 opsz=17,wght=700:20)> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:222 opsz=18,wght=700:221 opsz=17,wght=400:222 opsz=17,wght=700:221) -262> mark @MC_bottom_arabic;
+        pos ligature behDotless_noonghunna-ar.fina
+                <anchor (opsz=18,wght=400:759 opsz=18,wght=700:769 opsz=17,wght=400:759 opsz=17,wght=700:769) (opsz=18,wght=400:36 opsz=18,wght=700:16 opsz=17,wght=400:36 opsz=17,wght=700:16)> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:327 opsz=18,wght=700:333 opsz=17,wght=400:327 opsz=17,wght=700:333) (opsz=18,wght=400:-194 opsz=18,wght=700:-213 opsz=17,wght=400:-194 opsz=17,wght=700:-213)> mark @MC_bottom_arabic;
+        pos ligature behDotless_alefMaksura-ar
+                <anchor 688 (opsz=18,wght=400:-246 opsz=18,wght=700:-250 opsz=17,wght=400:-246 opsz=17,wght=700:-250)> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:370 opsz=18,wght=700:376 opsz=17,wght=400:370 opsz=17,wght=700:376) (opsz=18,wght=400:-306 opsz=18,wght=700:-322 opsz=17,wght=400:-306 opsz=17,wght=700:-322)> mark @MC_bottom_arabic;
+        pos ligature behDotless_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:737 opsz=18,wght=700:777 opsz=17,wght=400:737 opsz=17,wght=700:777) (opsz=18,wght=400:-206 opsz=18,wght=700:-216 opsz=17,wght=400:-206 opsz=17,wght=700:-216)> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:371 opsz=18,wght=700:377 opsz=17,wght=400:371 opsz=17,wght=700:377) (opsz=18,wght=400:-306 opsz=18,wght=700:-324 opsz=17,wght=400:-306 opsz=17,wght=700:-324)> mark @MC_bottom_arabic;
+        pos ligature seen_reh-ar
+                <anchor (opsz=18,wght=400:741 opsz=18,wght=700:771 opsz=17,wght=400:741 opsz=17,wght=700:771) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:58 opsz=18,wght=700:87 opsz=17,wght=400:58 opsz=17,wght=700:87) -262> mark @MC_bottom_arabic;
+        pos ligature seen_reh-ar.fina
+                <anchor (opsz=18,wght=400:741 opsz=18,wght=700:771 opsz=17,wght=400:741 opsz=17,wght=700:771) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:58 opsz=18,wght=700:87 opsz=17,wght=400:58 opsz=17,wght=700:87) -262> mark @MC_bottom_arabic;
+        pos ligature seen_rehLoop-ar
+                <anchor 905 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:227 opsz=18,wght=700:212 opsz=17,wght=400:227 opsz=17,wght=700:212) (opsz=18,wght=400:-332 opsz=18,wght=700:-345 opsz=17,wght=400:-332 opsz=17,wght=700:-345)> mark @MC_bottom_arabic;
+        pos ligature seen_rehLoop-ar.fina
+                <anchor 905 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:227 opsz=18,wght=700:212 opsz=17,wght=400:227 opsz=17,wght=700:212) (opsz=18,wght=400:-332 opsz=18,wght=700:-345 opsz=17,wght=400:-332 opsz=17,wght=700:-345)> mark @MC_bottom_arabic;
+        pos ligature seen_alefMaksura-ar
+                <anchor (opsz=18,wght=400:1066 opsz=18,wght=700:1135 opsz=17,wght=400:1066 opsz=17,wght=700:1135) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:371 opsz=18,wght=700:377 opsz=17,wght=400:371 opsz=17,wght=700:377) (opsz=18,wght=400:-306 opsz=18,wght=700:-324 opsz=17,wght=400:-306 opsz=17,wght=700:-324)> mark @MC_bottom_arabic;
+        pos ligature seen_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:1066 opsz=18,wght=700:1135 opsz=17,wght=400:1066 opsz=17,wght=700:1135) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:371 opsz=18,wght=700:377 opsz=17,wght=400:371 opsz=17,wght=700:377) (opsz=18,wght=400:-306 opsz=18,wght=700:-324 opsz=17,wght=400:-306 opsz=17,wght=700:-324)> mark @MC_bottom_arabic;
+        pos ligature sad_reh-ar
+                <anchor (opsz=18,wght=400:723 opsz=18,wght=700:730 opsz=17,wght=400:723 opsz=17,wght=700:730) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:58 opsz=18,wght=700:87 opsz=17,wght=400:58 opsz=17,wght=700:87) -262> mark @MC_bottom_arabic;
+        pos ligature sad_reh-ar.fina
+                <anchor (opsz=18,wght=400:723 opsz=18,wght=700:730 opsz=17,wght=400:723 opsz=17,wght=700:730) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:58 opsz=18,wght=700:87 opsz=17,wght=400:58 opsz=17,wght=700:87) -262> mark @MC_bottom_arabic;
+        pos ligature sad_rehLoop-ar
+                <anchor (opsz=18,wght=400:887 opsz=18,wght=700:864 opsz=17,wght=400:887 opsz=17,wght=700:864) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:222 opsz=18,wght=700:221 opsz=17,wght=400:222 opsz=17,wght=700:221) -262> mark @MC_bottom_arabic;
+        pos ligature sad_rehLoop-ar.fina
+                <anchor (opsz=18,wght=400:887 opsz=18,wght=700:864 opsz=17,wght=400:887 opsz=17,wght=700:864) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:222 opsz=18,wght=700:221 opsz=17,wght=400:222 opsz=17,wght=700:221) -262> mark @MC_bottom_arabic;
+        pos ligature sad_alefMaksura-ar
+                <anchor (opsz=18,wght=400:1021 opsz=18,wght=700:1072 opsz=17,wght=400:1021 opsz=17,wght=700:1072) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:373 opsz=18,wght=700:377 opsz=17,wght=400:373 opsz=17,wght=700:377) (opsz=18,wght=400:-306 opsz=18,wght=700:-324 opsz=17,wght=400:-306 opsz=17,wght=700:-324)> mark @MC_bottom_arabic;
+        pos ligature sad_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:1021 opsz=18,wght=700:1072 opsz=17,wght=400:1021 opsz=17,wght=700:1072) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:373 opsz=18,wght=700:377 opsz=17,wght=400:373 opsz=17,wght=700:377) (opsz=18,wght=400:-306 opsz=18,wght=700:-324 opsz=17,wght=400:-306 opsz=17,wght=700:-324)> mark @MC_bottom_arabic;
+        pos ligature fehDotless_alefMaksura-ar
+                <anchor (opsz=18,wght=400:670 opsz=18,wght=700:697 opsz=17,wght=400:670 opsz=17,wght=700:697) (opsz=18,wght=400:-306 opsz=18,wght=700:-322 opsz=17,wght=400:-306 opsz=17,wght=700:-322)> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:370 opsz=18,wght=700:376 opsz=17,wght=400:370 opsz=17,wght=700:376) (opsz=18,wght=400:-306 opsz=18,wght=700:-322 opsz=17,wght=400:-306 opsz=17,wght=700:-322)> mark @MC_bottom_arabic;
+        pos ligature kaf_alef-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:137 opsz=18,wght=700:154 opsz=17,wght=400:137 opsz=17,wght=700:154) 0> mark @MC_bottom_arabic;
+        pos ligature kaf_alef-ar.short
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:137 opsz=18,wght=700:154 opsz=17,wght=400:137 opsz=17,wght=700:154) 0> mark @MC_bottom_arabic;
+        pos ligature kaf_alef-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:137 opsz=18,wght=700:154 opsz=17,wght=400:137 opsz=17,wght=700:154) 0> mark @MC_bottom_arabic;
+        pos ligature kaf_alef-ar.fina.short
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:137 opsz=18,wght=700:154 opsz=17,wght=400:137 opsz=17,wght=700:154) 0> mark @MC_bottom_arabic;
+        pos ligature kaf_kafDotless-ar
+                <anchor (opsz=18,wght=400:858 opsz=18,wght=700:922 opsz=17,wght=400:858 opsz=17,wght=700:922) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:412 opsz=18,wght=700:410 opsz=17,wght=400:412 opsz=17,wght=700:410) -16> mark @MC_bottom_arabic;
+        pos ligature kaf_kafDotless-ar.fina
+                <anchor (opsz=18,wght=400:840 opsz=18,wght=700:905 opsz=17,wght=400:840 opsz=17,wght=700:905) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:412 opsz=18,wght=700:410 opsz=17,wght=400:412 opsz=17,wght=700:410) -16> mark @MC_bottom_arabic;
+        pos ligature kaf_lam-ar
+                <anchor (opsz=18,wght=400:736 opsz=18,wght=700:762 opsz=17,wght=400:736 opsz=17,wght=700:762) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:327 opsz=18,wght=700:333 opsz=17,wght=400:327 opsz=17,wght=700:333) -264> mark @MC_bottom_arabic;
+        pos ligature kaf_lam-ar.fina
+                <anchor (opsz=18,wght=400:718 opsz=18,wght=700:745 opsz=17,wght=400:718 opsz=17,wght=700:745) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:327 opsz=18,wght=700:333 opsz=17,wght=400:327 opsz=17,wght=700:333) -264> mark @MC_bottom_arabic;
+        pos ligature kaf_lam-ar.medi
+                <anchor (opsz=18,wght=400:282 opsz=18,wght=700:330 opsz=17,wght=400:282 opsz=17,wght=700:330) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:135 opsz=18,wght=700:155 opsz=17,wght=400:135 opsz=17,wght=700:155) 0> mark @MC_bottom_arabic;
+        pos ligature kaf_lam-ar.init
+                <anchor (opsz=18,wght=400:300 opsz=18,wght=700:346 opsz=17,wght=400:300 opsz=17,wght=700:347) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:135 opsz=18,wght=700:155 opsz=17,wght=400:135 opsz=17,wght=700:155) 0> mark @MC_bottom_arabic;
+        pos ligature kaf_lam_alef-ar
+                <anchor (opsz=18,wght=400:673 opsz=18,wght=700:726 opsz=17,wght=400:673 opsz=17,wght=700:726) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:477 opsz=18,wght=700:504 opsz=17,wght=400:477 opsz=17,wght=700:504) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:155 opsz=18,wght=700:175 opsz=17,wght=400:155 opsz=17,wght=700:175) 0> mark @MC_bottom_arabic;
+        pos ligature kaf_lam_alef-ar.fina
+                <anchor (opsz=18,wght=400:673 opsz=18,wght=700:709 opsz=17,wght=400:673 opsz=17,wght=700:709) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:477 opsz=18,wght=700:504 opsz=17,wght=400:477 opsz=17,wght=700:504) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:155 opsz=18,wght=700:175 opsz=17,wght=400:155 opsz=17,wght=700:175) 0> mark @MC_bottom_arabic;
+        pos ligature kaf_alefMaksura-ar
+                <anchor (opsz=18,wght=400:670 opsz=18,wght=700:711 opsz=17,wght=400:670 opsz=17,wght=700:711) (opsz=18,wght=400:-306 opsz=18,wght=700:-322 opsz=17,wght=400:-306 opsz=17,wght=700:-322)> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:370 opsz=18,wght=700:376 opsz=17,wght=400:370 opsz=17,wght=700:376) (opsz=18,wght=400:-306 opsz=18,wght=700:-322 opsz=17,wght=400:-306 opsz=17,wght=700:-322)> mark @MC_bottom_arabic;
+        pos ligature kaf_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:776 opsz=18,wght=700:780 opsz=17,wght=400:776 opsz=17,wght=700:780) (opsz=18,wght=400:-306 opsz=18,wght=700:-322 opsz=17,wght=400:-306 opsz=17,wght=700:-322)> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:370 opsz=18,wght=700:376 opsz=17,wght=400:370 opsz=17,wght=700:376) (opsz=18,wght=400:-306 opsz=18,wght=700:-322 opsz=17,wght=400:-306 opsz=17,wght=700:-322)> mark @MC_bottom_arabic;
+        pos ligature hehgoal_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:992 opsz=18,wght=700:1069 opsz=17,wght=400:992 opsz=17,wght=700:1069) (opsz=18,wght=400:6 opsz=18,wght=700:0 opsz=17,wght=400:6 opsz=17,wght=700:0)> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:371 opsz=18,wght=700:377 opsz=17,wght=400:371 opsz=17,wght=700:377) (opsz=18,wght=400:-306 opsz=18,wght=700:-324 opsz=17,wght=400:-306 opsz=17,wght=700:-324)> mark @MC_bottom_arabic;
+        pos ligature lam_alef-ar
+                <anchor (opsz=18,wght=400:425 opsz=18,wght=700:420 opsz=17,wght=400:425 opsz=17,wght=700:420) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:142 opsz=18,wght=700:108 opsz=17,wght=400:142 opsz=17,wght=700:108) 0> mark @MC_bottom_arabic;
+        pos ligature lam_alef-ar.fina
+                <anchor (opsz=18,wght=400:513 opsz=18,wght=700:542 opsz=17,wght=400:513 opsz=17,wght=700:542) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:191 opsz=18,wght=700:202 opsz=17,wght=400:191 opsz=17,wght=700:202) 0> mark @MC_bottom_arabic;
+        pos ligature lam_alefMaksura-ar
+                <anchor 688 (opsz=18,wght=400:-306 opsz=18,wght=700:-322 opsz=17,wght=400:-306 opsz=17,wght=700:-322)> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:370 opsz=18,wght=700:376 opsz=17,wght=400:370 opsz=17,wght=700:376) (opsz=18,wght=400:-306 opsz=18,wght=700:-322 opsz=17,wght=400:-306 opsz=17,wght=700:-322)> mark @MC_bottom_arabic;
+        pos ligature behDotless_yehbarree-ar
+                <anchor 632 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 0> mark @MC_bottom_arabic;
+        pos ligature behDotless_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:490 opsz=18,wght=700:511 opsz=17,wght=400:490 opsz=17,wght=700:511) -260> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:246 opsz=18,wght=700:226 opsz=17,wght=400:176 opsz=17,wght=700:176) -260> mark @MC_bottom_arabic;
+        pos ligature hah_yehbarree-ar
+                <anchor 632 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 0> mark @MC_bottom_arabic;
+        pos ligature hah_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:532 opsz=18,wght=700:532 opsz=17,wght=400:472 opsz=17,wght=700:532) -260> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 -260> mark @MC_bottom_arabic;
+        pos ligature seen_yehbarree-ar
+                <anchor (opsz=18,wght=400:733 opsz=18,wght=700:791 opsz=17,wght=400:733 opsz=17,wght=700:791) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 0> mark @MC_bottom_arabic;
+        pos ligature seen_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:733 opsz=18,wght=700:791 opsz=17,wght=400:733 opsz=17,wght=700:791) -268> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 -268> mark @MC_bottom_arabic;
+        pos ligature sad_yehbarree-ar
+                <anchor (opsz=18,wght=400:695 opsz=18,wght=700:659 opsz=17,wght=400:695 opsz=17,wght=700:659) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 0> mark @MC_bottom_arabic;
+        pos ligature sad_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:695 opsz=18,wght=700:659 opsz=17,wght=400:695 opsz=17,wght=700:659) -260> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 -260> mark @MC_bottom_arabic;
+        pos ligature tah_yehbarree-ar
+                <anchor (opsz=18,wght=400:695 opsz=18,wght=700:659 opsz=17,wght=400:695 opsz=17,wght=700:659) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 0> mark @MC_bottom_arabic;
+        pos ligature tah_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:695 opsz=18,wght=700:659 opsz=17,wght=400:695 opsz=17,wght=700:659) -260> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 -260> mark @MC_bottom_arabic;
+        pos ligature ain_yehbarree-ar
+                <anchor (opsz=18,wght=400:695 opsz=18,wght=700:659 opsz=17,wght=400:695 opsz=17,wght=700:659) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 0> mark @MC_bottom_arabic;
+        pos ligature ain_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:483 opsz=18,wght=700:503 opsz=17,wght=400:483 opsz=17,wght=700:503) -260> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:246 opsz=18,wght=700:216 opsz=17,wght=400:176 opsz=17,wght=700:186) -260> mark @MC_bottom_arabic;
+        pos ligature fehDotless_yehbarree-ar
+                <anchor (opsz=18,wght=400:695 opsz=18,wght=700:659 opsz=17,wght=400:695 opsz=17,wght=700:659) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 0> mark @MC_bottom_arabic;
+        pos ligature fehDotless_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:455 opsz=18,wght=700:485 opsz=17,wght=400:495 opsz=17,wght=700:525) -260> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:226 opsz=18,wght=700:206 opsz=17,wght=400:186 opsz=17,wght=700:196) -260> mark @MC_bottom_arabic;
+        pos ligature kaf_yehbarree-ar
+                <anchor (opsz=18,wght=400:485 opsz=18,wght=700:519 opsz=17,wght=400:485 opsz=17,wght=700:519) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:176 opsz=18,wght=700:156 opsz=17,wght=400:176 opsz=17,wght=700:156) 0> mark @MC_bottom_arabic;
+        pos ligature kaf_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:555 opsz=18,wght=700:519 opsz=17,wght=400:555 opsz=17,wght=700:519) -260> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:176 opsz=18,wght=700:156 opsz=17,wght=400:176 opsz=17,wght=700:156) -260> mark @MC_bottom_arabic;
+        pos ligature lam_yehbarree-ar
+                <anchor (opsz=18,wght=400:485 opsz=18,wght=700:519 opsz=17,wght=400:485 opsz=17,wght=700:519) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:176 opsz=18,wght=700:156 opsz=17,wght=400:176 opsz=17,wght=700:156) 0> mark @MC_bottom_arabic;
+        pos ligature lam_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:485 opsz=18,wght=700:502 opsz=17,wght=400:490 opsz=17,wght=700:502) -260> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:176 opsz=18,wght=700:156 opsz=17,wght=400:176 opsz=17,wght=700:156) -260> mark @MC_bottom_arabic;
+        pos ligature meem_yehbarree-ar
+                <anchor (opsz=18,wght=400:704 opsz=18,wght=700:703 opsz=17,wght=400:704 opsz=17,wght=700:703) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:246 opsz=18,wght=700:346 opsz=17,wght=400:246 opsz=17,wght=700:346) 0> mark @MC_bottom_arabic;
+        pos ligature meem_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:665 opsz=18,wght=700:664 opsz=17,wght=400:665 opsz=17,wght=700:664) -260> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 -260> mark @MC_bottom_arabic;
+        pos ligature heh_yehbarree-ar
+                <anchor (opsz=18,wght=400:632 opsz=18,wght=700:599 opsz=17,wght=400:632 opsz=17,wght=700:599) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 0> mark @MC_bottom_arabic;
+        pos ligature heh_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:522 opsz=18,wght=700:599 opsz=17,wght=400:522 opsz=17,wght=700:599) -260> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 -260> mark @MC_bottom_arabic;
+        pos ligature hehgoal_yehbarree-ar
+                <anchor (opsz=18,wght=400:684 opsz=18,wght=700:737 opsz=17,wght=400:684 opsz=17,wght=700:737) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:276 opsz=18,wght=700:326 opsz=17,wght=400:276 opsz=17,wght=700:326) 0> mark @MC_bottom_arabic;
+        pos ligature hehgoal_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:558 opsz=18,wght=700:560 opsz=17,wght=400:558 opsz=17,wght=700:560) (opsz=18,wght=400:-335 opsz=18,wght=700:-367 opsz=17,wght=400:-335 opsz=17,wght=700:-367)> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 -260> mark @MC_bottom_arabic;
+        pos ligature hehDoachashmee_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:632 opsz=18,wght=700:599 opsz=17,wght=400:632 opsz=17,wght=700:599) -260> mark @MC_bottom_arabic
+            ligComponent
+                <anchor 246 -260> mark @MC_bottom_arabic;
+        pos ligature allah-ar
+                <anchor (opsz=18,wght=400:1200 opsz=18,wght=700:1248 opsz=17,wght=400:1200 opsz=17,wght=700:1248) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:264 opsz=18,wght=700:280 opsz=17,wght=400:264 opsz=17,wght=700:280) 0> mark @MC_bottom_arabic;
+        pos ligature basmalah-ar
+                <anchor (opsz=18,wght=400:6354 opsz=18,wght=700:6869 opsz=17,wght=400:6354 opsz=17,wght=700:6869) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:3447 opsz=18,wght=700:3703 opsz=17,wght=400:3447 opsz=17,wght=700:3703) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:5957 opsz=18,wght=700:6389 opsz=17,wght=400:5957 opsz=17,wght=700:6389) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:4970 opsz=18,wght=700:5353 opsz=17,wght=400:4972 opsz=17,wght=700:5323) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:2459 opsz=18,wght=700:2647 opsz=17,wght=400:2461 opsz=17,wght=700:2617) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:3214 opsz=18,wght=700:3426 opsz=17,wght=400:3214 opsz=17,wght=700:3426) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:5724 opsz=18,wght=700:6132 opsz=17,wght=400:5724 opsz=17,wght=700:6132) 0> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:5309 opsz=18,wght=700:5703 opsz=17,wght=400:5309 opsz=17,wght=700:5703) (opsz=18,wght=400:-247 opsz=18,wght=700:-248 opsz=17,wght=400:-247 opsz=17,wght=700:-248)> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:4323 opsz=18,wght=700:4672 opsz=17,wght=400:4323 opsz=17,wght=700:4672) (opsz=18,wght=400:0 opsz=18,wght=700:-14 opsz=17,wght=400:0 opsz=17,wght=700:-14)> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:13610 opsz=18,wght=700:14276 opsz=17,wght=400:13610 opsz=17,wght=700:14276) (opsz=18,wght=400:6 opsz=18,wght=700:0 opsz=17,wght=400:6 opsz=17,wght=700:0)> mark @MC_bottom_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:2799 opsz=18,wght=700:3001 opsz=17,wght=400:2799 opsz=17,wght=700:3001) (opsz=18,wght=400:-247 opsz=18,wght=700:-248 opsz=17,wght=400:-247 opsz=17,wght=700:-248)> mark @MC_bottom_arabic;
+    } mark2liga_bottom_arabic;
+
+    lookup mark2liga_bottom.right_arabic {
+        pos ligature kaf_alef-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:137 opsz=18,wght=700:174 opsz=17,wght=400:137 opsz=17,wght=700:174) (opsz=18,wght=400:100 opsz=18,wght=700:150 opsz=17,wght=400:100 opsz=17,wght=700:150)> mark @MC_bottom.right_arabic;
+        pos ligature kaf_alef-ar.short
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:137 opsz=18,wght=700:174 opsz=17,wght=400:137 opsz=17,wght=700:174) (opsz=18,wght=400:100 opsz=18,wght=700:150 opsz=17,wght=400:100 opsz=17,wght=700:150)> mark @MC_bottom.right_arabic;
+        pos ligature kaf_alef-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:137 opsz=18,wght=700:174 opsz=17,wght=400:137 opsz=17,wght=700:174) (opsz=18,wght=400:100 opsz=18,wght=700:150 opsz=17,wght=400:100 opsz=17,wght=700:150)> mark @MC_bottom.right_arabic;
+        pos ligature kaf_alef-ar.fina.short
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:137 opsz=18,wght=700:174 opsz=17,wght=400:137 opsz=17,wght=700:174) (opsz=18,wght=400:100 opsz=18,wght=700:150 opsz=17,wght=400:100 opsz=17,wght=700:150)> mark @MC_bottom.right_arabic;
+        pos ligature kaf_lam_alef-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:72 opsz=18,wght=700:92 opsz=17,wght=400:72 opsz=17,wght=700:92) (opsz=18,wght=400:93 opsz=18,wght=700:152 opsz=17,wght=400:93 opsz=17,wght=700:152)> mark @MC_bottom.right_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:72 opsz=18,wght=700:92 opsz=17,wght=400:72 opsz=17,wght=700:92) (opsz=18,wght=400:93 opsz=18,wght=700:152 opsz=17,wght=400:93 opsz=17,wght=700:152)> mark @MC_bottom.right_arabic;
+        pos ligature kaf_lam_alef-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:72 opsz=18,wght=700:92 opsz=17,wght=400:72 opsz=17,wght=700:92) (opsz=18,wght=400:93 opsz=18,wght=700:152 opsz=17,wght=400:93 opsz=17,wght=700:152)> mark @MC_bottom.right_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:72 opsz=18,wght=700:92 opsz=17,wght=400:72 opsz=17,wght=700:92) (opsz=18,wght=400:93 opsz=18,wght=700:152 opsz=17,wght=400:93 opsz=17,wght=700:152)> mark @MC_bottom.right_arabic;
+        pos ligature lam_alef-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:177 opsz=18,wght=700:244 opsz=17,wght=400:177 opsz=17,wght=700:244) (opsz=18,wght=400:100 opsz=18,wght=700:140 opsz=17,wght=400:100 opsz=17,wght=700:140)> mark @MC_bottom.right_arabic;
+        pos ligature lam_alef-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:72 opsz=18,wght=700:92 opsz=17,wght=400:72 opsz=17,wght=700:92) (opsz=18,wght=400:93 opsz=18,wght=700:152 opsz=17,wght=400:93 opsz=17,wght=700:152)> mark @MC_bottom.right_arabic;
+    } mark2liga_bottom.right_arabic;
+
+    lookup mark2liga_center_arabic {
+        pos ligature behDotless_reh-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:60 opsz=18,wght=700:78 opsz=17,wght=400:60 opsz=17,wght=700:78) (opsz=18,wght=400:20 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:70)> mark @MC_center_arabic;
+        pos ligature seen_reh-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:60 opsz=18,wght=700:78 opsz=17,wght=400:60 opsz=17,wght=700:78) (opsz=18,wght=400:20 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:70)> mark @MC_center_arabic;
+        pos ligature seen_reh-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:60 opsz=18,wght=700:78 opsz=17,wght=400:60 opsz=17,wght=700:78) (opsz=18,wght=400:20 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:70)> mark @MC_center_arabic;
+        pos ligature sad_reh-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:60 opsz=18,wght=700:78 opsz=17,wght=400:60 opsz=17,wght=700:78) (opsz=18,wght=400:20 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:70)> mark @MC_center_arabic;
+        pos ligature sad_reh-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:60 opsz=18,wght=700:78 opsz=17,wght=400:60 opsz=17,wght=700:78) (opsz=18,wght=400:20 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:70)> mark @MC_center_arabic;
+        pos ligature kaf_alef-ar
+                <anchor (opsz=18,wght=400:445 opsz=18,wght=700:471 opsz=17,wght=400:445 opsz=17,wght=700:471) (opsz=18,wght=400:578 opsz=18,wght=700:601 opsz=17,wght=400:578 opsz=17,wght=700:601)> mark @MC_center_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:12 opsz=18,wght=700:16 opsz=17,wght=400:12 opsz=17,wght=700:16) 0> mark @MC_center_arabic;
+        pos ligature kaf_alef-ar.fina
+                <anchor (opsz=18,wght=400:445 opsz=18,wght=700:478 opsz=17,wght=400:445 opsz=17,wght=700:478) (opsz=18,wght=400:578 opsz=18,wght=700:601 opsz=17,wght=400:578 opsz=17,wght=700:601)> mark @MC_center_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:12 opsz=18,wght=700:16 opsz=17,wght=400:12 opsz=17,wght=700:16) 0> mark @MC_center_arabic;
+        pos ligature kaf_kafDotless-ar
+                <anchor (opsz=18,wght=400:1027 opsz=18,wght=700:1086 opsz=17,wght=400:1027 opsz=17,wght=700:1086) (opsz=18,wght=400:578 opsz=18,wght=700:601 opsz=17,wght=400:578 opsz=17,wght=700:601)> mark @MC_center_arabic
+            ligComponent
+                <anchor 0 0> mark @MC_center_arabic;
+        pos ligature kaf_kafDotless-ar.fina
+                <anchor (opsz=18,wght=400:1027 opsz=18,wght=700:1086 opsz=17,wght=400:1027 opsz=17,wght=700:1086) (opsz=18,wght=400:578 opsz=18,wght=700:601 opsz=17,wght=400:578 opsz=17,wght=700:601)> mark @MC_center_arabic
+            ligComponent
+                <anchor 0 0> mark @MC_center_arabic;
+        pos ligature kaf_lam-ar
+                <anchor (opsz=18,wght=400:905 opsz=18,wght=700:926 opsz=17,wght=400:905 opsz=17,wght=700:926) (opsz=18,wght=400:578 opsz=18,wght=700:601 opsz=17,wght=400:578 opsz=17,wght=700:601)> mark @MC_center_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature kaf_lam-ar.fina
+                <anchor (opsz=18,wght=400:905 opsz=18,wght=700:926 opsz=17,wght=400:905 opsz=17,wght=700:926) (opsz=18,wght=400:579 opsz=18,wght=700:601 opsz=17,wght=400:579 opsz=17,wght=700:601)> mark @MC_center_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature kaf_lam-ar.medi
+                <anchor (opsz=18,wght=400:469 opsz=18,wght=700:511 opsz=17,wght=400:469 opsz=17,wght=700:511) (opsz=18,wght=400:578 opsz=18,wght=700:601 opsz=17,wght=400:578 opsz=17,wght=700:601)> mark @MC_center_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature kaf_lam-ar.init
+                <anchor (opsz=18,wght=400:469 opsz=18,wght=700:511 opsz=17,wght=400:469 opsz=17,wght=700:511) (opsz=18,wght=400:578 opsz=18,wght=700:601 opsz=17,wght=400:578 opsz=17,wght=700:601)> mark @MC_center_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature kaf_lam_alef-ar
+                <anchor (opsz=18,wght=400:842 opsz=18,wght=700:890 opsz=17,wght=400:842 opsz=17,wght=700:890) (opsz=18,wght=400:578 opsz=18,wght=700:601 opsz=17,wght=400:578 opsz=17,wght=700:601)> mark @MC_center_arabic
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>;
+        pos ligature kaf_lam_alef-ar.fina
+                <anchor (opsz=18,wght=400:842 opsz=18,wght=700:890 opsz=17,wght=400:842 opsz=17,wght=700:890) (opsz=18,wght=400:578 opsz=18,wght=700:601 opsz=17,wght=400:578 opsz=17,wght=700:601)> mark @MC_center_arabic
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>;
+        pos ligature kaf_alefMaksura-ar
+                <anchor (opsz=18,wght=400:705 opsz=18,wght=700:725 opsz=17,wght=400:705 opsz=17,wght=700:725) (opsz=18,wght=400:586 opsz=18,wght=700:611 opsz=17,wght=400:586 opsz=17,wght=700:611)> mark @MC_center_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature kaf_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:692 opsz=18,wght=700:720 opsz=17,wght=400:692 opsz=17,wght=700:720) (opsz=18,wght=400:584 opsz=18,wght=700:615 opsz=17,wght=400:584 opsz=17,wght=700:615)> mark @MC_center_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature kaf_yehbarree-ar
+                <anchor (opsz=18,wght=400:494 opsz=18,wght=700:527 opsz=17,wght=400:494 opsz=17,wght=700:527) 945> mark @MC_center_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature kaf_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:638 opsz=18,wght=700:653 opsz=17,wght=400:638 opsz=17,wght=700:653) (opsz=18,wght=400:673 opsz=18,wght=700:674 opsz=17,wght=400:673 opsz=17,wght=700:674)> mark @MC_center_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature basmalah-ar
+                <anchor (opsz=18,wght=400:5233 opsz=18,wght=700:5616 opsz=17,wght=400:5233 opsz=17,wght=700:5616) (opsz=18,wght=400:20 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:70)> mark @MC_center_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:2723 opsz=18,wght=700:2914 opsz=17,wght=400:2723 opsz=17,wght=700:2914) (opsz=18,wght=400:20 opsz=18,wght=700:60 opsz=17,wght=400:50 opsz=17,wght=700:70)> mark @MC_center_arabic
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>;
+    } mark2liga_center_arabic;
+
+    lookup mark2liga_ring_arabic {
+        pos ligature behDotless_noonghunna-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:271 opsz=18,wght=700:333 opsz=17,wght=400:271 opsz=17,wght=700:333) 0> mark @MC_ring_arabic;
+        pos ligature kaf_alefMaksura-ar
+                <anchor (opsz=18,wght=400:679 opsz=18,wght=700:676 opsz=17,wght=400:679 opsz=17,wght=700:676) (opsz=18,wght=400:514 opsz=18,wght=700:533 opsz=17,wght=400:514 opsz=17,wght=700:533)> mark @MC_ring_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature kaf_alefMaksura-ar.fina
+                <anchor (opsz=18,wght=400:667 opsz=18,wght=700:671 opsz=17,wght=400:667 opsz=17,wght=700:671) (opsz=18,wght=400:513 opsz=18,wght=700:537 opsz=17,wght=400:513 opsz=17,wght=700:537)> mark @MC_ring_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature kaf_yehbarree-ar
+                <anchor (opsz=18,wght=400:471 opsz=18,wght=700:477 opsz=17,wght=400:471 opsz=17,wght=700:477) (opsz=18,wght=400:874 opsz=18,wght=700:868 opsz=17,wght=400:874 opsz=17,wght=700:868)> mark @MC_ring_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature kaf_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:610 opsz=18,wght=700:604 opsz=17,wght=400:610 opsz=17,wght=700:604) (opsz=18,wght=400:600 opsz=18,wght=700:596 opsz=17,wght=400:600 opsz=17,wght=700:596)> mark @MC_ring_arabic
+            ligComponent
+                <anchor NULL>;
+    } mark2liga_ring_arabic;
+
+    lookup mark2liga_stroke_arabic {
+        pos ligature behDotless_reh-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:229 opsz=18,wght=700:267 opsz=17,wght=400:229 opsz=17,wght=700:267) (opsz=18,wght=400:-44 opsz=18,wght=700:-14 opsz=17,wght=400:-44 opsz=17,wght=700:-14)> mark @MC_stroke_arabic;
+        pos ligature seen_reh-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:229 opsz=18,wght=700:267 opsz=17,wght=400:229 opsz=17,wght=700:267) (opsz=18,wght=400:-44 opsz=18,wght=700:-14 opsz=17,wght=400:-44 opsz=17,wght=700:-14)> mark @MC_stroke_arabic;
+        pos ligature seen_reh-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:229 opsz=18,wght=700:267 opsz=17,wght=400:229 opsz=17,wght=700:267) (opsz=18,wght=400:-44 opsz=18,wght=700:-14 opsz=17,wght=400:-44 opsz=17,wght=700:-14)> mark @MC_stroke_arabic;
+        pos ligature sad_reh-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:229 opsz=18,wght=700:267 opsz=17,wght=400:229 opsz=17,wght=700:267) (opsz=18,wght=400:-44 opsz=18,wght=700:-14 opsz=17,wght=400:-44 opsz=17,wght=700:-14)> mark @MC_stroke_arabic;
+        pos ligature sad_reh-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:229 opsz=18,wght=700:267 opsz=17,wght=400:229 opsz=17,wght=700:267) (opsz=18,wght=400:-44 opsz=18,wght=700:-14 opsz=17,wght=400:-44 opsz=17,wght=700:-14)> mark @MC_stroke_arabic;
+        pos ligature kaf_alef-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:103 opsz=18,wght=700:92 opsz=17,wght=400:103 opsz=17,wght=700:92) (opsz=18,wght=400:261 opsz=18,wght=700:291 opsz=17,wght=400:261 opsz=17,wght=700:291)> mark @MC_stroke_arabic;
+        pos ligature kaf_alef-ar.short
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:103 opsz=18,wght=700:92 opsz=17,wght=400:103 opsz=17,wght=700:92) (opsz=18,wght=400:261 opsz=18,wght=700:291 opsz=17,wght=400:261 opsz=17,wght=700:291)> mark @MC_stroke_arabic;
+        pos ligature kaf_alef-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:103 opsz=18,wght=700:92 opsz=17,wght=400:103 opsz=17,wght=700:92) (opsz=18,wght=400:261 opsz=18,wght=700:291 opsz=17,wght=400:261 opsz=17,wght=700:291)> mark @MC_stroke_arabic;
+        pos ligature kaf_alef-ar.fina.short
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:103 opsz=18,wght=700:92 opsz=17,wght=400:103 opsz=17,wght=700:92) (opsz=18,wght=400:261 opsz=18,wght=700:291 opsz=17,wght=400:261 opsz=17,wght=700:291)> mark @MC_stroke_arabic;
+        pos ligature kaf_lam-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:573 opsz=18,wght=700:575 opsz=17,wght=400:573 opsz=17,wght=700:575) (opsz=18,wght=400:261 opsz=18,wght=700:271 opsz=17,wght=400:261 opsz=17,wght=700:271)> mark @MC_stroke_arabic;
+        pos ligature kaf_lam-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:573 opsz=18,wght=700:575 opsz=17,wght=400:573 opsz=17,wght=700:575) (opsz=18,wght=400:261 opsz=18,wght=700:271 opsz=17,wght=400:261 opsz=17,wght=700:271)> mark @MC_stroke_arabic;
+        pos ligature kaf_lam-ar.medi
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:137 opsz=18,wght=700:160 opsz=17,wght=400:137 opsz=17,wght=700:160) (opsz=18,wght=400:261 opsz=18,wght=700:271 opsz=17,wght=400:261 opsz=17,wght=700:271)> mark @MC_stroke_arabic;
+        pos ligature kaf_lam-ar.init
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:137 opsz=18,wght=700:160 opsz=17,wght=400:137 opsz=17,wght=700:160) (opsz=18,wght=400:261 opsz=18,wght=700:271 opsz=17,wght=400:261 opsz=17,wght=700:271)> mark @MC_stroke_arabic;
+        pos ligature kaf_lam_alef-ar
+                <anchor (opsz=18,wght=400:520 opsz=18,wght=700:547 opsz=17,wght=400:520 opsz=17,wght=700:547) (opsz=18,wght=400:531 opsz=18,wght=700:601 opsz=17,wght=400:531 opsz=17,wght=700:601)> mark @MC_stroke_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:520 opsz=18,wght=700:536 opsz=17,wght=400:520 opsz=17,wght=700:536) 661> mark @MC_stroke_arabic
+            ligComponent
+                <anchor 263 (opsz=18,wght=400:389 opsz=18,wght=700:419 opsz=17,wght=400:389 opsz=17,wght=700:419)> mark @MC_stroke_arabic;
+        pos ligature kaf_lam_alef-ar.fina
+                <anchor (opsz=18,wght=400:520 opsz=18,wght=700:547 opsz=17,wght=400:520 opsz=17,wght=700:547) (opsz=18,wght=400:531 opsz=18,wght=700:601 opsz=17,wght=400:531 opsz=17,wght=700:601)> mark @MC_stroke_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:520 opsz=18,wght=700:536 opsz=17,wght=400:520 opsz=17,wght=700:536) 661> mark @MC_stroke_arabic
+            ligComponent
+                <anchor 263 (opsz=18,wght=400:389 opsz=18,wght=700:419 opsz=17,wght=400:389 opsz=17,wght=700:419)> mark @MC_stroke_arabic;
+        pos ligature lam_alef-ar
+                <anchor (opsz=18,wght=400:442 opsz=18,wght=700:452 opsz=17,wght=400:442 opsz=17,wght=700:452) (opsz=18,wght=400:563 opsz=18,wght=700:666 opsz=17,wght=400:563 opsz=17,wght=700:666)> mark @MC_stroke_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:195 opsz=18,wght=700:165 opsz=17,wght=400:195 opsz=17,wght=700:165) (opsz=18,wght=400:493 opsz=18,wght=700:551 opsz=17,wght=400:493 opsz=17,wght=700:551)> mark @MC_stroke_arabic;
+        pos ligature lam_alef-ar.fina
+                <anchor (opsz=18,wght=400:520 opsz=18,wght=700:547 opsz=17,wght=400:520 opsz=17,wght=700:547) (opsz=18,wght=400:531 opsz=18,wght=700:601 opsz=17,wght=400:531 opsz=17,wght=700:601)> mark @MC_stroke_arabic
+            ligComponent
+                <anchor 263 (opsz=18,wght=400:389 opsz=18,wght=700:419 opsz=17,wght=400:389 opsz=17,wght=700:419)> mark @MC_stroke_arabic;
+        pos ligature lam_alefMaksura-ar
+                <anchor (opsz=18,wght=400:689 opsz=18,wght=700:691 opsz=17,wght=400:689 opsz=17,wght=700:691) 471> mark @MC_stroke_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature lam_yehbarree-ar
+                <anchor (opsz=18,wght=400:470 opsz=18,wght=700:495 opsz=17,wght=400:470 opsz=17,wght=700:495) (opsz=18,wght=400:631 opsz=18,wght=700:687 opsz=17,wght=400:631 opsz=17,wght=700:687)> mark @MC_stroke_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature lam_yehbarree-ar.fina
+                <anchor (opsz=18,wght=400:492 opsz=18,wght=700:507 opsz=17,wght=400:492 opsz=17,wght=700:507) 471> mark @MC_stroke_arabic
+            ligComponent
+                <anchor NULL>;
+        pos ligature basmalah-ar
+                <anchor (opsz=18,wght=400:3450 opsz=18,wght=700:3700 opsz=17,wght=400:3450 opsz=17,wght=700:3700) (opsz=18,wght=400:431 opsz=18,wght=700:441 opsz=17,wght=400:431 opsz=17,wght=700:441)> mark @MC_stroke_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:5960 opsz=18,wght=700:6386 opsz=17,wght=400:5960 opsz=17,wght=700:6386) (opsz=18,wght=400:431 opsz=18,wght=700:441 opsz=17,wght=400:431 opsz=17,wght=700:441)> mark @MC_stroke_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:3216 opsz=18,wght=700:3433 opsz=17,wght=400:3216 opsz=17,wght=700:3433) 471> mark @MC_stroke_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:5726 opsz=18,wght=700:6139 opsz=17,wght=400:5726 opsz=17,wght=700:6139) 471> mark @MC_stroke_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:5402 opsz=18,wght=700:5805 opsz=17,wght=400:5402 opsz=17,wght=700:5805) (opsz=18,wght=400:-44 opsz=18,wght=700:-14 opsz=17,wght=400:-44 opsz=17,wght=700:-14)> mark @MC_stroke_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:2892 opsz=18,wght=700:3103 opsz=17,wght=400:2892 opsz=17,wght=700:3103) (opsz=18,wght=400:-44 opsz=18,wght=700:-14 opsz=17,wght=400:-44 opsz=17,wght=700:-14)> mark @MC_stroke_arabic
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>
+            ligComponent
+                <anchor NULL>;
+    } mark2liga_stroke_arabic;
+
+    lookup mark2liga_stroke.left_arabic {
+        pos ligature kaf_lam_alef-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:287 opsz=18,wght=700:289 opsz=17,wght=400:287 opsz=17,wght=700:289) (opsz=18,wght=400:340 opsz=18,wght=700:366 opsz=17,wght=400:340 opsz=17,wght=700:366)> mark @MC_stroke.left_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:287 opsz=18,wght=700:289 opsz=17,wght=400:287 opsz=17,wght=700:289) (opsz=18,wght=400:340 opsz=18,wght=700:366 opsz=17,wght=400:340 opsz=17,wght=700:366)> mark @MC_stroke.left_arabic;
+        pos ligature kaf_lam_alef-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:287 opsz=18,wght=700:289 opsz=17,wght=400:287 opsz=17,wght=700:289) (opsz=18,wght=400:340 opsz=18,wght=700:366 opsz=17,wght=400:340 opsz=17,wght=700:366)> mark @MC_stroke.left_arabic
+            ligComponent
+                <anchor (opsz=18,wght=400:287 opsz=18,wght=700:289 opsz=17,wght=400:287 opsz=17,wght=700:289) (opsz=18,wght=400:340 opsz=18,wght=700:366 opsz=17,wght=400:340 opsz=17,wght=700:366)> mark @MC_stroke.left_arabic;
+        pos ligature lam_alef-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:258 opsz=18,wght=700:208 opsz=17,wght=400:258 opsz=17,wght=700:208) (opsz=18,wght=400:398 opsz=18,wght=700:431 opsz=17,wght=400:398 opsz=17,wght=700:431)> mark @MC_stroke.left_arabic;
+        pos ligature lam_alef-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:287 opsz=18,wght=700:289 opsz=17,wght=400:287 opsz=17,wght=700:289) (opsz=18,wght=400:340 opsz=18,wght=700:366 opsz=17,wght=400:340 opsz=17,wght=700:366)> mark @MC_stroke.left_arabic;
+    } mark2liga_stroke.left_arabic;
+
+    lookup mark2liga_tail_arabic {
+        pos ligature behDotless_alefMaksura-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:135 opsz=18,wght=700:155 opsz=17,wght=400:135 opsz=17,wght=700:155)> mark @MC_tail_arabic;
+        pos ligature behDotless_alefMaksura-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:135 opsz=18,wght=700:153 opsz=17,wght=400:135 opsz=17,wght=700:153)> mark @MC_tail_arabic;
+        pos ligature seen_alefMaksura-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:135 opsz=18,wght=700:153 opsz=17,wght=400:135 opsz=17,wght=700:153)> mark @MC_tail_arabic;
+        pos ligature seen_alefMaksura-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:135 opsz=18,wght=700:153 opsz=17,wght=400:135 opsz=17,wght=700:153)> mark @MC_tail_arabic;
+        pos ligature sad_alefMaksura-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:135 opsz=18,wght=700:153 opsz=17,wght=400:135 opsz=17,wght=700:153)> mark @MC_tail_arabic;
+        pos ligature sad_alefMaksura-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:135 opsz=18,wght=700:153 opsz=17,wght=400:135 opsz=17,wght=700:153)> mark @MC_tail_arabic;
+        pos ligature fehDotless_alefMaksura-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:135 opsz=18,wght=700:153 opsz=17,wght=400:135 opsz=17,wght=700:153)> mark @MC_tail_arabic;
+        pos ligature kaf_alefMaksura-ar
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:135 opsz=18,wght=700:155 opsz=17,wght=400:135 opsz=17,wght=700:155)> mark @MC_tail_arabic;
+        pos ligature kaf_alefMaksura-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:135 opsz=18,wght=700:155 opsz=17,wght=400:135 opsz=17,wght=700:155)> mark @MC_tail_arabic;
+        pos ligature hehgoal_alefMaksura-ar.fina
+                <anchor NULL>
+            ligComponent
+                <anchor (opsz=18,wght=400:122 opsz=18,wght=700:136 opsz=17,wght=400:122 opsz=17,wght=700:136) (opsz=18,wght=400:135 opsz=18,wght=700:153 opsz=17,wght=400:135 opsz=17,wght=700:153)> mark @MC_tail_arabic;
+    } mark2liga_tail_arabic;
+
+} mark;
+
+feature mark {
+    @IgnoreAfterBeh_arabic = [lam-ar.medi lam_alef-ar.fina behDotless-ar.medi behDotless-ar.medi.high behDotless_reh-ar.fina behDotless_rehLoop-ar.fina];
+    @AfterBeh_arabic = [behDotless-ar.medi behDotless-ar.medi.high behDotless_reh-ar.fina behDotless_rehLoop-ar.fina hah-ar.medi dal-ar.fina reh-ar.fina sad-ar.fina sad-ar.medi sad_reh-ar.fina sad_alefMaksura-ar.fina sad_yehbarree-ar.fina tah-ar.fina tah-ar.medi kafDotless-ar.fina kafswash-ar.fina kafswash-ar.medi lam-ar.medi lam-ar.fina lam_alef-ar.fina meem-ar.medi meem-ar.fina meem-ar.fina.alt heh-ar.fina hehDoachashmee-ar.medi hehDoachashmee-ar.fina];
+    @RehKernedDots_arabic = [dotbelow-ar twodotsverticalbelow-ar twodotshorizontalbelow-ar threedotsdownbelow-ar threedotsupbelow-ar fourdotsbelow-ar threedotshorizontalbelow-ar vbelow-ar vinvertedbelow-ar ring-ar ringbelow-ar fourbelow-ar];
+    # Move dots below initial beh to the left if there
+    # is room for that, for better visual centering.
+    lookup beh_dots_arabic {
+        lookupflag UseMarkFilteringSet @MC_bottom_arabic;
+        # FIXME: we need different values for different masters.
+        pos behDotless-ar.init @MC_bottom_arabic' <30 0 0 0> alef-ar.fina @MC_bottom_arabic;
+        pos behDotless-ar.init @MC_bottom_arabic' <30 0 0 0> @MC_bottom_arabic alef-ar.fina @MC_bottom_arabic;
+        pos behDotless-ar.init @MC_bottom_arabic' <-100 0 0 0> alef-ar.fina;
+        pos behDotless-ar.init @MC_bottom_arabic' <-100 0 0 0> @MC_bottom_arabic alef-ar.fina;
+        ignore pos behDotless-ar.init @MC_bottom_arabic' @IgnoreAfterBeh_arabic @MC_bottom_arabic;
+        ignore pos behDotless-ar.init @MC_bottom_arabic' @MC_bottom_arabic @IgnoreAfterBeh_arabic @MC_bottom_arabic;
+        pos behDotless-ar.init @MC_bottom_arabic' <-80 0 0 0> @AfterBeh_arabic;
+        pos behDotless-ar.init @MC_bottom_arabic' <-80 0 0 0> @MC_bottom_arabic @AfterBeh_arabic;
+        ignore pos @kern1.reh_arabic behDotless-ar.init' @RehKernedDots_arabic @IgnoreAfterBeh_arabic @MC_bottom_arabic;
+        ignore pos @kern1.reh_arabic behDotless-ar.init' @RehKernedDots_arabic @MC_bottom_arabic @IgnoreAfterBeh_arabic @MC_bottom_arabic;
+        pos @kern1.reh_arabic behDotless-ar.init' <0 0 -80 0> @RehKernedDots_arabic [@AfterBeh_arabic alef-ar.fina];
+        pos @kern1.reh_arabic behDotless-ar.init' <0 0 -80 0> @RehKernedDots_arabic @MC_bottom_arabic [@AfterBeh_arabic alef-ar.fina];
+    } beh_dots_arabic;
+
+    lookup teh_dots_pos_arabic {
+        lookupflag UseMarkFilteringSet [@dots.above_arabic dummy];
+        ignore pos [behDotless_reh-ar.fina behDotless_rehLoop-ar.fina] @dots.above_arabic' @dots.above_arabic;
+        pos [behDotless_reh-ar.fina behDotless_rehLoop-ar.fina] @dots.above_arabic' <-120 -80 0 0>;
+    } teh_dots_pos_arabic;
+
+    @yehbarree.before1_arabic = [behDotless-ar.init behDotless-ar.medi behDotless-ar.init.high behDotless-ar.medi.high seen-ar.init seen-ar.medi seen-ar.init.wide seen-ar.medi.wide sad-ar.init sad-ar.medi tah-ar.init tah-ar.medi ain-ar.init ain-ar.medi fehDotless-ar.init fehDotless-ar.medi kaf-ar.init kaf-ar.medi lam-ar.init lam-ar.medi meem-ar.init meem-ar.medi];
+    @yehbarree.before2_arabic = [behDotless-ar.medi behDotless-ar.medi.high lam-ar.medi hehgoal-ar.medi hehgoal-ar.medi.yehbarree];
+    #kaf-ar.medi
+    valueRecordDef <0 -260 0 0> DOT_SHIFT;
+    lookup yehbarree_marks_arabic {
+        lookupflag UseMarkFilteringSet @MC_bottom_arabic;
+        pos @yehbarree.before1_arabic @MC_bottom_arabic' <0 -260 0 0> [behDotless_yehbarree-ar.fina hah_yehbarree-ar.fina tah_yehbarree-ar.fina ain_yehbarree-ar.fina fehDotless_yehbarree-ar.fina kaf_yehbarree-ar.fina lam_yehbarree-ar.fina meem_yehbarree-ar.fina heh_yehbarree-ar.fina hehgoal_yehbarree-ar.fina hehDoachashmee_yehbarree-ar.fina];
+        pos @yehbarree.before1_arabic @MC_bottom_arabic' <0 -260 0 0> @yehbarree.before2_arabic [behDotless_yehbarree-ar.fina hah_yehbarree-ar.fina ain_yehbarree-ar.fina fehDotless_yehbarree-ar.fina kaf_yehbarree-ar.fina lam_yehbarree-ar.fina heh_yehbarree-ar.fina hehgoal_yehbarree-ar.fina];
+        pos @yehbarree.before1_arabic @MC_bottom_arabic' <0 -260 0 0> @yehbarree.before2_arabic @MC_bottom_arabic [behDotless_yehbarree-ar.fina hah_yehbarree-ar.fina ain_yehbarree-ar.fina fehDotless_yehbarree-ar.fina kaf_yehbarree-ar.fina lam_yehbarree-ar.fina heh_yehbarree-ar.fina hehgoal_yehbarree-ar.fina];
+        pos [hehgoal-ar.init hehgoal-ar.init.ascending] @MC_bottom_arabic' <0 -260 0 0> [behDotless_yehbarree-ar.fina hah_yehbarree-ar.fina ain_yehbarree-ar.fina fehDotless_yehbarree-ar.fina kaf_yehbarree-ar.fina lam_yehbarree-ar.fina heh_yehbarree-ar.fina hehgoal_yehbarree-ar.fina];
+        pos [hehgoal-ar.init hehgoal-ar.init.ascending] @MC_bottom_arabic' <0 -260 0 0> [behDotless-ar.medi behDotless-ar.medi.high lam-ar.medi hehgoal-ar.medi hehgoal-ar.medi.yehbarree] [behDotless_yehbarree-ar.fina hah_yehbarree-ar.fina ain_yehbarree-ar.fina fehDotless_yehbarree-ar.fina kaf_yehbarree-ar.fina lam_yehbarree-ar.fina heh_yehbarree-ar.fina hehgoal_yehbarree-ar.fina];
+        pos [hehgoal-ar.init hehgoal-ar.init.ascending] @MC_bottom_arabic' <0 -260 0 0> [behDotless-ar.medi behDotless-ar.medi.high lam-ar.medi hehgoal-ar.medi hehgoal-ar.medi.yehbarree] @MC_bottom_arabic [behDotless_yehbarree-ar.fina hah_yehbarree-ar.fina ain_yehbarree-ar.fina fehDotless_yehbarree-ar.fina kaf_yehbarree-ar.fina lam_yehbarree-ar.fina heh_yehbarree-ar.fina hehgoal_yehbarree-ar.fina];
+        pos [hah-ar.init hah-ar.medi] @MC_bottom_arabic' <0 -260 0 0> [behDotless_yehbarree-ar.fina hah_yehbarree-ar.fina ain_yehbarree-ar.fina fehDotless_yehbarree-ar.fina kaf_yehbarree-ar.fina lam_yehbarree-ar.fina heh_yehbarree-ar.fina hehgoal_yehbarree-ar.fina];
+    } yehbarree_marks_arabic;
+
+    lookup small_meem_arabic {
+        lookupflag 0;
+        pos [kasra-ar kasratan-ar openkasratan-ar]' <0 -100 0 0> meembelow-ar;
+    } small_meem_arabic;
+
+} mark;
+
+feature mkmk {
+    lookup mark2mark_bottom_arabic {
+        @MFS_mark2mark_bottom_arabic = [dummy dotbelow-ar dotbelow_threedotsdownbelow-ar twodotshorizontalbelow-ar twodotshorizontalbelow_tahabove-ar twodotsverticalbelow-ar threedotshorizontalbelow-ar threedotsupbelow-ar threedotsdownbelow-ar fourdotsbelow-ar hamzabelow-ar wavyhamzabelow-ar vbelow-ar vinvertedbelow-ar ring-ar fourbelow-ar doubleverticalbarbelow-ar tahbelow-ar rounddotattachedbelow-ar kasraattached-ar kasraattachedright-ar ringbelow-ar hehgoalMark-ar kasra-ar kasratan-ar openkasratan-ar kasraDotbelow-ar kasrasmall-ar kasraCurly-ar kasratanCurly-ar dammaturnedbelow-ar sukunbelow-ar toneloopbelow-ar leftarrowheadbelow-ar rightarrowheadbelow-ar toneonedotbelow-ar tonetwodotsbelow-ar rhombusStopbelow-ar rounddotbelow-ar largerounddotbelow-ar circlebelow-ar dotcirclebelow-ar alefbelow-ar meembelow-ar wawbelow-ar noonKasrabelow-ar seenbelow-ar];
+        lookupflag UseMarkFilteringSet @MFS_mark2mark_bottom_arabic;
+        pos mark dotbelow-ar
+            <anchor (opsz=18,wght=400:51 opsz=18,wght=700:63 opsz=17,wght=400:77 opsz=17,wght=700:83) (opsz=18,wght=400:-214 opsz=18,wght=700:-236 opsz=17,wght=400:-266 opsz=17,wght=700:-278)> mark @MC_bottom_arabic;
+        pos mark dotbelow_threedotsdownbelow-ar
+            <anchor (opsz=18,wght=400:77 opsz=18,wght=700:97 opsz=17,wght=400:111 opsz=17,wght=700:116) (opsz=18,wght=400:-379 opsz=18,wght=700:-437 opsz=17,wght=400:-470 opsz=17,wght=700:-493)> mark @MC_bottom_arabic;
+        pos mark twodotshorizontalbelow-ar
+            <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:-214 opsz=18,wght=700:-236 opsz=17,wght=400:-265 opsz=17,wght=700:-278)> mark @MC_bottom_arabic;
+        pos mark twodotshorizontalbelow_tahabove-ar
+            <anchor (opsz=18,wght=400:115 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:-454 opsz=18,wght=700:-487 opsz=17,wght=400:-480 opsz=17,wght=700:-493)> mark @MC_bottom_arabic;
+        pos mark twodotsverticalbelow-ar
+            <anchor (opsz=18,wght=400:52 opsz=18,wght=700:63 opsz=17,wght=400:76 opsz=17,wght=700:84) (opsz=18,wght=400:-320 opsz=18,wght=700:-369 opsz=17,wght=400:-406 opsz=17,wght=700:-420)> mark @MC_bottom_arabic;
+        pos mark threedotshorizontalbelow-ar
+            <anchor (opsz=18,wght=400:159 opsz=18,wght=700:196 opsz=17,wght=400:219 opsz=17,wght=700:227) (opsz=18,wght=400:-214 opsz=18,wght=700:-236 opsz=17,wght=400:-265 opsz=17,wght=700:-278)> mark @MC_bottom_arabic;
+        pos mark threedotsupbelow-ar
+            <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:-316 opsz=18,wght=700:-358 opsz=17,wght=400:-397 opsz=17,wght=700:-420)> mark @MC_bottom_arabic;
+        pos mark threedotsdownbelow-ar
+            <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:-316 opsz=18,wght=700:-358 opsz=17,wght=400:-398 opsz=17,wght=700:-410)> mark @MC_bottom_arabic;
+        pos mark fourdotsbelow-ar
+            <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:-326 opsz=18,wght=700:-371 opsz=17,wght=400:-404 opsz=17,wght=700:-423)> mark @MC_bottom_arabic;
+        pos mark hamzabelow-ar
+            <anchor (opsz=18,wght=400:93 opsz=18,wght=700:131 opsz=17,wght=400:117 opsz=17,wght=700:131) (opsz=18,wght=400:-273 opsz=18,wght=700:-341 opsz=17,wght=400:-315 opsz=17,wght=700:-341)> mark @MC_bottom_arabic;
+        pos mark wavyhamzabelow-ar
+            <anchor (opsz=18,wght=400:162 opsz=18,wght=700:199 opsz=17,wght=400:162 opsz=17,wght=700:199) (opsz=18,wght=400:-316 opsz=18,wght=700:-376 opsz=17,wght=400:-356 opsz=17,wght=700:-376)> mark @MC_bottom_arabic;
+        pos mark vbelow-ar
+            <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) (opsz=18,wght=400:-264 opsz=18,wght=700:-278 opsz=17,wght=400:-264 opsz=17,wght=700:-278)> mark @MC_bottom_arabic;
+        pos mark vinvertedbelow-ar
+            <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) (opsz=18,wght=400:-264 opsz=18,wght=700:-278 opsz=17,wght=400:-264 opsz=17,wght=700:-278)> mark @MC_bottom_arabic;
+        pos mark ring-ar
+            <anchor (opsz=18,wght=400:97 opsz=18,wght=700:101 opsz=17,wght=400:97 opsz=17,wght=700:101) (opsz=18,wght=400:-381 opsz=18,wght=700:-400 opsz=17,wght=400:-407 opsz=17,wght=700:-416)> mark @MC_bottom_arabic;
+        pos mark fourbelow-ar
+            <anchor 86 (opsz=18,wght=400:-359 opsz=18,wght=700:-372 opsz=17,wght=400:-359 opsz=17,wght=700:-372)> mark @MC_bottom_arabic;
+        pos mark tahbelow-ar
+            <anchor (opsz=18,wght=400:115 opsz=18,wght=700:121 opsz=17,wght=400:115 opsz=17,wght=700:121) (opsz=18,wght=400:-310 opsz=18,wght=700:-352 opsz=17,wght=400:-310 opsz=17,wght=700:-352)> mark @MC_bottom_arabic;
+        pos mark rounddotattachedbelow-ar
+            <anchor (opsz=18,wght=400:70 opsz=18,wght=700:73 opsz=17,wght=400:70 opsz=17,wght=700:73) -265> mark @MC_bottom_arabic;
+        pos mark ringbelow-ar
+            <anchor (opsz=18,wght=400:97 opsz=18,wght=700:101 opsz=17,wght=400:97 opsz=17,wght=700:101) (opsz=18,wght=400:-326 opsz=18,wght=700:-335 opsz=17,wght=400:-326 opsz=17,wght=700:-335)> mark @MC_bottom_arabic;
+        pos mark hehgoalMark-ar
+            <anchor (opsz=18,wght=400:48 opsz=18,wght=700:63 opsz=17,wght=400:48 opsz=17,wght=700:63) (opsz=18,wght=400:-269 opsz=18,wght=700:-325 opsz=17,wght=400:-269 opsz=17,wght=700:-325)> mark @MC_bottom_arabic;
+        pos mark kasra-ar
+            <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) (opsz=18,wght=400:-206 opsz=18,wght=700:-228 opsz=17,wght=400:-206 opsz=17,wght=700:-228)> mark @MC_bottom_arabic;
+        pos mark kasratan-ar
+            <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) (opsz=18,wght=400:-347 opsz=18,wght=700:-394 opsz=17,wght=400:-347 opsz=17,wght=700:-394)> mark @MC_bottom_arabic;
+        pos mark openkasratan-ar
+            <anchor (opsz=18,wght=400:150 opsz=18,wght=700:159 opsz=17,wght=400:150 opsz=17,wght=700:159) (opsz=18,wght=400:-305 opsz=18,wght=700:-354 opsz=17,wght=400:-305 opsz=17,wght=700:-354)> mark @MC_bottom_arabic;
+        pos mark kasraDotbelow-ar
+            <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) (opsz=18,wght=400:-190 opsz=18,wght=700:-224 opsz=17,wght=400:-205 opsz=17,wght=700:-237)> mark @MC_bottom_arabic;
+        pos mark kasraCurly-ar
+            <anchor (opsz=18,wght=400:106 opsz=18,wght=700:122 opsz=17,wght=400:106 opsz=17,wght=700:122) (opsz=18,wght=400:-206 opsz=18,wght=700:-228 opsz=17,wght=400:-206 opsz=17,wght=700:-228)> mark @MC_bottom_arabic;
+        pos mark kasratanCurly-ar
+            <anchor (opsz=18,wght=400:106 opsz=18,wght=700:122 opsz=17,wght=400:106 opsz=17,wght=700:122) (opsz=18,wght=400:-347 opsz=18,wght=700:-394 opsz=17,wght=400:-347 opsz=17,wght=700:-394)> mark @MC_bottom_arabic;
+        pos mark dammaturnedbelow-ar
+            <anchor (opsz=18,wght=400:109 opsz=18,wght=700:115 opsz=17,wght=400:109 opsz=17,wght=700:115) (opsz=18,wght=400:-408 opsz=18,wght=700:-443 opsz=17,wght=400:-408 opsz=17,wght=700:-443)> mark @MC_bottom_arabic;
+        pos mark sukunbelow-ar
+            <anchor (opsz=18,wght=400:84 opsz=18,wght=700:88 opsz=17,wght=400:84 opsz=17,wght=700:88) (opsz=18,wght=400:-360 opsz=18,wght=700:-368 opsz=17,wght=400:-360 opsz=17,wght=700:-368)> mark @MC_bottom_arabic;
+        pos mark toneloopbelow-ar
+            <anchor (opsz=18,wght=400:102 opsz=18,wght=700:120 opsz=17,wght=400:102 opsz=17,wght=700:120) (opsz=18,wght=400:-286 opsz=18,wght=700:-324 opsz=17,wght=400:-286 opsz=17,wght=700:-324)> mark @MC_bottom_arabic;
+        pos mark leftarrowheadbelow-ar
+            <anchor (opsz=18,wght=400:75 opsz=18,wght=700:74 opsz=17,wght=400:75 opsz=17,wght=700:74) (opsz=18,wght=400:-265 opsz=18,wght=700:-271 opsz=17,wght=400:-265 opsz=17,wght=700:-271)> mark @MC_bottom_arabic;
+        pos mark rightarrowheadbelow-ar
+            <anchor (opsz=18,wght=400:75 opsz=18,wght=700:74 opsz=17,wght=400:75 opsz=17,wght=700:74) (opsz=18,wght=400:-265 opsz=18,wght=700:-271 opsz=17,wght=400:-265 opsz=17,wght=700:-271)> mark @MC_bottom_arabic;
+        pos mark toneonedotbelow-ar
+            <anchor (opsz=18,wght=400:39 opsz=18,wght=700:44 opsz=17,wght=400:39 opsz=17,wght=700:44) -206> mark @MC_bottom_arabic;
+        pos mark tonetwodotsbelow-ar
+            <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) -206> mark @MC_bottom_arabic;
+        pos mark rhombusStopbelow-ar
+            <anchor (opsz=18,wght=400:85 opsz=18,wght=700:111 opsz=17,wght=400:85 opsz=17,wght=700:111) (opsz=18,wght=400:-278 opsz=18,wght=700:-333 opsz=17,wght=400:-278 opsz=17,wght=700:-333)> mark @MC_bottom_arabic;
+        pos mark rounddotbelow-ar
+            <anchor (opsz=18,wght=400:70 opsz=18,wght=700:73 opsz=17,wght=400:70 opsz=17,wght=700:73) -265> mark @MC_bottom_arabic;
+        pos mark largerounddotbelow-ar
+            <anchor (opsz=18,wght=400:114 opsz=18,wght=700:126 opsz=17,wght=400:114 opsz=17,wght=700:126) (opsz=18,wght=400:-338 opsz=18,wght=700:-360 opsz=17,wght=400:-338 opsz=17,wght=700:-360)> mark @MC_bottom_arabic;
+        pos mark circlebelow-ar
+            <anchor (opsz=18,wght=400:124 opsz=18,wght=700:140 opsz=17,wght=400:124 opsz=17,wght=700:140) (opsz=18,wght=400:-358 opsz=18,wght=700:-391 opsz=17,wght=400:-358 opsz=17,wght=700:-391)> mark @MC_bottom_arabic;
+        pos mark dotcirclebelow-ar
+            <anchor (opsz=18,wght=400:124 opsz=18,wght=700:140 opsz=17,wght=400:124 opsz=17,wght=700:140) (opsz=18,wght=400:-358 opsz=18,wght=700:-391 opsz=17,wght=400:-358 opsz=17,wght=700:-391)> mark @MC_bottom_arabic;
+        pos mark alefbelow-ar
+            <anchor (opsz=18,wght=400:32 opsz=18,wght=700:43 opsz=17,wght=400:33 opsz=17,wght=700:43) (opsz=18,wght=400:-420 opsz=18,wght=700:-436 opsz=17,wght=400:-420 opsz=17,wght=700:-436)> mark @MC_bottom_arabic;
+        pos mark meembelow-ar
+            <anchor (opsz=18,wght=400:91 opsz=18,wght=700:101 opsz=17,wght=400:91 opsz=17,wght=700:101) -320> mark @MC_bottom_arabic;
+        pos mark wawbelow-ar
+            <anchor (opsz=18,wght=400:83 opsz=18,wght=700:96 opsz=17,wght=400:83 opsz=17,wght=700:96) -320> mark @MC_bottom_arabic;
+        pos mark noonKasrabelow-ar
+            <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) -460> mark @MC_bottom_arabic;
+        pos mark seenbelow-ar
+            <anchor (opsz=18,wght=400:177 opsz=18,wght=700:189 opsz=17,wght=400:177 opsz=17,wght=700:189) -320> mark @MC_bottom_arabic;
+    } mark2mark_bottom_arabic;
+
+    lookup mark2mark_bottom.meem_arabic {
+        @MFS_mark2mark_bottom.meem_arabic = [meembelow-ar kasra-ar kasratan-ar openkasratan-ar];
+        lookupflag UseMarkFilteringSet @MFS_mark2mark_bottom.meem_arabic;
+        pos mark kasra-ar
+            <anchor 53 -144> mark @MC_bottom.meem_arabic;
+        pos mark kasratan-ar
+            <anchor 53 -144> mark @MC_bottom.meem_arabic;
+        pos mark openkasratan-ar
+            <anchor 53 (opsz=18,wght=400:-246 opsz=18,wght=700:-274 opsz=17,wght=400:-246 opsz=17,wght=700:-274)> mark @MC_bottom.meem_arabic;
+    } mark2mark_bottom.meem_arabic;
+
+    lookup mark2mark_digits_arabic {
+        @MFS_mark2mark_digits_arabic = [zero.mark one.mark two.mark three.mark four.mark five.mark six.mark seven.mark eight.mark nine.mark zero-ar.mark one-ar.mark two-ar.mark three-ar.mark four-ar.mark five-ar.mark six-ar.mark seven-ar.mark eight-ar.mark nine-ar.mark zero-persian.alt.mark two-persian.mark four-persian.mark four-persian.alt.mark five-persian.mark six-persian.mark seven-persian.mark seven-persian.alt.mark zero.small one.small two.small three.small four.small five.small six.small seven.small eight.small nine.small zero-ar.small one-ar.small two-ar.small three-ar.small four-ar.small five-ar.small six-ar.small seven-ar.small eight-ar.small nine-ar.small zero-persian.alt.small two-persian.small four-persian.small four-persian.alt.small five-persian.small six-persian.small seven-persian.small seven-persian.alt.small];
+        lookupflag UseMarkFilteringSet @MFS_mark2mark_digits_arabic;
+        pos mark zero.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark one.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark two.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark three.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark four.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark five.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark six.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark seven.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark eight.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark nine.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark zero-ar.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark one-ar.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark two-ar.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark three-ar.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark four-ar.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark five-ar.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark six-ar.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark seven-ar.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark eight-ar.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark nine-ar.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark zero-persian.alt.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark two-persian.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark four-persian.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark four-persian.alt.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark five-persian.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark six-persian.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark seven-persian.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark seven-persian.alt.mark
+            <anchor (opsz=18,wght=400:642 opsz=18,wght=700:728 opsz=17,wght=400:642 opsz=17,wght=700:728) 0> mark @MC_digits_arabic;
+        pos mark zero.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark one.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark two.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark three.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark four.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark five.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark six.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark seven.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark eight.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark nine.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark zero-ar.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark one-ar.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark two-ar.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark three-ar.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark four-ar.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark five-ar.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark six-ar.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark seven-ar.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark eight-ar.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark nine-ar.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark zero-persian.alt.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark two-persian.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark four-persian.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark four-persian.alt.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark five-persian.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark six-persian.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark seven-persian.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+        pos mark seven-persian.alt.small
+            <anchor (opsz=18,wght=400:425 opsz=18,wght=700:460 opsz=17,wght=400:425 opsz=17,wght=700:460) 0> mark @MC_digits_arabic;
+    } mark2mark_digits_arabic;
+
+    lookup mark2mark_top_arabic {
+        @MFS_mark2mark_top_arabic = [dummy dotabove-ar dotabove_threedotsupabove-ar dotabove_vabove-ar dotabove_vinvertedabove-ar dotabove_tahabove-ar twodotshorizontalabove-ar twodotshorizontalabove_vabove-ar twodotshorizontalabove_tahabove-ar twodotsverticalabove-ar threedotshorizontalabove-ar threedotsupabove-ar threedotsdownabove-ar fourdotsabove-ar hamzaabove-ar wavyhamzaabove-ar wasla-ar madda-ar vabove-ar vinvertedabove-ar gafsarkashabove-ar gafsarkashabove-ar.short grafsarkashabove-ar grafsarkashabove-ar.short commaabove-ar twoabove-ar threeabove-ar fourabove-ar tahabove-ar tahabove_vabove-ar tehabove-ar noonabove-ar dotbelow_threedotsdownbelow-ar twodotshorizontalbelow_tahabove-ar rounddotattachedabove-ar fathaattached-ar fathaattachedright-ar miniKeheh-ar hamzaaboveMark-ar maddaMark-ar vaboveMark-ar vinvertedaboveMark-ar shadda-ar fatha-ar damma-ar dammainverted-ar dammainverted-ar.alt dammareversed-ar fathatan-ar dammatan-ar openfathatan-ar opendammatan-ar sukun-ar fathasmall-ar dammasmall-ar fathaCurly-ar dammaCurly-ar fathatanCurly-ar dammatanCurly-ar dammaDot-ar fathaHorizont-ar fathatwodots-ar fathaDotabove-ar fathaRing-ar noonghunnaabove-ar noonghunnaabovesideways-ar toneloopabove-ar leftarrowheadabove-ar rightarrowheadabove-ar doublerightarrowheadabove-ar doublerightarrowheadDotabove-ar rightarrowheadDotabove-ar toneonedotabove-ar tonetwodotsabove-ar sukunoval-ar sukunround-ar jazm-ar rhombusStopabove-ar rounddotabove-ar largerounddotabove-ar maddalong-ar doubleMadda-ar doubleHafmadda-ar maddaWaajib-ar alefabove-ar alefMokhassas-ar zahabove-ar meemabove-ar wawabove-ar yehabove-farsi yehabove-ar barreyehabove-ar noonKasraabove-ar rehHahabove-ar rehDadabove-ar sallallahouAlayheWassallamcomb-ar alayheAssallamcomb-ar takhallusabove-ar footnotemarkerabove-ar safhaabove-ar wawbelow-ar];
+        lookupflag UseMarkFilteringSet @MFS_mark2mark_top_arabic;
+        pos mark gafsarkashabove-ar
+            <anchor (opsz=18,wght=400:100 opsz=18,wght=700:107 opsz=17,wght=400:100 opsz=17,wght=700:107) (opsz=18,wght=400:619 opsz=18,wght=700:629 opsz=17,wght=400:619 opsz=17,wght=700:629)> mark @MC_top_arabic;
+        pos mark gafsarkashabove-ar.short
+            <anchor (opsz=18,wght=400:100 opsz=18,wght=700:107 opsz=17,wght=400:100 opsz=17,wght=700:107) (opsz=18,wght=400:619 opsz=18,wght=700:629 opsz=17,wght=400:619 opsz=17,wght=700:629)> mark @MC_top_arabic;
+        pos mark grafsarkashabove-ar
+            <anchor 227 (opsz=18,wght=400:806 opsz=18,wght=700:806 opsz=17,wght=400:846 opsz=17,wght=700:846)> mark @MC_top_arabic;
+        pos mark grafsarkashabove-ar.short
+            <anchor 227 (opsz=18,wght=400:796 opsz=18,wght=700:796 opsz=17,wght=400:846 opsz=17,wght=700:846)> mark @MC_top_arabic;
+        pos mark tahabove_vabove-ar
+            <anchor (opsz=18,wght=400:115 opsz=18,wght=700:95 opsz=17,wght=400:115 opsz=17,wght=700:95) (opsz=18,wght=400:1026 opsz=18,wght=700:1082 opsz=17,wght=400:1026 opsz=17,wght=700:1082)> mark @MC_top_arabic;
+        pos mark miniKeheh-ar
+            <anchor (opsz=18,wght=400:79 opsz=18,wght=700:93 opsz=17,wght=400:79 opsz=17,wght=700:93) (opsz=18,wght=400:680 opsz=18,wght=700:730 opsz=17,wght=400:690 opsz=17,wght=700:740)> mark @MC_top_arabic;
+        pos mark sukunoval-ar
+            <anchor (opsz=18,wght=400:84 opsz=18,wght=700:88 opsz=17,wght=400:84 opsz=17,wght=700:88) (opsz=18,wght=400:972 opsz=18,wght=700:985 opsz=17,wght=400:972 opsz=17,wght=700:985)> mark @MC_top_arabic;
+        pos mark sukunround-ar
+            <anchor (opsz=18,wght=400:84 opsz=18,wght=700:93 opsz=17,wght=400:84 opsz=17,wght=700:93) (opsz=18,wght=400:951 opsz=18,wght=700:975 opsz=17,wght=400:951 opsz=17,wght=700:975)> mark @MC_top_arabic;
+        pos mark alefabove-ar
+            <anchor (opsz=18,wght=400:84 opsz=18,wght=700:82 opsz=17,wght=400:84 opsz=17,wght=700:82) (opsz=18,wght=400:971 opsz=18,wght=700:990 opsz=17,wght=400:971 opsz=17,wght=700:990)> mark @MC_top_arabic;
+        pos mark yehabove-ar
+            <anchor (opsz=18,wght=400:136 opsz=18,wght=700:142 opsz=17,wght=400:136 opsz=17,wght=700:136) 1039> mark @MC_top_arabic;
+        pos mark rehHahabove-ar
+            <anchor (opsz=18,wght=400:154 opsz=18,wght=700:168 opsz=17,wght=400:154 opsz=17,wght=700:168) 723> mark @MC_top_arabic;
+        pos mark rehDadabove-ar
+            <anchor (opsz=18,wght=400:160 opsz=18,wght=700:172 opsz=17,wght=400:160 opsz=17,wght=700:172) 723> mark @MC_top_arabic;
+        pos mark sallallahouAlayheWassallamcomb-ar
+            <anchor (opsz=18,wght=400:119 opsz=18,wght=700:122 opsz=17,wght=400:119 opsz=17,wght=700:122) (opsz=18,wght=400:723 opsz=18,wght=700:723 opsz=17,wght=400:823 opsz=17,wght=700:823)> mark @MC_top_arabic;
+        pos mark alayheAssallamcomb-ar
+            <anchor (opsz=18,wght=400:118 opsz=18,wght=700:152 opsz=17,wght=400:118 opsz=17,wght=700:152) (opsz=18,wght=400:723 opsz=18,wght=700:723 opsz=17,wght=400:823 opsz=17,wght=700:823)> mark @MC_top_arabic;
+        pos mark takhallusabove-ar
+            <anchor (opsz=18,wght=400:120 opsz=18,wght=700:134 opsz=17,wght=400:120 opsz=17,wght=700:134) (opsz=18,wght=400:723 opsz=18,wght=700:723 opsz=17,wght=400:823 opsz=17,wght=700:823)> mark @MC_top_arabic;
+        pos mark safhaabove-ar
+            <anchor (opsz=18,wght=400:174 opsz=18,wght=700:181 opsz=17,wght=400:174 opsz=17,wght=700:181) 823> mark @MC_top_arabic;
+        pos mark wawbelow-ar
+            <anchor (opsz=18,wght=400:90 opsz=18,wght=700:101 opsz=17,wght=400:90 opsz=17,wght=700:101) -110> mark @MC_top_arabic;
+    } mark2mark_top_arabic;
+
+    lookup mark2mark_top.meem_arabic {
+        @MFS_mark2mark_top.meem_arabic = [meemabove-ar fatha-ar damma-ar fathatan-ar openfathatan-ar opendammatan-ar];
+        lookupflag UseMarkFilteringSet @MFS_mark2mark_top.meem_arabic;
+        pos mark fatha-ar
+            <anchor 53 (opsz=18,wght=400:774 opsz=18,wght=700:797 opsz=17,wght=400:774 opsz=17,wght=700:797)> mark @MC_top.meem_arabic;
+        pos mark damma-ar
+            <anchor 0 (opsz=18,wght=400:766 opsz=18,wght=700:788 opsz=17,wght=400:766 opsz=17,wght=700:788)> mark @MC_top.meem_arabic;
+        pos mark fathatan-ar
+            <anchor 0 (opsz=18,wght=400:859 opsz=18,wght=700:901 opsz=17,wght=400:859 opsz=17,wght=700:901)> mark @MC_top.meem_arabic;
+        pos mark openfathatan-ar
+            <anchor 53 (opsz=18,wght=400:774 opsz=18,wght=700:797 opsz=17,wght=400:774 opsz=17,wght=700:797)> mark @MC_top.meem_arabic;
+        pos mark opendammatan-ar
+            <anchor 0 (opsz=18,wght=400:766 opsz=18,wght=700:788 opsz=17,wght=400:766 opsz=17,wght=700:788)> mark @MC_top.meem_arabic;
+    } mark2mark_top.meem_arabic;
+
+    lookup mark2mark_top.tashkil_arabic {
+        @MFS_mark2mark_top.tashkil_arabic = [hamzaaboveMark-ar maddaMark-ar vaboveMark-ar vinvertedaboveMark-ar shadda-ar fatha-ar damma-ar dammainverted-ar dammainverted-ar.alt dammareversed-ar fathatan-ar dammatan-ar openfathatan-ar opendammatan-ar sukun-ar fathasmall-ar dammasmall-ar fathaCurly-ar dammaCurly-ar fathatanCurly-ar dammatanCurly-ar dammaDot-ar fathaHorizont-ar fathatwodots-ar fathaDotabove-ar fathaRing-ar noonghunnaabove-ar noonghunnaabovesideways-ar toneloopabove-ar leftarrowheadabove-ar rightarrowheadabove-ar doublerightarrowheadabove-ar doublerightarrowheadDotabove-ar rightarrowheadDotabove-ar toneonedotabove-ar tonetwodotsabove-ar jazm-ar rhombusStopabove-ar rounddotabove-ar largerounddotabove-ar maddalong-ar doubleMadda-ar doubleHafmadda-ar maddaWaajib-ar alefabove-ar alefMokhassas-ar zahabove-ar wawabove-ar yehabove-farsi noonKasraabove-ar footnotemarkerabove-ar dotabove-ar dotabove_threedotsupabove-ar dotabove_vabove-ar dotabove_vinvertedabove-ar dotabove_tahabove-ar twodotshorizontalabove-ar twodotshorizontalabove_vabove-ar twodotshorizontalabove_tahabove-ar twodotsverticalabove-ar threedotshorizontalabove-ar threedotsupabove-ar threedotsdownabove-ar fourdotsabove-ar hamzaabove-ar wavyhamzaabove-ar wasla-ar madda-ar vabove-ar vinvertedabove-ar commaabove-ar twoabove-ar threeabove-ar fourabove-ar tahabove-ar tahabove_vabove-ar tehabove-ar noonabove-ar dotbelow_threedotsdownbelow-ar twodotshorizontalbelow_tahabove-ar rounddotattachedabove-ar miniKeheh-ar hamzafloating-ar meemabove-ar barreyehabove-ar seenabove-ar];
+        lookupflag UseMarkFilteringSet @MFS_mark2mark_top.tashkil_arabic;
+        pos mark dotabove-ar
+            <anchor (opsz=18,wght=400:52 opsz=18,wght=700:64 opsz=17,wght=400:78 opsz=17,wght=700:84) (opsz=18,wght=400:664 opsz=18,wght=700:686 opsz=17,wght=400:715 opsz=17,wght=700:728)> mark @MC_top.tashkil_arabic;
+        pos mark dotabove_threedotsupabove-ar
+            <anchor (opsz=18,wght=400:79 opsz=18,wght=700:97 opsz=17,wght=400:111 opsz=17,wght=700:116) (opsz=18,wght=400:829 opsz=18,wght=700:886 opsz=17,wght=400:919 opsz=17,wght=700:943)> mark @MC_top.tashkil_arabic;
+        pos mark dotabove_vabove-ar
+            <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) (opsz=18,wght=400:896 opsz=18,wght=700:932 opsz=17,wght=400:949 opsz=17,wght=700:976)> mark @MC_top.tashkil_arabic;
+        pos mark dotabove_vinvertedabove-ar
+            <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) (opsz=18,wght=400:898 opsz=18,wght=700:934 opsz=17,wght=400:949 opsz=17,wght=700:1002)> mark @MC_top.tashkil_arabic;
+        pos mark dotabove_tahabove-ar
+            <anchor (opsz=18,wght=400:115 opsz=18,wght=700:121 opsz=17,wght=400:115 opsz=17,wght=700:121) (opsz=18,wght=400:940 opsz=18,wght=700:1004 opsz=17,wght=400:991 opsz=17,wght=700:1046)> mark @MC_top.tashkil_arabic;
+        pos mark twodotshorizontalabove-ar
+            <anchor (opsz=18,wght=400:105 opsz=18,wght=700:129 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:664 opsz=18,wght=700:686 opsz=17,wght=400:715 opsz=17,wght=700:728)> mark @MC_top.tashkil_arabic;
+        pos mark twodotshorizontalabove_vabove-ar
+            <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:896 opsz=18,wght=700:932 opsz=17,wght=400:949 opsz=17,wght=700:976)> mark @MC_top.tashkil_arabic;
+        pos mark twodotshorizontalabove_tahabove-ar
+            <anchor (opsz=18,wght=400:115 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:940 opsz=18,wght=700:1004 opsz=17,wght=400:991 opsz=17,wght=700:1046)> mark @MC_top.tashkil_arabic;
+        pos mark twodotsverticalabove-ar
+            <anchor (opsz=18,wght=400:52 opsz=18,wght=700:63 opsz=17,wght=400:79 opsz=17,wght=700:84) (opsz=18,wght=400:770 opsz=18,wght=700:823 opsz=17,wght=400:856 opsz=17,wght=700:870)> mark @MC_top.tashkil_arabic;
+        pos mark threedotshorizontalabove-ar
+            <anchor (opsz=18,wght=400:158 opsz=18,wght=700:195 opsz=17,wght=400:218 opsz=17,wght=700:227) (opsz=18,wght=400:664 opsz=18,wght=700:686 opsz=17,wght=400:709 opsz=17,wght=700:728)> mark @MC_top.tashkil_arabic;
+        pos mark threedotsupabove-ar
+            <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:766 opsz=18,wght=700:808 opsz=17,wght=400:847 opsz=17,wght=700:870)> mark @MC_top.tashkil_arabic;
+        pos mark threedotsdownabove-ar
+            <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:766 opsz=18,wght=700:808 opsz=17,wght=400:846 opsz=17,wght=700:860)> mark @MC_top.tashkil_arabic;
+        pos mark fourdotsabove-ar
+            <anchor (opsz=18,wght=400:105 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:769 opsz=18,wght=700:821 opsz=17,wght=400:854 opsz=17,wght=700:873)> mark @MC_top.tashkil_arabic;
+        pos mark hamzaabove-ar
+            <anchor (opsz=18,wght=400:93 opsz=18,wght=700:131 opsz=17,wght=400:119 opsz=17,wght=700:131) (opsz=18,wght=400:912 opsz=18,wght=700:964 opsz=17,wght=400:961 opsz=17,wght=700:981)> mark @MC_top.tashkil_arabic;
+        pos mark wavyhamzaabove-ar
+            <anchor (opsz=18,wght=400:165 opsz=18,wght=700:223 opsz=17,wght=400:182 opsz=17,wght=700:223) (opsz=18,wght=400:710 opsz=18,wght=700:770 opsz=17,wght=400:740 opsz=17,wght=700:770)> mark @MC_top.tashkil_arabic;
+        pos mark wasla-ar
+            <anchor (opsz=18,wght=400:141 opsz=18,wght=700:158 opsz=17,wght=400:141 opsz=17,wght=700:158) (opsz=18,wght=400:718 opsz=18,wght=700:758 opsz=17,wght=400:713 opsz=17,wght=700:757)> mark @MC_top.tashkil_arabic;
+        pos mark madda-ar
+            <anchor (opsz=18,wght=400:136 opsz=18,wght=700:155 opsz=17,wght=400:136 opsz=17,wght=700:155) (opsz=18,wght=400:658 opsz=18,wght=700:698 opsz=17,wght=400:655 opsz=17,wght=700:694)> mark @MC_top.tashkil_arabic;
+        pos mark vabove-ar
+            <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) (opsz=18,wght=400:713 opsz=18,wght=700:727 opsz=17,wght=400:713 opsz=17,wght=700:727)> mark @MC_top.tashkil_arabic;
+        pos mark vinvertedabove-ar
+            <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) (opsz=18,wght=400:713 opsz=18,wght=700:727 opsz=17,wght=400:713 opsz=17,wght=700:727)> mark @MC_top.tashkil_arabic;
+        pos mark commaabove-ar
+            <anchor (opsz=18,wght=400:60 opsz=18,wght=700:77 opsz=17,wght=400:60 opsz=17,wght=700:77) (opsz=18,wght=400:814 opsz=18,wght=700:858 opsz=17,wght=400:814 opsz=17,wght=700:858)> mark @MC_top.tashkil_arabic;
+        pos mark twoabove-ar
+            <anchor (opsz=18,wght=400:89 opsz=18,wght=700:114 opsz=17,wght=400:92 opsz=17,wght=700:115) (opsz=18,wght=400:809 opsz=18,wght=700:829 opsz=17,wght=400:809 opsz=17,wght=700:829)> mark @MC_top.tashkil_arabic;
+        pos mark threeabove-ar
+            <anchor (opsz=18,wght=400:121 opsz=18,wght=700:148 opsz=17,wght=400:122 opsz=17,wght=700:145) (opsz=18,wght=400:804 opsz=18,wght=700:822 opsz=17,wght=400:807 opsz=17,wght=700:821)> mark @MC_top.tashkil_arabic;
+        pos mark fourabove-ar
+            <anchor (opsz=18,wght=400:91 opsz=18,wght=700:100 opsz=17,wght=400:90 opsz=17,wght=700:96) (opsz=18,wght=400:809 opsz=18,wght=700:823 opsz=17,wght=400:809 opsz=17,wght=700:824)> mark @MC_top.tashkil_arabic;
+        pos mark tahabove-ar
+            <anchor (opsz=18,wght=400:117 opsz=18,wght=700:121 opsz=17,wght=400:114 opsz=17,wght=700:121) (opsz=18,wght=400:760 opsz=18,wght=700:802 opsz=17,wght=400:760 opsz=17,wght=700:802)> mark @MC_top.tashkil_arabic;
+        pos mark tahabove_vabove-ar
+            <anchor (opsz=18,wght=400:117 opsz=18,wght=700:121 opsz=17,wght=400:114 opsz=17,wght=700:121) (opsz=18,wght=400:760 opsz=18,wght=700:802 opsz=17,wght=400:760 opsz=17,wght=700:802)> mark @MC_top.tashkil_arabic;
+        pos mark tehabove-ar
+            <anchor (opsz=18,wght=400:128 opsz=18,wght=700:136 opsz=17,wght=400:128 opsz=17,wght=700:133) (opsz=18,wght=400:739 opsz=18,wght=700:782 opsz=17,wght=400:750 opsz=17,wght=700:782)> mark @MC_top.tashkil_arabic;
+        pos mark noonabove-ar
+            <anchor (opsz=18,wght=400:104 opsz=18,wght=700:107 opsz=17,wght=400:106 opsz=17,wght=700:109) (opsz=18,wght=400:826 opsz=18,wght=700:852 opsz=17,wght=400:833 opsz=17,wght=700:861)> mark @MC_top.tashkil_arabic;
+        pos mark dotbelow_threedotsdownbelow-ar
+            <anchor (opsz=18,wght=400:79 opsz=18,wght=700:97 opsz=17,wght=400:111 opsz=17,wght=700:116) (opsz=18,wght=400:-429 opsz=18,wght=700:-486 opsz=17,wght=400:-519 opsz=17,wght=700:-543)> mark @MC_top.tashkil_arabic;
+        pos mark twodotshorizontalbelow_tahabove-ar
+            <anchor (opsz=18,wght=400:115 opsz=18,wght=700:130 opsz=17,wght=400:148 opsz=17,wght=700:155) (opsz=18,wght=400:-24 opsz=18,wght=700:7 opsz=17,wght=400:1 opsz=17,wght=700:43)> mark @MC_top.tashkil_arabic;
+        pos mark rounddotattachedabove-ar
+            <anchor (opsz=18,wght=400:70 opsz=18,wght=700:73 opsz=17,wght=400:70 opsz=17,wght=700:73) (opsz=18,wght=400:903 opsz=18,wght=700:911 opsz=17,wght=400:903 opsz=17,wght=700:911)> mark @MC_top.tashkil_arabic;
+        pos mark miniKeheh-ar
+            <anchor (opsz=18,wght=400:79 opsz=18,wght=700:93 opsz=17,wght=400:79 opsz=17,wght=700:93) (opsz=18,wght=400:830 opsz=18,wght=700:860 opsz=17,wght=400:830 opsz=17,wght=700:880)> mark @MC_top.tashkil_arabic;
+        pos mark hamzafloating-ar
+            <anchor (opsz=18,wght=400:93 opsz=18,wght=700:131 opsz=17,wght=400:117 opsz=17,wght=700:131) (opsz=18,wght=400:912 opsz=18,wght=700:964 opsz=17,wght=400:962 opsz=17,wght=700:981)> mark @MC_top.tashkil_arabic;
+        pos mark hamzaaboveMark-ar
+            <anchor (opsz=18,wght=400:93 opsz=18,wght=700:131 opsz=17,wght=400:117 opsz=17,wght=700:131) (opsz=18,wght=400:912 opsz=18,wght=700:964 opsz=17,wght=400:962 opsz=17,wght=700:981)> mark @MC_top.tashkil_arabic;
+        pos mark maddaMark-ar
+            <anchor (opsz=18,wght=400:136 opsz=18,wght=700:155 opsz=17,wght=400:136 opsz=17,wght=700:155) (opsz=18,wght=400:861 opsz=18,wght=700:900 opsz=17,wght=400:861 opsz=17,wght=700:900)> mark @MC_top.tashkil_arabic;
+        pos mark vaboveMark-ar
+            <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) (opsz=18,wght=400:919 opsz=18,wght=700:933 opsz=17,wght=400:919 opsz=17,wght=700:933)> mark @MC_top.tashkil_arabic;
+        pos mark vinvertedaboveMark-ar
+            <anchor (opsz=18,wght=400:93 opsz=18,wght=700:103 opsz=17,wght=400:93 opsz=17,wght=700:103) (opsz=18,wght=400:919 opsz=18,wght=700:933 opsz=17,wght=400:919 opsz=17,wght=700:933)> mark @MC_top.tashkil_arabic;
+        pos mark shadda-ar
+            <anchor (opsz=18,wght=400:103 opsz=18,wght=700:119 opsz=17,wght=400:113 opsz=17,wght=700:131) (opsz=18,wght=400:867 opsz=18,wght=700:875 opsz=17,wght=400:878 opsz=17,wght=700:889)> mark @MC_top.tashkil_arabic;
+        pos mark fatha-ar
+            <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) (opsz=18,wght=400:807 opsz=18,wght=700:832 opsz=17,wght=400:807 opsz=17,wght=700:832)> mark @MC_top.tashkil_arabic;
+        pos mark damma-ar
+            <anchor (opsz=18,wght=400:114 opsz=18,wght=700:128 opsz=17,wght=400:114 opsz=17,wght=700:128) (opsz=18,wght=400:983 opsz=18,wght=700:1008 opsz=17,wght=400:983 opsz=17,wght=700:1008)> mark @MC_top.tashkil_arabic;
+        pos mark dammainverted-ar
+            <anchor (opsz=18,wght=400:85 opsz=18,wght=700:107 opsz=17,wght=400:96 opsz=17,wght=700:107) (opsz=18,wght=400:983 opsz=18,wght=700:1008 opsz=17,wght=400:983 opsz=17,wght=700:1008)> mark @MC_top.tashkil_arabic;
+        pos mark dammainverted-ar.alt
+            <anchor (opsz=18,wght=400:60 opsz=18,wght=700:77 opsz=17,wght=400:60 opsz=17,wght=700:77) (opsz=18,wght=400:1029 opsz=18,wght=700:1039 opsz=17,wght=400:1029 opsz=17,wght=700:1039)> mark @MC_top.tashkil_arabic;
+        pos mark dammareversed-ar
+            <anchor (opsz=18,wght=400:96 opsz=18,wght=700:107 opsz=17,wght=400:84 opsz=17,wght=700:107) (opsz=18,wght=400:983 opsz=18,wght=700:1008 opsz=17,wght=400:983 opsz=17,wght=700:1008)> mark @MC_top.tashkil_arabic;
+        pos mark fathatan-ar
+            <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) (opsz=18,wght=400:903 opsz=18,wght=700:948 opsz=17,wght=400:903 opsz=17,wght=700:948)> mark @MC_top.tashkil_arabic;
+        pos mark dammatan-ar
+            <anchor (opsz=18,wght=400:141 opsz=18,wght=700:149 opsz=17,wght=400:141 opsz=17,wght=700:149) (opsz=18,wght=400:1127 opsz=18,wght=700:1150 opsz=17,wght=400:1127 opsz=17,wght=700:1150)> mark @MC_top.tashkil_arabic;
+        pos mark openfathatan-ar
+            <anchor (opsz=18,wght=400:150 opsz=18,wght=700:159 opsz=17,wght=400:150 opsz=17,wght=700:159) (opsz=18,wght=400:925 opsz=18,wght=700:971 opsz=17,wght=400:925 opsz=17,wght=700:971)> mark @MC_top.tashkil_arabic;
+        pos mark opendammatan-ar
+            <anchor (opsz=18,wght=400:183 opsz=18,wght=700:214 opsz=17,wght=400:183 opsz=17,wght=700:214) (opsz=18,wght=400:983 opsz=18,wght=700:1008 opsz=17,wght=400:983 opsz=17,wght=700:1008)> mark @MC_top.tashkil_arabic;
+        pos mark sukun-ar
+            <anchor (opsz=18,wght=400:84 opsz=18,wght=700:88 opsz=17,wght=400:84 opsz=17,wght=700:88) (opsz=18,wght=400:903 opsz=18,wght=700:911 opsz=17,wght=400:903 opsz=17,wght=700:911)> mark @MC_top.tashkil_arabic;
+        pos mark fathasmall-ar
+            <anchor (opsz=18,wght=400:79 opsz=18,wght=700:84 opsz=17,wght=400:79 opsz=17,wght=700:84) (opsz=18,wght=400:787 opsz=18,wght=700:807 opsz=17,wght=400:787 opsz=17,wght=700:807)> mark @MC_top.tashkil_arabic;
+        pos mark dammasmall-ar
+            <anchor (opsz=18,wght=400:76 opsz=18,wght=700:84 opsz=17,wght=400:76 opsz=17,wght=700:84) (opsz=18,wght=400:926 opsz=18,wght=700:945 opsz=17,wght=400:926 opsz=17,wght=700:945)> mark @MC_top.tashkil_arabic;
+        pos mark fathaCurly-ar
+            <anchor (opsz=18,wght=400:106 opsz=18,wght=700:122 opsz=17,wght=400:106 opsz=17,wght=700:122) (opsz=18,wght=400:807 opsz=18,wght=700:852 opsz=17,wght=400:807 opsz=17,wght=700:852)> mark @MC_top.tashkil_arabic;
+        pos mark dammaCurly-ar
+            <anchor (opsz=18,wght=400:118 opsz=18,wght=700:130 opsz=17,wght=400:118 opsz=17,wght=700:130) (opsz=18,wght=400:966 opsz=18,wght=700:991 opsz=17,wght=400:966 opsz=17,wght=700:991)> mark @MC_top.tashkil_arabic;
+        pos mark fathatanCurly-ar
+            <anchor (opsz=18,wght=400:106 opsz=18,wght=700:122 opsz=17,wght=400:106 opsz=17,wght=700:122) (opsz=18,wght=400:903 opsz=18,wght=700:986 opsz=17,wght=400:903 opsz=17,wght=700:986)> mark @MC_top.tashkil_arabic;
+        pos mark dammatanCurly-ar
+            <anchor (opsz=18,wght=400:164 opsz=18,wght=700:188 opsz=17,wght=400:164 opsz=17,wght=700:188) (opsz=18,wght=400:1109 opsz=18,wght=700:1141 opsz=17,wght=400:1109 opsz=17,wght=700:1141)> mark @MC_top.tashkil_arabic;
+        pos mark dammaDot-ar
+            <anchor (opsz=18,wght=400:137 opsz=18,wght=700:147 opsz=17,wght=400:137 opsz=17,wght=700:147) (opsz=18,wght=400:983 opsz=18,wght=700:1008 opsz=17,wght=400:983 opsz=17,wght=700:1008)> mark @MC_top.tashkil_arabic;
+        pos mark fathaHorizont-ar
+            <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) (opsz=18,wght=400:763 opsz=18,wght=700:785 opsz=17,wght=400:763 opsz=17,wght=700:785)> mark @MC_top.tashkil_arabic;
+        pos mark fathatwodots-ar
+            <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) (opsz=18,wght=400:885 opsz=18,wght=700:936 opsz=17,wght=400:913 opsz=17,wght=700:960)> mark @MC_top.tashkil_arabic;
+        pos mark fathaDotabove-ar
+            <anchor (opsz=18,wght=400:101 opsz=18,wght=700:107 opsz=17,wght=400:101 opsz=17,wght=700:107) (opsz=18,wght=400:846 opsz=18,wght=700:884 opsz=17,wght=400:860 opsz=17,wght=700:896)> mark @MC_top.tashkil_arabic;
+        pos mark fathaRing-ar
+            <anchor (opsz=18,wght=400:102 opsz=18,wght=700:120 opsz=17,wght=400:102 opsz=17,wght=700:107) (opsz=18,wght=400:895 opsz=18,wght=700:911 opsz=17,wght=400:895 opsz=17,wght=700:911)> mark @MC_top.tashkil_arabic;
+        pos mark noonghunnaabove-ar
+            <anchor (opsz=18,wght=400:82 opsz=18,wght=700:94 opsz=17,wght=400:82 opsz=17,wght=700:94) (opsz=18,wght=400:914 opsz=18,wght=700:938 opsz=17,wght=400:914 opsz=17,wght=700:938)> mark @MC_top.tashkil_arabic;
+        pos mark toneloopabove-ar
+            <anchor (opsz=18,wght=400:102 opsz=18,wght=700:120 opsz=17,wght=400:102 opsz=17,wght=700:120) (opsz=18,wght=400:872 opsz=18,wght=700:912 opsz=17,wght=400:872 opsz=17,wght=700:912)> mark @MC_top.tashkil_arabic;
+        pos mark leftarrowheadabove-ar
+            <anchor (opsz=18,wght=400:75 opsz=18,wght=700:74 opsz=17,wght=400:75 opsz=17,wght=700:74) (opsz=18,wght=400:871 opsz=18,wght=700:877 opsz=17,wght=400:871 opsz=17,wght=700:877)> mark @MC_top.tashkil_arabic;
+        pos mark rightarrowheadabove-ar
+            <anchor (opsz=18,wght=400:75 opsz=18,wght=700:74 opsz=17,wght=400:75 opsz=17,wght=700:74) (opsz=18,wght=400:871 opsz=18,wght=700:877 opsz=17,wght=400:871 opsz=17,wght=700:877)> mark @MC_top.tashkil_arabic;
+        pos mark doublerightarrowheadabove-ar
+            <anchor 151 (opsz=18,wght=400:871 opsz=18,wght=700:877 opsz=17,wght=400:871 opsz=17,wght=700:877)> mark @MC_top.tashkil_arabic;
+        pos mark doublerightarrowheadDotabove-ar
+            <anchor 208 (opsz=18,wght=400:871 opsz=18,wght=700:877 opsz=17,wght=400:871 opsz=17,wght=700:877)> mark @MC_top.tashkil_arabic;
+        pos mark rightarrowheadDotabove-ar
+            <anchor (opsz=18,wght=400:122 opsz=18,wght=700:126 opsz=17,wght=400:127 opsz=17,wght=700:130) (opsz=18,wght=400:871 opsz=18,wght=700:877 opsz=17,wght=400:871 opsz=17,wght=700:877)> mark @MC_top.tashkil_arabic;
+        pos mark jazm-ar
+            <anchor (opsz=18,wght=400:100 opsz=18,wght=700:110 opsz=17,wght=400:100 opsz=17,wght=700:110) (opsz=18,wght=400:864 opsz=18,wght=700:910 opsz=17,wght=400:864 opsz=17,wght=700:910)> mark @MC_top.tashkil_arabic;
+        pos mark rhombusStopabove-ar
+            <anchor (opsz=18,wght=400:85 opsz=18,wght=700:112 opsz=17,wght=400:85 opsz=17,wght=700:112) (opsz=18,wght=400:884 opsz=18,wght=700:939 opsz=17,wght=400:884 opsz=17,wght=700:939)> mark @MC_top.tashkil_arabic;
+        pos mark rounddotabove-ar
+            <anchor (opsz=18,wght=400:70 opsz=18,wght=700:73 opsz=17,wght=400:70 opsz=17,wght=700:73) (opsz=18,wght=400:903 opsz=18,wght=700:911 opsz=17,wght=400:903 opsz=17,wght=700:911)> mark @MC_top.tashkil_arabic;
+        pos mark largerounddotabove-ar
+            <anchor (opsz=18,wght=400:114 opsz=18,wght=700:125 opsz=17,wght=400:114 opsz=17,wght=700:125) (opsz=18,wght=400:944 opsz=18,wght=700:967 opsz=17,wght=400:944 opsz=17,wght=700:967)> mark @MC_top.tashkil_arabic;
+        pos mark alefabove-ar
+            <anchor (opsz=18,wght=400:33 opsz=18,wght=700:43 opsz=17,wght=400:22 opsz=17,wght=700:33) (opsz=18,wght=400:971 opsz=18,wght=700:993 opsz=17,wght=400:971 opsz=17,wght=700:993)> mark @MC_top.tashkil_arabic;
+        pos mark alefMokhassas-ar
+            <anchor (opsz=18,wght=400:180 opsz=18,wght=700:195 opsz=17,wght=400:180 opsz=17,wght=700:195) (opsz=18,wght=400:971 opsz=18,wght=700:993 opsz=17,wght=400:971 opsz=17,wght=700:993)> mark @MC_top.tashkil_arabic;
+        pos mark zahabove-ar
+            <anchor (opsz=18,wght=400:118 opsz=18,wght=700:121 opsz=17,wght=400:115 opsz=17,wght=700:121) (opsz=18,wght=400:949 opsz=18,wght=700:989 opsz=17,wght=400:961 opsz=17,wght=700:1009)> mark @MC_top.tashkil_arabic;
+        pos mark meemabove-ar
+            <anchor (opsz=18,wght=400:91 opsz=18,wght=700:101 opsz=17,wght=400:91 opsz=17,wght=700:101) (opsz=18,wght=400:992 opsz=18,wght=700:1002 opsz=17,wght=400:992 opsz=17,wght=700:1002)> mark @MC_top.tashkil_arabic;
+        pos mark wawabove-ar
+            <anchor (opsz=18,wght=400:84 opsz=18,wght=700:94 opsz=17,wght=400:84 opsz=17,wght=700:107) (opsz=18,wght=400:961 opsz=18,wght=700:992 opsz=17,wght=400:961 opsz=17,wght=700:992)> mark @MC_top.tashkil_arabic;
+        pos mark yehabove-farsi
+            <anchor (opsz=18,wght=400:131 opsz=18,wght=700:138 opsz=17,wght=400:131 opsz=17,wght=700:138) 993> mark @MC_top.tashkil_arabic;
+        pos mark barreyehabove-ar
+            <anchor 139 (opsz=18,wght=400:882 opsz=18,wght=700:888 opsz=17,wght=400:882 opsz=17,wght=700:888)> mark @MC_top.tashkil_arabic;
+        pos mark seenabove-ar
+            <anchor 218 1303> mark @MC_top.tashkil_arabic;
+    } mark2mark_top.tashkil_arabic;
+
+} mkmk;
+
+lookup arabicspace_arabic {
+    pos space (opsz=18,wght=400:-20 opsz=18,wght=700:-20 opsz=17,wght=400:-44 opsz=17,wght=700:-42);
+    pos thinspace (opsz=18,wght=400:-94 opsz=18,wght=700:-93 opsz=17,wght=400:-94 opsz=17,wght=700:-93);
+    pos hairspace -54;
+} arabicspace_arabic;
+
+feature locl {
+    script arab;
+    language FAR;
+    lookup arabicspace_arabic;
+    language KSH;
+    lookup arabicspace_arabic;
+    language RHG;
+    lookup arabicspace_arabic;
+    language SND;
+    lookup arabicspace_arabic;
+    language URD;
+    lookup arabicspace_arabic;
+    language dflt;
+    lookup arabicspace_arabic;
+} locl;
+
+# Give automatic code a place to live; Arabic declares these features so we need
+# to give the generated code a placeholder so it still gets made
+feature mark {
+    # Automatic Code
+} mark;
+
+feature mkmk {
+    # Automatic Code
+} mkmk;

--- a/source/GoogleSans/telugu-Italic-variable.fea
+++ b/source/GoogleSans/telugu-Italic-variable.fea
@@ -1,0 +1,149 @@
+feature dist {
+    # Automatic Code End
+    # ------
+    # Italic
+    # ------
+    lookup TEL2_dflt_dist_vattuPositioningSpacing {
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [kha-telugu.below khai-telugu.below]' <0 0 (opsz=18,wght=400:614 opsz=18,wght=700:650 opsz=17,wght=400:619 opsz=17,wght=700:655) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [ga-telugu.below gai-telugu.below]' <0 0 (opsz=18,wght=400:462 opsz=18,wght=700:483 opsz=17,wght=400:462 opsz=17,wght=700:483) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [gha-telugu.below ghai-telugu.below]' <0 0 (opsz=18,wght=400:837 opsz=18,wght=700:869 opsz=17,wght=400:837 opsz=17,wght=700:877) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [nga-telugu.below ngai-telugu.below]' <0 0 (opsz=18,wght=400:556 opsz=18,wght=700:597 opsz=17,wght=400:556 opsz=17,wght=700:595) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [ja-telugu.below jai-telugu.below]' <0 0 (opsz=18,wght=400:550 opsz=18,wght=700:591 opsz=17,wght=400:574 opsz=17,wght=700:608) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [jha-telugu.below jhai-telugu.below]' <0 0 (opsz=18,wght=400:929 opsz=18,wght=700:955 opsz=17,wght=400:929 opsz=17,wght=700:959) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [nya-telugu.below nyai-telugu.below]' <0 0 (opsz=18,wght=400:722 opsz=18,wght=700:750 opsz=17,wght=400:722 opsz=17,wght=700:764) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [tta-telugu.below ttai-telugu.below]' <0 0 (opsz=18,wght=400:568 opsz=18,wght=700:594 opsz=17,wght=400:568 opsz=17,wght=700:594) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [ttha-telugu.below tthai-telugu.below]' <0 0 (opsz=18,wght=400:418 opsz=18,wght=700:455 opsz=17,wght=400:418 opsz=17,wght=700:454) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [dda-telugu.below ddai-telugu.below ddha-telugu.below ddhai-telugu.below]' <0 0 (opsz=18,wght=400:552 opsz=18,wght=700:581 opsz=17,wght=400:552 opsz=17,wght=700:580) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [nna-telugu.below nnai-telugu.below]' <0 0 (opsz=18,wght=400:572 opsz=18,wght=700:600 opsz=17,wght=400:563 opsz=17,wght=700:600) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [ta-telugu.below tai-telugu.below]' <0 0 (opsz=18,wght=400:771 opsz=18,wght=700:801 opsz=17,wght=400:769 opsz=17,wght=700:799) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [tha-telugu.below thai-telugu.below da-telugu.below dai-telugu.below dha-telugu.below dhai-telugu.below]' <0 0 (opsz=18,wght=400:560 opsz=18,wght=700:590 opsz=17,wght=400:562 opsz=17,wght=700:599) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [rra-telugu.below rrai-telugu.below]' <0 0 (opsz=18,wght=400:614 opsz=18,wght=700:651 opsz=17,wght=400:635 opsz=17,wght=700:671) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [la-telugu.below lai-telugu.below]' <0 0 (opsz=18,wght=400:668 opsz=18,wght=700:741 opsz=17,wght=400:667 opsz=17,wght=700:744) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [llla-telugu.below lllai-telugu.below]' <0 0 (opsz=18,wght=400:622 opsz=18,wght=700:660 opsz=17,wght=400:626 opsz=17,wght=700:672) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [ssa-telugu.below ssai-telugu.below]' <0 0 (opsz=18,wght=400:660 opsz=18,wght=700:714 opsz=17,wght=400:677 opsz=17,wght=700:733) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [ssa-telugu.below.alt ssai-telugu.below.alt]' <0 0 (opsz=18,wght=400:717 opsz=18,wght=700:799 opsz=17,wght=400:715 opsz=17,wght=700:797) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [ha-telugu.below hai-telugu.below]' <0 0 (opsz=18,wght=400:921 opsz=18,wght=700:968 opsz=17,wght=400:919 opsz=17,wght=700:972) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [t_ra-telugu.below]' <0 0 (opsz=18,wght=400:919 opsz=18,wght=700:983 opsz=17,wght=400:919 opsz=17,wght=700:983) 0>;
+    } TEL2_dflt_dist_vattuPositioningSpacing;
+
+} dist;
+
+feature blwm {
+    # Automatic Code End
+    # ------
+    # Italic
+    # ------
+    markClass [kha-telugu.below] <anchor (opsz=18,wght=400:-395 opsz=18,wght=700:-409 opsz=17,wght=400:-400 opsz=17,wght=700:-421) 0> @mark_vattu;
+    markClass [ga-telugu.below] <anchor (opsz=18,wght=400:-270 opsz=18,wght=700:-277 opsz=17,wght=400:-269 opsz=17,wght=700:-277) 0> @mark_vattu;
+    markClass [gha-telugu.below] <anchor (opsz=18,wght=400:-455 opsz=18,wght=700:-471 opsz=17,wght=400:-456 opsz=17,wght=700:-476) 0> @mark_vattu;
+    markClass [nga-telugu.below] <anchor (opsz=18,wght=400:-306 opsz=18,wght=700:-325 opsz=17,wght=400:-305 opsz=17,wght=700:-323) 0> @mark_vattu;
+    markClass [ja-telugu.below] <anchor (opsz=18,wght=400:-309 opsz=18,wght=700:-330 opsz=17,wght=400:-320 opsz=17,wght=700:-339) 0> @mark_vattu;
+    markClass [jha-telugu.below] <anchor (opsz=18,wght=400:-497 opsz=18,wght=700:-508 opsz=17,wght=400:-496 opsz=17,wght=700:-511) 0> @mark_vattu;
+    markClass [nya-telugu.below] <anchor (opsz=18,wght=400:-378 opsz=18,wght=700:-389 opsz=17,wght=400:-375 opsz=17,wght=700:-407) 0> @mark_vattu;
+    markClass [tta-telugu.below] <anchor (opsz=18,wght=400:-318 opsz=18,wght=700:-330 opsz=17,wght=400:-315 opsz=17,wght=700:-329) 0> @mark_vattu;
+    markClass [ttha-telugu.below] <anchor (opsz=18,wght=400:-239 opsz=18,wght=700:-258 opsz=17,wght=400:-236 opsz=17,wght=700:-256) 0> @mark_vattu;
+    markClass [dda-telugu.below ddha-telugu.below] <anchor (opsz=18,wght=400:-317 opsz=18,wght=700:-331 opsz=17,wght=400:-315 opsz=17,wght=700:-330) 0> @mark_vattu;
+    markClass [nna-telugu.below] <anchor (opsz=18,wght=400:-322 opsz=18,wght=700:-334 opsz=17,wght=400:-308 opsz=17,wght=700:-331) 0> @mark_vattu;
+    markClass [ta-telugu.below] <anchor (opsz=18,wght=400:-434 opsz=18,wght=700:-448 opsz=17,wght=400:-436 opsz=17,wght=700:-450) 0> @mark_vattu;
+    markClass [tha-telugu.below da-telugu.below dha-telugu.below] <anchor (opsz=18,wght=400:-317 opsz=18,wght=700:-332 opsz=17,wght=400:-316 opsz=17,wght=700:-336) 0> @mark_vattu;
+    markClass [rra-telugu.below] <anchor (opsz=18,wght=400:-335 opsz=18,wght=700:-355 opsz=17,wght=400:-344 opsz=17,wght=700:-363) 0> @mark_vattu;
+    markClass [la-telugu.below] <anchor (opsz=18,wght=400:-366 opsz=18,wght=700:-405 opsz=17,wght=400:-366 opsz=17,wght=700:-403) 0> @mark_vattu;
+    markClass [llla-telugu.below] <anchor (opsz=18,wght=400:-343 opsz=18,wght=700:-361 opsz=17,wght=400:-344 opsz=17,wght=700:-365) 0> @mark_vattu;
+    markClass [ssa-telugu.below] <anchor (opsz=18,wght=400:-383 opsz=18,wght=700:-407 opsz=17,wght=400:-398 opsz=17,wght=700:-417) 0> @mark_vattu;
+    markClass [ssa-telugu.below.alt] <anchor (opsz=18,wght=400:-426 opsz=18,wght=700:-431 opsz=17,wght=400:-420 opsz=17,wght=700:-430) 0> @mark_vattu;
+    markClass [ha-telugu.below] <anchor (opsz=18,wght=400:-491 opsz=18,wght=700:-513 opsz=17,wght=400:-490 opsz=17,wght=700:-515) 0> @mark_vattu;
+    markClass [t_ra-telugu.below] <anchor (opsz=18,wght=400:-491 opsz=18,wght=700:-480 opsz=17,wght=400:-510 opsz=17,wght=700:-546) 0> @mark_vattu;
+    lookup TEL2_dflt_blwm_vattu_to_vattu {
+        pos mark [kha-telugu.below khai-telugu.below]
+            <anchor (opsz=18,wght=400:301 opsz=18,wght=700:323 opsz=17,wght=400:314 opsz=17,wght=700:331) 0> mark @mark_vattu;
+        pos mark [ga-telugu.below gai-telugu.below]
+            <anchor (opsz=18,wght=400:274 opsz=18,wght=700:288 opsz=17,wght=400:288 opsz=17,wght=700:303) 0> mark @mark_vattu;
+        pos mark [gha-telugu.below ghai-telugu.below]
+            <anchor (opsz=18,wght=400:464 opsz=18,wght=700:480 opsz=17,wght=400:476 opsz=17,wght=700:498) 0> mark @mark_vattu;
+        pos mark [nga-telugu.below ngai-telugu.below]
+            <anchor (opsz=18,wght=400:332 opsz=18,wght=700:354 opsz=17,wght=400:346 opsz=17,wght=700:369) 0> mark @mark_vattu;
+        pos mark [ja-telugu.below jai-telugu.below]
+            <anchor (opsz=18,wght=400:323 opsz=18,wght=700:343 opsz=17,wght=400:349 opsz=17,wght=700:366) 0> mark @mark_vattu;
+        pos mark [jha-telugu.below jhai-telugu.below]
+            <anchor (opsz=18,wght=400:514 opsz=18,wght=700:529 opsz=17,wght=400:528 opsz=17,wght=700:545) 0> mark @mark_vattu;
+        pos mark [nya-telugu.below nyai-telugu.below]
+            <anchor (opsz=18,wght=400:426 opsz=18,wght=700:443 opsz=17,wght=400:442 opsz=17,wght=700:454) 0> mark @mark_vattu;
+        pos mark [tta-telugu.below ttai-telugu.below]
+            <anchor (opsz=18,wght=400:332 opsz=18,wght=700:346 opsz=17,wght=400:348 opsz=17,wght=700:362) 0> mark @mark_vattu;
+        pos mark [ttha-telugu.below tthai-telugu.below]
+            <anchor (opsz=18,wght=400:261 opsz=18,wght=700:279 opsz=17,wght=400:277 opsz=17,wght=700:295) 0> mark @mark_vattu;
+        pos mark [dda-telugu.below ddha-telugu.below ddai-telugu.below ddhai-telugu.below]
+            <anchor (opsz=18,wght=400:317 opsz=18,wght=700:332 opsz=17,wght=400:332 opsz=17,wght=700:347) 0> mark @mark_vattu;
+        pos mark [nna-telugu.below nnai-telugu.below]
+            <anchor (opsz=18,wght=400:332 opsz=18,wght=700:348 opsz=17,wght=400:350 opsz=17,wght=700:366) 0> mark @mark_vattu;
+        pos mark [ta-telugu.below tai-telugu.below]
+            <anchor (opsz=18,wght=400:419 opsz=18,wght=700:435 opsz=17,wght=400:428 opsz=17,wght=700:446) 0> mark @mark_vattu;
+        pos mark [tha-telugu.below da-telugu.below dha-telugu.below thai-telugu.below dai-telugu.below dhai-telugu.below]
+            <anchor (opsz=18,wght=400:325 opsz=18,wght=700:340 opsz=17,wght=400:341 opsz=17,wght=700:360) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below]
+            <anchor (opsz=18,wght=400:424 opsz=18,wght=700:441 opsz=17,wght=400:429 opsz=17,wght=700:451) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt01]
+            <anchor (opsz=18,wght=400:459 opsz=18,wght=700:478 opsz=17,wght=400:463 opsz=17,wght=700:487) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt02]
+            <anchor (opsz=18,wght=400:541 opsz=18,wght=700:561 opsz=17,wght=400:545 opsz=17,wght=700:570) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt03]
+            <anchor (opsz=18,wght=400:576 opsz=18,wght=700:597 opsz=17,wght=400:580 opsz=17,wght=700:606) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt04]
+            <anchor (opsz=18,wght=400:624 opsz=18,wght=700:647 opsz=17,wght=400:625 opsz=17,wght=700:653) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt05]
+            <anchor (opsz=18,wght=400:718 opsz=18,wght=700:743 opsz=17,wght=400:720 opsz=17,wght=700:749) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt06]
+            <anchor (opsz=18,wght=400:805 opsz=18,wght=700:833 opsz=17,wght=400:806 opsz=17,wght=700:837) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt07]
+            <anchor (opsz=18,wght=400:835 opsz=18,wght=700:864 opsz=17,wght=400:835 opsz=17,wght=700:868) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt08]
+            <anchor (opsz=18,wght=400:940 opsz=18,wght=700:972 opsz=17,wght=400:941 opsz=17,wght=700:974) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt09]
+            <anchor (opsz=18,wght=400:1010 opsz=18,wght=700:1044 opsz=17,wght=400:1011 opsz=17,wght=700:1045) 0> mark @mark_vattu;
+        pos mark [rra-telugu.below rrai-telugu.below]
+            <anchor (opsz=18,wght=400:361 opsz=18,wght=700:378 opsz=17,wght=400:386 opsz=17,wght=700:405) 0> mark @mark_vattu;
+        pos mark [la-telugu.below lai-telugu.below]
+            <anchor (opsz=18,wght=400:384 opsz=18,wght=700:418 opsz=17,wght=400:396 opsz=17,wght=700:438) 0> mark @mark_vattu;
+        pos mark [llla-telugu.below lllai-telugu.below]
+            <anchor (opsz=18,wght=400:361 opsz=18,wght=700:381 opsz=17,wght=400:377 opsz=17,wght=700:404) 0> mark @mark_vattu;
+        pos mark [ssa-telugu.below ssai-telugu.below]
+            <anchor (opsz=18,wght=400:359 opsz=18,wght=700:389 opsz=17,wght=400:374 opsz=17,wght=700:413) 0> mark @mark_vattu;
+        pos mark [ssa-telugu.below.alt ssai-telugu.below.alt]
+            <anchor (opsz=18,wght=400:373 opsz=18,wght=700:450 opsz=17,wght=400:390 opsz=17,wght=700:464) 0> mark @mark_vattu;
+        pos mark [ha-telugu.below hai-telugu.below]
+            <anchor (opsz=18,wght=400:512 opsz=18,wght=700:537 opsz=17,wght=400:524 opsz=17,wght=700:554) 0> mark @mark_vattu;
+        pos mark [t_ra-telugu.below]
+            <anchor (opsz=18,wght=400:510 opsz=18,wght=700:585 opsz=17,wght=400:504 opsz=17,wght=700:534) 0> mark @mark_vattu;
+    } TEL2_dflt_blwm_vattu_to_vattu;
+
+    lookup TEL2_dflt_blwm_spacing_vattu_to_vattu {
+        pos base [ka-telugu.below]
+            <anchor (opsz=18,wght=400:753 opsz=18,wght=700:777 opsz=17,wght=400:774 opsz=17,wght=700:801) 0> mark @mark_vattu;
+        pos base [ca-telugu.below cha-telugu.below]
+            <anchor (opsz=18,wght=400:573 opsz=18,wght=700:589 opsz=17,wght=400:615 opsz=17,wght=700:611) 0> mark @mark_vattu;
+        pos base [na-telugu.below]
+            <anchor (opsz=18,wght=400:704 opsz=18,wght=700:752 opsz=17,wght=400:725 opsz=17,wght=700:772) 0> mark @mark_vattu;
+        pos base [pa-telugu.below pha-telugu.below]
+            <anchor (opsz=18,wght=400:544 opsz=18,wght=700:568 opsz=17,wght=400:564 opsz=17,wght=700:587) 0> mark @mark_vattu;
+        pos base [ba-telugu.below bha-telugu.below]
+            <anchor (opsz=18,wght=400:595 opsz=18,wght=700:640 opsz=17,wght=400:619 opsz=17,wght=700:662) 0> mark @mark_vattu;
+        pos base [ma-telugu.below]
+            <anchor (opsz=18,wght=400:428 opsz=18,wght=700:465 opsz=17,wght=400:448 opsz=17,wght=700:482) 0> mark @mark_vattu;
+        pos base [ya-telugu.below]
+            <anchor (opsz=18,wght=400:657 opsz=18,wght=700:715 opsz=17,wght=400:679 opsz=17,wght=700:737) 0> mark @mark_vattu;
+        pos base [lla-telugu.below]
+            <anchor (opsz=18,wght=400:577 opsz=18,wght=700:617 opsz=17,wght=400:594 opsz=17,wght=700:627) 0> mark @mark_vattu;
+        pos base [va-telugu.below]
+            <anchor (opsz=18,wght=400:567 opsz=18,wght=700:599 opsz=17,wght=400:587 opsz=17,wght=700:619) 0> mark @mark_vattu;
+        pos base [sha-telugu.below]
+            <anchor (opsz=18,wght=400:496 opsz=18,wght=700:569 opsz=17,wght=400:517 opsz=17,wght=700:592) 0> mark @mark_vattu;
+        pos base [sa-telugu.below]
+            <anchor (opsz=18,wght=400:651 opsz=18,wght=700:683 opsz=17,wght=400:671 opsz=17,wght=700:703) 0> mark @mark_vattu;
+    } TEL2_dflt_blwm_spacing_vattu_to_vattu;
+
+    lookup TEL2_dflt_blwm_spacing_akhands_to_vattus {
+        pos base [k_ssa-telugu]
+            <anchor (opsz=18,wght=400:755 opsz=18,wght=700:786 opsz=17,wght=400:768 opsz=17,wght=700:800) 0> mark @mark_vattu;
+    } TEL2_dflt_blwm_spacing_akhands_to_vattus;
+
+} blwm;

--- a/source/GoogleSans/telugu-variable.fea
+++ b/source/GoogleSans/telugu-variable.fea
@@ -1,0 +1,149 @@
+feature dist {
+    # Automatic Code End
+    # -------
+    # Regular
+    # -------
+    lookup TEL2_dflt_dist_vattuPositioningSpacing {
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [kha-telugu.below khai-telugu.below]' <0 0 (opsz=18,wght=400:596 opsz=18,wght=700:635 opsz=17,wght=400:602 opsz=17,wght=700:641) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [ga-telugu.below gai-telugu.below]' <0 0 (opsz=18,wght=400:454 opsz=18,wght=700:476 opsz=17,wght=400:454 opsz=17,wght=700:476) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [gha-telugu.below ghai-telugu.below]' <0 0 (opsz=18,wght=400:831 opsz=18,wght=700:871 opsz=17,wght=400:827 opsz=17,wght=700:869) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [nga-telugu.below ngai-telugu.below]' <0 0 (opsz=18,wght=400:563 opsz=18,wght=700:609 opsz=17,wght=400:568 opsz=17,wght=700:612) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [ja-telugu.below jai-telugu.below]' <0 0 (opsz=18,wght=400:563 opsz=18,wght=700:613 opsz=17,wght=400:589 opsz=17,wght=700:625) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [jha-telugu.below jhai-telugu.below]' <0 0 (opsz=18,wght=400:926 opsz=18,wght=700:957 opsz=17,wght=400:930 opsz=17,wght=700:961) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [nya-telugu.below nyai-telugu.below]' <0 0 (opsz=18,wght=400:718 opsz=18,wght=700:748 opsz=17,wght=400:748 opsz=17,wght=700:779) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [tta-telugu.below ttai-telugu.below]' <0 0 (opsz=18,wght=400:566 opsz=18,wght=700:592 opsz=17,wght=400:566 opsz=17,wght=700:592) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [ttha-telugu.below tthai-telugu.below]' <0 0 (opsz=18,wght=400:416 opsz=18,wght=700:456 opsz=17,wght=400:416 opsz=17,wght=700:456) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [dda-telugu.below ddai-telugu.below ddha-telugu.below ddhai-telugu.below]' <0 0 (opsz=18,wght=400:554 opsz=18,wght=700:593 opsz=17,wght=400:554 opsz=17,wght=700:598) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [nna-telugu.below nnai-telugu.below]' <0 0 (opsz=18,wght=400:548 opsz=18,wght=700:580 opsz=17,wght=400:549 opsz=17,wght=700:581) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [ta-telugu.below tai-telugu.below]' <0 0 (opsz=18,wght=400:748 opsz=18,wght=700:774 opsz=17,wght=400:748 opsz=17,wght=700:774) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [tha-telugu.below thai-telugu.below da-telugu.below dai-telugu.below dha-telugu.below dhai-telugu.below]' <0 0 (opsz=18,wght=400:558 opsz=18,wght=700:592 opsz=17,wght=400:558 opsz=17,wght=700:596) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [rra-telugu.below rrai-telugu.below]' <0 0 (opsz=18,wght=400:610 opsz=18,wght=700:647 opsz=17,wght=400:630 opsz=17,wght=700:667) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [la-telugu.below lai-telugu.below]' <0 0 (opsz=18,wght=400:668 opsz=18,wght=700:740 opsz=17,wght=400:670 opsz=17,wght=700:746) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [llla-telugu.below lllai-telugu.below]' <0 0 (opsz=18,wght=400:621 opsz=18,wght=700:658 opsz=17,wght=400:622 opsz=17,wght=700:668) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [ssa-telugu.below ssai-telugu.below]' <0 0 (opsz=18,wght=400:675 opsz=18,wght=700:733 opsz=17,wght=400:675 opsz=17,wght=700:733) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [ssa-telugu.below.alt ssai-telugu.below.alt]' <0 0 (opsz=18,wght=400:729 opsz=18,wght=700:811 opsz=17,wght=400:729 opsz=17,wght=700:811) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [ha-telugu.below hai-telugu.below]' <0 0 (opsz=18,wght=400:907 opsz=18,wght=700:960 opsz=17,wght=400:907 opsz=17,wght=700:959) 0>;
+        pos [k_ssa-telugu @TEL_NonSpacingVattus @TEL_SpacingVattus @TEL_NonSpacingVattus_Stacking] [t_ra-telugu.below]' <0 0 (opsz=18,wght=400:930 opsz=18,wght=700:988 opsz=17,wght=400:930 opsz=17,wght=700:988) 0>;
+    } TEL2_dflt_dist_vattuPositioningSpacing;
+
+} dist;
+
+feature blwm {
+    # Automatic Code End
+    # -------
+    # Regular
+    # -------
+    markClass [kha-telugu.below] <anchor (opsz=18,wght=400:-298 opsz=18,wght=700:-318 opsz=17,wght=400:-301 opsz=17,wght=700:-322) 0> @mark_vattu;
+    markClass [ga-telugu.below] <anchor (opsz=18,wght=400:-227 opsz=18,wght=700:-238 opsz=17,wght=400:-227 opsz=17,wght=700:-238) 0> @mark_vattu;
+    markClass [gha-telugu.below] <anchor (opsz=18,wght=400:-416 opsz=18,wght=700:-439 opsz=17,wght=400:-414 opsz=17,wght=700:-438) 0> @mark_vattu;
+    markClass [nga-telugu.below] <anchor (opsz=18,wght=400:-282 opsz=18,wght=700:-305 opsz=17,wght=400:-284 opsz=17,wght=700:-306) 0> @mark_vattu;
+    markClass [ja-telugu.below] <anchor (opsz=18,wght=400:-282 opsz=18,wght=700:-307 opsz=17,wght=400:-295 opsz=17,wght=700:-313) 0> @mark_vattu;
+    markClass [jha-telugu.below] <anchor (opsz=18,wght=400:-463 opsz=18,wght=700:-480 opsz=17,wght=400:-465 opsz=17,wght=700:-483) 0> @mark_vattu;
+    markClass [nya-telugu.below] <anchor (opsz=18,wght=400:-359 opsz=18,wght=700:-374 opsz=17,wght=400:-374 opsz=17,wght=700:-389) 0> @mark_vattu;
+    markClass [tta-telugu.below] <anchor (opsz=18,wght=400:-283 opsz=18,wght=700:-296 opsz=17,wght=400:-283 opsz=17,wght=700:-296) 0> @mark_vattu;
+    markClass [ttha-telugu.below] <anchor (opsz=18,wght=400:-208 opsz=18,wght=700:-228 opsz=17,wght=400:-208 opsz=17,wght=700:-228) 0> @mark_vattu;
+    markClass [dda-telugu.below ddha-telugu.below] <anchor (opsz=18,wght=400:-279 opsz=18,wght=700:-296 opsz=17,wght=400:-279 opsz=17,wght=700:-298) 0> @mark_vattu;
+    markClass [nna-telugu.below] <anchor (opsz=18,wght=400:-274 opsz=18,wght=700:-290 opsz=17,wght=400:-275 opsz=17,wght=700:-291) 0> @mark_vattu;
+    markClass [ta-telugu.below] <anchor (opsz=18,wght=400:-374 opsz=18,wght=700:-387 opsz=17,wght=400:-374 opsz=17,wght=700:-387) 0> @mark_vattu;
+    markClass [tha-telugu.below da-telugu.below dha-telugu.below] <anchor (opsz=18,wght=400:-279 opsz=18,wght=700:-296 opsz=17,wght=400:-279 opsz=17,wght=700:-298) 0> @mark_vattu;
+    markClass [rra-telugu.below] <anchor (opsz=18,wght=400:-305 opsz=18,wght=700:-324 opsz=17,wght=400:-315 opsz=17,wght=700:-334) 0> @mark_vattu;
+    markClass [la-telugu.below] <anchor (opsz=18,wght=400:-334 opsz=18,wght=700:-370 opsz=17,wght=400:-335 opsz=17,wght=700:-373) 0> @mark_vattu;
+    markClass [llla-telugu.below] <anchor (opsz=18,wght=400:-311 opsz=18,wght=700:-329 opsz=17,wght=400:-311 opsz=17,wght=700:-334) 0> @mark_vattu;
+    markClass [ssa-telugu.below] <anchor (opsz=18,wght=400:-338 opsz=18,wght=700:-367 opsz=17,wght=400:-338 opsz=17,wght=700:-367) 0> @mark_vattu;
+    markClass [ssa-telugu.below.alt] <anchor (opsz=18,wght=400:-380 opsz=18,wght=700:-418 opsz=17,wght=400:-380 opsz=17,wght=700:-418) 0> @mark_vattu;
+    markClass [ha-telugu.below] <anchor (opsz=18,wght=400:-454 opsz=18,wght=700:-480 opsz=17,wght=400:-454 opsz=17,wght=700:-480) 0> @mark_vattu;
+    markClass [t_ra-telugu.below] <anchor (opsz=18,wght=400:71 opsz=18,wght=700:47 opsz=17,wght=400:71 opsz=17,wght=700:47) 0> @mark_vattu;
+    lookup TEL2_dflt_blwm_vattu_to_vattu {
+        pos mark [kha-telugu.below khai-telugu.below]
+            <anchor (opsz=18,wght=400:380 opsz=18,wght=700:399 opsz=17,wght=400:396 opsz=17,wght=700:416) 0> mark @mark_vattu;
+        pos mark [ga-telugu.below gai-telugu.below]
+            <anchor (opsz=18,wght=400:309 opsz=18,wght=700:320 opsz=17,wght=400:322 opsz=17,wght=700:335) 0> mark @mark_vattu;
+        pos mark [gha-telugu.below ghai-telugu.below]
+            <anchor (opsz=18,wght=400:497 opsz=18,wght=700:514 opsz=17,wght=400:508 opsz=17,wght=700:528) 0> mark @mark_vattu;
+        pos mark [nga-telugu.below ngai-telugu.below]
+            <anchor (opsz=18,wght=400:363 opsz=18,wght=700:386 opsz=17,wght=400:379 opsz=17,wght=700:403) 0> mark @mark_vattu;
+        pos mark [ja-telugu.below jai-telugu.below]
+            <anchor (opsz=18,wght=400:363 opsz=18,wght=700:388 opsz=17,wght=400:389 opsz=17,wght=700:409) 0> mark @mark_vattu;
+        pos mark [jha-telugu.below jhai-telugu.below]
+            <anchor (opsz=18,wght=400:545 opsz=18,wght=700:559 opsz=17,wght=400:560 opsz=17,wght=700:575) 0> mark @mark_vattu;
+        pos mark [nya-telugu.below nyai-telugu.below]
+            <anchor (opsz=18,wght=400:441 opsz=18,wght=700:456 opsz=17,wght=400:469 opsz=17,wght=700:487) 0> mark @mark_vattu;
+        pos mark [tta-telugu.below ttai-telugu.below]
+            <anchor (opsz=18,wght=400:365 opsz=18,wght=700:378 opsz=17,wght=400:378 opsz=17,wght=700:393) 0> mark @mark_vattu;
+        pos mark [ttha-telugu.below tthai-telugu.below]
+            <anchor (opsz=18,wght=400:290 opsz=18,wght=700:310 opsz=17,wght=400:303 opsz=17,wght=700:325) 0> mark @mark_vattu;
+        pos mark [dda-telugu.below ddha-telugu.below ddai-telugu.below ddhai-telugu.below]
+            <anchor (opsz=18,wght=400:357 opsz=18,wght=700:379 opsz=17,wght=400:370 opsz=17,wght=700:397) 0> mark @mark_vattu;
+        pos mark [nna-telugu.below nnai-telugu.below]
+            <anchor (opsz=18,wght=400:356 opsz=18,wght=700:372 opsz=17,wght=400:369 opsz=17,wght=700:387) 0> mark @mark_vattu;
+        pos mark [ta-telugu.below tai-telugu.below]
+            <anchor (opsz=18,wght=400:456 opsz=18,wght=700:469 opsz=17,wght=400:469 opsz=17,wght=700:484) 0> mark @mark_vattu;
+        pos mark [tha-telugu.below da-telugu.below dha-telugu.below thai-telugu.below dai-telugu.below dhai-telugu.below]
+            <anchor (opsz=18,wght=400:361 opsz=18,wght=700:378 opsz=17,wght=400:374 opsz=17,wght=700:395) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below]
+            <anchor (opsz=18,wght=400:421 opsz=18,wght=700:436 opsz=17,wght=400:434 opsz=17,wght=700:451) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt01]
+            <anchor (opsz=18,wght=400:456 opsz=18,wght=700:472 opsz=17,wght=400:469 opsz=17,wght=700:487) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt02]
+            <anchor (opsz=18,wght=400:539 opsz=18,wght=700:557 opsz=17,wght=400:552 opsz=17,wght=700:572) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt03]
+            <anchor (opsz=18,wght=400:575 opsz=18,wght=700:593 opsz=17,wght=400:588 opsz=17,wght=700:608) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt04]
+            <anchor (opsz=18,wght=400:623 opsz=18,wght=700:641 opsz=17,wght=400:636 opsz=17,wght=700:656) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt05]
+            <anchor (opsz=18,wght=400:717 opsz=18,wght=700:738 opsz=17,wght=400:730 opsz=17,wght=700:753) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt06]
+            <anchor (opsz=18,wght=400:807 opsz=18,wght=700:828 opsz=17,wght=400:820 opsz=17,wght=700:843) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt07]
+            <anchor (opsz=18,wght=400:836 opsz=18,wght=700:859 opsz=17,wght=400:849 opsz=17,wght=700:874) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt08]
+            <anchor (opsz=18,wght=400:943 opsz=18,wght=700:967 opsz=17,wght=400:956 opsz=17,wght=700:982) 0> mark @mark_vattu;
+        pos mark [ra-telugu.below.alt09]
+            <anchor (opsz=18,wght=400:1013 opsz=18,wght=700:1039 opsz=17,wght=400:1027 opsz=17,wght=700:1055) 0> mark @mark_vattu;
+        pos mark [rra-telugu.below rrai-telugu.below]
+            <anchor (opsz=18,wght=400:387 opsz=18,wght=700:405 opsz=17,wght=400:410 opsz=17,wght=700:430) 0> mark @mark_vattu;
+        pos mark [la-telugu.below lai-telugu.below]
+            <anchor (opsz=18,wght=400:416 opsz=18,wght=700:452 opsz=17,wght=400:430 opsz=17,wght=700:470) 0> mark @mark_vattu;
+        pos mark [llla-telugu.below lllai-telugu.below]
+            <anchor (opsz=18,wght=400:392 opsz=18,wght=700:411 opsz=17,wght=400:406 opsz=17,wght=700:431) 0> mark @mark_vattu;
+        pos mark [ssa-telugu.below ssai-telugu.below]
+            <anchor (opsz=18,wght=400:419 opsz=18,wght=700:448 opsz=17,wght=400:432 opsz=17,wght=700:463) 0> mark @mark_vattu;
+        pos mark [ssa-telugu.below.alt ssai-telugu.below.alt]
+            <anchor (opsz=18,wght=400:431 opsz=18,wght=700:475 opsz=17,wght=400:444 opsz=17,wght=700:490) 0> mark @mark_vattu;
+        pos mark [ha-telugu.below hai-telugu.below]
+            <anchor (opsz=18,wght=400:535 opsz=18,wght=700:562 opsz=17,wght=400:548 opsz=17,wght=700:576) 0> mark @mark_vattu;
+        pos mark [t_ra-telugu.below]
+            <anchor (opsz=18,wght=400:556 opsz=18,wght=700:580 opsz=17,wght=400:569 opsz=17,wght=700:595) 0> mark @mark_vattu;
+    } TEL2_dflt_blwm_vattu_to_vattu;
+
+    lookup TEL2_dflt_blwm_spacing_vattu_to_vattu {
+        pos base [ka-telugu.below]
+            <anchor (opsz=18,wght=400:752 opsz=18,wght=700:765 opsz=17,wght=400:778 opsz=17,wght=700:793) 0> mark @mark_vattu;
+        pos base [ca-telugu.below cha-telugu.below]
+            <anchor (opsz=18,wght=400:595 opsz=18,wght=700:601 opsz=17,wght=400:621 opsz=17,wght=700:629) 0> mark @mark_vattu;
+        pos base [na-telugu.below]
+            <anchor (opsz=18,wght=400:755 opsz=18,wght=700:783 opsz=17,wght=400:779 opsz=17,wght=700:810) 0> mark @mark_vattu;
+        pos base [pa-telugu.below pha-telugu.below]
+            <anchor (opsz=18,wght=400:567 opsz=18,wght=700:594 opsz=17,wght=400:593 opsz=17,wght=700:622) 0> mark @mark_vattu;
+        pos base [ba-telugu.below bha-telugu.below]
+            <anchor (opsz=18,wght=400:614 opsz=18,wght=700:644 opsz=17,wght=400:641 opsz=17,wght=700:673) 0> mark @mark_vattu;
+        pos base [ma-telugu.below]
+            <anchor (opsz=18,wght=400:490 opsz=18,wght=700:509 opsz=17,wght=400:476 opsz=17,wght=700:471) 0> mark @mark_vattu;
+        pos base [ya-telugu.below]
+            <anchor (opsz=18,wght=400:630 opsz=18,wght=700:667 opsz=17,wght=400:664 opsz=17,wght=700:701) 0> mark @mark_vattu;
+        pos base [lla-telugu.below]
+            <anchor (opsz=18,wght=400:568 opsz=18,wght=700:586 opsz=17,wght=400:594 opsz=17,wght=700:614) 0> mark @mark_vattu;
+        pos base [va-telugu.below]
+            <anchor (opsz=18,wght=400:604 opsz=18,wght=700:632 opsz=17,wght=400:630 opsz=17,wght=700:662) 0> mark @mark_vattu;
+        pos base [sha-telugu.below]
+            <anchor (opsz=18,wght=400:452 opsz=18,wght=700:474 opsz=17,wght=400:479 opsz=17,wght=700:503) 0> mark @mark_vattu;
+        pos base [sa-telugu.below]
+            <anchor (opsz=18,wght=400:674 opsz=18,wght=700:702 opsz=17,wght=400:700 opsz=17,wght=700:730) 0> mark @mark_vattu;
+    } TEL2_dflt_blwm_spacing_vattu_to_vattu;
+
+    lookup TEL2_dflt_blwm_spacing_akhands_to_vattus {
+        pos base [k_ssa-telugu]
+            <anchor (opsz=18,wght=400:841 opsz=18,wght=700:882 opsz=17,wght=400:844 opsz=17,wght=700:910) 0> mark @mark_vattu;
+    } TEL2_dflt_blwm_spacing_akhands_to_vattus;
+
+} blwm;


### PR DESCRIPTION
The script merges per-master FEA feature fragments into a single variable feature file by working on the feaLib AST rather than manipualting raw text wit regex (see the old reverted #699).
It walks the parallel statement trees together, performs a cross-master alignment check that zeros out values during comparison to catch structure mismatches loudly, and converts any ValueRecord fields or Anchor coordinates that vary across masters into VariableScalars.

In commit bbd67c672e08b72c5338df62660d78317646e47c, I also applied the merge script to the existing Telugo and Arabic features.

This allows to compile GoogleSans with fontc, which can't currently merge per-master features like varLib does (https://github.com/googlefonts/fontc/issues/1829). Right now fontc silently ignores GS's per-master features (silently takes the first one) because its identical-features check is too naive (https://github.com/googlefonts/fontc/pull/2027 fixes that, but breaks fontc CI's smoke test where we build GS from `HEAD`).

It also continues to build with fontmake of course. I verified locally that compiling GS with these merged variable features produces exactly the OTL tables (after otl-normalizer) as building GS from `main` branch with individual per-master features.

Closes #708 