### PR TITLE
Fix Android font builds

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -198,6 +198,11 @@ jobs:
         run: |
           make setup
           . .venv/bin/activate && make -j gs-android
+      - name: Upload Android fonts
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-fonts
+          path: build/GoogleSans/android
 
   build-and-check-figma:
     # Skip running in PRs to save time and resources. Create a 'build-*' branch


### PR DESCRIPTION
In 57fe71e, I accidentally deleted the step that uploads the built fonts to the workflow, which breaks releases and was just generally not the smartest thing I've done so far this year