### PR TITLE
Strip trailing whitespace from openTypeOS2WinAscent in Italic masters

### DIFF
--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/fontinfo.plist
@@ -53,7 +53,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1509       </integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/fontinfo.plist
@@ -88,7 +88,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1509       </integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/fontinfo.plist
@@ -53,7 +53,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1509       </integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/fontinfo.plist
@@ -94,7 +94,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1509       </integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1509       </integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1509       </integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1509       </integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/fontinfo.plist
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2VendorID</key>
     <string>GOOG</string>
     <key>openTypeOS2WinAscent</key>
-    <integer>1509       </integer>
+    <integer>1509</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>1079</integer>
     <key>postscriptBlueValues</key>


### PR DESCRIPTION
The 8 GoogleSans Italic master fontinfo.plist files stored openTypeOS2WinAscent with trailing whitespace after the number (introduced in b68d2979b). fontTools/ufoLib tolerate it, but norad -- and therefore fontc -- reject integer elements with surrounding whitespace and fail to read the source. Strip the whitespace; the value (1509) is unchanged, so the build output is unaffected. This unblocks the fontc GoogleSans smoke test on Italic (googlefonts/fontc#2054).