### PR TITLE
Drop stray _bottom/_top anchors from four Devanagari composites

### DIFF
--- a/sources/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="600"/>
-  <anchor x="457" y="-31" name="_bottom"/>
   <anchor x="414" y="679" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="600"/>
-  <anchor x="426" y="-31" name="_bottom"/>
   <anchor x="127" y="-193" name="nukta"/>
   <anchor x="414" y="679" name="top"/>
   <outline>

--- a/sources/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="693"/>
-  <anchor x="603" y="181" name="_top"/>
   <anchor x="307" y="19" name="bottom"/>
   <anchor x="300" y="-108" name="nukta"/>
   <anchor x="434" y="679" name="top"/>

--- a/sources/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSans-opsz17-wght380-GRAD-50.ufo/glyphs/nga-deva.glif
@@ -3,7 +3,6 @@
   <advance width="693"/>
   <unicode hex="0919"/>
   <guideline x="460" y="428" angle="0"/>
-  <anchor x="603" y="181" name="_top"/>
   <anchor x="307" y="19" name="bottom"/>
   <anchor x="300" y="-108" name="nukta"/>
   <anchor x="434" y="679" name="top"/>

--- a/sources/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="600"/>
-  <anchor x="457" y="-31" name="_bottom"/>
   <anchor x="414" y="679" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="600"/>
-  <anchor x="426" y="-31" name="_bottom"/>
   <anchor x="127" y="-193" name="nukta"/>
   <anchor x="414" y="679" name="top"/>
   <outline>

--- a/sources/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="693"/>
-  <anchor x="603" y="181" name="_top"/>
   <anchor x="307" y="19" name="bottom"/>
   <anchor x="300" y="-108" name="nukta"/>
   <anchor x="434" y="679" name="top"/>

--- a/sources/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSans-opsz17-wght380-GRAD0.ufo/glyphs/nga-deva.glif
@@ -3,7 +3,6 @@
   <advance width="693"/>
   <unicode hex="0919"/>
   <guideline x="460" y="428" angle="0"/>
-  <anchor x="603" y="181" name="_top"/>
   <anchor x="307" y="19" name="bottom"/>
   <anchor x="300" y="-108" name="nukta"/>
   <anchor x="434" y="679" name="top"/>

--- a/sources/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="600"/>
-  <anchor x="457" y="-31" name="_bottom"/>
   <anchor x="414" y="679" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="600"/>
-  <anchor x="426" y="-31" name="_bottom"/>
   <anchor x="127" y="-193" name="nukta"/>
   <anchor x="414" y="679" name="top"/>
   <outline>

--- a/sources/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="693"/>
-  <anchor x="603" y="181" name="_top"/>
   <anchor x="307" y="19" name="bottom"/>
   <anchor x="300" y="-108" name="nukta"/>
   <anchor x="434" y="679" name="top"/>

--- a/sources/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSans-opsz17-wght380-GRAD200.ufo/glyphs/nga-deva.glif
@@ -3,7 +3,6 @@
   <advance width="693"/>
   <unicode hex="0919"/>
   <guideline x="460" y="428" angle="0"/>
-  <anchor x="603" y="181" name="_top"/>
   <anchor x="307" y="19" name="bottom"/>
   <anchor x="300" y="-108" name="nukta"/>
   <anchor x="434" y="679" name="top"/>

--- a/sources/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="628"/>
-  <anchor x="474" y="-38" name="_bottom"/>
   <anchor x="431" y="690" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="628"/>
-  <anchor x="445" y="-38" name="_bottom"/>
   <anchor x="123" y="-220" name="nukta"/>
   <anchor x="431" y="690" name="top"/>
   <outline>

--- a/sources/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="720"/>
-  <anchor x="636" y="185" name="_top"/>
   <anchor x="322" y="20" name="bottom"/>
   <anchor x="315" y="-114" name="nukta"/>
   <anchor x="452" y="690" name="top"/>

--- a/sources/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSans-opsz17-wght734-GRAD0.ufo/glyphs/nga-deva.glif
@@ -2,7 +2,6 @@
 <glyph name="nga-deva" format="2">
   <advance width="720"/>
   <unicode hex="0919"/>
-  <anchor x="636" y="185" name="_top"/>
   <anchor x="322" y="20" name="bottom"/>
   <anchor x="315" y="-114" name="nukta"/>
   <anchor x="452" y="690" name="top"/>

--- a/sources/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="568"/>
-  <anchor x="441" y="-31" name="_bottom"/>
   <anchor x="398" y="660" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="568"/>
-  <anchor x="415" y="-31" name="_bottom"/>
   <anchor x="141" y="-183" name="nukta"/>
   <anchor x="398" y="660" name="top"/>
   <outline>

--- a/sources/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="662"/>
-  <anchor x="588" y="192" name="_top"/>
   <anchor x="304" y="1" name="bottom"/>
   <anchor x="284" y="-108" name="nukta"/>
   <anchor x="418" y="660" name="top"/>

--- a/sources/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSans-opsz18-wght380-GRAD-50.ufo/glyphs/nga-deva.glif
@@ -3,7 +3,6 @@
   <advance width="662"/>
   <unicode hex="0919"/>
   <guideline x="460" y="428" angle="0"/>
-  <anchor x="588" y="192" name="_top"/>
   <anchor x="304" y="1" name="bottom"/>
   <anchor x="284" y="-108" name="nukta"/>
   <anchor x="418" y="660" name="top"/>

--- a/sources/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="568"/>
-  <anchor x="441" y="-31" name="_bottom"/>
   <anchor x="398" y="660" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="568"/>
-  <anchor x="415" y="-31" name="_bottom"/>
   <anchor x="141" y="-183" name="nukta"/>
   <anchor x="398" y="660" name="top"/>
   <outline>

--- a/sources/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="662"/>
-  <anchor x="588" y="192" name="_top"/>
   <anchor x="304" y="1" name="bottom"/>
   <anchor x="284" y="-108" name="nukta"/>
   <anchor x="418" y="660" name="top"/>

--- a/sources/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSans-opsz18-wght380-GRAD0.ufo/glyphs/nga-deva.glif
@@ -3,7 +3,6 @@
   <advance width="662"/>
   <unicode hex="0919"/>
   <guideline x="460" y="428" angle="0"/>
-  <anchor x="588" y="192" name="_top"/>
   <anchor x="304" y="1" name="bottom"/>
   <anchor x="284" y="-108" name="nukta"/>
   <anchor x="418" y="660" name="top"/>

--- a/sources/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="568"/>
-  <anchor x="441" y="-31" name="_bottom"/>
   <anchor x="398" y="660" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="568"/>
-  <anchor x="415" y="-31" name="_bottom"/>
   <anchor x="141" y="-183" name="nukta"/>
   <anchor x="398" y="660" name="top"/>
   <outline>

--- a/sources/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="662"/>
-  <anchor x="588" y="192" name="_top"/>
   <anchor x="304" y="1" name="bottom"/>
   <anchor x="284" y="-108" name="nukta"/>
   <anchor x="418" y="660" name="top"/>

--- a/sources/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSans-opsz18-wght380-GRAD200.ufo/glyphs/nga-deva.glif
@@ -3,7 +3,6 @@
   <advance width="662"/>
   <unicode hex="0919"/>
   <guideline x="460" y="428" angle="0"/>
-  <anchor x="588" y="192" name="_top"/>
   <anchor x="304" y="1" name="bottom"/>
   <anchor x="284" y="-108" name="nukta"/>
   <anchor x="418" y="660" name="top"/>

--- a/sources/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="602"/>
-  <anchor x="464" y="-35" name="_bottom"/>
   <anchor x="418" y="671" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="602"/>
-  <anchor x="433" y="-35" name="_bottom"/>
   <anchor x="141" y="-223" name="nukta"/>
   <anchor x="418" y="671" name="top"/>
   <outline>

--- a/sources/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="696"/>
-  <anchor x="624" y="196" name="_top"/>
   <anchor x="320" y="0" name="bottom"/>
   <anchor x="301" y="-112" name="nukta"/>
   <anchor x="441" y="671" name="top"/>

--- a/sources/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSans-opsz18-wght734-GRAD0.ufo/glyphs/nga-deva.glif
@@ -2,7 +2,6 @@
 <glyph name="nga-deva" format="2">
   <advance width="696"/>
   <unicode hex="0919"/>
-  <anchor x="624" y="196" name="_top"/>
   <anchor x="320" y="0" name="bottom"/>
   <anchor x="301" y="-112" name="nukta"/>
   <anchor x="441" y="671" name="top"/>

--- a/sources/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="600"/>
-  <anchor x="405" y="-33" name="_bottom"/>
   <anchor x="491" y="679" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="600"/>
-  <anchor x="375" y="-31" name="_bottom"/>
   <anchor x="48" y="-193" name="nukta"/>
   <anchor x="491" y="679" name="top"/>
   <outline>

--- a/sources/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="679"/>
-  <anchor x="578" y="182" name="_top"/>
   <anchor x="291" y="6" name="bottom"/>
   <anchor x="259" y="-108" name="nukta"/>
   <anchor x="510" y="679" name="top"/>

--- a/sources/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght380-GRAD-50.ufo/glyphs/nga-deva.glif
@@ -3,7 +3,6 @@
   <advance width="679"/>
   <unicode hex="0919"/>
   <guideline x="460" y="428" angle="0"/>
-  <anchor x="578" y="182" name="_top"/>
   <anchor x="291" y="6" name="bottom"/>
   <anchor x="259" y="-108" name="nukta"/>
   <anchor x="510" y="679" name="top"/>

--- a/sources/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="600"/>
-  <anchor x="405" y="-33" name="_bottom"/>
   <anchor x="491" y="679" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="600"/>
-  <anchor x="375" y="-31" name="_bottom"/>
   <anchor x="48" y="-193" name="nukta"/>
   <anchor x="491" y="679" name="top"/>
   <outline>

--- a/sources/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="679"/>
-  <anchor x="578" y="182" name="_top"/>
   <anchor x="291" y="6" name="bottom"/>
   <anchor x="259" y="-108" name="nukta"/>
   <anchor x="510" y="679" name="top"/>

--- a/sources/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght380-GRAD0.ufo/glyphs/nga-deva.glif
@@ -3,7 +3,6 @@
   <advance width="679"/>
   <unicode hex="0919"/>
   <guideline x="460" y="428" angle="0"/>
-  <anchor x="578" y="182" name="_top"/>
   <anchor x="291" y="6" name="bottom"/>
   <anchor x="259" y="-108" name="nukta"/>
   <anchor x="510" y="679" name="top"/>

--- a/sources/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="600"/>
-  <anchor x="405" y="-33" name="_bottom"/>
   <anchor x="491" y="679" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="600"/>
-  <anchor x="375" y="-31" name="_bottom"/>
   <anchor x="48" y="-193" name="nukta"/>
   <anchor x="491" y="679" name="top"/>
   <outline>

--- a/sources/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="679"/>
-  <anchor x="578" y="182" name="_top"/>
   <anchor x="291" y="6" name="bottom"/>
   <anchor x="259" y="-108" name="nukta"/>
   <anchor x="510" y="679" name="top"/>

--- a/sources/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght380-GRAD200.ufo/glyphs/nga-deva.glif
@@ -3,7 +3,6 @@
   <advance width="679"/>
   <unicode hex="0919"/>
   <guideline x="460" y="428" angle="0"/>
-  <anchor x="578" y="182" name="_top"/>
   <anchor x="291" y="6" name="bottom"/>
   <anchor x="259" y="-108" name="nukta"/>
   <anchor x="510" y="679" name="top"/>

--- a/sources/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="628"/>
-  <anchor x="417" y="-29" name="_bottom"/>
   <anchor x="510" y="690" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="628"/>
-  <anchor x="412" y="-29" name="_bottom"/>
   <anchor x="62" y="-211" name="nukta"/>
   <anchor x="510" y="690" name="top"/>
   <outline>

--- a/sources/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="706"/>
-  <anchor x="608" y="175" name="_top"/>
   <anchor x="292" y="-3" name="bottom"/>
   <anchor x="272" y="-114" name="nukta"/>
   <anchor x="530" y="690" name="top"/>

--- a/sources/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSansItalic-opsz17-wght734-GRAD0.ufo/glyphs/nga-deva.glif
@@ -2,7 +2,6 @@
 <glyph name="nga-deva" format="2">
   <advance width="706"/>
   <unicode hex="0919"/>
-  <anchor x="608" y="175" name="_top"/>
   <anchor x="292" y="-3" name="bottom"/>
   <anchor x="272" y="-114" name="nukta"/>
   <anchor x="530" y="690" name="top"/>

--- a/sources/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="568"/>
-  <anchor x="392" y="-30" name="_bottom"/>
   <anchor x="471" y="660" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="568"/>
-  <anchor x="363" y="-31" name="_bottom"/>
   <anchor x="62" y="-183" name="nukta"/>
   <anchor x="471" y="660" name="top"/>
   <outline>

--- a/sources/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="646"/>
-  <anchor x="577" y="192" name="_top"/>
   <anchor x="262" y="3" name="bottom"/>
   <anchor x="231" y="-108" name="nukta"/>
   <anchor x="491" y="660" name="top"/>

--- a/sources/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght380-GRAD-50.ufo/glyphs/nga-deva.glif
@@ -3,7 +3,6 @@
   <advance width="646"/>
   <unicode hex="0919"/>
   <guideline x="495" y="428" angle="0"/>
-  <anchor x="577" y="192" name="_top"/>
   <anchor x="262" y="3" name="bottom"/>
   <anchor x="231" y="-108" name="nukta"/>
   <anchor x="491" y="660" name="top"/>

--- a/sources/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="568"/>
-  <anchor x="392" y="-30" name="_bottom"/>
   <anchor x="471" y="660" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="568"/>
-  <anchor x="363" y="-31" name="_bottom"/>
   <anchor x="62" y="-183" name="nukta"/>
   <anchor x="471" y="660" name="top"/>
   <outline>

--- a/sources/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="646"/>
-  <anchor x="577" y="192" name="_top"/>
   <anchor x="262" y="3" name="bottom"/>
   <anchor x="231" y="-108" name="nukta"/>
   <anchor x="491" y="660" name="top"/>

--- a/sources/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght380-GRAD0.ufo/glyphs/nga-deva.glif
@@ -3,7 +3,6 @@
   <advance width="646"/>
   <unicode hex="0919"/>
   <guideline x="495" y="428" angle="0"/>
-  <anchor x="577" y="192" name="_top"/>
   <anchor x="262" y="3" name="bottom"/>
   <anchor x="231" y="-108" name="nukta"/>
   <anchor x="491" y="660" name="top"/>

--- a/sources/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="568"/>
-  <anchor x="392" y="-30" name="_bottom"/>
   <anchor x="471" y="660" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="568"/>
-  <anchor x="363" y="-31" name="_bottom"/>
   <anchor x="62" y="-183" name="nukta"/>
   <anchor x="471" y="660" name="top"/>
   <outline>

--- a/sources/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="646"/>
-  <anchor x="577" y="192" name="_top"/>
   <anchor x="262" y="3" name="bottom"/>
   <anchor x="231" y="-108" name="nukta"/>
   <anchor x="491" y="660" name="top"/>

--- a/sources/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght380-GRAD200.ufo/glyphs/nga-deva.glif
@@ -3,7 +3,6 @@
   <advance width="646"/>
   <unicode hex="0919"/>
   <guideline x="495" y="428" angle="0"/>
-  <anchor x="577" y="192" name="_top"/>
   <anchor x="262" y="3" name="bottom"/>
   <anchor x="231" y="-108" name="nukta"/>
   <anchor x="491" y="660" name="top"/>

--- a/sources/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/da_uM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uMatra-deva" format="2">
   <advance width="598"/>
-  <anchor x="404" y="-35" name="_bottom"/>
   <anchor x="491" y="671" name="top"/>
   <outline>
     <contour>

--- a/sources/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/da_uuM_atra-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="da_uuMatra-deva" format="2">
   <advance width="598"/>
-  <anchor x="371" y="-38" name="_bottom"/>
   <anchor x="46" y="-226" name="nukta"/>
   <anchor x="491" y="671" name="top"/>
   <outline>

--- a/sources/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ng-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/ng-deva.glif
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ng-deva" format="2">
   <advance width="684"/>
-  <anchor x="617" y="191" name="_top"/>
   <anchor x="277" y="0" name="bottom"/>
   <anchor x="255" y="-112" name="nukta"/>
   <anchor x="517" y="671" name="top"/>

--- a/sources/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/nga-deva.glif
+++ b/sources/GoogleSansItalic-opsz18-wght734-GRAD0.ufo/glyphs/nga-deva.glif
@@ -2,7 +2,6 @@
 <glyph name="nga-deva" format="2">
   <advance width="684"/>
   <unicode hex="0919"/>
-  <anchor x="617" y="191" name="_top"/>
   <anchor x="277" y="0" name="bottom"/>
   <anchor x="255" y="-112" name="nukta"/>
   <anchor x="517" y="671" name="top"/>


### PR DESCRIPTION
See https://github.com/googlefonts/googlesans/pull/772#issuecomment-5454002344

`da_uMatra-deva` and `da_uuMatra-deva` have `_bottom` alongside `top`, `nga-deva` and `ng-deva` have `_top` alongside `bottom`, and the cancellation step in anchor propagation drops the conflicting `top`/`bottom`, leaving marks unattached.

But the `_` anchors do nothing (all four glyphs are GDEF bases, so nothing attaches through them) so removing them stops the cancellation and lets propagation keep running.

I built both designspaces with fontc 1.0.0-rc.2: the seven regressed Devanagari words now shape with the same mark offsets as before the propagation change. The only GPOS difference is on those four bases, and it's all additions.

A diffenator3 run against #772 as it stands shows no Devanagari differences.

Only two words differ elsewhere: Gujarati રૅયુનિઑઁ, where propagation gives the composite `oCandra-gujarati` a top anchor so `candraBindu-gujarati` attaches (it doesn't in #772); and Hebrew װָאךְ, where the vowel point lands a few units off. I haven't chased the latter down. Maybe that's worth a designer's eye.