### PR TITLE
Set release fonts to use post v3

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -251,6 +251,13 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Check out source repository
+        uses: actions/checkout@v7
+      - name: Set up Python v3.12 environment
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
       - name: Save tag name
         id: vars
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
@@ -276,6 +283,12 @@ jobs:
           path: 'build/GoogleSans/figma'
       - name: Delete intermediate VFs
         run: rm -rf build/GoogleSans/.intermediate
+      - name: Setup venv
+        run: make setup
+      - name: Set post table to v3 for all fonts
+        run: |
+          find build/GoogleSans -type f -iname '*.ttf' \
+            -exec .venv/bin/python scripts/post_v3.py {} \;
       - name: Create build artifact zip archive
         id: release-archives
         run: |

--- a/scripts/post_v3.py
+++ b/scripts/post_v3.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from fontTools.ttLib import TTFont
+
+
+def process_font(read_from: Path, write_to: Path) -> None:
+    ttf = TTFont(read_from)
+    ttf["post"].formatType = 3.0  # type: ignore
+    ttf.save(write_to)
+
+
+if __name__ == "__main__":
+    from argparse import ArgumentParser
+
+    parser = ArgumentParser()
+    parser.add_argument(
+        "font",
+        type=Path,
+        help="path to TTF",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="path to write patched TTF to",
+    )
+
+    args = parser.parse_args()
+    output = args.output or args.font
+    process_font(args.font, output)
+    print(f"Wrote {args.font.name} to {output} with post v3")

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/G_.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/G_.logo.glif
@@ -1,45 +1,45 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.logo" format="2">
-  <advance width="796" />
-  <unicode hex="E000" />
+  <advance width="796"/>
+  <unicode hex="E000"/>
   <outline>
     <contour>
-      <point x="414" y="-16" type="qcurve" smooth="yes" />
-      <point x="518" y="-18" />
-      <point x="678" y="70" />
-      <point x="764" y="232" />
-      <point x="764" y="337" type="qcurve" smooth="yes" />
-      <point x="764" y="364" />
-      <point x="760" y="397" type="qcurve" />
-      <point x="412" y="397" type="line" />
-      <point x="412" y="294" type="line" />
-      <point x="656" y="294" type="line" />
-      <point x="650" y="227" />
-      <point x="586" y="134" />
-      <point x="482" y="88" />
-      <point x="416" y="88" type="qcurve" smooth="yes" />
-      <point x="343" y="88" />
-      <point x="225" y="156" />
-      <point x="157" y="280" />
-      <point x="157" y="358" type="qcurve" smooth="yes" />
-      <point x="157" y="439" />
-      <point x="226" y="562" />
-      <point x="344" y="628" />
-      <point x="416" y="628" type="qcurve" smooth="yes" />
-      <point x="474" y="628" />
-      <point x="564" y="590" />
-      <point x="606" y="546" type="qcurve" />
-      <point x="678" y="622" type="line" />
-      <point x="631" y="678" />
-      <point x="496" y="732" />
-      <point x="415" y="732" type="qcurve" smooth="yes" />
-      <point x="311" y="732" />
-      <point x="141" y="634" />
-      <point x="44" y="464" />
-      <point x="44" y="360" type="qcurve" smooth="yes" />
-      <point x="44" y="257" />
-      <point x="142" y="85" />
-      <point x="311" y="-16" />
+      <point x="414" y="-16" type="qcurve" smooth="yes"/>
+      <point x="518" y="-18"/>
+      <point x="678" y="70"/>
+      <point x="764" y="232"/>
+      <point x="764" y="337" type="qcurve" smooth="yes"/>
+      <point x="764" y="364"/>
+      <point x="760" y="397" type="qcurve"/>
+      <point x="412" y="397" type="line"/>
+      <point x="412" y="294" type="line"/>
+      <point x="656" y="294" type="line"/>
+      <point x="650" y="227"/>
+      <point x="586" y="134"/>
+      <point x="482" y="88"/>
+      <point x="416" y="88" type="qcurve" smooth="yes"/>
+      <point x="343" y="88"/>
+      <point x="225" y="156"/>
+      <point x="157" y="280"/>
+      <point x="157" y="358" type="qcurve" smooth="yes"/>
+      <point x="157" y="439"/>
+      <point x="226" y="562"/>
+      <point x="344" y="628"/>
+      <point x="416" y="628" type="qcurve" smooth="yes"/>
+      <point x="474" y="628"/>
+      <point x="564" y="590"/>
+      <point x="606" y="546" type="qcurve"/>
+      <point x="678" y="622" type="line"/>
+      <point x="631" y="678"/>
+      <point x="496" y="732"/>
+      <point x="415" y="732" type="qcurve" smooth="yes"/>
+      <point x="311" y="732"/>
+      <point x="141" y="634"/>
+      <point x="44" y="464"/>
+      <point x="44" y="360" type="qcurve" smooth="yes"/>
+      <point x="44" y="257"/>
+      <point x="142" y="85"/>
+      <point x="311" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/G_.super.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/G_.super.glif
@@ -1,54 +1,54 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="G.super" format="2">
-  <advance width="1000" />
+  <advance width="1000"/>
   <outline>
     <contour>
-      <point x="499" y="-41" type="qcurve" smooth="yes" />
-      <point x="676" y="-41" />
-      <point x="898" y="186" />
-      <point x="898" y="365" type="qcurve" smooth="yes" />
-      <point x="898" y="388" />
-      <point x="894" y="430" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="890" y="451" />
-      <point x="890" y="451" />
-      <point x="890" y="451" type="qcurve" />
-      <point x="498" y="451" type="line" />
-      <point x="498" y="451" />
-      <point x="498" y="451" />
-      <point x="498" y="451" type="qcurve" />
-      <point x="498" y="290" type="line" />
-      <point x="498" y="290" />
-      <point x="498" y="290" />
-      <point x="498" y="290" type="qcurve" />
-      <point x="722" y="290" type="line" />
-      <point x="710" y="218" />
-      <point x="587" y="124" />
-      <point x="500" y="124" type="qcurve" smooth="yes" />
-      <point x="396" y="124" />
-      <point x="252" y="275" />
-      <point x="252" y="375" type="qcurve" smooth="yes" />
-      <point x="252" y="474" />
-      <point x="396" y="625" />
-      <point x="498" y="625" type="qcurve" smooth="yes" />
-      <point x="547" y="625" />
-      <point x="628" y="592" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="658" y="564" />
-      <point x="658" y="564" />
-      <point x="658" y="564" type="qcurve" />
-      <point x="777" y="682" type="line" />
-      <point x="777" y="682" />
-      <point x="777" y="682" />
-      <point x="777" y="682" type="qcurve" />
-      <point x="723" y="733" />
-      <point x="582" y="791" />
-      <point x="499" y="791" type="qcurve" smooth="yes" />
-      <point x="326" y="791" />
-      <point x="83" y="544" />
-      <point x="83" y="375" type="qcurve" smooth="yes" />
-      <point x="83" y="206" />
-      <point x="324" y="-41" />
+      <point x="499" y="-41" type="qcurve" smooth="yes"/>
+      <point x="676" y="-41"/>
+      <point x="898" y="186"/>
+      <point x="898" y="365" type="qcurve" smooth="yes"/>
+      <point x="898" y="388"/>
+      <point x="894" y="430"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451"/>
+      <point x="890" y="451" type="qcurve"/>
+      <point x="498" y="451" type="line"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451"/>
+      <point x="498" y="451" type="qcurve"/>
+      <point x="498" y="290" type="line"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290"/>
+      <point x="498" y="290" type="qcurve"/>
+      <point x="722" y="290" type="line"/>
+      <point x="710" y="218"/>
+      <point x="587" y="124"/>
+      <point x="500" y="124" type="qcurve" smooth="yes"/>
+      <point x="396" y="124"/>
+      <point x="252" y="275"/>
+      <point x="252" y="375" type="qcurve" smooth="yes"/>
+      <point x="252" y="474"/>
+      <point x="396" y="625"/>
+      <point x="498" y="625" type="qcurve" smooth="yes"/>
+      <point x="547" y="625"/>
+      <point x="628" y="592"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564"/>
+      <point x="658" y="564" type="qcurve"/>
+      <point x="777" y="682" type="line"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682"/>
+      <point x="777" y="682" type="qcurve"/>
+      <point x="723" y="733"/>
+      <point x="582" y="791"/>
+      <point x="499" y="791" type="qcurve" smooth="yes"/>
+      <point x="326" y="791"/>
+      <point x="83" y="544"/>
+      <point x="83" y="375" type="qcurve" smooth="yes"/>
+      <point x="83" y="206"/>
+      <point x="324" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/G_oogle.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/G_oogle.logo.glif
@@ -1,14 +1,14 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Google.logo" format="2">
-  <advance width="3269" />
-  <unicode hex="E006" />
+  <advance width="3269"/>
+  <unicode hex="E006"/>
   <outline>
-    <component base="G.logo" />
-    <component base="o.logo" xOffset="796" />
-    <component base="o.logo" xOffset="1378" />
-    <component base="g.logo" xOffset="1959" />
-    <component base="l.logo" xOffset="2528" />
-    <component base="e.logo" xOffset="2718" />
+    <component base="G.logo"/>
+    <component base="o.logo" xOffset="796"/>
+    <component base="o.logo" xOffset="1378"/>
+    <component base="g.logo" xOffset="1959"/>
+    <component base="l.logo" xOffset="2528"/>
+    <component base="e.logo" xOffset="2718"/>
   </outline>
   <lib>
     <dict>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/e.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/e.logo.glif
@@ -1,52 +1,52 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e.logo" format="2">
-  <advance width="551" />
-  <unicode hex="E004" />
+  <advance width="551"/>
+  <unicode hex="E004"/>
   <outline>
     <contour>
-      <point x="282" y="-16" type="qcurve" smooth="yes" />
-      <point x="354" y="-16" />
-      <point x="472" y="53" />
-      <point x="506" y="109" type="qcurve" smooth="yes" />
-      <point x="506" y="109" />
-      <point x="506" y="109" />
-      <point x="506" y="109" type="qcurve" />
-      <point x="425" y="162" type="line" />
-      <point x="425" y="162" />
-      <point x="425" y="162" />
-      <point x="425" y="162" type="qcurve" smooth="yes" />
-      <point x="398" y="125" />
-      <point x="328" y="84" />
-      <point x="286" y="84" type="qcurve" smooth="yes" />
-      <point x="218" y="84" />
-      <point x="122" y="187" />
-      <point x="122" y="260" type="qcurve" />
-      <point x="122" y="260" type="line" />
-      <point x="122" y="338" />
-      <point x="205" y="433" />
-      <point x="275" y="433" type="qcurve" smooth="yes" />
-      <point x="316" y="433" />
-      <point x="384" y="385" />
-      <point x="402" y="332" type="qcurve" />
-      <point x="412" y="377" type="line" />
-      <point x="72" y="233" type="line" />
-      <point x="101" y="150" type="line" />
-      <point x="511" y="324" type="line" smooth="yes" />
-      <point x="511" y="324" />
-      <point x="511" y="324" />
-      <point x="511" y="324" type="qcurve" />
-      <point x="509" y="336" />
-      <point x="504" y="354" />
-      <point x="501" y="362" type="qcurve" smooth="yes" />
-      <point x="468" y="446" />
-      <point x="356" y="526" />
-      <point x="279" y="526" type="qcurve" smooth="yes" />
-      <point x="162" y="526" />
-      <point x="16" y="372" />
-      <point x="16" y="254" type="qcurve" />
-      <point x="16" y="254" type="line" />
-      <point x="16" y="132" />
-      <point x="166" y="-16" />
+      <point x="282" y="-16" type="qcurve" smooth="yes"/>
+      <point x="354" y="-16"/>
+      <point x="472" y="53"/>
+      <point x="506" y="109" type="qcurve" smooth="yes"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109"/>
+      <point x="506" y="109" type="qcurve"/>
+      <point x="425" y="162" type="line"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162"/>
+      <point x="425" y="162" type="qcurve" smooth="yes"/>
+      <point x="398" y="125"/>
+      <point x="328" y="84"/>
+      <point x="286" y="84" type="qcurve" smooth="yes"/>
+      <point x="218" y="84"/>
+      <point x="122" y="187"/>
+      <point x="122" y="260" type="qcurve"/>
+      <point x="122" y="260" type="line"/>
+      <point x="122" y="338"/>
+      <point x="205" y="433"/>
+      <point x="275" y="433" type="qcurve" smooth="yes"/>
+      <point x="316" y="433"/>
+      <point x="384" y="385"/>
+      <point x="402" y="332" type="qcurve"/>
+      <point x="412" y="377" type="line"/>
+      <point x="72" y="233" type="line"/>
+      <point x="101" y="150" type="line"/>
+      <point x="511" y="324" type="line" smooth="yes"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324"/>
+      <point x="511" y="324" type="qcurve"/>
+      <point x="509" y="336"/>
+      <point x="504" y="354"/>
+      <point x="501" y="362" type="qcurve" smooth="yes"/>
+      <point x="468" y="446"/>
+      <point x="356" y="526"/>
+      <point x="279" y="526" type="qcurve" smooth="yes"/>
+      <point x="162" y="526"/>
+      <point x="16" y="372"/>
+      <point x="16" y="254" type="qcurve"/>
+      <point x="16" y="254" type="line"/>
+      <point x="16" y="132"/>
+      <point x="166" y="-16"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/g.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/g.logo.glif
@@ -1,60 +1,60 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="g.logo" format="2">
-  <advance width="569" />
-  <unicode hex="E002" />
+  <advance width="569"/>
+  <unicode hex="E002"/>
   <outline>
     <contour>
-      <point x="275" y="-232" type="qcurve" smooth="yes" />
-      <point x="529" y="-232" />
-      <point x="529" y="59" type="qcurve" smooth="yes" />
-      <point x="529" y="510" type="line" />
-      <point x="425" y="510" type="line" />
-      <point x="425" y="446" type="line" />
-      <point x="423" y="446" type="line" />
-      <point x="398" y="484" />
-      <point x="312" y="526" />
-      <point x="260" y="526" type="qcurve" smooth="yes" />
-      <point x="186" y="526" />
-      <point x="77" y="456" />
-      <point x="18" y="335" />
-      <point x="18" y="258" type="qcurve" smooth="yes" />
-      <point x="18" y="181" />
-      <point x="77" y="62" />
-      <point x="188" y="-6" />
-      <point x="264" y="-6" type="qcurve" smooth="yes" />
-      <point x="302" y="-6" />
-      <point x="366" y="20" />
-      <point x="410" y="56" />
-      <point x="422" y="74" type="qcurve" />
-      <point x="425" y="74" type="line" />
-      <point x="425" y="28" type="line" smooth="yes" />
-      <point x="425" y="-49" />
-      <point x="348" y="-135" />
-      <point x="274" y="-135" type="qcurve" smooth="yes" />
-      <point x="225" y="-135" />
-      <point x="158" y="-84" />
-      <point x="134" y="-40" type="qcurve" />
-      <point x="40" y="-82" type="line" />
-      <point x="78" y="-160" />
-      <point x="189" y="-232" />
+      <point x="275" y="-232" type="qcurve" smooth="yes"/>
+      <point x="529" y="-232"/>
+      <point x="529" y="59" type="qcurve" smooth="yes"/>
+      <point x="529" y="510" type="line"/>
+      <point x="425" y="510" type="line"/>
+      <point x="425" y="446" type="line"/>
+      <point x="423" y="446" type="line"/>
+      <point x="398" y="484"/>
+      <point x="312" y="526"/>
+      <point x="260" y="526" type="qcurve" smooth="yes"/>
+      <point x="186" y="526"/>
+      <point x="77" y="456"/>
+      <point x="18" y="335"/>
+      <point x="18" y="258" type="qcurve" smooth="yes"/>
+      <point x="18" y="181"/>
+      <point x="77" y="62"/>
+      <point x="188" y="-6"/>
+      <point x="264" y="-6" type="qcurve" smooth="yes"/>
+      <point x="302" y="-6"/>
+      <point x="366" y="20"/>
+      <point x="410" y="56"/>
+      <point x="422" y="74" type="qcurve"/>
+      <point x="425" y="74" type="line"/>
+      <point x="425" y="28" type="line" smooth="yes"/>
+      <point x="425" y="-49"/>
+      <point x="348" y="-135"/>
+      <point x="274" y="-135" type="qcurve" smooth="yes"/>
+      <point x="225" y="-135"/>
+      <point x="158" y="-84"/>
+      <point x="134" y="-40" type="qcurve"/>
+      <point x="40" y="-82" type="line"/>
+      <point x="78" y="-160"/>
+      <point x="189" y="-232"/>
     </contour>
     <contour>
-      <point x="275" y="94" type="qcurve" smooth="yes" />
-      <point x="232" y="94" />
-      <point x="164" y="134" />
-      <point x="125" y="210" />
-      <point x="125" y="262" type="qcurve" smooth="yes" />
-      <point x="125" y="311" />
-      <point x="163" y="387" />
-      <point x="231" y="428" />
-      <point x="276" y="428" type="qcurve" smooth="yes" />
-      <point x="321" y="428" />
-      <point x="389" y="388" />
-      <point x="425" y="312" />
-      <point x="425" y="262" type="qcurve" smooth="yes" />
-      <point x="425" y="213" />
-      <point x="389" y="136" />
-      <point x="321" y="94" />
+      <point x="275" y="94" type="qcurve" smooth="yes"/>
+      <point x="232" y="94"/>
+      <point x="164" y="134"/>
+      <point x="125" y="210"/>
+      <point x="125" y="262" type="qcurve" smooth="yes"/>
+      <point x="125" y="311"/>
+      <point x="163" y="387"/>
+      <point x="231" y="428"/>
+      <point x="276" y="428" type="qcurve" smooth="yes"/>
+      <point x="321" y="428"/>
+      <point x="389" y="388"/>
+      <point x="425" y="312"/>
+      <point x="425" y="262" type="qcurve" smooth="yes"/>
+      <point x="425" y="213"/>
+      <point x="389" y="136"/>
+      <point x="321" y="94"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/l.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/l.logo.glif
@@ -1,13 +1,13 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="l.logo" format="2">
-  <advance width="190" />
-  <unicode hex="E003" />
+  <advance width="190"/>
+  <unicode hex="E003"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line" />
-      <point x="150" y="0" type="line" />
-      <point x="150" y="716" type="line" />
-      <point x="40" y="716" type="line" />
+      <point x="40" y="0" type="line"/>
+      <point x="150" y="0" type="line"/>
+      <point x="150" y="716" type="line"/>
+      <point x="40" y="716" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/o.logo.glif
+++ b/source/GoogleSans/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/o.logo.glif
@@ -1,43 +1,43 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o.logo" format="2">
-  <advance width="582" />
-  <unicode hex="E001" />
+  <advance width="582"/>
+  <unicode hex="E001"/>
   <outline>
     <contour>
-      <point x="290" y="-16" type="qcurve" smooth="yes" />
-      <point x="368" y="-16" />
-      <point x="490" y="54" />
-      <point x="559" y="179" />
-      <point x="559" y="257" type="qcurve" smooth="yes" />
-      <point x="559" y="336" />
-      <point x="489" y="460" />
-      <point x="366" y="528" />
-      <point x="290" y="528" type="qcurve" smooth="yes" />
-      <point x="214" y="528" />
-      <point x="92" y="460" />
-      <point x="22" y="337" />
-      <point x="22" y="257" type="qcurve" smooth="yes" />
-      <point x="22" y="179" />
-      <point x="90" y="54" />
-      <point x="213" y="-16" />
+      <point x="290" y="-16" type="qcurve" smooth="yes"/>
+      <point x="368" y="-16"/>
+      <point x="490" y="54"/>
+      <point x="559" y="179"/>
+      <point x="559" y="257" type="qcurve" smooth="yes"/>
+      <point x="559" y="336"/>
+      <point x="489" y="460"/>
+      <point x="366" y="528"/>
+      <point x="290" y="528" type="qcurve" smooth="yes"/>
+      <point x="214" y="528"/>
+      <point x="92" y="460"/>
+      <point x="22" y="337"/>
+      <point x="22" y="257" type="qcurve" smooth="yes"/>
+      <point x="22" y="179"/>
+      <point x="90" y="54"/>
+      <point x="213" y="-16"/>
     </contour>
     <contour>
-      <point x="290" y="78" type="qcurve" smooth="yes" />
-      <point x="242" y="78" />
-      <point x="169" y="126" />
-      <point x="128" y="208" />
-      <point x="128" y="257" type="qcurve" smooth="yes" />
-      <point x="128" y="308" />
-      <point x="172" y="388" />
-      <point x="246" y="434" />
-      <point x="290" y="434" type="qcurve" smooth="yes" />
-      <point x="337" y="434" />
-      <point x="411" y="386" />
-      <point x="452" y="306" />
-      <point x="452" y="257" type="qcurve" smooth="yes" />
-      <point x="452" y="208" />
-      <point x="411" y="126" />
-      <point x="338" y="78" />
+      <point x="290" y="78" type="qcurve" smooth="yes"/>
+      <point x="242" y="78"/>
+      <point x="169" y="126"/>
+      <point x="128" y="208"/>
+      <point x="128" y="257" type="qcurve" smooth="yes"/>
+      <point x="128" y="308"/>
+      <point x="172" y="388"/>
+      <point x="246" y="434"/>
+      <point x="290" y="434" type="qcurve" smooth="yes"/>
+      <point x="337" y="434"/>
+      <point x="411" y="386"/>
+      <point x="452" y="306"/>
+      <point x="452" y="257" type="qcurve" smooth="yes"/>
+      <point x="452" y="208"/>
+      <point x="411" y="126"/>
+      <point x="338" y="78"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
During the final release step, all fonts are edited to use post v3, granting savings in file size documented in #115 & #757 

This approach is preferable to #757 because it doesn't break our QA workflows

Did we ought to integrate this into the Makefile somehow? I'm hesitant to overwrite/modify either the intermediate or variable folder fonts because then that'll break QA (again), but also creating a new folder/package for these seems overblown and cumbersome.